### PR TITLE
Remove redundant content of the CultureInfoManager class in TodoTemplate (#5638)

### DIFF
--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Shared/Infra/CultureInfoManager.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Shared/Infra/CultureInfoManager.cs
@@ -53,51 +53,11 @@ public class CultureInfoManager
     /// </summary>
     public static CultureInfo CustomizeCultureInfoForFaCulture(CultureInfo cultureInfo)
     {
-        cultureInfo.DateTimeFormat.MonthNames = new[]
-        {
-            "فروردین", "اردیبهشت", "خرداد", "تیر", "مرداد", "شهریور", "مهر", "آبان", "آذر", "دی", "بهمن", "اسفند", ""
-        };
-
-        cultureInfo.DateTimeFormat.AbbreviatedMonthNames = new[]
-        {
-            "فرور", "ارد", "خرد", "تیر", "مرد", "شهر", "مهر", "آبا", "آذر", "دی", "بهم", "اسف", ""
-        };
-
-        cultureInfo.DateTimeFormat.MonthGenitiveNames = cultureInfo.DateTimeFormat.MonthNames;
-        cultureInfo.DateTimeFormat.AbbreviatedMonthGenitiveNames = cultureInfo.DateTimeFormat.AbbreviatedMonthNames;
-        cultureInfo.DateTimeFormat.DayNames = new[]
-        {
-            "یکشنبه", "دوشنبه", "ﺳﻪشنبه", "چهارشنبه", "پنجشنبه", "جمعه", "شنبه"
-        };
-
-        cultureInfo.DateTimeFormat.AbbreviatedDayNames = new[]
-        {
-            "ی", "د", "س", "چ", "پ", "ج", "ش"
-        };
-
-        cultureInfo.DateTimeFormat.ShortestDayNames = new[]
-        {
-            "ی", "د", "س", "چ", "پ", "ج", "ش"
-        };
-
         cultureInfo.DateTimeFormat.AMDesignator = "ق.ظ";
         cultureInfo.DateTimeFormat.PMDesignator = "ب.ظ";
         cultureInfo.DateTimeFormat.ShortDatePattern = "yyyy/MM/dd";
         cultureInfo.DateTimeFormat.FirstDayOfWeek = DayOfWeek.Saturday;
 
-        var cultureData = _cultureDataField.GetValue(cultureInfo.TextInfo);
-
-        _iReadingLayoutField.SetValue(cultureData, 1 /*rtl*/); // this affects cultureInfo.TextInfo.IsRightToLeft
-
-        if (cultureInfo.DateTimeFormat.Calendar is not PersianCalendar)
-        {
-            cultureInfo.DateTimeFormat.Calendar = new PersianCalendar();
-        }
-
         return cultureInfo;
     }
-
-    private static readonly FieldInfo _cultureDataField = typeof(TextInfo).GetField("_cultureData", BindingFlags.NonPublic | BindingFlags.Instance)!;
-
-    private static readonly FieldInfo _iReadingLayoutField = Type.GetType("System.Globalization.CultureData, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e")!.GetField("_iReadingLayout", BindingFlags.NonPublic | BindingFlags.Instance)!;
 }

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Shared/Infra/CultureInfoManager.cs
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Shared/Infra/CultureInfoManager.cs
@@ -56,7 +56,6 @@ public class CultureInfoManager
         cultureInfo.DateTimeFormat.AMDesignator = "ق.ظ";
         cultureInfo.DateTimeFormat.PMDesignator = "ب.ظ";
         cultureInfo.DateTimeFormat.ShortDatePattern = "yyyy/MM/dd";
-        cultureInfo.DateTimeFormat.FirstDayOfWeek = DayOfWeek.Saturday;
 
         return cultureInfo;
     }


### PR DESCRIPTION
this closes #5638 

@msynk All the unnecessary lines are removed from the `CustomizeCultureInfoForFaCulture` method.
Also, the `_cultureDataField` and `_iReadingLayoutField` fields are removed since you mentioned they have only been called in the `CustomizeCultureInfoForFaCulture` method.