### PR TITLE
Fix min supported macOS version in boilerplate (#6187)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
@@ -16,7 +16,7 @@
         <DefineConstants Condition=" '$(PwaEnabled)' == 'true' ">$(DefineConstants);PwaEnabled</DefineConstants>
 
         <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">14.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-mac'))">11.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-mac'))">13.1</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">24.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>


### PR DESCRIPTION
This closes #6187