### PR TITLE
Use interpolated string instead of FormattableString in BitOverlay (#8401)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
@@ -49,7 +49,7 @@ public partial class BitOverlay : BitComponentBase
 
     protected override void RegisterCssStyles()
     {
-        StyleBuilder.Register(() => _offsetTop > 0 ? FormattableString.Invariant($"top:{_offsetTop}px") : string.Empty);
+        StyleBuilder.Register(() => _offsetTop > 0 ? $"top:{_offsetTop}px" : string.Empty);
     }
 
     protected override void RegisterCssClasses()


### PR DESCRIPTION
This closes #8401 