### PR TITLE
Change default value of AutoToggleScroll in BitModal, BitDialog and BitPanel (#9041)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
@@ -18,7 +18,7 @@ public partial class BitDialog : BitComponentBase, IAsyncDisposable
     /// <summary>
     /// Enables the auto scrollbar toggle behavior of the Dialog.
     /// </summary>
-    [Parameter] public bool AutoToggleScroll { get; set; } = true;
+    [Parameter] public bool AutoToggleScroll { get; set; }
 
     /// <summary>
     /// When true, the Dialog will be positioned absolute instead of fixed.

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
@@ -16,7 +16,7 @@ public partial class BitModal : BitComponentBase, IAsyncDisposable
     /// <summary>
     /// Enables the auto scrollbar toggle behavior of the Modal.
     /// </summary>
-    [Parameter] public bool AutoToggleScroll { get; set; } = true;
+    [Parameter] public bool AutoToggleScroll { get; set; }
 
     /// <summary>
     /// When true, the Modal will be positioned absolute instead of fixed.

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor.cs
@@ -15,7 +15,7 @@ public partial class BitPanel : BitComponentBase
     /// <summary>
     /// Enables the auto scrollbar toggle behavior of the Panel.
     /// </summary>
-    [Parameter] public bool AutoToggleScroll { get; set; } = true;
+    [Parameter] public bool AutoToggleScroll { get; set; }
 
     /// <summary>
     /// The content of the Panel, it can be any custom tag or text.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
@@ -8,7 +8,7 @@ public partial class BitDialogDemo
         {
             Name = "AutoToggleScroll",
             Type = "bool",
-            DefaultValue = "true",
+            DefaultValue = "false",
             Description = "Enables the auto scrollbar toggle behavior of the Dialog."
         },
         new()

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor.cs
@@ -8,7 +8,7 @@ public partial class BitModalDemo
         {
             Name = "AutoToggleScroll",
             Type = "bool",
-            DefaultValue = "true",
+            DefaultValue = "false",
             Description = "Enables the auto scrollbar toggle behavior of the Modal.",
         },
         new()

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Panel/BitPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Panel/BitPanelDemo.razor.cs
@@ -8,7 +8,7 @@ public partial class BitPanelDemo
         {
             Name = "AutoToggleScroll",
             Type = "bool",
-            DefaultValue = "true",
+            DefaultValue = "false",
             Description = "Enables the auto scrollbar toggle behavior of the Panel.",
         },
         new()


### PR DESCRIPTION
closes #9041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `AutoToggleScroll` parameter for both `BitDialog` and `BitModal` components now requires explicit setting by users, as the default value has been removed.
  
- **Bug Fixes**
	- Adjusted the default behavior for the `AutoToggleScroll` parameter in demo components (`BitDialogDemo` and `BitModalDemo`) to reflect the new requirement, changing from `true` to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->