### PR TITLE
Fix disabled css style of AM and PM buttons in BitTimePicker (#8312)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.scss
@@ -328,7 +328,7 @@
     background-color: $clr-pri;
 
     &:disabled {
-        background-color: $clr-pri;
+        background-color: $clr-bg-dis;
     }
 
     @media (hover: hover) {


### PR DESCRIPTION
This closes #8312 