### PR TITLE
redundant check removed #5628

### DIFF
--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/Startup/Middlewares.cs
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Server/Api/Startup/Middlewares.cs
@@ -16,10 +16,7 @@ public class Middlewares
             app.UseDeveloperExceptionPage();
 
 #if BlazorWebAssembly
-            if (env.IsDevelopment())
-            {
-                app.UseWebAssemblyDebugging();
-            }
+            app.UseWebAssemblyDebugging();
 #endif
         }
 


### PR DESCRIPTION
this closes #5628

Hey @msynk 
The redundant `IsDevelopment` check in the `Middlewares.cs` of the AdminPanel template project, is removed.