### PR TITLE
Add appropriate code Highlighting in light mode #5472

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/wwwroot/prism-1.28.0/prism-okaidia-bit.css
+++ b/src/BlazorUI/Demo/Client/Core/wwwroot/prism-1.28.0/prism-okaidia-bit.css
@@ -1,1 +1,123 @@
-﻿code[class*=language-],pre[class*=language-]{color:#E8E8E8;background:0 0;text-shadow:0 1px rgba(0,0,0,.3);font-family:Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;font-size:1em;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;word-wrap:normal;line-height:1.5;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none}pre[class*=language-]{padding:1em;margin:.5em 0;overflow:auto;border-radius:.3em}:not(pre)>code[class*=language-],pre[class*=language-]{background:#0D1117}:not(pre)>code[class*=language-]{padding:.1em;border-radius:.3em;white-space:normal}.token.cdata,.token.comment,.token.doctype,.token.prolog{color:#8292a2}.token.punctuation{color:#E8E8E8}.token.namespace{opacity:.7}.token.constant,.token.deleted,.token.property,.token.symbol,.token.tag{color:#f92672}.token.boolean,.token.number{color:#ae81ff}.token.attr-name,.token.builtin,.token.char,.token.inserted,.token.selector,.token.string{color:#a6e22e}.language-css .token.string,.style .token.string,.token.entity,.token.operator,.token.url,.token.variable{color:#E8E8E8}.token.atrule,.token.attr-value,.token.class-name,.token.function{color:#e6db74}.token.keyword{color:#66d9ef}.token.important,.token.regex{color:#fd971f}.token.bold,.token.important{font-weight:700}.token.italic{font-style:italic}.token.entity{cursor:help}
+﻿:root[bit-theme=light] code[class*=language-],
+:root[bit-theme=light] pre[class*=language-] {
+  text-shadow: 0 1px rgba(90, 90, 90, 0.3);
+}
+
+:root[bit-theme=dark] code[class*=language-],
+:root[bit-theme=dark] pre[class*=language-] {
+  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+}
+
+code[class*=language-],
+pre[class*=language-] {
+  color: var(--bit-clr-secondary-text);
+  background: 0 0;
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  font-size: 1em;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+pre[class*=language-] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*=language-] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+:not(pre) > code[class*=language-],
+pre[class*=language-] {
+  background: var(--bit-clr-bg-secondary);
+}
+
+.token.namespace {
+  opacity: 0.7;
+}
+
+.token.cdata,
+.token.comment,
+.token.doctype,
+.token.prolog {
+  color: #8292a2;
+}
+
+.token.punctuation {
+  color: var(--bit-clr-primary-light);
+}
+
+.token.constant,
+.token.deleted,
+.token.property,
+.token.symbol,
+.token.tag {
+  color: var(--bit-clr-primary-dark);
+}
+
+.token.boolean,
+.token.number {
+  color: var(--bit-clr-act-active-pri);
+}
+
+.token.attr-name,
+.token.builtin,
+.token.char,
+.token.inserted,
+.token.selector,
+.token.string {
+  color: var(--bit-clr-act-hover-pri);
+}
+
+.language-css .token.string,
+.style .token.string,
+.token.entity,
+.token.operator,
+.token.url,
+.token.variable {
+  color: var(--bit-clr-primary-main);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.class-name,
+.token.function {
+  color: var(--bit-clr-act-hover-pri-dark);
+}
+
+.token.keyword {
+  color: var(--bit-clr-primary-main);
+}
+
+.token.important,
+.token.regex {
+  color: var(--bit-clr-act-hover-pri-light);
+}
+
+.token.bold,
+.token.important {
+  font-weight: 700;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}


### PR DESCRIPTION
closes #5472 

Steps produced: 
1. Created a **scss** file in `styles/prism-1.28.0/prism-okaidia-bit.scss`
2. Added color variables for those colors who are appliable. 
3. Added `:root[bit-theme=...]`  check  for text shadow. 
4. Changed some hard coded colors, so they can match with both dark and white theme. 