### PR TITLE
Initial implementation for Boilerplate's isOnline without signalR (#9209)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppComponentBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppComponentBase.cs
@@ -7,7 +7,7 @@ public partial class AppComponentBase : ComponentBase, IAsyncDisposable
     /// <summary>
     /// <inheritdoc cref="Parameters.IsOnline"/>
     /// </summary>
-    [CascadingParameter(Name = Parameters.IsOnline)] protected bool IsOnline { get; set; }
+    [CascadingParameter(Name = Parameters.IsOnline)] protected bool? IsOnline { get; set; }
     [CascadingParameter] protected Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
 
     [AutoInject] protected IJSRuntime JSRuntime = default!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/ClientAppCoordinator.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/ClientAppCoordinator.cs
@@ -188,14 +188,12 @@ public partial class ClientAppCoordinator : AppComponentBase
 
     private async Task HubConnectionConnected(string? connectionId)
     {
-        TelemetryContext.IsOnline = true;
         PubSubService.Publish(ClientPubSubMessages.IS_ONLINE_CHANGED, true);
         logger.LogInformation("SignalR connection {ConnectionId} established.", connectionId);
     }
 
     private async Task HubConnectionDisconnected(Exception? exception)
     {
-        TelemetryContext.IsOnline = false;
         PubSubService.Publish(ClientPubSubMessages.IS_ONLINE_CHANGED, false);
 
         if (exception is null)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/RootContainer.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/RootContainer.razor.cs
@@ -7,7 +7,7 @@ public partial class RootContainer
     /// <summary>
     /// <inheritdoc cref="Parameters.IsOnline"/>
     /// </summary>
-    [Parameter] public bool IsOnline { get; set; }
+    [Parameter] public bool? IsOnline { get; set; }
     [Parameter] public BitDir? CurrentDir { get; set; }
     [Parameter] public string? CurrentUrl { get; set; }
     [Parameter] public bool? IsAuthenticated { get; set; }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/RootLayout.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/RootLayout.razor.cs
@@ -11,18 +11,7 @@ public partial class RootLayout : IDisposable
     /// <summary>
     /// <inheritdoc cref="Parameters.IsOnline"/>
     /// </summary>
-    private bool isOnline
-        //#if (signalR == true)
-            = false;
-        //#else
-            //#if (IsInsideProjectTemplate == true)
-            /*
-            //#endif
-           = true;
-            //#if (IsInsideProjectTemplate == true)
-            */
-            //#endif
-        //#endif
+    private bool? isOnline = null;
     private bool? isAuthenticated;
 
     /// <summary>
@@ -39,6 +28,7 @@ public partial class RootLayout : IDisposable
     [AutoInject] private PubSubService pubSubService = default!;
     [AutoInject] private AuthenticationManager authManager = default!;
     [AutoInject] private IExceptionHandler exceptionHandler = default!;
+    [AutoInject] private ITelemetryContext telemetryContext = default!;
     [AutoInject] private NavigationManager navigationManager = default!;
     [AutoInject] private IPrerenderStateService prerenderStateService = default!;
 
@@ -70,13 +60,12 @@ public partial class RootLayout : IDisposable
                 StateHasChanged();
             }));
 
-            //#if (signalR == true)
             unsubscribers.Add(pubSubService.Subscribe(ClientPubSubMessages.IS_ONLINE_CHANGED, async payload =>
             {
                 isOnline = (bool)payload!;
+                telemetryContext.IsOnline = isOnline is true;
                 await InvokeAsync(StateHasChanged);
             }));
-            //#endif
 
             isAuthenticated = await prerenderStateService.GetValue(async () => (await AuthenticationStateTask).User.IsAuthenticated());
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/UserMenu.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/UserMenu.razor
@@ -14,7 +14,7 @@
                         Size=@BitPersonaSize.Size32
                         PrimaryText="@user.DisplayName"
                         Classes="@(new() { DetailsContainer="persona-details" })"
-                        Presence="@(IsOnline ? BitPersonaPresence.Online : BitPersonaPresence.Offline)" />
+                        Presence="@(IsOnline is null ? BitPersonaPresence.None : IsOnline is true ? BitPersonaPresence.Online : BitPersonaPresence.Offline)" />
             <BitIcon IconName="@BitIconName.ChevronDown" Size="BitSize.Small" Color="BitColor.Info" Class="menu-chevron" />
         </Template>
         <Body>
@@ -28,7 +28,7 @@
                                     Size="BitPersonaSize.Size48"
                                     PrimaryText="@user.DisplayName"
                                     SecondaryText="@(user.Email ?? user.PhoneNumber)"
-                                    Presence="@(IsOnline ? BitPersonaPresence.Online : BitPersonaPresence.Offline)">
+                                    Presence="@(IsOnline is null ? BitPersonaPresence.None : IsOnline is true ? BitPersonaPresence.Online : BitPersonaPresence.Offline)">
                             <ImageOverlayTemplate>
                                 <span>@Localizer[nameof(AppStrings.Edit)]</span>
                             </ImageOverlayTemplate>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ProfileSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ProfileSection.razor
@@ -32,7 +32,7 @@
                                         ImageUrl="@imageUrl"
                                         PrimaryText="@User?.FullName"
                                         Size=@BitPersonaSize.Size72
-                                        Presence="@(IsOnline ? BitPersonaPresence.Online : BitPersonaPresence.Offline)" />
+                                        Presence="@(IsOnline is null ? BitPersonaPresence.None : IsOnline is true ? BitPersonaPresence.Online : BitPersonaPresence.Offline)" />
                             <BitText Color="BitColor.Primary">
                                 @Localizer[nameof(AppStrings.UploadNewProfileImage)]
                             </BitText>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/SessionsSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/SessionsSection.razor
@@ -12,7 +12,7 @@
                             Size="BitPersonaSize.Size48"
                             Styles="@(new() { Image = "width:50%;height:50%" })"
                             ImageInitials="✓"
-                            Presence="@(IsOnline ? BitPersonaPresence.Online : BitPersonaPresence.Offline)"
+                            Presence="@(IsOnline is null ? BitPersonaPresence.None : IsOnline is true ? BitPersonaPresence.Online : BitPersonaPresence.Offline)"
                             ImageUrl="@($"/_content/Boilerplate.Client.Core/images/os/{GetImageUrl(currentSession.Device)}")" />
             </BitCard>
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Parameters.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Parameters.cs
@@ -15,8 +15,9 @@ public class Parameters
 
     /// <summary>
     /// Determines the connection status, with default behavior based on SignalR connection status.
-    /// If SignalR is not added to the project during initial project creation, this value will always be true by default.
+    /// If SignalR is not added to the project during initial project creation, this value will always be null by default.
     /// Alternatively, you can implement custom logic to control this value.
+    /// true => Online, false => Offline, null => Unknown
     /// </summary>
     public const string IsOnline = nameof(IsOnline);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/AppTelemetryContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/AppTelemetryContext.cs
@@ -25,7 +25,5 @@ public class AppTelemetryContext : ITelemetryContext
 
     public string? Environment { get; set; } = AppEnvironment.Current;
 
-    //#if (signalR == true)
     public bool IsOnline { get; set; }
-    //#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/ClientPubSubMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/ClientPubSubMessages.cs
@@ -10,14 +10,11 @@ public static partial class ClientPubSubMessages
     public const string OPEN_NAV_PANEL = nameof(OPEN_NAV_PANEL);
     public const string CULTURE_CHANGED = nameof(CULTURE_CHANGED);
     public const string PROFILE_UPDATED = nameof(PROFILE_UPDATED);
+    public const string IS_ONLINE_CHANGED = nameof(IS_ONLINE_CHANGED);
     public const string PAGE_TITLE_CHANGED = nameof(PAGE_TITLE_CHANGED);
     public const string ROUTE_DATA_UPDATED = nameof(ROUTE_DATA_UPDATED);
     public const string UPDATE_IDENTITY_HEADER_BACK_LINK = nameof(UPDATE_IDENTITY_HEADER_BACK_LINK);
     public const string IDENTITY_HEADER_BACK_LINK_CLICKED = nameof(IDENTITY_HEADER_BACK_LINK_CLICKED);
-
-    //#if (signalR == true)
-    public const string IS_ONLINE_CHANGED = nameof(IS_ONLINE_CHANGED);
-    //#endif
 
     public const string SHOW_DIAGNOSTIC_MODAL = nameof(SHOW_DIAGNOSTIC_MODAL);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/Contracts/ITelemetryContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/Contracts/ITelemetryContext.cs
@@ -44,9 +44,7 @@ public interface ITelemetryContext
 
     public string? Environment { get; set; }
 
-    //#if (signalR == true)
     public bool IsOnline { get; set; }
-    //#endif
 
     public Dictionary<string, object?> ToDictionary(Dictionary<string, object?>? additionalParameters = null)
     {
@@ -61,9 +59,7 @@ public interface ITelemetryContext
             { nameof(TimeZone), TimeZone },
             { nameof(Culture), Culture },
             { nameof(Environment), Environment },
-            //#if (signalR == true)
             { nameof(IsOnline), IsOnline }
-            //#endif
         };
 
         if (AppPlatform.IsBlazorHybrid)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/HttpMessageHandlers/ExceptionDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/HttpMessageHandlers/ExceptionDelegatingHandler.cs
@@ -1,8 +1,12 @@
-﻿using System.Net;
+﻿//+:cnd:noEmit
+using System.Net;
 
 namespace Boilerplate.Client.Core.Services.HttpMessageHandlers;
 
 public partial class ExceptionDelegatingHandler(IStringLocalizer<AppStrings> localizer,
+    //#if (signalR != true)
+    PubSubService pubSubService,
+    //#endif
     JsonSerializerOptions jsonSerializerOptions, 
     HttpMessageHandler handler)
     : DelegatingHandler(handler)
@@ -57,5 +61,11 @@ public partial class ExceptionDelegatingHandler(IStringLocalizer<AppStrings> loc
         {
             throw new ServerConnectionException(localizer[nameof(AppStrings.ServerConnectionException)], exp);
         }
+        //#if (signalR != true)
+        finally
+        {
+            pubSubService.Publish(ClientPubSubMessages.IS_ONLINE_CHANGED, serverCommunicationSuccess);
+        }
+        //#endif
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiAppInsightsTelemetryInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiAppInsightsTelemetryInitializer.cs
@@ -20,9 +20,7 @@ public partial class MauiAppInsightsTelemetryInitializer : ITelemetryInitializer
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.UserAgent)] = ITelemetryContext.Current.UserAgent;
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.TimeZone)] = ITelemetryContext.Current.TimeZone;
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.Culture)] = ITelemetryContext.Current.Culture;
-            //#if (signalR == true)
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.IsOnline)] = ITelemetryContext.Current.IsOnline.ToString().ToLowerInvariant();
-            //#endif
         }
 
         telemetry.Context.Session.IsFirst = VersionTracking.IsFirstLaunchEver;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsAppInsightsTelemetryInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsAppInsightsTelemetryInitializer.cs
@@ -20,9 +20,7 @@ public partial class WindowsAppInsightsTelemetryInitializer : ITelemetryInitiali
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.UserAgent)] = ITelemetryContext.Current.UserAgent;
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.TimeZone)] = ITelemetryContext.Current.TimeZone;
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.Culture)] = ITelemetryContext.Current.Culture;
-            //#if (signalR == true)
             telemetry.Context.GlobalProperties[nameof(ITelemetryContext.IsOnline)] = ITelemetryContext.Current.IsOnline.ToString().ToLowerInvariant();
-            //#endif
         }
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -63,7 +63,7 @@
         <!--/-:msbuild-conditional:noEmit -->
         <PackageVersion Include="Humanizer" Version="2.14.1" />
         <PackageVersion Include="QRCoder" Version="1.6.0" />
-        <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.0.0" />
+        <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.1.0" />
         <PackageVersion Include="FluentEmail.Smtp" Version="3.0.2" />
         <PackageVersion Include="FluentStorage" Version="5.6.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />


### PR DESCRIPTION
This closes #9209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced online status handling with nullable boolean properties, allowing for three states: Online, Offline, and Unknown.
  - Improved telemetry integration reflecting the online status consistently across components.

- **Bug Fixes**
  - Resolved issues with online status tracking during SignalR connection events.

- **Documentation**
  - Updated documentation for the `IsOnline` constant to clarify its behavior when SignalR is not included.

- **Chores**
  - Updated the `Magick.NET-Q16-AnyCPU` package version from 14.0.0 to 14.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->