### PR TITLE
Fix BitNumericTextField error when used with decimal type (#4124)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/NumericTextField/BitNumericTextField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/NumericTextField/BitNumericTextField.razor.cs
@@ -262,7 +262,7 @@ public partial class BitNumericTextField<TValue>
         _precision = Precision is not null ? Precision.Value : CalculatePrecision(Step);
         if (ValueHasBeenSet is false)
         {
-            SetValue(GetDoubleValueOrDefault(DefaultValue) ?? Math.Min(0, _internalMin.Value));
+            SetValue(GetDoubleValueOrDefault(DefaultValue) ?? 0);
         }
         else
         {


### PR DESCRIPTION
This closes #4124 