### PR TITLE
fix for missing wwwroot/.well-known folder in github artifacts (#9088)

### DIFF
--- a/.github/workflows/admin-sample.cd.yml
+++ b/.github/workflows/admin-sample.cd.yml
@@ -77,6 +77,7 @@ jobs:
       with:
         name: static-bundle
         path: ${{env.DOTNET_ROOT}}/static
+        include-hidden-files: true # Required for wwwroot/.well-known folder
 
   deploy_api_blazor:
     name: deploy api + blazor

--- a/.github/workflows/blazorui.demo.cd.yml
+++ b/.github/workflows/blazorui.demo.cd.yml
@@ -56,6 +56,7 @@ jobs:
       with:
         name: server-bundle
         path: ${{env.DOTNET_ROOT}}/server
+        include-hidden-files: true # Required for wwwroot/.well-known folder
 
   deploy_api_blazor:
     name: deploy api + blazor

--- a/.github/workflows/platform.website.cd.yml
+++ b/.github/workflows/platform.website.cd.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         name: server-bundle
         path: server
+        include-hidden-files: true # Required for wwwroot/.well-known folder
 
   deploy_api_blazor:
     name: deploy api + blazor

--- a/.github/workflows/sales.website.cd.yml
+++ b/.github/workflows/sales.website.cd.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         name: server-bundle
         path: server
+        include-hidden-files: true # Required for wwwroot/.well-known folder
 
   deploy_api_blazor:
     name: deploy api + blazor

--- a/.github/workflows/todo-sample.cd.yml
+++ b/.github/workflows/todo-sample.cd.yml
@@ -65,6 +65,7 @@ jobs:
       with:
         name: server-bundle
         path: ${{env.DOTNET_ROOT}}/server
+        include-hidden-files: true # Required for wwwroot/.well-known folder
 
   deploy_api_blazor:
     name: deploy api + blazor

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/cd.yml
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/cd.yml
@@ -69,6 +69,7 @@ jobs:
       with:
         name: server-bundle
         path: ${{env.DOTNET_ROOT}}/server
+        include-hidden-files: true # Required for wwwroot/.well-known folder
 
   deploy_api_blazor:
     name: deploy api + blazor


### PR DESCRIPTION
This closes #9088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for building and deploying Blazor hybrid applications on Android, iOS, and Windows.
	- Introduced a parameter to include hidden files during artifact uploads for various workflows.

- **Bug Fixes**
	- Ensured the correct configuration files are updated during builds across different platforms.

- **Enhancements**
	- Improved deployment processes by adding steps for signing and packaging applications.
	- Updated workflows to maintain compatibility with different operating systems and their specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->