### PR TITLE
Fix typo in the docs

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates08AppModelsPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates08AppModelsPage.razor
@@ -43,7 +43,7 @@
             Blazor WebAssembly (WASM) apps run client-side in the browser on a WebAssembly-based .NET runtime. The Blazor app, its dependencies,
             and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process.
             <br />
-            To use to Blazor WebAssembly:
+            To use the Blazor WebAssembly:
             <br />
             <ol>
                 <li>Open the file Core/Services/AppRenderMode.cs and change the <b>Current</b> field to <b>BlazorWebAssembly</b>.</li>
@@ -66,7 +66,7 @@
             Blazor seamlessly combines Blazor Server and WebAssembly.
             This approach enhances user interaction initially through Blazor Server, while simultaneously downloading Blazor WebAssembly for subsequent visits, reducing server load.
             <br />
-            To use to Blazor Auto:
+            To use the Blazor Auto:
             <br />
             <ol>
                 <li>Open the file Core/Services/AppRenderMode.cs and change the <b>Current</b> field to <b>Auto</b>.</li>


### PR DESCRIPTION
closes #7439

Correct typographical mistakes in the Blazor Webassembly and Blazor Auto descriptions.

* **Blazor Webassembly**: Change "To use to Blazor WebAssembly" to "To use the Blazor WebAssembly" in the first paragraph of the Blazor Webassembly description.
* **Blazor Auto**: Change "To use to Blazor Auto" to "To use the Blazor Auto" in the first paragraph of the Blazor Auto description.

