### PR TITLE
Make DotNetObjectReference initializations consistent (#8338)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitMenuButton/BitMenuButton.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitMenuButton/BitMenuButton.razor.cs
@@ -241,6 +241,8 @@ public partial class BitMenuButton<TItem> : BitComponentBase, IAsyncDisposable w
 
     protected override async Task OnInitializedAsync()
     {
+        _dotnetObj = DotNetObjectReference.Create(this);
+
         _calloutId = $"BitMenuButton-{UniqueId}-callout";
 
         if (SelectedItemHasBeenSet is false && DefaultSelectedItem is not null)
@@ -275,16 +277,6 @@ public partial class BitMenuButton<TItem> : BitComponentBase, IAsyncDisposable w
             item = _items.FirstOrDefault(GetIsEnabled);
             await AssignSelectedItem(item);
         }
-    }
-
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender)
-        {
-            _dotnetObj = DotNetObjectReference.Create(this);
-        }
-
-        base.OnAfterRender(firstRender);
     }
 
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Lists/Carousel/BitCarousel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Lists/Carousel/BitCarousel.razor.cs
@@ -17,7 +17,7 @@ public partial class BitCarousel : BitComponentBase, IAsyncDisposable
     private string _goRightButtonStyle = string.Empty;
     private readonly List<BitCarouselItem> _allItems = [];
     private System.Timers.Timer _autoPlayTimer = default!;
-    private DotNetObjectReference<BitCarousel>? _dotnetObjRef = default!;
+    private DotNetObjectReference<BitCarousel> _dotnetObjRef = default!;
 
 
 
@@ -92,6 +92,8 @@ public partial class BitCarousel : BitComponentBase, IAsyncDisposable
         await GotoPage(index - 1);
     }
 
+
+
     [JSInvokable("OnRootResize")]
     public async Task OnRootResize(ContentRect rect)
     {
@@ -118,6 +120,13 @@ public partial class BitCarousel : BitComponentBase, IAsyncDisposable
 
     protected override string RootElementClass => "bit-csl";
 
+    protected override void OnInitialized()
+    {
+        _dotnetObjRef = DotNetObjectReference.Create(this);
+
+        base.OnInitialized();
+    }
+
     protected override void OnParametersSet()
     {
         _internalScrollItemsCount = ScrollItemsCount;
@@ -133,7 +142,6 @@ public partial class BitCarousel : BitComponentBase, IAsyncDisposable
 
         if (firstRender is false) return;
 
-        _dotnetObjRef = DotNetObjectReference.Create(this);
         _resizeObserverId = await _js.BitObserversRegisterResize(RootElement, _dotnetObjRef, "OnRootResize");
 
         if (AutoPlay)
@@ -326,6 +334,7 @@ public partial class BitCarousel : BitComponentBase, IAsyncDisposable
             await GoRight();
         }
     }
+
     private async Task HandlePointerDown(MouseEventArgs e)
     {
         _isPointerDown = true;
@@ -333,6 +342,7 @@ public partial class BitCarousel : BitComponentBase, IAsyncDisposable
         await _js.SetStyle(_carousel, "cursor", "grabbing");
         StateHasChanged();
     }
+
     private async Task HandlePointerUp(MouseEventArgs e)
     {
         _isPointerDown = false;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Lists/Swiper/BitSwiper.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Lists/Swiper/BitSwiper.razor.cs
@@ -24,7 +24,7 @@ public partial class BitSwiper : BitComponentBase, IAsyncDisposable
     private string _resizeObserverId = string.Empty;
     private readonly List<BitSwiperItem> _allItems = [];
     private System.Timers.Timer _autoPlayTimer = default!;
-    private DotNetObjectReference<BitSwiper>? _dotnetObjRef = default!;
+    private DotNetObjectReference<BitSwiper> _dotnetObjRef = default!;
 
 
 
@@ -82,57 +82,6 @@ public partial class BitSwiper : BitComponentBase, IAsyncDisposable
 
 
 
-    internal void RegisterItem(BitSwiperItem item)
-    {
-        item.Index = _allItems.Count;
-
-        _allItems.Add(item);
-    }
-
-    internal void UnregisterItem(BitSwiperItem carouselItem) => _allItems.Remove(carouselItem);
-
-
-
-    protected override string RootElementClass => "bit-swp";
-
-    protected override async Task OnParametersSetAsync()
-    {
-        _directionStyle = Dir == BitDir.Rtl ? "direction:rtl" : "";
-
-        await base.OnParametersSetAsync();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await GetDimensions();
-
-        var itemsCount = _allItems.Count;
-        _internalScrollItemsCount = ScrollItemsCount < 1 ? 1
-                                  : ScrollItemsCount > itemsCount ? itemsCount
-                                  : ScrollItemsCount;
-
-        if (firstRender)
-        {
-            //if (AutoPlay)
-            //{
-            //    _autoPlayTimer = new System.Timers.Timer(AutoPlayInterval);
-            //    _autoPlayTimer.Elapsed += AutoPlayTimerElapsed;
-            //    _autoPlayTimer.Start();
-            //}
-
-            _dotnetObjRef = DotNetObjectReference.Create(this);
-            _resizeObserverId = await _js.BitObserversRegisterResize(RootElement, _dotnetObjRef, "OnRootResize");
-
-            await _js.BitSwiperRegisterPointerLeave(RootElement, DotNetObjectReference.Create(this));
-
-            SetNavigationButtonsVisibility(_translateX);
-        }
-
-        await base.OnAfterRenderAsync(firstRender);
-    }
-
-
-
     [JSInvokable("OnRootResize")]
     public async Task OnRootResize(ContentRect rect)
     {
@@ -160,6 +109,63 @@ public partial class BitSwiper : BitComponentBase, IAsyncDisposable
 
         var x = -(_lastDiffX / Math.Abs(_lastDiffX)) * (_swiperEffectiveWidth * swipeSpeed / 10) + _translateX;
         await Swipe(x);
+    }
+
+
+
+    internal void RegisterItem(BitSwiperItem item)
+    {
+        item.Index = _allItems.Count;
+
+        _allItems.Add(item);
+    }
+
+    internal void UnregisterItem(BitSwiperItem carouselItem) => _allItems.Remove(carouselItem);
+
+
+
+    protected override string RootElementClass => "bit-swp";
+
+    protected override void OnInitialized()
+    {
+        _dotnetObjRef = DotNetObjectReference.Create(this);
+
+        base.OnInitialized();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _directionStyle = Dir == BitDir.Rtl ? "direction:rtl" : "";
+
+        await base.OnParametersSetAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await GetDimensions();
+
+        var itemsCount = _allItems.Count;
+        _internalScrollItemsCount = ScrollItemsCount < 1 ? 1
+                                  : ScrollItemsCount > itemsCount ? itemsCount
+                                  : ScrollItemsCount;
+
+        if (firstRender)
+        {
+            //if (AutoPlay)
+            //{
+            //    _autoPlayTimer = new System.Timers.Timer(AutoPlayInterval);
+            //    _autoPlayTimer.Elapsed += AutoPlayTimerElapsed;
+            //    _autoPlayTimer.Start();
+            //}
+
+            _resizeObserverId = await _js.BitObserversRegisterResize(RootElement, _dotnetObjRef, "OnRootResize");
+
+            await _js.BitSwiperRegisterPointerLeave(RootElement, _dotnetObjRef);
+
+            SetNavigationButtonsVisibility(_translateX);
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
     }
 
 
@@ -254,6 +260,7 @@ public partial class BitSwiper : BitComponentBase, IAsyncDisposable
         _swiperEffectiveWidth = dimensions?.EffectiveSwiperWidth ?? 0;
         _translateX = dimensions?.SwiperTranslateX ?? 0;
     }
+
 
 
     public async ValueTask DisposeAsync()

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Callout/BitCallout.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Callout/BitCallout.razor.cs
@@ -113,20 +113,12 @@ public partial class BitCallout : BitComponentBase, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
+        _dotnetObj = DotNetObjectReference.Create(this);
+
         _anchorId = $"BitCallout-{UniqueId}-anchor";
         _contentId = $"BitCallout-{UniqueId}-content";
 
         await base.OnInitializedAsync();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await base.OnAfterRenderAsync(firstRender);
-
-        if (firstRender)
-        {
-            _dotnetObj = DotNetObjectReference.Create(this);
-        }
     }
 
 


### PR DESCRIPTION
closes #8338