### PR TITLE
Fix BitDropDown checkbox styling issue with long text (#4523)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Dropdown/BitDropdown.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Dropdown/BitDropdown.scss
@@ -308,6 +308,7 @@
         overflow: hidden;
         position: relative;
         width: spacing(2.5);
+        min-width: spacing(2.5);
         align-items: center;
         height: spacing(2.5);
         box-sizing: border-box;


### PR DESCRIPTION
this closes #4523