### PR TITLE
Fix the incorrect topic name in the `BitNav` demo page based on Fluent (#2881)

### DIFF
--- a/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Nav/BitNavDemo.razor
+++ b/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Nav/BitNavDemo.razor
@@ -2,7 +2,7 @@
 
 <ComponentDemo ComponentName="Nav" ComponentDescription="A navigation pane (Nav) provides links to the main areas of an app or site."
                ComponentParameters="componentParameters" EnumParameters="enumParameters" ComponentSubParameters="componentSubParameters">
-    <ComponentExampleBox Title="Basic Nav With Sample Links" HTMLSourceCode="@example1HTMLCode" CSharpSourceCode="@example1CSharpCode" ExampleId="example1">
+    <ComponentExampleBox Title="Basic nav with sample links" HTMLSourceCode="@example1HTMLCode" CSharpSourceCode="@example1CSharpCode" ExampleId="example1">
         <ExamplePreview>
             <BitNav Style="width: 208px;
                    height: 350px;
@@ -16,7 +16,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Nav With Wrapped Link Text And No Tooltips" HTMLSourceCode="@example2HTMLCode" CSharpSourceCode="@example2CSharpCode" ExampleId="example2">
+    <ComponentExampleBox Title="Nav with wrapped link text and no tooltips" HTMLSourceCode="@example2HTMLCode" CSharpSourceCode="@example2CSharpCode" ExampleId="example2">
         <ExamplePreview>
             <BitNav Style="width: 208px;
                    height: 350px;
@@ -31,7 +31,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Nav Without Url" HTMLSourceCode="@example3HTMLCode" CSharpSourceCode="@example3CSharpCode" ExampleId="example3">
+    <ComponentExampleBox Title="Nav similar to the one in this demo app" HTMLSourceCode="@example3HTMLCode" CSharpSourceCode="@example3CSharpCode" ExampleId="example3">
         <ExamplePreview>
             <BitNav Style="width: 300px;"
                     NavLinkItems="BasicNoUrlNavLinks"
@@ -41,7 +41,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Nav With Nested Links" HTMLSourceCode="@example4HTMLCode" CSharpSourceCode="@example4CSharpCode" ExampleId="example4">
+    <ComponentExampleBox Title="Nav with nested links" HTMLSourceCode="@example4HTMLCode" CSharpSourceCode="@example4CSharpCode" ExampleId="example4">
         <ExamplePreview>
             <BitNav NavLinkItems="NestedLinks"
                     AriaLabel="Nav example with nested links"
@@ -50,7 +50,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Nav With Custom Group Header" HTMLSourceCode="@example5HTMLCode" CSharpSourceCode="@example5CSharpCode" ExampleId="example5">
+    <ComponentExampleBox Title="Nav with custom group header" HTMLSourceCode="@example5HTMLCode" CSharpSourceCode="@example5CSharpCode" ExampleId="example5">
         <ExamplePreview>
             <BitNav NavLinkItems="CustomHeaderLinks"
                     RenderType="BitNavRenderType.Grouped"
@@ -62,7 +62,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Basic Nav, Top Of The Another Element" HTMLSourceCode="@example6HTMLCode" CSharpSourceCode="@example1CSharpCode" ExampleId="example6">
+    <ComponentExampleBox Title="Basic nav, top of the another element" HTMLSourceCode="@example6HTMLCode" CSharpSourceCode="@example1CSharpCode" ExampleId="example6">
         <ExamplePreview>
             <BitNav Style="width: 208px;
                             height: 350px;
@@ -78,7 +78,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Basic Nav With Manual Mode" HTMLSourceCode="@example7HTMLCode" CSharpSourceCode="@example7CSharpCode" ExampleId="example7">
+    <ComponentExampleBox Title="Basic nav with manual mode" HTMLSourceCode="@example7HTMLCode" CSharpSourceCode="@example7CSharpCode" ExampleId="example7">
         <ExamplePreview>
             <BitNav Style="width: 208px;
                    height: 350px;

--- a/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Nav/BitNavDemo.razor
+++ b/src/BlazorUI/Playground/Bit.BlazorUI.Playground/Web/Pages/Components/Nav/BitNavDemo.razor
@@ -62,7 +62,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Basic nav, top of the another element" HTMLSourceCode="@example6HTMLCode" CSharpSourceCode="@example1CSharpCode" ExampleId="example6">
+    <ComponentExampleBox Title="Basic Nav, Top Of The Another Element" HTMLSourceCode="@example6HTMLCode" CSharpSourceCode="@example1CSharpCode" ExampleId="example6">
         <ExamplePreview>
             <BitNav Style="width: 208px;
                             height: 350px;


### PR DESCRIPTION
this closes #2881 