### PR TITLE
Prerelease: Update Bit.Build.props for prerelease v-4.9.9-pre-01 (#4169)

### DIFF
--- a/src/Bit.Build.props
+++ b/src/Bit.Build.props
@@ -25,10 +25,10 @@
 		<PackageProjectUrl>https://github.com/bitfoundation/bitplatform</PackageProjectUrl>
 		<PackageIconUrl>https://avatars.githubusercontent.com/u/22663390</PackageIconUrl>
 
-		<ReleaseVersion>4.9.8</ReleaseVersion>
+		<ReleaseVersion>4.9.9</ReleaseVersion>
 
-		<PackageReleaseNotes>https://github.com/bitfoundation/bitplatform/releases/tag/v-$(ReleaseVersion)-pre-02</PackageReleaseNotes>
-		<PackageVersion>$(ReleaseVersion)-pre-02</PackageVersion>
+		<PackageReleaseNotes>https://github.com/bitfoundation/bitplatform/releases/tag/v-$(ReleaseVersion)-pre-01</PackageReleaseNotes>
+		<PackageVersion>$(ReleaseVersion)-pre-01</PackageVersion>
 
 		<!-- Version -->
 		<Version Condition=" '$(Configuration)' == 'Release' ">$(ReleaseVersion).$([System.DateTime]::Now.ToString(HHmm))</Version>


### PR DESCRIPTION
this closes #4169 