### PR TITLE
Update Butil Notification docs for android issues (#9206)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil08NotificationPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil08NotificationPage.razor
@@ -100,6 +100,9 @@
             <b>Show</b>: <br />
             Requests a native notification to show to the user.
             (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification" target="_blank">MDN</a>).
+            <br/>
+            <b>Note</b>: The Notification api has some limitation on Android and for it to work properly a
+            Service Worker needs to be registered first.
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>


### PR DESCRIPTION
closes #9206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added important notes regarding the limitations of the Notification API on Android devices, emphasizing the need for a registered Service Worker for proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->