### PR TITLE
Fix misspelled in project templates (#5138)

### DIFF
--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Infra/Iac/AdStack.cs
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Infra/Iac/AdStack.cs
@@ -146,7 +146,7 @@ public class AdStack : Stack
                     new NameValuePairArgs { Name = "SnapshotDebugger_EXTENSION_VERSION", Value = "disabled"},
                     new NameValuePairArgs { Name = "XDT_MicrosoftApplicationInsights_Mode", Value = "recommended" },
                     new NameValuePairArgs { Name = "XDT_MicrosoftApplicationInsights_PreemptSdk", Value = "disabled" },
-                    new NameValuePairArgs { Name = "AppSettings__EmailSettings__DefaulFromEmail", Value = defaultEmailFrom },
+                    new NameValuePairArgs { Name = "AppSettings__EmailSettings__DefaultFromEmail", Value = defaultEmailFrom },
                     new NameValuePairArgs { Name = "AppSettings__EmailSettings__Host", Value = emailServerHost },
                     new NameValuePairArgs { Name = "AppSettings__EmailSettings__Port", Value = emailServerPort },
                     new NameValuePairArgs { Name = "AppSettings__EmailSettings__UserName", Value = emailServerUserName },

--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/AppSettings.cs
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/AppSettings.cs
@@ -51,7 +51,7 @@ public class EmailSettings
     public int Port { get; set; }
     public string UserName { get; set; } = default!;
     public string Password { get; set; } = default!;
-    public string DefaulFromEmail { get; set; } = default!;
+    public string DefaultFromEmail { get; set; } = default!;
     public string DefaultFromName { get; set; } = default!;
     public bool HasCredential => (string.IsNullOrEmpty(UserName) is false) && (string.IsNullOrEmpty(Password) is false);
 }

--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/Startup/Services.cs
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/Startup/Services.cs
@@ -121,7 +121,7 @@ public static class Services
 
         services.AddHealthChecks(env, configuration);
 
-        var fluentEmailServiceBuilder = services.AddFluentEmail(appSettings.EmailSettings.DefaulFromEmail, appSettings.EmailSettings.DefaultFromName)
+        var fluentEmailServiceBuilder = services.AddFluentEmail(appSettings.EmailSettings.DefaultFromEmail, appSettings.EmailSettings.DefaultFromName)
             .AddRazorRenderer();
 
         if (appSettings.EmailSettings.UseLocalFolderForEmails)

--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/appsettings.json
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/appsettings.json
@@ -34,7 +34,7 @@
         "EmailSettings": {
             "Host": "LocalFolder", // Local folder means storing emails as .eml file in bin/Debug/net7.0/sent-emails folder (Recommended for testing purposes only) instead of sending them using smtp server.
             "Port": "25",
-            "DefaulFromEmail": "info@adminpanel.com",
+            "DefaultFromEmail": "info@adminpanel.com",
             "DefaultFromName": "AdminPanel",
             "UserName": null,
             "Password": null

--- a/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Api/AppSettings.cs
+++ b/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Api/AppSettings.cs
@@ -51,7 +51,7 @@ public class EmailSettings
     public int Port { get; set; }
     public string UserName { get; set; } = default!;
     public string Password { get; set; } = default!;
-    public string DefaulFromEmail { get; set; } = default!;
+    public string DefaultFromEmail { get; set; } = default!;
     public string DefaultFromName { get; set; } = default!;
     public bool HasCredential => (string.IsNullOrEmpty(UserName) is false) && (string.IsNullOrEmpty(Password) is false);
 }

--- a/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Api/Startup/Services.cs
+++ b/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Api/Startup/Services.cs
@@ -120,7 +120,7 @@ public static class Services
 
         services.AddHealthChecks(env, configuration);
 
-        var fluentEmailServiceBuilder = services.AddFluentEmail(appSettings.EmailSettings.DefaulFromEmail, appSettings.EmailSettings.DefaultFromName)
+        var fluentEmailServiceBuilder = services.AddFluentEmail(appSettings.EmailSettings.DefaultFromEmail, appSettings.EmailSettings.DefaultFromName)
             .AddRazorRenderer();
 
         if (appSettings.EmailSettings.UseLocalFolderForEmails)

--- a/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Api/appsettings.json
+++ b/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Api/appsettings.json
@@ -34,7 +34,7 @@
         "EmailSettings": {
             "Host": "LocalFolder", // Local folder means storing emails as .eml file in bin/Debug/net7.0/sent-emails folder (Recommended for testing purposes only) instead of sending them using smtp server.
             "Port": "25",
-            "DefaulFromEmail": "info@BlazorDual.com",
+            "DefaultFromEmail": "info@BlazorDual.com",
             "DefaultFromName": "BlazorDual",
             "UserName": null,
             "Password": null

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Infra/Iac/TdStack.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Infra/Iac/TdStack.cs
@@ -146,7 +146,7 @@ public class TdStack : Stack
                     new NameValuePairArgs { Name = "SnapshotDebugger_EXTENSION_VERSION", Value = "disabled"},
                     new NameValuePairArgs { Name = "XDT_MicrosoftApplicationInsights_Mode", Value = "recommended" },
                     new NameValuePairArgs { Name = "XDT_MicrosoftApplicationInsights_PreemptSdk", Value = "disabled" },
-                    new NameValuePairArgs { Name = "AppSettings__EmailSettings__DefaulFromEmail", Value = defaultEmailFrom },
+                    new NameValuePairArgs { Name = "AppSettings__EmailSettings__DefaultFromEmail", Value = defaultEmailFrom },
                     new NameValuePairArgs { Name = "AppSettings__EmailSettings__Host", Value = emailServerHost },
                     new NameValuePairArgs { Name = "AppSettings__EmailSettings__Port", Value = emailServerPort },
                     new NameValuePairArgs { Name = "AppSettings__EmailSettings__UserName", Value = emailServerUserName },

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/AppSettings.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/AppSettings.cs
@@ -51,7 +51,7 @@ public class EmailSettings
     public int Port { get; set; }
     public string UserName { get; set; } = default!;
     public string Password { get; set; } = default!;
-    public string DefaulFromEmail { get; set; } = default!;
+    public string DefaultFromEmail { get; set; } = default!;
     public string DefaultFromName { get; set; } = default!;
     public bool HasCredential => (string.IsNullOrEmpty(UserName) is false) && (string.IsNullOrEmpty(Password) is false);
 }

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Services.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Services.cs
@@ -1,6 +1,5 @@
 ﻿//-:cnd:noEmit
 using System.IO.Compression;
-using System.Linq;
 using System.Net.Mail;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.OData;
@@ -121,7 +120,7 @@ public static class Services
 
         services.AddHealthChecks(env, configuration);
 
-        var fluentEmailServiceBuilder = services.AddFluentEmail(appSettings.EmailSettings.DefaulFromEmail, appSettings.EmailSettings.DefaultFromName)
+        var fluentEmailServiceBuilder = services.AddFluentEmail(appSettings.EmailSettings.DefaultFromEmail, appSettings.EmailSettings.DefaultFromName)
             .AddRazorRenderer();
 
         if (appSettings.EmailSettings.UseLocalFolderForEmails)

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/appsettings.json
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/appsettings.json
@@ -34,7 +34,7 @@
         "EmailSettings": {
             "Host": "LocalFolder", // Local folder means storing emails as .eml file in bin/Debug/net7.0/sent-emails folder (Recommended for testing purposes only) instead of sending them using smtp server.
             "Port": "25",
-            "DefaulFromEmail": "info@TodoTemplate.com",
+            "DefaultFromEmail": "info@TodoTemplate.com",
             "DefaultFromName": "TodoTemplate",
             "UserName": null,
             "Password": null


### PR DESCRIPTION
Fix misspelled configuration key related to appsettings.json "DefaulFromEmail" => "DefaultFromEmail".

this closes #5138 