### PR TITLE
Remove null warning for "AppHttpClientHandler"

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Services/Implementations/AppHttpClientHandler.cs
+++ b/src/BlazorUI/Demo/Client/Core/Services/Implementations/AppHttpClientHandler.cs
@@ -20,22 +20,27 @@ public partial class AppHttpClientHandler : HttpClientHandler
 
         if (response.IsSuccessStatusCode is false && response.Content.Headers.ContentType?.MediaType?.Contains("application/json", StringComparison.InvariantCultureIgnoreCase) is true)
         {
-            if (response.Headers.TryGetValues("Request-ID", out IEnumerable<string>? values) && values is not null && values.Any())
+            if (response.Headers.TryGetValues("Request-ID", out var values) && values is not null && values.Any())
             {
-                RestErrorInfo restError = await response.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo);
+                var restError = await response.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo);
 
-                Type exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError.ExceptionType) ?? typeof(UnknownException);
+                ArgumentNullException.ThrowIfNull(nameof(restError));
 
-                var args = new List<object> { typeof(KnownException).IsAssignableFrom(exceptionType) ? new LocalizedString(restError.Key!, restError.Message!) : restError.Message };
+                var exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError?.ExceptionType ?? string.Empty) ?? typeof(UnknownException);
+
+                List<object> args = new()
+                {
+                    typeof(KnownException).IsAssignableFrom(exceptionType)
+                        ? new LocalizedString(restError!.Key ?? string.Empty, restError.Message ?? string.Empty)
+                        : restError!.Message ?? string.Empty
+                };
 
                 if (exceptionType == typeof(ResourceValidationException))
                 {
                     args.Add(restError.Payload);
                 }
 
-                Exception exp = (Exception)Activator.CreateInstance(exceptionType, args.ToArray());
-
-                throw exp;
+                throw (Exception)(Activator.CreateInstance(exceptionType, args.ToArray()) ?? new Exception());
             }
         }
 

--- a/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Web/Services/Implementations/AppHttpClientHandler.cs
+++ b/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Web/Services/Implementations/AppHttpClientHandler.cs
@@ -1,6 +1,6 @@
 ﻿//-:cnd:noEmit
-using System.Net;
 using System.Globalization;
+using System.Net;
 using System.Net.Http.Headers;
 
 namespace BlazorDual.Web.Services.Implementations;
@@ -21,7 +21,7 @@ public partial class AppHttpClientHandler : HttpClientHandler
         }
 
 #if MultilingualEnabled && BlazorServer
-        string cultureCookie = $"c={CultureInfo.CurrentCulture.Name}|uic={CultureInfo.CurrentCulture.Name}";
+        var cultureCookie = $"c={CultureInfo.CurrentCulture.Name}|uic={CultureInfo.CurrentCulture.Name}";
         request.Headers.Add("Cookie", $".AspNetCore.Culture={cultureCookie}");
 #endif
 
@@ -34,22 +34,27 @@ public partial class AppHttpClientHandler : HttpClientHandler
 
         if (response.IsSuccessStatusCode is false && response.Content.Headers.ContentType?.MediaType?.Contains("application/json", StringComparison.InvariantCultureIgnoreCase) is true)
         {
-            if (response.Headers.TryGetValues("Request-ID", out IEnumerable<string>? values) && values is not null && values.Any())
+            if (response.Headers.TryGetValues("Request-ID", out var values) && values is not null && values.Any())
             {
-                RestErrorInfo restError = await response.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo, cancellationToken) ?? new();
+                var restError = await response.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo, cancellationToken) ?? new();
 
-                Type exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError.ExceptionType!) ?? typeof(UnknownException);
+                ArgumentNullException.ThrowIfNull(nameof(restError));
 
-                var args = new List<object> { typeof(KnownException).IsAssignableFrom(exceptionType) ? new LocalizedString(restError.Key!, restError.Message!) : restError.Message! };
+                var exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError?.ExceptionType ?? string.Empty) ?? typeof(UnknownException);
+
+                List<object> args = new()
+                {
+                    typeof(KnownException).IsAssignableFrom(exceptionType)
+                        ? new LocalizedString(restError!.Key ?? string.Empty, restError.Message ?? string.Empty)
+                        : restError!.Message ?? string.Empty
+                };
 
                 if (exceptionType == typeof(ResourceValidationException))
                 {
                     args.Add(restError.Payload);
                 }
 
-                Exception exp = (Exception)Activator.CreateInstance(exceptionType, args.ToArray())!;
-
-                throw exp;
+                throw (Exception)(Activator.CreateInstance(exceptionType, args.ToArray()) ?? new Exception());
             }
         }
 

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/Core/Services/Implementations/AppHttpClientHandler.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/Core/Services/Implementations/AppHttpClientHandler.cs
@@ -21,7 +21,7 @@ public partial class AppHttpClientHandler : HttpClientHandler
         }
 
 #if MultilingualEnabled && (BlazorServer || BlazorHybrid)
-        string cultureCookie = $"c={CultureInfo.CurrentCulture.Name}|uic={CultureInfo.CurrentCulture.Name}";
+        var cultureCookie = $"c={CultureInfo.CurrentCulture.Name}|uic={CultureInfo.CurrentCulture.Name}";
         request.Headers.Add("Cookie", $".AspNetCore.Culture={cultureCookie}");
 #endif
 
@@ -34,22 +34,27 @@ public partial class AppHttpClientHandler : HttpClientHandler
 
         if (response.IsSuccessStatusCode is false && response.Content.Headers.ContentType?.MediaType?.Contains("application/json", StringComparison.InvariantCultureIgnoreCase) is true)
         {
-            if (response.Headers.TryGetValues("Request-ID", out IEnumerable<string>? values) && values is not null && values.Any())
+            if (response.Headers.TryGetValues("Request-ID", out var values) && values is not null && values.Any())
             {
-                RestErrorInfo restError = await response!.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo, cancellationToken);
+                var restError = await response!.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo, cancellationToken);
 
-                Type exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError!.ExceptionType!) ?? typeof(UnknownException);
+                ArgumentNullException.ThrowIfNull(nameof(restError));
 
-                var args = new List<object> { typeof(KnownException).IsAssignableFrom(exceptionType) ? new LocalizedString(restError.Key!, restError.Message!) : restError.Message! };
+                var exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError?.ExceptionType ?? string.Empty) ?? typeof(UnknownException);
+
+                List<object> args = new()
+                {
+                    typeof(KnownException).IsAssignableFrom(exceptionType)
+                        ? new LocalizedString(restError!.Key ?? string.Empty, restError.Message ?? string.Empty)
+                        : restError!.Message ?? string.Empty
+                };
 
                 if (exceptionType == typeof(ResourceValidationException))
                 {
                     args.Add(restError.Payload);
                 }
 
-                Exception exp = (Exception)Activator.CreateInstance(exceptionType, args.ToArray())!;
-
-                throw exp;
+                throw (Exception)(Activator.CreateInstance(exceptionType, args.ToArray()) ?? new Exception());
             }
         }
 

--- a/src/Websites/Careers/src/Bit.Websites.Careers.Web/Services/Implementations/AppHttpClientHandler.cs
+++ b/src/Websites/Careers/src/Bit.Websites.Careers.Web/Services/Implementations/AppHttpClientHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Net;
-using System.Globalization;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 
 namespace Bit.Websites.Careers.Web.Services.Implementations;
 
@@ -23,22 +21,27 @@ public partial class AppHttpClientHandler : HttpClientHandler
 
         if (response.IsSuccessStatusCode is false && response.Content.Headers.ContentType?.MediaType?.Contains("application/json", StringComparison.InvariantCultureIgnoreCase) is true)
         {
-            if (response.Headers.TryGetValues("Request-ID", out IEnumerable<string>? values) && values is not null && values.Any())
+            if (response.Headers.TryGetValues("Request-ID", out var values) && values is not null && values.Any())
             {
-                RestErrorInfo restError = await response.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo);
+                var restError = await response.Content.ReadFromJsonAsync(AppJsonContext.Default.RestErrorInfo);
 
-                Type exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError.ExceptionType) ?? typeof(UnknownException);
+                ArgumentNullException.ThrowIfNull(nameof(restError));
 
-                var args = new List<object> { typeof(KnownException).IsAssignableFrom(exceptionType) ? new LocalizedString(restError.Key!, restError.Message!) : restError.Message };
+                var exceptionType = typeof(RestErrorInfo).Assembly.GetType(restError?.ExceptionType ?? string.Empty) ?? typeof(UnknownException);
+
+                List<object> args = new()
+                {
+                    typeof(KnownException).IsAssignableFrom(exceptionType)
+                        ? new LocalizedString(restError!.Key ?? string.Empty, restError.Message ?? string.Empty)
+                        : restError!.Message ?? string.Empty
+                };
 
                 if (exceptionType == typeof(ResourceValidationException))
                 {
                     args.Add(restError.Payload);
                 }
 
-                Exception exp = (Exception)Activator.CreateInstance(exceptionType, args.ToArray());
-
-                throw exp;
+                throw (Exception)(Activator.CreateInstance(exceptionType, args.ToArray()) ?? new Exception());
             }
         }
 


### PR DESCRIPTION
This PR will close #5224 

### Remove null warning for `AppHttpClientHandler`

This pull request will remove null warnings for `AppHttpClientHandler.cs` as we discussed in this issue: #5224

### Checklist before requesting a review

- [x] I have performed a self-review of my code

### Changes

- For consistency with the rest of the application, I use the same coding style.

### Notes
 - This PR is a completed version of the older one: #5255, #5257
 - I cannot currently prepare my development environment for these projects, so I am unable to oversee them:
   - TodoTemplate
   - Platform website
   - Sales website