### PR TITLE
Fix incorrect label for the `Custom Label` sample of the `BitToggle` component demo page (#2555)

### DIFF
--- a/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Toggle/BitToggleDemo.razor
+++ b/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Toggle/BitToggleDemo.razor
@@ -41,7 +41,7 @@
             <div class="m-t-15">
                 <BitToggle @bind-Value="IsToggleUnChecked" IsEnabled="true" OnText="On" OffText="Off">
                     <LabelFragment>
-                        Custom Inline Label
+                        Custom Label
                     </LabelFragment>
                 </BitToggle>
             </div>

--- a/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Toggle/BitToggleDemo.razor.cs
+++ b/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Toggle/BitToggleDemo.razor.cs
@@ -188,7 +188,7 @@ private bool IsToggleUnChecked = false;";
     private readonly string example2HTMLCode = @"<div>
     <BitToggle @bind-Value=""IsToggleUnChecked"" IsEnabled=""true"" OnText=""On"" OffText=""Off"">
         <LabelFragment>
-            Custom Inline Label
+            Custom Label
         </LabelFragment>
     </BitToggle>
 </div>


### PR DESCRIPTION
this closes #2555 