### PR TITLE
Update the title of the Default BitPivot section of the Pivot demo page

### DIFF
--- a/src/BlazorUI/Demo/Client/Core/Pages/Components/Pivot/BitPivotDemo.razor
+++ b/src/BlazorUI/Demo/Client/Core/Pages/Components/Pivot/BitPivotDemo.razor
@@ -9,7 +9,7 @@
                ComponentParameters="componentParameters"
                ComponentSubClasses="componentSubClasses"
                ComponentSubEnums="componentSubEnums">
-    <ComponentExampleBox Title="Default BitPivot" RazorCode="@example1RazorCode" Id="example1">
+    <ComponentExampleBox Title="Basic" RazorCode="@example1RazorCode" Id="example1">
         <ExamplePreview>
             <BitPivot>
                 <BitPivotItem HeaderText="File">


### PR DESCRIPTION
Fixes #5655 

Updated the title under the pivot section in the demo page.

Hope this solves the issue.

Looking forward for merging this PR.