### PR TITLE
Add ItemWrapper property to ClassStyles of BitMenuButton (#9012)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitMenuButton/BitMenuButton.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitMenuButton/BitMenuButton.razor
@@ -96,7 +96,7 @@
 
                 var template = GetTemplate(item);
                 var isEnabled = GetIsEnabled(item);
-                <li role="presentation" @key="GetKey(item)">
+                <li role="presentation" @key="GetKey(item)" style="@Styles?.ItemWrapper" class="@Classes?.ItemWrapper">
                     <button @onclick="() => HandleOnItemClick(item)" @onclick:stopPropagation
                             role="menuitem"
                             type="@_buttonType.GetValue()"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitMenuButton/BitMenuButtonClassStyles.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitMenuButton/BitMenuButtonClassStyles.cs
@@ -58,6 +58,11 @@ public class BitMenuButtonClassStyles
     public string? Icon { get; set; }
 
     /// <summary>
+    /// Custom CSS classes/styles for each item wrapper of the BitMenuButton.
+    /// </summary>
+    public string? ItemWrapper { get; set; }
+
+    /// <summary>
     /// Custom CSS classes/styles for each item of the BitMenuButton.
     /// </summary>
     public string? ItemButton { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/MenuButton/BitMenuButtonDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/MenuButton/BitMenuButtonDemo.razor.cs
@@ -417,6 +417,13 @@ public partial class BitMenuButtonDemo
                },
                new()
                {
+                   Name = "ItemWrapper",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for each item wrapper of the BitMenuButton."
+               },
+               new()
+               {
                    Name = "ItemButton",
                    Type = "string?",
                    DefaultValue = "null",


### PR DESCRIPTION
This closes #9012 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual presentation of menu items with customizable styles.
	- Introduced a new property for custom CSS classes/styles for item wrappers in the menu button.

- **Bug Fixes**
	- Maintained existing functionality and user experience while improving styling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->