### PR TITLE
Fix `BitButton` and friends to be type="submit" in a form via default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,6 @@ custom.aprof
 
 /src/Sales/Bit.Sales.WebSite/Web/**/*.css
 /src/Sales/Bit.Sales.WebSite/Web/**/*.js
+
+# MacOS files
+.DS_Store

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitActionButtonTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitActionButtonTests.cs
@@ -145,7 +145,7 @@ public class BitActionButtonTests : BunitTestContext
         var bitActionButton = component.Find(".bit-act-btn");
 
         var buttonTypeName = buttonType == BitButtonType.Button ? "button" : buttonType == BitButtonType.Submit ? "submit" : "reset";
-        Assert.AreEqual(bitActionButton.GetAttribute("type"), buttonTypeName);
+        Assert.AreEqual(buttonTypeName, bitActionButton.GetAttribute("type"));
     }
     
     [TestMethod]

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitActionButtonTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitActionButtonTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bit.BlazorUI.Tests.Buttons;
@@ -145,5 +146,32 @@ public class BitActionButtonTests : BunitTestContext
 
         var buttonTypeName = buttonType == BitButtonType.Button ? "button" : buttonType == BitButtonType.Submit ? "submit" : "reset";
         Assert.AreEqual(bitActionButton.GetAttribute("type"), buttonTypeName);
+    }
+    
+    [TestMethod]
+    public void BitActionButtonSubmitStateInEditContextTest()
+    {
+        var com = RenderComponent<BitActionButton>(parameters =>
+        {
+            parameters.Add(p => p.EditContext, new EditContext(this));
+        });
+        
+        var bitButton = com.Find(".bit-act-btn");
+
+        Assert.AreEqual("submit", bitButton.GetAttribute("type"));
+    }
+    
+    [TestMethod]
+    public void BitActionButtonButtonStateNotOverridenInEditContextTest()
+    {
+        var com = RenderComponent<BitActionButton>(parameters =>
+        {
+            parameters.Add(p => p.EditContext, new EditContext(this));
+            parameters.Add(p => p.ButtonType, BitButtonType.Button);
+        });
+        
+        var bitButton = com.Find(".bit-act-btn");
+
+        Assert.AreEqual("button", bitButton.GetAttribute("type"));
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTest.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTest.razor
@@ -25,7 +25,8 @@
     [Parameter] public string Href { get; set; }
     [Parameter] public string Title { get; set; }
     [Parameter] public string Target { get; set; }
-    [Parameter] public BitButtonType ButtonType { get; set; }
+    [Parameter] public BitButtonType? ButtonType { get; set; }
+    [Parameter] public EditContext EditContext { get; set; }
 
     public int CurrentCount { get; set; }
 

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTest.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTest.razor
@@ -25,8 +25,7 @@
     [Parameter] public string Href { get; set; }
     [Parameter] public string Title { get; set; }
     [Parameter] public string Target { get; set; }
-    [Parameter] public BitButtonType? ButtonType { get; set; }
-    [Parameter] public EditContext EditContext { get; set; }
+    [Parameter] public BitButtonType ButtonType { get; set; }
 
     public int CurrentCount { get; set; }
 

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTests.cs
@@ -181,7 +181,7 @@ public class BitButtonTests : BunitTestContext
     [TestMethod]
     public void BitButtonSubmitStateInEditContextTest()
     {
-        var com = RenderComponent<BitButtonTest>(parameters =>
+        var com = RenderComponent<BitButton>(parameters =>
         {
             parameters.Add(p => p.EditContext, new EditContext(this));
         });
@@ -194,7 +194,7 @@ public class BitButtonTests : BunitTestContext
     [TestMethod]
     public void BitButtonButtonStateNotOverridenInEditContextTest()
     {
-        var com = RenderComponent<BitButtonTest>(parameters =>
+        var com = RenderComponent<BitButton>(parameters =>
         {
             parameters.Add(p => p.EditContext, new EditContext(this));
             parameters.Add(p => p.ButtonType, BitButtonType.Button);

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitButtonTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bit.BlazorUI.Tests.Buttons;
@@ -156,7 +157,7 @@ public class BitButtonTests : BunitTestContext
 
         var bitButton = com.Find(".bit-btn");
 
-        Assert.AreEqual(bitButton.HasAttribute("aria-hidden"), expectedResult);
+        Assert.AreEqual(expectedResult, bitButton.HasAttribute("aria-hidden"));
     }
 
     [DataTestMethod,
@@ -174,6 +175,33 @@ public class BitButtonTests : BunitTestContext
         var bitButton = com.Find(".bit-btn");
 
         var buttonTypeName = buttonType == BitButtonType.Button ? "button" : buttonType == BitButtonType.Submit ? "submit" : "reset";
-        Assert.AreEqual(bitButton.GetAttribute("type"), buttonTypeName);
+        Assert.AreEqual(buttonTypeName, bitButton.GetAttribute("type"));
+    }
+
+    [TestMethod]
+    public void BitButtonSubmitStateInEditContextTest()
+    {
+        var com = RenderComponent<BitButtonTest>(parameters =>
+        {
+            parameters.Add(p => p.EditContext, new EditContext(this));
+        });
+        
+        var bitButton = com.Find(".bit-btn");
+
+        Assert.AreEqual("submit", bitButton.GetAttribute("type"));
+    }
+    
+    [TestMethod]
+    public void BitButtonButtonStateNotOverridenInEditContextTest()
+    {
+        var com = RenderComponent<BitButtonTest>(parameters =>
+        {
+            parameters.Add(p => p.EditContext, new EditContext(this));
+            parameters.Add(p => p.ButtonType, BitButtonType.Button);
+        });
+        
+        var bitButton = com.Find(".bit-btn");
+
+        Assert.AreEqual("button", bitButton.GetAttribute("type"));
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitIconButtonTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitIconButtonTests.cs
@@ -112,17 +112,16 @@ public class BitIconButtonTests : BunitTestContext
         DataRow(false),
         DataRow(null)
     ]
-    public void BitIconButtonAriaHiddenTest(bool ariaHidden)
+    public void BitIconButtonAriaHiddenTest(bool expectedAriaHidden)
     {
         var com = RenderComponent<BitIconButtonTest>(parameters =>
         {
-            parameters.Add(p => p.AriaHidden, ariaHidden);
+            parameters.Add(p => p.AriaHidden, expectedAriaHidden);
         });
 
         var bitIconButton = com.Find(".bit-ico-btn");
-        var expectedResult = ariaHidden ? true : false;
 
-        Assert.AreEqual(bitIconButton.HasAttribute("aria-hidden"), expectedResult);
+        Assert.AreEqual(expectedAriaHidden, bitIconButton.HasAttribute("aria-hidden"));
     }
 
     [DataTestMethod,

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitIconButtonTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Buttons/BitIconButtonTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bit.BlazorUI.Tests.Buttons;
@@ -160,5 +161,32 @@ public class BitIconButtonTests : BunitTestContext
 
         var buttonTypeName = buttonType == BitButtonType.Button ? "button" : buttonType == BitButtonType.Submit ? "submit" : "reset";
         Assert.AreEqual(bitIconButton.GetAttribute("type"), buttonTypeName);
+    }
+    
+    [TestMethod]
+    public void BitIconButtonSubmitStateInEditContextTest()
+    {
+        var com = RenderComponent<BitIconButton>(parameters =>
+        {
+            parameters.Add(p => p.EditContext, new EditContext(this));
+        });
+        
+        var bitButton = com.Find(".bit-ico-btn");
+
+        Assert.AreEqual("submit", bitButton.GetAttribute("type"));
+    }
+    
+    [TestMethod]
+    public void BitIconButtonButtonStateNotOverridenInEditContextTest()
+    {
+        var com = RenderComponent<BitIconButton>(parameters =>
+        {
+            parameters.Add(p => p.EditContext, new EditContext(this));
+            parameters.Add(p => p.ButtonType, BitButtonType.Button);
+        });
+        
+        var bitButton = com.Find(".bit-ico-btn");
+
+        Assert.AreEqual("button", bitButton.GetAttribute("type"));
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitActionButton/BitActionButton.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitActionButton/BitActionButton.razor
@@ -29,7 +29,7 @@ else
             @attributes="HtmlAttributes"
             style="@StyleBuilder.Value"
             class="@ClassBuilder.Value"
-            type="@ButtonType.GetValue()"
+            type="@ButtonType?.GetValue()"
             aria-label="@AriaLabel"
             aria-describedby="@AriaDescription"
             aria-hidden="@AriaHidden"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitActionButton/BitActionButton.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitActionButton/BitActionButton.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace Bit.BlazorUI;
@@ -51,7 +52,12 @@ public partial class BitActionButton
     /// <summary>
     /// The type of the button
     /// </summary>
-    [Parameter] public BitButtonType ButtonType { get; set; } = BitButtonType.Button;
+    [Parameter] public BitButtonType? ButtonType { get; set; }
+
+    /// <summary>
+    /// The EditContext, which is set if the button is inside an <see cref="EditForm"/>
+    /// </summary>
+    [CascadingParameter] public EditContext? EditContext { get; set; }
 
     /// <summary>
     /// Callback for when the button clicked
@@ -66,6 +72,8 @@ public partial class BitActionButton
         {
             tabIndex = AllowDisabledFocus ? null : -1;
         }
+        
+        ButtonType ??= EditContext is null ? BitButtonType.Button : BitButtonType.Submit;
 
         await base.OnInitializedAsync();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.razor
@@ -27,7 +27,7 @@ else
             aria-describedby="@AriaDescription"
             aria-hidden="@AriaHidden"
             tabindex="@tabIndex"
-            type="@ButtonType.GetValue()"
+            type="@ButtonType?.GetValue()"
             title="@Title"
             @onclick="HandleOnClick">
         @ChildContent

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace Bit.BlazorUI;
@@ -67,7 +68,12 @@ public partial class BitButton
     /// <summary>
     /// The type of the button
     /// </summary>
-    [Parameter] public BitButtonType ButtonType { get; set; } = BitButtonType.Button;
+    [Parameter] public BitButtonType? ButtonType { get; set; }
+
+    /// <summary>
+    /// The EditContext, which is set if the button is inside an <see cref="EditForm"/>
+    /// </summary>
+    [CascadingParameter] public EditContext? EditContext { get; set; }
 
     protected override string RootElementClass => "bit-btn";
 
@@ -86,6 +92,8 @@ public partial class BitButton
         {
             tabIndex = AllowDisabledFocus ? null : -1;
         }
+
+        ButtonType ??= EditContext is null ? BitButtonType.Button : BitButtonType.Submit;
 
         await base.OnInitializedAsync();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitCompoundButton/BitCompoundButton.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitCompoundButton/BitCompoundButton.razor
@@ -40,7 +40,7 @@ else
             aria-describedby="@AriaDescription"
             aria-hidden="@AriaHidden"
             tabindex="@tabIndex"
-            type="@ButtonType.GetValue()"
+            type="@ButtonType?.GetValue()"
             title="@Title"
             @onclick="HandleOnClick">
         <span class="no-text-select">

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitCompoundButton/BitCompoundButton.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitCompoundButton/BitCompoundButton.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace Bit.BlazorUI;
@@ -67,7 +68,12 @@ public partial class BitCompoundButton
     /// <summary>
     /// The type of the button
     /// </summary>
-    [Parameter] public BitButtonType ButtonType { get; set; } = BitButtonType.Button;
+    [Parameter] public BitButtonType? ButtonType { get; set; }
+
+    /// <summary>
+    /// The EditContext, which is set if the button is inside an <see cref="EditForm"/>
+    /// </summary>
+    [CascadingParameter] public EditContext? EditContext { get; set; }
 
     /// <summary>
     /// Callback for when the compound button clicked
@@ -93,6 +99,8 @@ public partial class BitCompoundButton
         {
             tabIndex = AllowDisabledFocus ? null : -1;
         }
+        
+        ButtonType ??= EditContext is null ? BitButtonType.Button : BitButtonType.Submit;
 
         await base.OnInitializedAsync();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitIconButton/BitIconButton.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitIconButton/BitIconButton.razor
@@ -25,7 +25,7 @@ else
             @attributes="HtmlAttributes"
             style="@StyleBuilder.Value"
             class="@ClassBuilder.Value"
-            type="@ButtonType.GetValue()"
+            type="@ButtonType?.GetValue()"
             aria-label="@AriaLabel"
             aria-describedby="@AriaDescription"
             aria-hidden="@AriaHidden"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitIconButton/BitIconButton.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitIconButton/BitIconButton.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace Bit.BlazorUI;
@@ -51,7 +52,12 @@ public partial class BitIconButton
     /// <summary>
     /// The type of the button
     /// </summary>
-    [Parameter] public BitButtonType ButtonType { get; set; } = BitButtonType.Button;
+    [Parameter] public BitButtonType? ButtonType { get; set; }
+
+    /// <summary>
+    /// The EditContext, which is set if the button is inside an <see cref="EditForm"/>
+    /// </summary>
+    [CascadingParameter] public EditContext? EditContext { get; set; }
 
     protected override string RootElementClass => "bit-ico-btn";
 
@@ -61,6 +67,8 @@ public partial class BitIconButton
         {
             tabIndex = AllowDisabledFocus ? null : -1;
         }
+        
+        ButtonType ??= EditContext is null ? BitButtonType.Button : BitButtonType.Submit;
 
         await base.OnInitializedAsync();
     }


### PR DESCRIPTION
this closes #2874 

This PR addressed the issue, which was in the discussion #2866 .

I took the liberty and created a small PR, which might go in the right direction. Feedback very welcome.