### PR TITLE
Prerelease `v-2.0.0-pre-2` II (#2480)

### DIFF
--- a/src/Bit.Build.props
+++ b/src/Bit.Build.props
@@ -27,8 +27,8 @@
 
 		<ReleaseVersion>2.0.0</ReleaseVersion>
 
-		<PackageReleaseNotes>https://github.com/bitfoundation/bitplatform/releases/tag/v-$(ReleaseVersion)-pre-01</PackageReleaseNotes>
-		<PackageVersion>$(ReleaseVersion)-pre-01</PackageVersion>
+		<PackageReleaseNotes>https://github.com/bitfoundation/bitplatform/releases/tag/v-$(ReleaseVersion)-pre-02</PackageReleaseNotes>
+		<PackageVersion>$(ReleaseVersion)-pre-02</PackageVersion>
 
 		<!-- Version -->
 		<Version>$(ReleaseVersion).$([System.DateTime]::Now.ToString(HHmm))</Version>


### PR DESCRIPTION
this closes #2480