### PR TITLE
Fix misspelling `HealthCheckSettings` in the `Sales` website (#2836)

### DIFF
--- a/src/Sales/Bit.Sales.WebSite/Api/AppSettings.cs
+++ b/src/Sales/Bit.Sales.WebSite/Api/AppSettings.cs
@@ -8,7 +8,7 @@ public class AppSettings
 
     public EmailSettings EmailSettings { get; set; } = default!;
 
-    public HealCheckSettings HealCheckSettings { get; set; } = default!;
+    public HealthCheckSettings HealthCheckSettings { get; set; } = default!;
 
     public ReceiverEmailSetting ReceiverEmailSetting { get; set; } = default!;
 
@@ -17,7 +17,7 @@ public class AppSettings
     public string WebServerAddress { get; set; } = default!;
 }
 
-public class HealCheckSettings
+public class HealthCheckSettings
 {
     public bool EnableHealthChecks { get; set; }
 }

--- a/src/Sales/Bit.Sales.WebSite/Api/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Sales/Bit.Sales.WebSite/Api/Extensions/IServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ public static class IServiceCollectionExtensions
     {
         var appsettings = configuration.GetSection(nameof(AppSettings)).Get<AppSettings>();
 
-        var healthCheckSettings = appsettings.HealCheckSettings;
+        var healthCheckSettings = appsettings.HealthCheckSettings;
 
         if (healthCheckSettings.EnableHealthChecks is false)
             return;

--- a/src/Sales/Bit.Sales.WebSite/Api/Startup/Middlewares.cs
+++ b/src/Sales/Bit.Sales.WebSite/Api/Startup/Middlewares.cs
@@ -62,7 +62,7 @@ public class Middlewares
 
             var appsettings = configuration.GetSection(nameof(AppSettings)).Get<AppSettings>();
 
-            var healthCheckSettings = appsettings.HealCheckSettings;
+            var healthCheckSettings = appsettings.HealthCheckSettings;
 
             if (healthCheckSettings.EnableHealthChecks)
             {

--- a/src/Sales/Bit.Sales.WebSite/Api/appsettings.json
+++ b/src/Sales/Bit.Sales.WebSite/Api/appsettings.json
@@ -35,7 +35,7 @@
       "UserName": null,
       "Password": null
     },
-    "HealCheckSettings": {
+    "HealthCheckSettings": {
       "EnableHealthChecks": true
     },
     "ReceiverEmailSetting": {


### PR DESCRIPTION
This closes #2836 