### PR TITLE
Replace DoubleChevronDown icons with DoubleChevronUp in BlazorUI (#9236)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor
@@ -32,14 +32,14 @@
         @if (Truncate && Multiline is false)
         {
             <button style="@Styles?.ExpanderButton" class="bit-msg-exb @Classes?.ExpanderButton" @onclick="ToggleExpand" type="button">
-                <i style="@Styles?.ExpanderIcon" class="bit-msg-exi bit-icon bit-icon--@(_isExpanded ? CollapseIcon : ExpandIcon) @Classes?.ExpanderIcon" aria-hidden="true" />
+                <i style="@Styles?.ExpanderIcon" class="bit-msg-exi bit-icon bit-icon--@(_isExpanded ? (CollapseIcon ?? "DoubleChevronUp") : (ExpandIcon ?? "DoubleChevronUp bit-ico-r180")) @Classes?.ExpanderIcon" aria-hidden="true" />
             </button>
         }
 
         @if (OnDismiss.HasDelegate)
         {
             <button style="@Styles?.DismissButton" class="bit-msg-dmb @Classes?.DismissButton" @onclick="OnDismiss" type="button">
-                <i style="@Styles?.DismissIcon" class="bit-msg-dmi bit-icon bit-icon--@DismissIcon @Classes?.DismissIcon" aria-hidden="true" />
+                <i style="@Styles?.DismissIcon" class="bit-msg-dmi bit-icon bit-icon--@(DismissIcon ?? "Cancel") @Classes?.DismissIcon" aria-hidden="true" />
             </button>
         }
     </div>

--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor.cs
@@ -44,7 +44,7 @@ public partial class BitMessage : BitComponentBase
     [Parameter] public RenderFragment? Content { get; set; }
 
     /// <summary>
-    /// Custom Fabric icon name to replace the dismiss icon.
+    /// Custom Fabric icon name to replace the dismiss icon. If unset, default will be the Fabric Cancel icon.
     /// </summary>
     [Parameter] public string? DismissIcon { get; set; }
 
@@ -57,7 +57,7 @@ public partial class BitMessage : BitComponentBase
     /// <summary>
     /// Custom Fabric icon name for the expand icon in Truncate mode.
     /// </summary>
-    [Parameter] public string ExpandIcon { get; set; }
+    [Parameter] public string? ExpandIcon { get; set; }
 
     /// <summary>
     /// Prevents rendering the icon of the message.

--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor.cs
@@ -28,9 +28,9 @@ public partial class BitMessage : BitComponentBase
     [Parameter] public BitMessageClassStyles? Classes { get; set; }
 
     /// <summary>
-    /// Custom Fabric icon name for the collapse icon in Truncate mode. If unset, default will be the Fabric DoubleChevronUp icon.
+    /// Custom Fabric icon name for the collapse icon in Truncate mode.
     /// </summary>
-    [Parameter] public string CollapseIcon { get; set; } = "DoubleChevronUp";
+    [Parameter] public string? CollapseIcon { get; set; }
 
     /// <summary>
     /// The general color of the message.
@@ -44,9 +44,9 @@ public partial class BitMessage : BitComponentBase
     [Parameter] public RenderFragment? Content { get; set; }
 
     /// <summary>
-    /// Custom Fabric icon name to replace the dismiss icon. If unset, default will be the Fabric Cancel icon.
+    /// Custom Fabric icon name to replace the dismiss icon.
     /// </summary>
-    [Parameter] public string DismissIcon { get; set; } = "Cancel";
+    [Parameter] public string? DismissIcon { get; set; }
 
     /// <summary>
     /// Determines the elevation of the message, a scale from 1 to 24.
@@ -55,9 +55,9 @@ public partial class BitMessage : BitComponentBase
     public int? Elevation { get; set; }
 
     /// <summary>
-    /// Custom Fabric icon name for the expand icon in Truncate mode. If unset, default will be the Fabric DoubleChevronDown icon.
+    /// Custom Fabric icon name for the expand icon in Truncate mode.
     /// </summary>
-    [Parameter] public string ExpandIcon { get; set; } = "DoubleChevronDown";
+    [Parameter] public string ExpandIcon { get; set; }
 
     /// <summary>
     /// Prevents rendering the icon of the message.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor.cs
@@ -39,9 +39,9 @@ public partial class BitMessageDemo
         new()
         {
             Name = "CollapseIcon",
-            Type = "string",
-            DefaultValue = "DoubleChevronUp",
-            Description = "Custom Fabric icon name for the collapse icon in Truncate mode. If unset, default will be the Fabric DoubleChevronUp icon.",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Custom Fabric icon name for the collapse icon in Truncate mode.",
         },
         new()
         {
@@ -62,8 +62,8 @@ public partial class BitMessageDemo
         new()
         {
             Name = "DismissIcon",
-            Type = "string",
-            DefaultValue = "Cancel",
+            Type = "string?",
+            DefaultValue = "null",
             Description = "Custom Fabric icon name to replace the dismiss icon. If unset, default will be the Fabric Cancel icon.",
         },
         new()
@@ -76,9 +76,9 @@ public partial class BitMessageDemo
         new()
         {
             Name = "ExpandIcon",
-            Type = "string",
-            DefaultValue = "DoubleChevronDown",
-            Description = "Custom Fabric icon name for the expand icon in Truncate mode. If unset, default will be the Fabric DoubleChevronDown icon.",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Custom Fabric icon name for the expand icon in Truncate mode.",
         },
         new()
         {


### PR DESCRIPTION
This closes #9236 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced icon handling for the expander and dismiss buttons in notifications, ensuring default icons are displayed when specific icons are not set.

- **Bug Fixes**
	- Improved robustness of icon rendering logic by allowing null values for icon parameters, preventing potential issues when icons are not defined.

- **Documentation**
	- Updated parameter descriptions to reflect changes in default icon behavior for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->