### PR TITLE
Remove redundant AllowCredentials call in TodoTemplate (#5631)

### DIFF
--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Middlewares.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Middlewares.cs
@@ -49,7 +49,7 @@ public class Middlewares
         app.UseRouting();
 
         app.UseCors(options => options.WithOrigins("https://localhost:4041" /*BlazorServer*/, "http://localhost:8001" /*BlazorElectron*/, "https://0.0.0.0" /*BlazorHybrid*/, "app://0.0.0.0" /*BlazorHybrid*/)
-            .AllowAnyHeader().AllowAnyMethod().AllowCredentials());
+            .AllowAnyHeader().AllowAnyMethod());
 
         app.UseResponseCaching();
         app.UseAuthentication();


### PR DESCRIPTION
This closes #5631