### PR TITLE
Add non-interactive items to BitBreadcrumb (#9040)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor
@@ -97,7 +97,7 @@
                     {
                         <span aria-current="@(GetIsSelected(item) ? "page" : null)"
                               style="@GetStyles(item, false)"
-                              class="bit-brc-itm bit-brc-noc @GetClasses(item, false)">
+                              class="bit-brc-nii @GetClasses(item, false)">
                             @if (template is not null)
                             {
                                 @template(item)
@@ -202,7 +202,7 @@
                     {
                         <span aria-current="@(GetIsSelected(item) ? "page" : null)"
                               style="@GetStyles(item, true)"
-                              class="bit-brc-ofi bit-brc-noc @GetClasses(item, true)">
+                              class="bit-brc-ofn @GetClasses(item, true)">
                               @if (overflowTemplate is not null)
                               {
                                   @overflowTemplate(item)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor
@@ -67,7 +67,7 @@
                             }
                         </a>
                     }
-                    else
+                    else if (OnItemClick.HasDelegate)
                     {
                         <button type="button"
                                 aria-current="@(GetIsSelected(item) ? "page" : null)"
@@ -92,6 +92,30 @@
                                 <span style="@Styles?.ItemText" class="@Classes?.ItemText">@GetItemText(item)</span>
                             }
                         </button>
+                    }
+                    else 
+                    {
+                        <span aria-current="@(GetIsSelected(item) ? "page" : null)"
+                              style="@GetStyles(item, false)"
+                              class="bit-brc-itm bit-brc-noc @GetClasses(item, false)">
+                            @if (template is not null)
+                            {
+                                @template(item)
+                            }
+                            else if (ItemTemplate is not null)
+                            {
+                                @ItemTemplate(item)
+                            }
+                            else
+                            {
+                                var iconName = GetIconName(item);
+                                @if (iconName.HasValue())
+                                {
+                                    <i style="@Styles?.ItemIcon" class="bit-icon bit-icon--@iconName @Classes?.ItemIcon" />
+                                }
+                                <span style="@Styles?.ItemText" class="@Classes?.ItemText">@GetItemText(item)</span>
+                            }
+                        </span>
                     }
                 }
             </li>
@@ -148,7 +172,7 @@
                             }
                         </a>
                     }
-                    else
+                    else if (OnItemClick.HasDelegate)
                     {
                         <button type="button"
                                 aria-current="@(GetIsSelected(item) ? "page" : null)"
@@ -173,6 +197,30 @@
                                 <span style="@Styles?.OverflowItemText" class="@Classes?.OverflowItemText">@GetItemText(item)</span>
                             }
                         </button>
+                    }
+                    else
+                    {
+                        <span aria-current="@(GetIsSelected(item) ? "page" : null)"
+                              style="@GetStyles(item, true)"
+                              class="bit-brc-ofi bit-brc-noc @GetClasses(item, true)">
+                              @if (overflowTemplate is not null)
+                              {
+                                  @overflowTemplate(item)
+                              }
+                              else if (OverflowTemplate is not null)
+                              {
+                                  @OverflowTemplate(item)
+                              }
+                              else
+                              {
+                                  var iconName = GetIconName(item);
+                                  @if (iconName.HasValue())
+                                  {
+                                      <i style="@Styles?.OverflowItemIcon" class="bit-icon bit-icon--@iconName @Classes?.OverflowItemIcon" />
+                                  }
+                                  <span style="@Styles?.OverflowItemText" class="@Classes?.OverflowItemText">@GetItemText(item)</span>
+                              }
+                        </span>
                     }
                 </li>
             }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor.cs
@@ -176,6 +176,7 @@ public partial class BitBreadcrumb<TItem> : BitComponentBase, IAsyncDisposable w
     {
         if (IsEnabled is false) return;
         if (GetIsEnabled(item) is false) return;
+        if (OnItemClick.HasDelegate is false) return;
 
         await OnItemClick.InvokeAsync(item);
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
@@ -73,12 +73,6 @@
     padding: 0 spacing(1);
     font-size: spacing(2.5);
     line-height: spacing(4.5);
-
-    @media (hover: hover) {
-        &:hover {
-            background-color: $clr-bg-pri-hover;
-        }
-    }
 }
 
 .bit-brc-itm {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
@@ -145,6 +145,16 @@
     }
 }
 
+.bit-brc-noc {
+    cursor: default;
+
+    @media (hover: hover) {
+        &:hover {
+            background-color: inherit;
+        }
+    }
+}
+
 .bit-brc-ovl {
     top: 0;
     left: 0;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
@@ -64,10 +64,10 @@
     }
 }
 
-.bit-brc-itm {
+.bit-brc-itm,
+.bit-brc-nii {
     display: flex;
     gap: spacing(1);
-    cursor: pointer;
     font-weight: 400;
     color: $clr-fg-pri;
     padding: 0 spacing(1);
@@ -81,14 +81,14 @@
     }
 }
 
-.bit-brc-nii {
-    display: flex;
-    gap: spacing(1);
-    font-weight: 400;
-    color: $clr-fg-pri;
-    padding: 0 spacing(1);
-    font-size: spacing(2.5);
-    line-height: spacing(4.5);
+.bit-brc-itm {
+    cursor: pointer;
+
+    @media (hover: hover) {
+        &:hover {
+            background-color: $clr-bg-pri-hover;
+        }
+    }
 }
 
 .bit-brc-rvi {
@@ -123,38 +123,7 @@
     max-height: spacing(88.875);
 }
 
-.bit-brc-ofi {
-    width: 100%;
-    display: flex;
-    gap: spacing(1);
-    cursor: pointer;
-    overflow: hidden;
-    text-align: left;
-    font-weight: 400;
-    user-select: none;
-    color: $clr-fg-pri;
-    position: relative;
-    align-items: center;
-    white-space: nowrap;
-    height: spacing(4.5);
-    outline: transparent;
-    padding: 0 spacing(1);
-    text-decoration: none;
-    box-sizing: border-box;
-    text-overflow: ellipsis;
-    font-size: spacing(1.75);
-    min-width: spacing(22.5);
-    line-height: spacing(2.5);
-    background-color: transparent;
-    border: $shp-border-width $shp-border-style transparent;
-
-    @media (hover: hover) {
-        &:hover {
-            background-color: $clr-bg-pri-hover;
-        }
-    }
-}
-
+.bit-brc-ofi,
 .bit-brc-ofn {
     width: 100%;
     display: flex;
@@ -178,6 +147,16 @@
     line-height: spacing(2.5);
     background-color: transparent;
     border: $shp-border-width $shp-border-style transparent;
+}
+
+.bit-brc-ofi {
+    cursor: pointer;
+
+    @media (hover: hover) {
+        &:hover {
+            background-color: $clr-bg-pri-hover;
+        }
+    }
 }
 
 .bit-brc-ovl {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.scss
@@ -81,6 +81,16 @@
     }
 }
 
+.bit-brc-nii {
+    display: flex;
+    gap: spacing(1);
+    font-weight: 400;
+    color: $clr-fg-pri;
+    padding: 0 spacing(1);
+    font-size: spacing(2.5);
+    line-height: spacing(4.5);
+}
+
 .bit-brc-rvi {
     flex-direction: row-reverse;
     justify-content: space-between;
@@ -145,14 +155,29 @@
     }
 }
 
-.bit-brc-noc {
-    cursor: default;
-
-    @media (hover: hover) {
-        &:hover {
-            background-color: inherit;
-        }
-    }
+.bit-brc-ofn {
+    width: 100%;
+    display: flex;
+    gap: spacing(1);
+    overflow: hidden;
+    text-align: left;
+    font-weight: 400;
+    user-select: none;
+    color: $clr-fg-pri;
+    position: relative;
+    align-items: center;
+    white-space: nowrap;
+    height: spacing(4.5);
+    outline: transparent;
+    padding: 0 spacing(1);
+    text-decoration: none;
+    box-sizing: border-box;
+    text-overflow: ellipsis;
+    font-size: spacing(1.75);
+    min-width: spacing(22.5);
+    line-height: spacing(2.5);
+    background-color: transparent;
+    border: $shp-border-width $shp-border-style transparent;
 }
 
 .bit-brc-ovl {


### PR DESCRIPTION
This closes #9040 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced item rendering in the Breadcrumb component, allowing for clearer differentiation between interactive and non-interactive items.
	- Introduced a new CSS class for improved cursor behavior on non-interactive items.

- **Bug Fixes**
	- Improved error handling in item click events to prevent null reference exceptions.

- **Style**
	- Added new CSS class `.bit-brc-noc` for better visual feedback on non-clickable items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->