### PR TITLE
Add missing definition in all C# code samples in the `BitBreadcrumb` component (#2556)

### DIFF
--- a/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Breadcrumb/BitBreadcrumbDemo.razor.cs
+++ b/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Breadcrumb/BitBreadcrumbDemo.razor.cs
@@ -212,6 +212,8 @@ public partial class BitBreadcrumbDemo
 </div>";
 
     private readonly string example1CSharpCode = @"
+public string OnClickValue { get; set; } = string.Empty;
+
 private List<BitBreadcrumbItem> GetBreadcrumbItems()
 {
     return new List<BitBreadcrumbItem>()


### PR DESCRIPTION
this closes #2556 