### PR TITLE
Fix `BitDialog` title on safari (#5576)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Dialog/BitDialog.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Dialog/BitDialog.scss
@@ -52,10 +52,8 @@
 }
 
 .bit-dlg-hdr {
-    top: 0;
     z-index: 1;
     display: flex;
-    position: sticky;
     align-items: center;
     overflow-wrap: anywhere;
     background-color: $color-background-primary;


### PR DESCRIPTION
Closes #5576