### PR TITLE
Update title of position section of Modal demo page (#5674)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor
@@ -1,4 +1,4 @@
-﻿@page "/components/modal"
+@page "/components/modal"
 
 <PageOutlet Url="components/modal"
             Title="Modal"
@@ -184,7 +184,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="BitModal with position" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
+    <ComponentExampleBox Title="Position" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
         <ExamplePreview>
             <div class="example-desc">To set the modal position on the page you can use the Position parameter.</div>
             <div>


### PR DESCRIPTION
closes #5674

Update the title of the 'BitModal with position' section to 'Position' in the `BitModalDemo.razor` file.

* Change the title of the section from 'BitModal with position' to 'Position'.
* Update the file `src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor` to reflect this change.

