### PR TITLE
Set default framework to .NET 9 in Boilerplate (#9228)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "$schema": "http://json.schemastore.org/template",
     "author": "bit platform",
     "classifications": [
@@ -20,7 +20,7 @@
             "type": "parameter",
             "description": "The target framework for the project.",
             "datatype": "choice",
-            "defaultValue": "net8.0",
+            "defaultValue": "net9.0",
             "choices": [
                 {
                     "choice": "net8.0",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/App.xaml.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/App.xaml.cs
@@ -46,7 +46,7 @@ public partial class App
             //#if (IsInsideProjectTemplate)
             /*
             //#endif
-            const int minimumSupportedWebViewVersion = 83;
+            const int minimumSupportedWebViewVersion = 84;
             //#if (IsInsideProjectTemplate)
             */
             //#endif


### PR DESCRIPTION
This closes #9228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default framework option to support .NET 9.0 in template configurations.
	- Increased the minimum supported WebView version for Android to 84, prompting users to update if necessary.

- **Bug Fixes**
	- Enhanced error handling for WebView version checks to ensure users receive appropriate alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->