### PR TITLE
Add Microsoft SocialSignIn to Boilerplate project template (#8326)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/ErrorPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/ErrorPage.razor
@@ -1,0 +1,9 @@
+﻿@attribute [Route(Urls.ErrorPage)]
+@inherits AppComponentBase
+
+<div class="main">
+    <h1 class="title">Error</h1>
+    <div class="description">
+        @Message
+    </div>
+</div>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/ErrorPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/ErrorPage.razor.cs
@@ -1,0 +1,7 @@
+﻿namespace Boilerplate.Client.Core.Components.Pages;
+
+public partial class ErrorPage
+{
+    [SupplyParameterFromQuery(Name = "message"), Parameter] public string? Message { get; set; }
+    
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/ErrorPage.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/ErrorPage.razor.scss
@@ -1,0 +1,30 @@
+﻿@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-flow: column nowrap;
+}
+
+.title {
+    font-weight: 600;
+    font-size: rem2(120px);
+    line-height: rem2(168px);
+
+    @include lt-xl {
+        font-size: rem2(100px);
+    }
+}
+
+.description {
+    font-weight: 400;
+    font-size: rem2(18px);
+    line-height: rem2(28px);
+
+    @include lt-xl {
+        font-size: rem2(16px);
+        line-height: rem2(24px);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignInPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignInPage.razor
@@ -48,6 +48,15 @@
                        OnClick="WrapHandled(TwitterSignIn)">
                 @Localizer[AppStrings.TwitterSignInButtonText]
             </BitButton>
+            <br />
+            <BitButton Style="width:300px"
+                       IsLoading="isWaiting"
+                       Color="BitColor.Tertiary"
+                       Variant="BitVariant.Outline"
+                       ButtonType="BitButtonType.Button"
+                       OnClick="WrapHandled(MicrosoftSignIn)">
+                @Localizer[AppStrings.MicrosoftSignInButtonText]
+            </BitButton>
             <br /><br />
             <BitSeparator Style="width:100%">Or</BitSeparator>
             <br />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignInPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignInPage.razor.cs
@@ -172,6 +172,11 @@ public partial class SignInPage
     {
         await SocialSignIn("Twitter");
     }
+    
+    private async Task MicrosoftSignIn()
+    {
+        await SocialSignIn("Microsoft");
+    }
 
     private async Task SocialSignIn(string provider)
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUpPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUpPage.razor
@@ -45,6 +45,15 @@
                    OnClick="WrapHandled(TwitterSignUp)">
             @Localizer[AppStrings.TwitterSignUpButtonText]
         </BitButton>
+        <br />
+        <BitButton Style="width:300px"
+                   IsLoading="isWaiting"
+                   Color="BitColor.Tertiary"
+                   Variant="BitVariant.Outline"
+                   ButtonType="BitButtonType.Button"
+                   OnClick="WrapHandled(MicrosoftSignUp)">
+            @Localizer[AppStrings.MicrosoftSignUpButtonText]
+        </BitButton>
         <br /><br />
         <BitSeparator Style="width:100%">Or</BitSeparator>
         <br />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUpPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUpPage.razor.cs
@@ -83,6 +83,11 @@ public partial class SignUpPage
     {
         await SocialSignUp("Twitter");
     }
+    
+    private async Task MicrosoftSignUp()
+    {
+        await SocialSignUp("Microsoft");
+    }
 
     private async Task SocialSignUp(string provider)
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Boilerplate.Server.Api.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Boilerplate.Server.Api.csproj
@@ -22,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.8" />
         <PackageReference Include="QRCoder" Version="1.6.0" />
         <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="13.10.0" />
         <PackageReference Include="FluentEmail.Smtp" Version="3.0.2" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -75,6 +75,11 @@
         "Twitter": {
             "ConsumerKey": "",
             "ConsumerSecret": ""
+        },
+        "MicrosoftAccount": {
+            "ClientId": "",
+            "ClientSecret": "",
+            "TenantId": "" //Optional To Restrict To Specific Tenant
         }
     },
     "AllowedHosts": "*",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -985,4 +985,10 @@
     <value>You need to pass the Google reCAPTCHA challenge.</value>
   </data>
     <!--#endif -->
+    <data name="MicrosoftSignInButtonText" xml:space="preserve">
+    <value>Sign in with Microsoft</value>
+  </data>
+    <data name="MicrosoftSignUpButtonText" xml:space="preserve">
+    <value>Sign up with Microsoft</value>
+  </data>
 </root>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Urls.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Urls.cs
@@ -41,4 +41,6 @@ public static class Urls
     //#endif
 
     public const string AboutPage = "/about";
+    
+    public const string ErrorPage = "/error";
 }


### PR DESCRIPTION
closes #8326 

Add MS Auth with ability to restrict to specific tenant, errors are directed to a new generic error page that takes in a query param message.