### PR TITLE
Incorrect title for the binding sample of the BitSplitButton demo page

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/SplitButton/_BitSplitButtonCustomDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/SplitButton/_BitSplitButtonCustomDemo.razor
@@ -283,7 +283,7 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Controlled" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example28">
+<ComponentExampleBox Title="Binding" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example28">
     <ExamplePreview>
         <div class="example-content">
             <div>

--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/SplitButton/_BitSplitButtonItemDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/SplitButton/_BitSplitButtonItemDemo.razor
@@ -195,7 +195,7 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Controlled" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example18">
+<ComponentExampleBox Title="Binding" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example18">
     <ExamplePreview>
         <div class="example-content">
             <div>

--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/SplitButton/_BitSplitButtonOptionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Buttons/SplitButton/_BitSplitButtonOptionDemo.razor
@@ -297,7 +297,7 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Controlled" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example38">
+<ComponentExampleBox Title="Binding" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example38">
     <ExamplePreview>
         <div class="example-content">
             <div>


### PR DESCRIPTION
replaced `Controlled` with `Binding` for splitButton title on the demo page