### PR TITLE
Change access level and use readonly

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Typography/BitTypography.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Typography/BitTypography.cs
@@ -4,7 +4,7 @@ namespace Bit.BlazorUI;
 
 public partial class BitTypography : BitComponentBase
 {
-    public static Dictionary<BitTypographyVariant, string> VariantMapping = new()
+    protected static readonly Dictionary<BitTypographyVariant, string> VariantMapping = new()
     {
         { BitTypographyVariant.Body1, "p" },
         { BitTypographyVariant.Body2, "p" },


### PR DESCRIPTION
this closes #5185 

## Change access level and make the `VariantMapping` property read-only.

This pull request has a minor improvement, `VariantMapping` was public and mutable which implies that it's possible to get new values after initialisation while it seems it's not likely to change nor to have public access

## Checklist before requesting a review

- [x] I have performed a self-review of my code


## Changes

- Change the `VariantMapping` access level and make it read-only

## Concerns

- I'm not familiar with this project, so in some circumstances, it's likely this property change or even be visible in other projects!

