### PR TITLE
Fix font icon preloading on Blazor Hybrid (#6271)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Maui/wwwroot/index.html
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Maui/wwwroot/index.html
@@ -11,7 +11,7 @@
     <link rel="preload" href="_content/Bit.BlazorUI.Demo.Client.Core/images/github-icon-dark.svg" as="image">
     <link rel="preload" href="_content/Bit.BlazorUI.Demo.Client.Core/images/github-icon-light.svg" as="image">
 
-    <link rel="preload" href="_content/Bit.BlazorUI.Icons/fonts/FabMDL2.4.46.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="_content/Bit.BlazorUI.Icons/fonts/FabMDL2.4.66.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="_content/Bit.BlazorUI.Assets/fonts/segoe-ui-bold.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="_content/Bit.BlazorUI.Assets/fonts/segoe-ui-light.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="_content/Bit.BlazorUI.Assets/fonts/segoe-ui-normal.woff2" as="font" type="font/woff2" crossorigin>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/index.html
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
-    <link rel="preload" href="_content/Bit.BlazorUI.Icons/fonts/FabMDL2.4.46.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="_content/Bit.BlazorUI.Icons/fonts/FabMDL2.4.66.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="_content/Bit.BlazorUI.Assets/fonts/segoe-ui-bold.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="_content/Bit.BlazorUI.Assets/fonts/segoe-ui-light.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="_content/Bit.BlazorUI.Assets/fonts/segoe-ui-normal.woff2" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
Closes #6271