### PR TITLE
Remove redundant content of the BitAccordionDemo.razor (#5744)

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Accordion/BitAccordionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Accordion/BitAccordionDemo.razor
@@ -140,4 +140,3 @@
     private bool AccordionToggleIsEnabled;
     private bool AccordionToggleIsExpanded;
 }
-


### PR DESCRIPTION
this closes #5744