### PR TITLE
add the missing com.apple.security.cs.allow-jit entitelment to the Boilerplate project template (#7451)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/MacCatalyst/Entitlements.Release.plist
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/MacCatalyst/Entitlements.Release.plist
@@ -8,5 +8,7 @@
         <true />
         <key>com.apple.security.network.client</key>
         <true />
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
     </dict>
 </plist>


### PR DESCRIPTION
This closes #7451