### PR TITLE
Fix `BitProgressIndicator` animation flicker on safari (#5570)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/ProgressIndicator/BitProgressIndicator.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/ProgressIndicator/BitProgressIndicator.scss
@@ -7,8 +7,8 @@
 
     @keyframes bit-pin-animation {
         0% {
-            left: 0%;
-            transform: translateX(-100%);
+            left: -100%;
+            transform: translateX(100%);
         }
 
         100% {


### PR DESCRIPTION
Closes #5570