### PR TITLE
Remove redundant IsDevelopment check in TodoTemplate (#5630)

### DIFF
--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Middlewares.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Middlewares.cs
@@ -16,10 +16,7 @@ public class Middlewares
             app.UseDeveloperExceptionPage();
 
 #if BlazorWebAssembly
-            if (env.IsDevelopment())
-            {
-                app.UseWebAssemblyDebugging();
-            }
+            app.UseWebAssemblyDebugging();
 #endif
         }
 


### PR DESCRIPTION
…Startup/Middleware.cs #5630

removed redundant IsDevelopment condition in bitplatform/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Server/Api/Startup/Middleware.cs l.18 ff

this closes #5630 