### PR TITLE
Add missing System.Net.Http.Json using in the generated code of HttpClient source generator (#7420)

### DIFF
--- a/src/SourceGenerators/Bit.SourceGenerators/HttpClientProxy/HttpClientProxySourceGenerator.cs
+++ b/src/SourceGenerators/Bit.SourceGenerators/HttpClientProxy/HttpClientProxySourceGenerator.cs
@@ -62,6 +62,7 @@ public class HttpClientProxySourceGenerator : ISourceGenerator
 
         StringBuilder finalSource = new(@$"
 using System.Text.Json;
+using System.Net.Http.Json;
 using System.Web;
 
 namespace Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
closes #7420 