### PR TITLE
Update title of With Custom Class section of Icon demo (#5680)

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Icon/BitIconDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Icon/BitIconDemo.razor
@@ -19,7 +19,7 @@
             </div>
         </ExamplePreview>
     </ComponentExampleBox>
-    <ComponentExampleBox Title="With Custom Class" RazorCode="@example2RazorCode" Id="example2">
+    <ComponentExampleBox Title="CSS Class" RazorCode="@example2RazorCode" Id="example2">
         <ExamplePreview>
             <div>
                 <BitIcon IconName="@BitIconName.Accept" AriaLabel="accept" Class="icon-class" />


### PR DESCRIPTION
this closes #5680 

This Pull Request addresses issue #5680, which requested the update of the section title in the Icon demo page. The current title "With Custom Class" was considered too long and not appropriate, and it has been changed to "CSS Class" for better clarity.

The related demo file is "BitIconDemo.razor" in the "Bit.BlazorUI.Demo.Client.Core" project.

Please review and merge if everything looks good.