### PR TITLE
Fix naming conflict between the BlazorWeb project template and the BlazorWebAssembly sdk (#6002)

### DIFF
--- a/src/Templates/BlazorWeb/Bit.BlazorWeb/src/BlazorWeb.Client/BlazorWeb.Client.csproj
+++ b/src/Templates/BlazorWeb/Bit.BlazorWeb/src/BlazorWeb.Client/BlazorWeb.Client.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<!--/-:replacements:noEmit -->
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<!--/+:replacements:noEmit -->
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>

--- a/src/Templates/BlazorWeb/Bit.BlazorWeb/src/BlazorWeb.Client/Services/RenderModeProvider.cs
+++ b/src/Templates/BlazorWeb/Bit.BlazorWeb/src/BlazorWeb.Client/Services/RenderModeProvider.cs
@@ -5,11 +5,11 @@ namespace BlazorWeb.Client.Services;
 public static class RenderModeProvider
 {
     static IComponentRenderMode PrerenderEnabledAuto = RenderMode.InteractiveAuto;
-    static IComponentRenderMode PrerenderEnabledBlazorWebAssembly = RenderMode.InteractiveWebAssembly;
+    static IComponentRenderMode PrerenderEnabledBlazorWasm = RenderMode.InteractiveWebAssembly;
     static IComponentRenderMode PrerenderEnabledBlazorServer = RenderMode.InteractiveServer;
 
     static IComponentRenderMode Auto = new InteractiveAutoRenderMode(prerender: false);
-    static IComponentRenderMode BlazorWebAssembly = new InteractiveWebAssemblyRenderMode(prerender: false);
+    static IComponentRenderMode BlazorWasm = new InteractiveWebAssemblyRenderMode(prerender: false);
     static IComponentRenderMode BlazorServer = new InteractiveServerRenderMode(prerender: false);
 
     // PrerenderOnly: In order to have prerender only mode, simply remove @rendermode usages from App.razor


### PR DESCRIPTION
This closes #6002