### PR TITLE
Add support for Escape key press to dismiss the modal in the BitModal component

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
@@ -238,5 +238,20 @@ public class BitModalTests : BunitTestContext
         Assert.IsTrue(modalElement.ClassList.Contains(positionClass));
     }
 
+    [TestMethod]
+    public void BitModalEscapeKeyPressTest()
+    {
+        var isOpen = true;
+        var com = RenderComponent<BitModal>(parameters =>
+        {
+            parameters.Bind(p => p.IsOpen, isOpen, newValue => isOpen = newValue);
+        });
+
+        var modalElement = com.Find(".bit-mdl");
+        modalElement.KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+        Assert.IsFalse(isOpen);
+    }
+
     private void HandleIsOpenChanged(bool isOpen) => isModalOpen = isOpen;
 }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
@@ -1,4 +1,4 @@
-﻿@namespace Bit.BlazorUI
+@namespace Bit.BlazorUI
 @inherits BitComponentBase
 
 @if (IsOpen)
@@ -11,7 +11,8 @@
          role=@((IsAlert ?? (IsBlocking && IsModeless is false))? "alertdialog": "dialog")
          aria-modal="@((IsModeless is false).ToString())"
          aria-labelledby="@TitleAriaId"
-         aria-describedby="@SubtitleAriaId">
+         aria-describedby="@SubtitleAriaId"
+         @onkeydown="HandleOnKeyDown">
         <div style="@Styles?.Container" class="bit-mdl-doc @GetPositionClass() @Classes?.Container" role="document">
             @if (IsModeless is false)
             {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
@@ -156,7 +156,13 @@ public partial class BitModal : BitComponentBase, IDisposable
         StateHasChanged();
     }
 
-
+    private async Task HandleOnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            await CloseModal(new MouseEventArgs());
+        }
+    }
 
     private async Task CloseModal(MouseEventArgs e)
     {


### PR DESCRIPTION
Related to #1970

Add support for Escape key press to dismiss the `BitModal` component.

* **BitModal.razor**
  - Add `@onkeydown="HandleOnKeyDown"` to the root `div` element.

* **BitModal.razor.cs**
  - Add a private method `HandleOnKeyDown` to handle the Escape key press event.
  - In `HandleOnKeyDown`, check if the pressed key is "Escape" and call `CloseModal`.

* **BitModalTests.cs**
  - Add a test method `BitModalEscapeKeyPressTest` to verify the Escape key press functionality.
  - In `BitModalEscapeKeyPressTest`, simulate the Escape key press event and assert that the modal is closed.
