### PR TITLE
Fix boilerplate invalid code generation issue (#9063)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/App.xaml.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/App.xaml.cs
@@ -36,6 +36,7 @@ public partial class App
 
             await deviceCoordinator.ApplyTheme(AppInfo.Current.RequestedTheme is AppTheme.Dark);
 
+//-:cnd:noEmit
 #if Android
             if (Version.TryParse(Android.Webkit.WebView.CurrentWebViewPackage?.VersionName, out var webViewVersion) &&
         webViewVersion.Major < 83)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiTelemetryInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiTelemetryInitializer.cs
@@ -13,7 +13,7 @@ public partial class MauiTelemetryInitializer : ITelemetryInitializer
             telemetry.Context.Session.Id = ITelemetryContext.Current.AppSessionId.ToString();
             telemetry.Context.Component.Version = ITelemetryContext.Current.AppVersion;
             telemetry.Context.Device.OperatingSystem = ITelemetryContext.Current.OS;
-            telemetry.Context.User.Id = ITelemetryContext.Current.UserId?.ToString();
+            telemetry.Context.User.AuthenticatedUserId = ITelemetryContext.Current.UserId?.ToString();
 
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.UserSessionId)] = ITelemetryContext.Current.UserSessionId?.ToString();
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.WebView)] = ITelemetryContext.Current.WebView;
@@ -28,6 +28,7 @@ public partial class MauiTelemetryInitializer : ITelemetryInitializer
         telemetry.Context.Session.IsFirst = VersionTracking.IsFirstLaunchEver;
         telemetry.Context.Device.OemName = DeviceInfo.Current.Manufacturer;
         telemetry.Context.Device.Model = DeviceInfo.Current.Model;
+        telemetry.Context.Device.Type = DeviceInfo.Idiom.ToString();
 
         if (AppPlatform.IsIosOnMacOS)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
@@ -31,7 +31,7 @@ self.externalAssets = [
         "url": "/"
     },
     {
-        url: "_framework/blazor.web.js?v=8.0.403"
+        url: "_framework/blazor.web.js?ver=8.0.403"
     },
     {
         "url": "Boilerplate.Server.Web.styles.css"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsTelemetryInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsTelemetryInitializer.cs
@@ -13,7 +13,7 @@ public partial class WindowsTelemetryInitializer : ITelemetryInitializer
             telemetry.Context.Session.Id = ITelemetryContext.Current.AppSessionId.ToString();
             telemetry.Context.Component.Version = ITelemetryContext.Current.AppVersion;
             telemetry.Context.Device.OperatingSystem = ITelemetryContext.Current.OS;
-            telemetry.Context.User.Id = ITelemetryContext.Current.UserId?.ToString();
+            telemetry.Context.User.AuthenticatedUserId = ITelemetryContext.Current.UserId?.ToString();
 
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.UserSessionId)] = ITelemetryContext.Current.UserSessionId?.ToString();
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.WebView)] = ITelemetryContext.Current.WebView;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
@@ -64,7 +64,7 @@
 
     @if (HttpContext.Request.IsCrawlerClient() is false)
     {
-        <Script src="_framework/blazor.web.js?v=8.0.403" autostart="false"></Script>
+        <Script src="_framework/blazor.web.js?ver=8.0.403" autostart="false"></Script>
         <!-- Ensure that the version of `blazor.web.js` matches the version specified in `service-worker.published.js`.
              This alignment is necessary for the PWA functionality of the Blazor app to work correctly. -->
         @if (serverWebSettings.WebAppRender.PwaEnabled)


### PR DESCRIPTION
This closes #9063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Android users will receive an alert to update their WebView if the version is below 83, with a direct link to the Google Play Store for convenience.
  
- **Bug Fixes**
  - Updated URL parameters for asset versioning in the service worker and Blazor framework to improve cache behavior and asset retrieval.

These changes enhance user experience by ensuring compatibility and efficient asset management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->