### PR TITLE
fix(blazorui): resolve incorrect title of Basic BitModal section of the Modal demo page (#5673)

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Modal/BitModalDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Modal/BitModalDemo.razor
@@ -9,7 +9,7 @@
                ComponentParameters="componentParameters"
                ComponentSubClasses="componentSubClasses"
                ComponentSubEnums="componentSubEnums">
-    <ComponentExampleBox Title="Basic BitModal" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
+    <ComponentExampleBox Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
         <ExamplePreview>
             <div>
                 <BitButton OnClick=@(() => IsOpen = true)>Open Modal</BitButton>


### PR DESCRIPTION
This closes #5673.