### PR TITLE
Fix Screen Flicker Issue in Light Theme (#5372)

### DIFF
--- a/src/BlazorUI/Demo/Client/App/wwwroot/index.html
+++ b/src/BlazorUI/Demo/Client/App/wwwroot/index.html
@@ -27,6 +27,10 @@
     <link rel="stylesheet" href="_content/Bit.BlazorUI.Demo.Client.Core/prism-1.28.0/prism-okaidia-bit.css" />
 
     <style>
+        body {
+            background-color: #0D2960;
+        }
+        
         .lds-wrapper {
             top: 50%;
             left: 50%;

--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Client/App/wwwroot/index.html
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Client/App/wwwroot/index.html
@@ -21,6 +21,10 @@
     <link rel="stylesheet" href="_content/AdminPanel.Client.Core/AdminPanel.Client.Core.bundle.scp.css" />
 
     <style>
+        body {
+            background-color: #0D2960;
+        }
+
         .lds-wrapper {
             top: 50%;
             left: 50%;

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/App/wwwroot/index.html
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/App/wwwroot/index.html
@@ -20,6 +20,10 @@
     <link rel="stylesheet" href="_content/TodoTemplate.Client.Core/TodoTemplate.Client.Core.bundle.scp.css" />
 
     <style>
+        body {
+            background-color: #0D2960;
+        }
+        
         .lds-wrapper {
             top: 50%;
             left: 50%;


### PR DESCRIPTION
this closes #5372

This pull request addresses the issue of screen flickering with black color in the light theme. The problem occurs when either the user has selected a light theme or the device's default theme is set to light.