### PR TITLE
Move AutoFocus parameter to BitTextInputBase (#9042)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/BitTextInputBase.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/BitTextInputBase.cs
@@ -13,6 +13,11 @@ public abstract class BitTextInputBase<TValue> : BitInputBase<TValue>
 
 
     /// <summary>
+    /// Determines if the text input is auto focused on first render.
+    /// </summary>
+    [Parameter] public bool AutoFocus { get; set; }
+
+    /// <summary>
     /// The debounce time in milliseconds.
     /// </summary>
     [Parameter] public int DebounceTime { get; set; }
@@ -37,6 +42,11 @@ public abstract class BitTextInputBase<TValue> : BitInputBase<TValue>
         {
             switch (parameter.Key)
             {
+                case nameof(AutoFocus):
+                    AutoFocus = (bool)parameter.Value;
+                    parametersDictionary.Remove(parameter.Key);
+                    break;
+
                 case nameof(DebounceTime):
                     DebounceTime = (int)parameter.Value;
                     parametersDictionary.Remove(parameter.Key);
@@ -55,6 +65,18 @@ public abstract class BitTextInputBase<TValue> : BitInputBase<TValue>
         }
 
         return base.SetParametersAsync(ParameterView.FromDictionary(parametersDictionary!));
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender is false || IsEnabled is false) return;
+
+        if (AutoFocus)
+        {
+            await InputElement.FocusAsync();
+        }
     }
 
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TextField/BitTextField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TextField/BitTextField.razor.cs
@@ -21,11 +21,6 @@ public partial class BitTextField : BitTextInputBase<string?>
     [Parameter] public string? AutoComplete { get; set; }
 
     /// <summary>
-    /// Determines if the text field is auto focused on first render.
-    /// </summary>
-    [Parameter] public bool AutoFocus { get; set; }
-
-    /// <summary>
     /// Whether to show the reveal password button for input type 'password'.
     /// </summary>
     [Parameter] public bool CanRevealPassword { get; set; }
@@ -235,18 +230,6 @@ public partial class BitTextField : BitTextInputBase<string?>
         }
 
         await base.OnInitializedAsync();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await base.OnAfterRenderAsync(firstRender);
-
-        if (firstRender is false || IsEnabled is false) return;
-
-        if (AutoFocus)
-        {
-            await InputElement.FocusAsync();
-        }
     }
 
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out string? result, [NotNullWhen(false)] out string? parsingErrorMessage)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/ComponentDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/ComponentDemo.razor.cs
@@ -244,6 +244,13 @@ public partial class ComponentDemo
     [
         new()
         {
+            Name = "AutoFocus",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Determines if the text input is auto focused on first render.",
+        },
+        new()
+        {
             Name = "DebounceTime",
             Type = "int",
             DefaultValue = "0",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TextField/BitTextFieldDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TextField/BitTextFieldDemo.razor.cs
@@ -13,13 +13,6 @@ public partial class BitTextFieldDemo
         },
         new()
         {
-            Name = "AutoFocus",
-            Type = "bool",
-            DefaultValue = "false",
-            Description = "Determines if the text field is auto focused on first render.",
-        },
-        new()
-        {
             Name = "CanRevealPassword",
             Type = "bool",
             DefaultValue = "false",


### PR DESCRIPTION
closes #9042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `AutoFocus` property for the text input component, allowing it to automatically focus on the first render.
	- Added `AutoFocus` parameter to the demo component for enhanced configuration options.

- **Bug Fixes**
	- Removed the `AutoFocus` parameter from the text field component, streamlining its initialization process and focus behavior.

These updates improve user experience by simplifying focus management and providing more control over text input behavior during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->