### PR TITLE
Fix inconsistent field names in BitTimePicker (#7213)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TimePickers/TimePicker/BitTimePickerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TimePickers/TimePicker/BitTimePickerDemo.razor.cs
@@ -173,7 +173,7 @@ public partial class BitTimePickerDemo
         },
         new()
         {
-            Name = "HourStep",
+            Name = "ValueChanged",
             Type = "EventCallback<TimeSpan?>",
             Description = "Callback for when the on time value changed.",
         },


### PR DESCRIPTION
This closes #7213 