### PR TITLE
Rename the `AutoInject` namespace to `Microsoft.Extensions.DependencyInjection` (#2292)

### DIFF
--- a/src/Tooling/Bit.Tooling.SourceGenerators/AutoInject/AutoInjectAttribute.cs
+++ b/src/Tooling/Bit.Tooling.SourceGenerators/AutoInject/AutoInjectAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Microsoft.Extensions.DependencyInjection.Abstractions;
+namespace Microsoft.Extensions.DependencyInjection;
 
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 public sealed class AutoInjectAttribute : Attribute

--- a/src/Tooling/Bit.Tooling.SourceGenerators/AutoInject/AutoInjectSourceGenerator.cs
+++ b/src/Tooling/Bit.Tooling.SourceGenerators/AutoInject/AutoInjectSourceGenerator.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.DependencyInjection.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Tooling.SourceGenerators;
 

--- a/src/Tooling/Bit.Tooling.SourceGenerators/AutoInject/AutoInjectSyntaxReceiver.cs
+++ b/src/Tooling/Bit.Tooling.SourceGenerators/AutoInject/AutoInjectSyntaxReceiver.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.DependencyInjection.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Tooling.SourceGenerators;
 


### PR DESCRIPTION
this closes #2292 