### PR TITLE
Enable response compression for text/html mime-type in the Playground project (#2094)

### DIFF
--- a/src/Client/Web/Playground/Bit.Client.Web.BlazorUI.Playground/Api/Startup/Services.cs
+++ b/src/Client/Web/Playground/Bit.Client.Web.BlazorUI.Playground/Api/Startup/Services.cs
@@ -31,7 +31,7 @@ public static class Services
         services.AddResponseCompression(opts =>
         {
             opts.EnableForHttps = true;
-            opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Where(m => m != "text/html").Concat(new[] { "application/octet-stream" }).ToArray();
+            opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/octet-stream" }).ToArray();
             opts.Providers.Add<BrotliCompressionProvider>();
             opts.Providers.Add<GzipCompressionProvider>();
         })

--- a/src/Client/Web/Playground/Bit.Client.Web.BlazorUI.Playground/Web/Startup/Services.cs
+++ b/src/Client/Web/Playground/Bit.Client.Web.BlazorUI.Playground/Web/Startup/Services.cs
@@ -26,7 +26,7 @@ public class Services
         services.AddResponseCompression(opts =>
             {
                 opts.EnableForHttps = true;
-                opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Where(m => m != "text/html").Concat(new[] { "application/octet-stream" }).ToArray();
+                opts.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/octet-stream" }).ToArray();
                 opts.Providers.Add<BrotliCompressionProvider>();
                 opts.Providers.Add<GzipCompressionProvider>();
             })


### PR DESCRIPTION
this closes #2094