### PR TITLE
feat(blazorui): Incorrect capitalization of the IsReadOnly parameter in the BitTextField components (#5615)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Slider/BitSlider.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Slider/BitSlider.razor.cs
@@ -82,7 +82,7 @@ public partial class BitSlider
     /// Whether to render the Slider as readonly
     /// </summary>
     [Parameter]
-    public bool IsReadonly
+    public bool isReadOnly
     {
         get => isReadOnly;
         set
@@ -245,7 +245,7 @@ public partial class BitSlider
     {
         ClassBuilder.Register(() => Classes?.Root);
 
-        ClassBuilder.Register(() => IsReadonly ? $"{RootElementClass}-rdl" : string.Empty);
+        ClassBuilder.Register(() => isReadOnly ? $"{RootElementClass}-rdl" : string.Empty);
 
         ClassBuilder.Register(() => $"{RootElementClass}-{(IsRanged ? "rgd-" : null)}{(IsVertical ? "vrt" : "hrz")}");
     }


### PR DESCRIPTION
This closes