### PR TITLE
Fix incorrect page title of the Separator demo page (#5684)

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Separator/BitSeparatorDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Separator/BitSeparatorDemo.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/separator"
 
 <PageOutlet Url="components/separator"
-            Title="BitSeparator"
+            Title="Separator"
             Description="separator component of the bit BlazorUI components" />
 
 <div>


### PR DESCRIPTION
This closes #5684