### PR TITLE
feat(blazorui): Redundant content of the BitAccordionDemo.razor demo (#5744)

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Accordion/BitAccordionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Accordion/BitAccordionDemo.razor
@@ -138,5 +138,5 @@
 @code {
     private byte controlledAccordionExpandedItem = 1;
     private bool AccordionToggleIsEnabled;
-    private bool AccordionToggleIsExpanded;
+    private bool AccordionToggleIsExpanded;  
 }


### PR DESCRIPTION
This closes