### PR TITLE
Fix inconsistent naming of element parameter in components with BuildRenderTree (#7860)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Tests/Element/BitElementTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Element/BitElementTests.cs
@@ -15,17 +15,17 @@ public class BitElementTests : BunitTestContext
      DataRow(null)
     ]
     [TestMethod]
-    public void BitElementTagTest(string tag)
+    public void BitElementTagTest(string element)
     {
         var com = RenderComponent<BitElement>(parameters =>
         {
-            if (tag.HasValue())
+            if (element.HasValue())
             {
-                parameters.Add(p => p.Element, tag);
+                parameters.Add(p => p.Element, element);
             }
         });
 
-        var expectedElement = tag ?? "div";
+        var expectedElement = element ?? "div";
 
         var expectedHtml = $"<{expectedElement} diff:ignore></{expectedElement}>";
 
@@ -35,20 +35,18 @@ public class BitElementTests : BunitTestContext
     [DataTestMethod]
     [DataRow("input", "placeholder", "Enter text")]
     [DataRow("a", "href", "/")]
-    public void BitElementTagWithAttributesTest(string tag, string attribute, string attributeValue)
+    public void BitElementTagWithAttributesTest(string element, string attribute, string attributeValue)
     {
         var com = RenderComponent<BitElement>(parameters =>
         {
-            parameters.Add(p => p.Element, tag);
+            parameters.Add(p => p.Element, element);
             parameters.Add(p => p.HtmlAttributes, new Dictionary<string, object>
             {
                 { attribute, attributeValue }
             });
         });
 
-        var element = com.Find(tag);
-
-        var expectedHtml = $"<{tag} {attribute}=\"{attributeValue}\" diff:ignore></{tag}>";
+        var expectedHtml = $"<{element} {attribute}=\"{attributeValue}\" diff:ignore></{element}>";
         com.MarkupMatches(expectedHtml);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Element/BitElementTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Element/BitElementTests.cs
@@ -21,7 +21,7 @@ public class BitElementTests : BunitTestContext
         {
             if (tag.HasValue())
             {
-                parameters.Add(p => p.Tag, tag);
+                parameters.Add(p => p.Element, tag);
             }
         });
 
@@ -39,7 +39,7 @@ public class BitElementTests : BunitTestContext
     {
         var com = RenderComponent<BitElement>(parameters =>
         {
-            parameters.Add(p => p.Tag, tag);
+            parameters.Add(p => p.Element, tag);
             parameters.Add(p => p.HtmlAttributes, new Dictionary<string, object>
             {
                 { attribute, attributeValue }

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Labels/BitLabelTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Labels/BitLabelTests.cs
@@ -13,17 +13,4 @@ public class BitLabelTests : BunitTestContext
         var bitLabel = component.Find(".bit-lbl");
         Assert.AreEqual(expectedResult, bitLabel.ClassList.Contains("bit-lbl-req"));
     }
-
-
-    [DataTestMethod,
-    DataRow(true),
-    DataRow(false)
-]
-    public void BitLabelShouldRespectIsEnabled(bool isEnabled)
-    {
-        var component = RenderComponent<BitLabel>(parameters =>
-        {
-            parameters.Add(p => p.IsEnabled, isEnabled);
-        });
-    }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Labels/BitLabelTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Labels/BitLabelTests.cs
@@ -13,4 +13,17 @@ public class BitLabelTests : BunitTestContext
         var bitLabel = component.Find(".bit-lbl");
         Assert.AreEqual(expectedResult, bitLabel.ClassList.Contains("bit-lbl-req"));
     }
+
+
+    [DataTestMethod,
+    DataRow(true),
+    DataRow(false)
+]
+    public void BitLabelShouldRespectIsEnabled(bool isEnabled)
+    {
+        var component = RenderComponent<BitLabel>(parameters =>
+        {
+            parameters.Add(p => p.IsEnabled, isEnabled);
+        });
+    }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Typography/BitTypographyTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Typography/BitTypographyTests.cs
@@ -117,7 +117,7 @@ public class BitTypographyTests : BunitTestContext
     {
         var com = RenderComponent<BitTypography>(parameters =>
         {
-            parameters.Add(p => p.Component, component);
+            parameters.Add(p => p.Element, component);
         });
 
         var defaultVariant = BitTypographyVariant.Subtitle1;

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Typography/BitTypographyTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Typography/BitTypographyTests.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Globalization;
-using AngleSharp.Text;
-using Bunit;
+﻿using System.Globalization;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bunit;
 
 namespace Bit.BlazorUI.Tests.Typography;
 
@@ -113,18 +112,18 @@ public class BitTypographyTests : BunitTestContext
         DataRow(null)
     ]
     [TestMethod]
-    public void BitTypographyComponentTest(string component)
+    public void BitTypographyComponentTest(string element)
     {
         var com = RenderComponent<BitTypography>(parameters =>
         {
-            parameters.Add(p => p.Element, component);
+            parameters.Add(p => p.Element, element);
         });
 
         var defaultVariant = BitTypographyVariant.Subtitle1;
         var defaultElement = VariantMapping[defaultVariant];
 
-        var element = com.Find(component ?? defaultElement);
+        var el = com.Find(element ?? defaultElement);
 
-        Assert.IsTrue(element.ClassList.Contains("bit-tpg"));
+        Assert.IsTrue(el.ClassList.Contains("bit-tpg"));
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Element/BitElement.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Element/BitElement.cs
@@ -10,9 +10,9 @@ public partial class BitElement : BitComponentBase
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// The HTML tag used for the root node.
+    /// The custom html element used for the root node. The default is "div".
     /// </summary>
-    [Parameter] public string Tag { get; set; } = "div";
+    [Parameter] public string? Element { get; set; }
 
 
     protected override string RootElementClass => "bit-elm";
@@ -20,7 +20,7 @@ public partial class BitElement : BitComponentBase
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
-        builder.OpenElement(0, Tag);
+        builder.OpenElement(0, Element ?? "div");
         builder.AddMultipleAttributes(1, RuntimeHelpers.TypeCheck(HtmlAttributes));
         builder.AddAttribute(2, "id", _Id);
         builder.AddAttribute(3, "style", StyleBuilder.Value);

--- a/src/BlazorUI/Bit.BlazorUI/Components/Stack/BitStack.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Stack/BitStack.cs
@@ -30,14 +30,14 @@ public partial class BitStack : BitComponentBase
 
 
     /// <summary>
-    /// Defines how to render the Stack.
-    /// </summary>
-    [Parameter] public string As { get; set; } = "div";
-
-    /// <summary>
     /// The content of the Typography.
     /// </summary>
     [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// The custom html element used for the root node. The default is "div".
+    /// </summary>
+    [Parameter] public string? Element { get; set; }
 
     /// <summary>
     /// Defines the spacing between Stack children.
@@ -192,7 +192,7 @@ public partial class BitStack : BitComponentBase
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
-        builder.OpenElement(0, As);
+        builder.OpenElement(0, Element ?? "div");
         builder.AddMultipleAttributes(1, RuntimeHelpers.TypeCheck(HtmlAttributes));
         builder.AddAttribute(2, "id", _Id);
         builder.AddAttribute(3, "style", StyleBuilder.Value);

--- a/src/BlazorUI/Bit.BlazorUI/Components/Typography/BitTypography.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Typography/BitTypography.cs
@@ -34,9 +34,9 @@ public partial class BitTypography : BitComponentBase
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// The component used for the root node.
+    /// The custom html element used for the root node.
     /// </summary>
-    [Parameter] public string? Component { get; set; }
+    [Parameter] public string? Element { get; set; }
 
     /// <summary>
     /// If true, the text will have a bottom margin.
@@ -101,7 +101,7 @@ public partial class BitTypography : BitComponentBase
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
-        builder.OpenElement(0, Component ?? VariantMapping[Variant]);
+        builder.OpenElement(0, Element ?? VariantMapping[Variant]);
         builder.AddMultipleAttributes(1, RuntimeHelpers.TypeCheck(HtmlAttributes));
         builder.AddAttribute(2, "id", _Id);
         builder.AddAttribute(3, "style", StyleBuilder.Value);

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Element/BitElementDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Element/BitElementDemo.razor
@@ -14,16 +14,16 @@
     </ComponentExampleBox>
     <ComponentExampleBox Title="Tag" RazorCode="@example2RazorCode" CsharpCode="@example2CsharpCode" Id="example2">
         <ExamplePreview>
-            <BitElement Tag="input" placeholder="Input" />
+            <BitElement Element="input" placeholder="Input" />
             <br /><br />
-            <BitElement Tag="a" href="https://bitplatform.dev/" target="_blank">Anchor (Link)</BitElement>
+            <BitElement Element="a" href="https://bitplatform.dev/" target="_blank">Anchor (Link)</BitElement>
             <br /><br />
-            <BitElement Tag="button" @onclick="@(() => counter++)">Button (Click count @counter)</BitElement>
+            <BitElement Element="button" @onclick="@(() => counter++)">Button (Click count @counter)</BitElement>
         </ExamplePreview>
     </ComponentExampleBox>
     <ComponentExampleBox Title="Advanced" RazorCode="@example3RazorCode" CsharpCode="@example3CsharpCode" Id="example3">
         <ExamplePreview>
-            <BitElement Tag="@elementTag"
+            <BitElement Element="@elementTag"
                         placeholder="@elementTag"
                         target="_blank"
                         href="https://bitplatform.dev/">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Element/BitElementDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Element/BitElementDemo.razor.cs
@@ -13,10 +13,10 @@ public partial class BitElementDemo
         },
         new()
         {
-            Name = "Tag",
-            Type = "string",
-            DefaultValue = "div",
-            Description = "The HTML tag used for the root node.",
+            Name = "Element",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The custom html element used for the root node. The default is \"div\".",
         }
     };
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Stack/BitStackDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Stack/BitStackDemo.razor.cs
@@ -5,17 +5,17 @@ public partial class BitStackDemo
     {
         new()
         {
-            Name = "As",
-            Type = "string",
-            DefaultValue = "div",
-            Description = "Defines how to render the Stack."
-        },
-        new()
-        {
             Name = "ChildContent",
             Type = "RenderFragment?",
             DefaultValue = "null",
             Description = "The content of the Typography."
+        },
+        new()
+        {
+            Name = "Element",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The custom html element used for the root node. The default is \"div\"."
         },
         new()
         {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Typography/BitTypographyDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Typography/BitTypographyDemo.razor.cs
@@ -13,10 +13,10 @@ public partial class BitTypographyDemo
         },
         new()
         {
-            Name = "Component",
+            Name = "Element",
             Type = "string?",
             DefaultValue = "null",
-            Description = "The component used for the root node.",
+            Description = "The custom html element used for the root node.",
         },
         new()
         {


### PR DESCRIPTION
closes #7860