### PR TITLE
Remove redundant ButtonType parameter from BitActionButton's Link Button demo (#5376)

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/BitActionButtonDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/BitActionButtonDemo.razor
@@ -73,7 +73,7 @@
                 <BitActionButton IconName="@BitIconName.Website" Target="_blank" Href="https://github.com/bitfoundation/bitplatform">
                     Open Bit Platform In New Tab
                 </BitActionButton>
-                <BitActionButton IconName="@BitIconName.Website" Href="https://github.com/bitfoundation/bitplatform" ButtonStyle="BitButtonStyle.Standard">
+                <BitActionButton IconName="@BitIconName.Website" Href="https://github.com/bitfoundation/bitplatform">
                     Go To Bit Platform
                 </BitActionButton>
             </div>

--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/BitActionButtonDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/BitActionButtonDemo.razor.cs
@@ -226,7 +226,7 @@ Collapsed: [ <BitActionButton Visibility=""BitVisibility.Collapsed"">Collapsed A
     Open Bit Platform In New Tab
 </BitActionButton>
 
-<BitActionButton IconName=""@BitIconName.Website"" Href=""https://github.com/bitfoundation/bitplatform"" ButtonStyle=""BitButtonStyle.Standard"">
+<BitActionButton IconName=""@BitIconName.Website"" Href=""https://github.com/bitfoundation/bitplatform"">
     Go To Bit Platform
 </BitActionButton>";
 


### PR DESCRIPTION
Closes #5376 