### PR TITLE
Update ChangePrerenderResponseStatusCode usages to use the new name (#5760)

### DIFF
--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Client/Core/Shared/NotAuthorizedComponent.razor
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Client/Core/Shared/NotAuthorizedComponent.razor
@@ -1,6 +1,6 @@
 ﻿@inherits AppComponentBase
 
-<ChangeResponseStatusCode StatusCode="System.Net.HttpStatusCode.Unauthorized" />
+<ChangePrerenderResponseStatusCode StatusCode="System.Net.HttpStatusCode.Unauthorized" />
 
 <AuthorizeView>
     <div class="main">

--- a/src/Templates/AdminPanel/Bit.AdminPanel/src/Client/Core/Shared/PageNotFound.razor
+++ b/src/Templates/AdminPanel/Bit.AdminPanel/src/Client/Core/Shared/PageNotFound.razor
@@ -1,6 +1,6 @@
 ﻿@inherits AppComponentBase
 
-<ChangeResponseStatusCode StatusCode="System.Net.HttpStatusCode.NotFound" />
+<ChangePrerenderResponseStatusCode StatusCode="System.Net.HttpStatusCode.NotFound" />
 
 <div class="main">
     <h1 class="title">404</h1>

--- a/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Web/Shared/NotAuthorizedComponent.razor
+++ b/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Web/Shared/NotAuthorizedComponent.razor
@@ -1,6 +1,6 @@
 ﻿@inherits AppComponentBase
 
-<ChangeResponseStatusCode StatusCode="System.Net.HttpStatusCode.Unauthorized" />
+<ChangePrerenderResponseStatusCode StatusCode="System.Net.HttpStatusCode.Unauthorized" />
 
 <AuthorizeView>
     <div class="main">

--- a/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Web/Shared/PageNotFound.razor
+++ b/src/Templates/BlazorDual/Bit.BlazorDual/src/BlazorDual.Web/Shared/PageNotFound.razor
@@ -1,6 +1,6 @@
 ﻿@inherits AppComponentBase
 
-<ChangeResponseStatusCode StatusCode="System.Net.HttpStatusCode.NotFound" />
+<ChangePrerenderResponseStatusCode StatusCode="System.Net.HttpStatusCode.NotFound" />
 
 <div class="main">
     <h1 class="title">404</h1>

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/Core/Shared/NotAuthorizedComponent.razor
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/Core/Shared/NotAuthorizedComponent.razor
@@ -1,6 +1,6 @@
 ﻿@inherits AppComponentBase
 
-<ChangeResponseStatusCode StatusCode="System.Net.HttpStatusCode.Unauthorized" />
+<ChangePrerenderResponseStatusCode StatusCode="System.Net.HttpStatusCode.Unauthorized" />
 
 <AuthorizeView>
     <div class="main">

--- a/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/Core/Shared/PageNotFound.razor
+++ b/src/Templates/TodoTemplate/Bit.TodoTemplate/src/Client/Core/Shared/PageNotFound.razor
@@ -1,6 +1,6 @@
 ﻿@inherits AppComponentBase
 
-<ChangeResponseStatusCode StatusCode="System.Net.HttpStatusCode.NotFound" />
+<ChangePrerenderResponseStatusCode StatusCode="System.Net.HttpStatusCode.NotFound" />
 
 <div class="main">
     <h1 class="title">404</h1>


### PR DESCRIPTION
This closes #5760