### PR TITLE
Add missing IsSupported api to Butil Notification (#9173)

### DIFF
--- a/src/Butil/Bit.Butil/Publics/Notification.cs
+++ b/src/Butil/Bit.Butil/Publics/Notification.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.NetworkInformation;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
 namespace Bit.Butil;
@@ -11,6 +10,14 @@ namespace Bit.Butil;
 /// </summary>
 public class Notification(IJSRuntime js)
 {
+    /// <summary>
+    /// Checks if the runtime (browser or web-view) is supporting the Web Notification API.
+    /// </summary>
+    public async ValueTask<bool> IsSupported()
+    {
+        return await js.InvokeAsync<bool>("BitButil.notification.isSupported");
+    }
+
     /// <summary>
     /// Requests a native notification to show to the user.
     /// <br/>

--- a/src/Butil/Bit.Butil/Scripts/notification.ts
+++ b/src/Butil/Bit.Butil/Scripts/notification.ts
@@ -2,10 +2,15 @@ var BitButil = BitButil || {};
 
 (function (butil: any) {
     butil.notification = {
+        isSupported,
         show,
         getPermission,
         requestPermission
     };
+
+    function isSupported() {
+        return ('Notification' in window);
+    }
 
     function show(title: string, options?: NotificationOptions) {
         const notification = new Notification(title, options);


### PR DESCRIPTION
closes #9173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to check if the Web Notification API is supported in the runtime.
	- Added a function to verify the availability of the Notification API in the current browser environment. 

These enhancements ensure smoother functionality when utilizing notification features in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->