### PR TITLE
Add missing unit of `MaxSize` in `BitFileUpload` demo page (#2654)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/FileUpload/BitFileUpload.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/FileUpload/BitFileUpload.razor.cs
@@ -67,7 +67,7 @@ public partial class BitFileUpload : IAsyncDisposable
     [Parameter] public RenderFragment? LabelFragment { get; set; }
 
     /// <summary>
-    /// Specifies the maximum size of the file (0 for unlimited).
+    /// Specifies the maximum size (byte) of the file (0 for unlimited).
     /// </summary>
     [Parameter] public long MaxSize { get; set; }
 

--- a/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/FileUpload/BitFileUploadDemo.razor.cs
+++ b/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/FileUpload/BitFileUploadDemo.razor.cs
@@ -77,7 +77,7 @@ public partial class BitFileUploadDemo
         },
         new ComponentParameter
         {
-            Name = "MaxSize",
+            Name = "MaxSize (byte)",
             Type = "long",
             DefaultValue = "0",
             Description = "Specifies the maximum size of the file (0 for unlimited)."


### PR DESCRIPTION
this closes #2654 