### PR TITLE
Rename CallOnSet attribute methods (#9073)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButtonGroup/BitButtonGroup.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButtonGroup/BitButtonGroup.razor.cs
@@ -20,7 +20,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
     /// The content of the BitButtonGroup, that are BitButtonGroupOption components.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetChildContentAndItems))]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
@@ -33,7 +33,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
     ///  List of Item, each of which can be a button with different action in the ButtonGroup.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetChildContentAndItems))]
     public IEnumerable<TItem> Items { get; set; } = [];
 
     /// <summary>
@@ -169,7 +169,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
         }
     }
 
-    private void HandleParameterChanges()
+    private void OnSetChildContentAndItems()
     {
         if (ChildContent is not null) return;
         if (Items.Any() is false || Items == _oldItems) return;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Calendar/BitCalendar.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Calendar/BitCalendar.razor.cs
@@ -107,7 +107,7 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
     /// CultureInfo for the Calendar.
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public CultureInfo? Culture { get; set; }
 
     /// <summary>
@@ -189,21 +189,21 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
     /// Whether the month picker is shown or hidden.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowMonthPicker { get; set; } = true;
 
     /// <summary>
     /// The maximum allowable date of the calendar.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? MaxDate { get; set; }
 
     /// <summary>
     /// The minimum allowable date of the calendar.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? MinDate { get; set; }
 
     /// <summary>
@@ -245,7 +245,7 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
     /// Whether the time picker should be shown or not.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowTimePicker { get; set; }
 
     /// <summary>
@@ -302,7 +302,7 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
     /// Specifies the date and time of the calendar when it is showing without any selected value.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? StartingValue { get; set; }
 
 
@@ -325,7 +325,7 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
     {
         OnValueChanged += HandleOnValueChanged;
 
-        HandleParameterChanges();
+        OnSetParameters();
 
         base.OnInitialized();
     }
@@ -373,10 +373,10 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
 
     private void HandleOnValueChanged(object? sender, EventArgs args)
     {
-        HandleParameterChanges();
+        OnSetParameters();
     }
 
-    private void HandleParameterChanges()
+    private void OnSetParameters()
     {
         _showTimePicker = ShowTimePicker && ShowTimePickerAsOverlay is false;
         _showMonthPicker = _showTimePicker is false && ShowMonthPicker && ShowMonthPickerAsOverlay is false;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/ChoiceGroup/BitChoiceGroup.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/ChoiceGroup/BitChoiceGroup.razor.cs
@@ -20,7 +20,7 @@ public partial class BitChoiceGroup<TItem, TValue> : BitInputBase<TValue> where 
     /// The content of the ChoiceGroup, a list of BitChoiceGroupOption components.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
@@ -32,7 +32,7 @@ public partial class BitChoiceGroup<TItem, TValue> : BitInputBase<TValue> where 
     /// Default selected item for ChoiceGroup.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public TValue? DefaultValue { get; set; }
 
     /// <summary>
@@ -49,7 +49,7 @@ public partial class BitChoiceGroup<TItem, TValue> : BitInputBase<TValue> where 
     /// Sets the data source that populates the items of the list.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public IEnumerable<TItem> Items { get; set; } = [];
 
     /// <summary>
@@ -155,7 +155,7 @@ public partial class BitChoiceGroup<TItem, TValue> : BitInputBase<TValue> where 
 
 
 
-    private void HandleParameterChanges()
+    private void OnSetParameters()
     {
         if (ChildContent is not null) return;
         if (Items.Any() is false || Items == _oldItems) return;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.razor.cs
@@ -62,7 +62,7 @@ public partial class BitCircularTimePicker : BitInputBase<TimeSpan?>, IAsyncDisp
     /// CultureInfo for the TimePicker
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetCulture))]
     public CultureInfo? Culture { get; set; }
 
     /// <summary>
@@ -349,7 +349,7 @@ public partial class BitCircularTimePicker : BitInputBase<TimeSpan?>, IAsyncDisp
         await OnClick.InvokeAsync();
     }
 
-    private void HandleParameterChanges()
+    private void OnSetCulture()
     {
         _culture = Culture ?? CultureInfo.CurrentUICulture;
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/DatePicker/BitDatePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/DatePicker/BitDatePicker.razor.cs
@@ -136,7 +136,7 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
     /// CultureInfo for the DatePicker.
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public CultureInfo? Culture { get; set; }
 
     /// <summary>
@@ -277,14 +277,14 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
     /// The maximum date allowed for the DatePicker.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? MaxDate { get; set; }
 
     /// <summary>
     /// The minimum date allowed for the DatePicker.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? MinDate { get; set; }
 
     /// <summary>
@@ -346,14 +346,14 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
     /// Show month picker on top of date picker when visible.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowMonthPickerAsOverlay { get; set; }
 
     /// <summary>
     /// Whether or not render the time-picker.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowTimePicker { get; set; }
 
     /// <summary>
@@ -400,7 +400,7 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
     /// Show month picker on top of date picker when visible.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowTimePickerAsOverlay { get; set; }
 
     /// <summary>
@@ -422,14 +422,14 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
     /// Specifies the date and time of the date-picker when it is opened without any selected value.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? StartingValue { get; set; }
 
     /// <summary>
     /// Whether the date-picker is rendered standalone or with the input component and callout.
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool Standalone { get; set; }
 
 
@@ -489,7 +489,7 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
 
         OnValueChanged += HandleOnValueChanged;
 
-        HandleParameterChanges();
+        OnSetParameters();
 
         base.OnInitialized();
     }
@@ -642,10 +642,10 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
 
     private void HandleOnValueChanged(object? sender, EventArgs args)
     {
-        HandleParameterChanges();
+        OnSetParameters();
     }
 
-    private void HandleParameterChanges()
+    private void OnSetParameters()
     {
         _culture = Culture ?? CultureInfo.CurrentUICulture;
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/DateRangePicker/BitDateRangePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/DateRangePicker/BitDateRangePicker.razor.cs
@@ -212,7 +212,7 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
     /// CultureInfo for the DateRangePicker.
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public CultureInfo? Culture { get; set; }
 
     /// <summary>
@@ -343,14 +343,14 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
     /// The maximum date allowed for the DateRangePicker.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? MaxDate { get; set; }
 
     /// <summary>
     /// The minimum date allowed for the DateRangePicker.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public DateTimeOffset? MinDate { get; set; }
 
     /// <summary>
@@ -402,14 +402,14 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
     /// Show month picker on top of date range picker when visible.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowMonthPickerAsOverlay { get; set; }
 
     /// <summary>
     /// Whether or not render the time-picker.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowTimePicker { get; set; }
 
     /// <summary>
@@ -461,7 +461,7 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
     /// Show month picker on top of date range picker when visible.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool ShowTimePickerAsOverlay { get; set; }
 
     /// <summary>
@@ -488,14 +488,14 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
     /// Specifies the date and time of the date and time picker when it is opened without any selected value.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public BitDateRangePickerValue? StartingValue { get; set; }
 
     /// <summary>
     /// Whether the DateRangePicker is rendered standalone or with the input component and callout.
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetParameters))]
     public bool Standalone { get; set; }
 
 
@@ -555,7 +555,7 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
 
         OnValueChanged += HandleOnValueChanged;
 
-        HandleParameterChanges();
+        OnSetParameters();
 
         base.OnInitialized();
     }
@@ -711,10 +711,10 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
 
     private void HandleOnValueChanged(object? sender, EventArgs args)
     {
-        HandleParameterChanges();
+        OnSetParameters();
     }
 
-    private void HandleParameterChanges()
+    private void OnSetParameters()
     {
         _culture = Culture ?? CultureInfo.CurrentUICulture;
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.razor.cs
@@ -122,7 +122,7 @@ public partial class BitTimePicker : BitInputBase<TimeSpan?>, IAsyncDisposable
     /// CultureInfo for the TimePicker
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetCulture))]
     public CultureInfo? Culture { get; set; }
 
     /// <summary>
@@ -427,7 +427,7 @@ public partial class BitTimePicker : BitInputBase<TimeSpan?>, IAsyncDisposable
         await OnClick.InvokeAsync();
     }
 
-    private void HandleParameterChanges()
+    private void OnSetCulture()
     {
         _culture = Culture ?? CultureInfo.CurrentUICulture;
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Badge/BitBadge.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Badge/BitBadge.razor.cs
@@ -26,7 +26,7 @@ public partial class BitBadge : BitComponentBase
     /// Content you want inside the badge. Supported types are string and integer.
     /// </summary>
     [Parameter] 
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetContentAndMax))]
     public object? Content { get; set; }
 
     /// <summary>
@@ -49,7 +49,7 @@ public partial class BitBadge : BitComponentBase
     /// Max value to display when content is integer type.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(HandleParameterChanges))]
+    [CallOnSet(nameof(OnSetContentAndMax))]
     public int? Max { get; set; }
 
     /// <summary>
@@ -156,7 +156,7 @@ public partial class BitBadge : BitComponentBase
         await OnClick.InvokeAsync(e);
     }
 
-    private void HandleParameterChanges()
+    private void OnSetContentAndMax()
     {
         if (Content is string stringContent)
         {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Splitter/BitSplitter.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Splitter/BitSplitter.razor.cs
@@ -80,7 +80,7 @@ public partial class BitSplitter : BitComponentBase
     /// Sets the orientation of BitSplitter to vertical.
     /// </summary>
     [Parameter, ResetClassBuilder]
-    [CallOnSet(nameof(ResetPaneDimensions))]
+    [CallOnSet(nameof(OnSetVertical))]
     public bool Vertical { get; set; }
 
 
@@ -109,7 +109,7 @@ public partial class BitSplitter : BitComponentBase
 
 
 
-    private async Task ResetPaneDimensions()
+    private async Task OnSetVertical()
     {
         await _js.BitSplitterResetPaneDimensions(_firstPanelRef);
         await _js.BitSplitterResetPaneDimensions(_secondPanelRef);

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Link/BitLink.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Link/BitLink.razor.cs
@@ -19,7 +19,7 @@ public partial class BitLink : BitComponentBase
     /// URL the link points to.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(OnSetRelAndHref))]
+    [CallOnSet(nameof(OnSetHrefAndRel))]
     public string? Href { get; set; }
 
     /// <summary>
@@ -37,7 +37,7 @@ public partial class BitLink : BitComponentBase
     /// If Href provided, specifies the relationship between the current document and the linked document.
     /// </summary>
     [Parameter]
-    [CallOnSet(nameof(OnSetRelAndHref))]
+    [CallOnSet(nameof(OnSetHrefAndRel))]
     public BitAnchorRel? Rel { get; set; }
 
     /// <summary>
@@ -76,7 +76,7 @@ public partial class BitLink : BitComponentBase
         await _js.ScrollElementIntoView(Href![1..]);
     }
 
-    private void OnSetRelAndHref()
+    private void OnSetHrefAndRel()
     {
         if (Rel.HasValue is false || Href.HasNoValue() || Href!.StartsWith('#'))
         {


### PR DESCRIPTION
This closes #9073 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Improved parameter handling across various components for better clarity and consistency.
  
- **Refactor**
	- Renamed methods to enhance readability and maintainability, including:
		- `HandleParameterChanges` to `OnSetParameters` in multiple input components.
		- `HandleParameterChanges` to `OnSetChildContentAndItems` in `BitButtonGroup`.
		- `HandleParameterChanges` to `OnSetContentAndMax` in `BitBadge`.
		- `ResetPaneDimensions` to `OnSetVertical` in `BitSplitter`.
		- `OnSetRelAndHref` to `OnSetHrefAndRel` in `BitLink`.

- **Bug Fixes**
	- Ensured consistent handling of parameters across components without altering core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->