### PR TITLE
Fix alignment of link button text to match normal button text alignment (#5922)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.scss
@@ -13,7 +13,8 @@
     border-radius: $shape-border-radius;
     font-family: $typography-font-family;
     font-weight: $typography-font-weight;
-    line-height: 1.6;
+    display: inline-flex;
+    align-items: center;
 
     &.bit-dis {
         cursor: default;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.scss
@@ -13,6 +13,7 @@
     border-radius: $shape-border-radius;
     font-family: $typography-font-family;
     font-weight: $typography-font-weight;
+    line-height: 1.6;
 
     &.bit-dis {
         cursor: default;


### PR DESCRIPTION
This closes #5922 