### PR TITLE
Return Activity.Current?.Id as RequestId in failed responses (#6934)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Boilerplate.Server/Services/ServerExceptionHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Boilerplate.Server/Services/ServerExceptionHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Diagnostics;
+using System.Net;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Diagnostics;
@@ -15,7 +16,7 @@ public partial class ServerExceptionHandler : IExceptionHandler
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception e, CancellationToken cancellationToken)
     {
         // Using the Request-Id header, one can find the log for server-related exceptions
-        httpContext.Response.Headers.Append(HeaderNames.RequestId, httpContext.TraceIdentifier);
+        httpContext.Response.Headers.Append(HeaderNames.RequestId, Activity.Current?.Id ?? httpContext.TraceIdentifier);
 
         var exception = UnWrapException(e);
         var knownException = exception as KnownException;


### PR DESCRIPTION
This closes #6934