### PR TITLE
Fix disabled css style of AM and PM buttons in BitDatePicker (#8324)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/DatePicker/BitDatePicker.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/DatePicker/BitDatePicker.scss
@@ -749,7 +749,7 @@
     background-color: $clr-pri;
 
     &:disabled {
-        background-color: $clr-pri;
+        background-color: $clr-bg-dis;
     }
 
     @media (hover: hover) {


### PR DESCRIPTION
This closes #8324 