### PR TITLE
Add AutoReset parameter to BitFileUpload (#9221)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Tests/Components/Inputs/FileUpload/BitFileUploadTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Components/Inputs/FileUpload/BitFileUploadTests.cs
@@ -31,7 +31,7 @@ public class BitFileUploadTests : BunitTestContext
     {
         var com = RenderComponent<BitFileUpload>(parameters =>
         {
-            parameters.Add(p => p.MultiSelect, isMultiSelect);
+            parameters.Add(p => p.Multiple, isMultiSelect);
         });
 
         var bitFileUpload = com.Find(".bit-upl-fi");

--- a/src/BlazorUI/Bit.BlazorUI.Tests/Components/Inputs/FileUpload/BitFileUploadTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Components/Inputs/FileUpload/BitFileUploadTests.cs
@@ -27,15 +27,15 @@ public class BitFileUploadTests : BunitTestContext
        DataRow(true),
        DataRow(false)
     ]
-    public void BitFileUploadMultipleAttributeTest(bool isMultiSelect)
+    public void BitFileUploadMultipleAttributeTest(bool isMultiple)
     {
         var com = RenderComponent<BitFileUpload>(parameters =>
         {
-            parameters.Add(p => p.Multiple, isMultiSelect);
+            parameters.Add(p => p.Multiple, isMultiple);
         });
 
         var bitFileUpload = com.Find(".bit-upl-fi");
-        Assert.AreEqual(isMultiSelect, bitFileUpload.HasAttribute("multiple"));
+        Assert.AreEqual(isMultiple, bitFileUpload.HasAttribute("multiple"));
     }
 
     [TestMethod]

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUpload.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUpload.razor
@@ -9,24 +9,20 @@
 
     @if (LabelTemplate is not null)
     {
-        <label for="@InputId">
-            @LabelTemplate
-        </label>
+        @LabelTemplate
     }
     else if (Label.HasValue())
     {
-        <label class="bit-upl-lbl" for="@InputId">
-            @Label
-        </label>
+        <button class="bit-upl-lbl" @onclick="Browse">@Label</button>
     }
 
     <input @ref="_inputRef" @onchange="HandleOnChange"
-           class="bit-upl-fi"
-           id="@InputId"
            type="file"
+           id="@InputId"
+           class="bit-upl-fi"
+           multiple="@Multiple"
            disabled="@(IsEnabled is false)"
            aria-labelledby="@(Label.HasValue() ? Label : null)"
-           multiple="@MultiSelect"
            accept="@(Accept ?? string.Join(",", AllowedExtensions))" />
 
     @if (Files is not null)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUpload.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUpload.razor.cs
@@ -43,12 +43,17 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     [Parameter] public bool AutoChunkSize { get; set; }
 
     /// <summary>
+    /// Automatically resets the file-upload before starting to browse for files.
+    /// </summary>
+    [Parameter] public bool AutoReset { get; set; }
+
+    /// <summary>
     /// Automatically starts the upload file(s) process immediately after selecting the file(s).
     /// </summary>
     [Parameter] public bool AutoUpload { get; set; }
 
     /// <summary>
-    /// Enables or disables the chunked upload feature.
+    /// Enables the chunked upload.
     /// </summary>
     [Parameter] public bool ChunkedUpload { get; set; }
 
@@ -70,9 +75,9 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     [Parameter] public string FailedRemoveMessage { get; set; } = "File remove failed";
 
     /// <summary>
-    /// Enables multi-file select and upload.
+    /// Enables multi-file selection.
     /// </summary>
-    [Parameter] public bool MultiSelect { get; set; }
+    [Parameter] public bool Multiple { get; set; }
 
     /// <summary>
     /// The text of select file button.
@@ -192,12 +197,12 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     public IReadOnlyList<BitFileInfo>? Files { get; private set; }
 
     /// <summary>
-    /// General upload status.
+    /// The general status of the upload.
     /// </summary>
     public BitFileUploadStatus UploadStatus { get; private set; }
 
     /// <summary>
-    /// File input id.
+    /// The id of the file input element.
     /// </summary>
     public string? InputId { get; private set; }
 
@@ -207,7 +212,7 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     public bool IsRemoving { get; private set; }
 
     /// <summary>
-    /// Starts Uploading the file(s).
+    /// Starts uploading the file(s).
     /// </summary>
     public async Task Upload(BitFileInfo? fileInfo = null, string? uploadUrl = null)
     {
@@ -234,12 +239,11 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Pause upload.
+    /// Pauses the upload.
     /// </summary>
     /// <param name="fileInfo">
-    /// null => all files | else => specific file
+    /// null (default) => all files | else => specific file
     /// </param>
-    /// <returns></returns>
     public void PauseUpload(BitFileInfo? fileInfo = null)
     {
         if (Files is null) return;
@@ -258,12 +262,11 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Cancel upload.
+    /// Cancels the upload.
     /// </summary>
     /// <param name="fileInfo">
-    /// null => all files | else => specific file
+    /// null (default) => all files | else => specific file
     /// </param>
-    /// <returns></returns>
     public void CancelUpload(BitFileInfo? fileInfo = null)
     {
         if (Files is null) return;
@@ -287,7 +290,6 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     /// <param name="fileInfo">
     /// null => all files | else => specific file
     /// </param>
-    /// <returns></returns>
     public async Task RemoveFile(BitFileInfo? fileInfo = null)
     {
         if (Files is null) return;
@@ -311,14 +313,27 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Open a file selection dialog
+    /// Opens a file selection dialog.
     /// </summary>
-    /// <returns></returns>
     public async Task Browse()
     {
         if (IsEnabled is false) return;
 
+        if (AutoReset)
+        {
+            await Reset();
+        }
+
         await _js.BitFileUploadBrowse(_inputRef);
+    }
+
+    /// <summary>
+    /// Resets the file-upload.
+    /// </summary>
+    public async Task Reset()
+    {
+        Files = [];
+        await _js.BitFileUploadReset(UniqueId, _inputRef);
     }
 
 
@@ -417,7 +432,7 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
     {
         var url = AddQueryString(UploadUrl, UploadRequestQueryStrings);
 
-        Files = await _js.BitFileUploadReset(UniqueId, _dotnetObj, _inputRef, url, UploadRequestHttpHeaders);
+        Files = await _js.BitFileUploadSetup(UniqueId, _dotnetObj, _inputRef, url, UploadRequestHttpHeaders);
 
         if (Files is null) return;
 
@@ -706,7 +721,7 @@ public partial class BitFileUpload : BitComponentBase, IAsyncDisposable
 
             try
             {
-                await _js.BitFileUploadDispose(UniqueId);
+                await _js.BitFileUploadClear(UniqueId);
             }
             catch (JSDisconnectedException) { } // we can ignore this exception here
         }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUpload.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUpload.ts
@@ -2,14 +2,14 @@
     export class FileUpload {
         private static _fileUploaders: BitFileUploader[] = [];
 
-        public static reset(
+        public static setup(
             id: string,
             dotnetReference: DotNetObject,
             inputElement: HTMLInputElement,
             uploadEndpointUrl: string,
             headers: Record<string, string>) {
 
-            FileUpload._fileUploaders = FileUpload._fileUploaders.filter(u => u.id !== id);
+            FileUpload.clear(id);
 
             const files = Array.from(inputElement.files!).map((file, index) => ({
                 name: file.name,
@@ -50,7 +50,7 @@
             }
         }
 
-        public static setupDragDrop(dropZoneElement: HTMLElement, inputFile: HTMLInputElement) {
+        public static setupDragDrop(dropZoneElement: HTMLElement, inputElement: HTMLInputElement) {
 
             function onDragHover(e: DragEvent) {
                 e.preventDefault();
@@ -62,15 +62,15 @@
 
             function onDrop(e: DragEvent) {
                 e.preventDefault();
-                inputFile.files = e.dataTransfer!.files;
+                inputElement.files = e.dataTransfer!.files;
                 const event = new Event('change', { bubbles: true });
-                inputFile.dispatchEvent(event);
+                inputElement.dispatchEvent(event);
             }
 
             function onPaste(e: ClipboardEvent) {
-                inputFile.files = e.clipboardData!.files;
+                inputElement.files = e.clipboardData!.files;
                 const event = new Event('change', { bubbles: true });
-                inputFile.dispatchEvent(event);
+                inputElement.dispatchEvent(event);
             }
 
             dropZoneElement.addEventListener("dragenter", onDragHover);
@@ -91,12 +91,17 @@
 
         }
 
-        public static browse(inputFile: HTMLInputElement) {
-            inputFile.click();
+        public static browse(inputElement: HTMLInputElement) {
+            inputElement.click();
         }
 
-        public static dispose(id: string) {
+        public static clear(id: string) {
             FileUpload._fileUploaders = FileUpload._fileUploaders.filter(u => u.id !== id);
+        }
+
+        public static reset(id: string, inputElement: HTMLInputElement,) {
+            FileUpload.clear(id);
+            inputElement.value = '';
         }
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUploadJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUploadJsRuntimeExtensions.cs
@@ -5,22 +5,22 @@ namespace Bit.BlazorUI;
 internal static class BitFileUploadJsRuntimeExtensions
 {
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitFileInfo))]
-    internal static ValueTask<BitFileInfo[]> BitFileUploadReset(this IJSRuntime jsRuntime,
+    internal static ValueTask<BitFileInfo[]> BitFileUploadSetup(this IJSRuntime jsRuntime,
                                                                      string id,
                                                                      DotNetObjectReference<BitFileUpload>? dotnetObjectReference,
                                                                      ElementReference element,
                                                                      string uploadAddress,
                                                                      IReadOnlyDictionary<string, string> uploadRequestHttpHeaders)
     {
-        return jsRuntime.Invoke<BitFileInfo[]>("BitBlazorUI.FileUpload.reset", id, dotnetObjectReference, element, uploadAddress, uploadRequestHttpHeaders);
+        return jsRuntime.Invoke<BitFileInfo[]>("BitBlazorUI.FileUpload.setup", id, dotnetObjectReference, element, uploadAddress, uploadRequestHttpHeaders);
     }
 
-    internal static ValueTask BitFileUploadUpload(this IJSRuntime jsRuntime, 
-                                                       string id, 
-                                                       long from, 
-                                                       long to, 
-                                                       int index, 
-                                                       string? uploadUrl, 
+    internal static ValueTask BitFileUploadUpload(this IJSRuntime jsRuntime,
+                                                       string id,
+                                                       long from,
+                                                       long to,
+                                                       int index,
+                                                       string? uploadUrl,
                                                        IReadOnlyDictionary<string, string>? httpHeaders)
     {
         return (httpHeaders is null ? jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.upload", id, from, to, index, uploadUrl)
@@ -32,8 +32,8 @@ internal static class BitFileUploadJsRuntimeExtensions
         return jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.pause", id, index);
     }
 
-    internal static ValueTask<IJSObjectReference> BitFileUploadSetupDragDrop(this IJSRuntime jsRuntime, 
-                                                                                  ElementReference dragDropZoneElement, 
+    internal static ValueTask<IJSObjectReference> BitFileUploadSetupDragDrop(this IJSRuntime jsRuntime,
+                                                                                  ElementReference dragDropZoneElement,
                                                                                   ElementReference inputFileElement)
     {
         return jsRuntime.Invoke<IJSObjectReference>("BitBlazorUI.FileUpload.setupDragDrop", dragDropZoneElement, inputFileElement);
@@ -44,8 +44,13 @@ internal static class BitFileUploadJsRuntimeExtensions
         return jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.browse", inputFileElement);
     }
 
-    internal static ValueTask BitFileUploadDispose(this IJSRuntime jsRuntime, string id)
+    internal static ValueTask BitFileUploadClear(this IJSRuntime jsRuntime, string id)
     {
-        return jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.dispose", id);
+        return jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.clear", id);
+    }
+
+    internal static ValueTask BitFileUploadReset(this IJSRuntime jsRuntime, string id, ElementReference inputFileElement)
+    {
+        return jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.reset", id, inputFileElement);
     }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor
@@ -13,73 +13,69 @@
 
     <ComponentExampleBox Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
         <ExamplePreview>
-            <div>Files can be uploaded automatically after selecting them.</div><br />
+            <div>Files can be uploaded after selecting them.</div><br />
             <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl" />
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Auto & Multiple" RazorCode="@example2RazorCode" CsharpCode="@example2CsharpCode" Id="example2">
+    <ComponentExampleBox Title="Multiple" RazorCode="@example2RazorCode" CsharpCode="@example2CsharpCode" Id="example2">
         <ExamplePreview>
-            <div>Multiple files can be selected to upload automatically.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           AutoUpload
-                           MultiSelect
-                           UploadUrl="@UploadUrl" />
+            <div>Multiple files can be selected.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl" Multiple />
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="MaxSize" RazorCode="@example3RazorCode" CsharpCode="@example3CsharpCode" Id="example3">
+    <ComponentExampleBox Title="AutoUpload" RazorCode="@example3RazorCode" CsharpCode="@example3CsharpCode" Id="example3">
         <ExamplePreview>
-            <div>Multiple files can be selected to upload automatically with limited size.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           AutoUpload
-                           MultiSelect
-                           UploadUrl="@UploadUrl"
-                           MaxSize="1024 * 1024 * 1" />
+            <div>The BitFileUpload can automatically starts the upload after file selection is done.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl" AutoUpload />
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="AllowedExtensions" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
+    <ComponentExampleBox Title="AutoReset" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
         <ExamplePreview>
-            <div>Single or multiple file uploading limited only by file extensions, which in this case the allowed file extensions include gif, jpg and mp4.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           MultiSelect
-                           UploadUrl="@UploadUrl"
+            <div>Automatically resets the BitFileUpload state each time before browsing files.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl" AutoReset />
+        </ExamplePreview>
+    </ComponentExampleBox>
+
+    <ComponentExampleBox Title="MaxSize" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+        <ExamplePreview>
+            <div>The file size can be limited using the MaxSize parameter.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl" MaxSize="1024 * 1024 * 1" />
+        </ExamplePreview>
+    </ComponentExampleBox>
+
+    <ComponentExampleBox Title="AllowedExtensions" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+        <ExamplePreview>
+            <div>Limits file browsing by the provided file extensions.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl"
                            AllowedExtensions="@(new List<string> { ".gif",".jpg",".mp4" })" />
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Removable" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+    <ComponentExampleBox Title="Removable" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
         <ExamplePreview>
-            <div>Single or multiple file uploading with remove functionality enabled.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           MultiSelect
-                           ShowRemoveButton
-                           UploadUrl="@UploadUrl"
-                           RemoveUrl="@RemoveUrl" />
+            <div>Enables the remove functionality of the BitFileUpload.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl"
+                           ShowRemoveButton RemoveUrl="@RemoveUrl" />
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Events" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+    <ComponentExampleBox Title="Events" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
         <ExamplePreview>
-            <div>Multiple files can be selected to upload automatically with calling all upload complete event.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           AutoUpload
-                           MultiSelect
-                           UploadUrl="@UploadUrl"
+            <div>Different events can be configured for the upload process.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl"
                            OnAllUploadsComplete="@(() => onAllUploadsCompleteText = "All File Uploaded")"
                            OnUploading="@(info => info.HttpHeaders = new Dictionary<string, string> { {"key1", "value1"} })" />
             <div>@onAllUploadsCompleteText</div>
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Configuring http request" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+    <ComponentExampleBox Title="Http requests" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
         <ExamplePreview>
-            <div>Multiple files can be selected to upload and remove with custom http headers and query strings.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           MultiSelect
-                           UploadUrl="@UploadUrl"
-                           RemoveUrl="@RemoveUrl"
+            <div>The http requests of Upload and Remove can be customized with http headers and query strings.</div><br />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@UploadUrl" RemoveUrl="@RemoveUrl"
                            UploadRequestQueryStrings="@(new Dictionary<string, string>{ {"qs1", "qsValue1" } })"
                            UploadRequestHttpHeaders="@(new Dictionary<string, string>{ {"header1", "value1" } })"
                            RemoveRequestQueryStrings="@(new Dictionary<string, string>{ {"qs2", "qsValue2" } })"
@@ -87,26 +83,17 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Chunked" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+    <ComponentExampleBox Title="Chunked" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
         <ExamplePreview>
             <div>Files can be uploaded in chunks.</div><br />
-            <BitFileUpload Label="Select or drag and drop files"
-                           ChunkedUpload
-                           UploadUrl="@ChunkedUploadUrl" />
+            <BitFileUpload Label="Select or drag and drop files" UploadUrl="@ChunkedUploadUrl" ChunkedUpload />
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Templates" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+    <ComponentExampleBox Title="Templates" RazorCode="@example11RazorCode" CsharpCode="@example11CsharpCode" Id="example11">
         <ExamplePreview>
-            <div>Use custom template for file upload.</div><br />
-            <BitFileUpload @ref="bitFileUpload"
-                           Label=""
-                           UploadUrl="@UploadUrl"
-                           RemoveUrl="@RemoveUrl"
-                           MaxSize="1024 * 1024 * 2"
-                           SuccessfulUploadMessage="File upload succeeded"
-                           NotAllowedExtensionErrorMessage="File type not supported"
-                           AllowedExtensions="@(new List<string> { ".jpeg", ".jpg", ".png", ".bpm" })">
+            <div>The BitFileUpload can be further customized using templates.</div><br />
+            <BitFileUpload @ref="bitFileUpload" UploadUrl="@UploadUrl" RemoveUrl="@RemoveUrl">
                 <LabelTemplate>
                     @if (FileUploadIsEmpty())
                     {
@@ -182,7 +169,7 @@
         </ExamplePreview>
     </ComponentExampleBox>
 
-    <ComponentExampleBox Title="Public API" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
+    <ComponentExampleBox Title="Public API" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
         <ExamplePreview>
             <div>Use a custom method for the open file selection dialog.</div><br />
             <BitFileUpload @ref="bitFileUploadWithBrowseFile"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor
@@ -97,7 +97,7 @@
                 <LabelTemplate>
                     @if (FileUploadIsEmpty())
                     {
-                        <div class="browse-file">
+                        <div class="browse-file" @onclick="() => bitFileUpload.Browse()">
                             <div class="browse-file-header">
                                 <i class="bit-icon bit-icon--CloudUpload" />
                                 <div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor.cs
@@ -27,6 +27,13 @@ public partial class BitFileUploadDemo
         },
         new()
         {
+            Name = "AutoReset",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Automatically resets the file-upload before starting to browse for files."
+        },
+        new()
+        {
             Name = "AutoUpload",
             Type = "bool",
             DefaultValue = "false",
@@ -37,7 +44,7 @@ public partial class BitFileUploadDemo
             Name = "ChunkedUpload",
             Type = "bool",
             DefaultValue = "false",
-            Description = "Enables or disables the chunked upload feature."
+            Description = "Enables the chunked upload."
         },
         new()
         {
@@ -48,10 +55,10 @@ public partial class BitFileUploadDemo
         },
         new()
         {
-            Name = "MultiSelect",
+            Name = "Multiple",
             Type = "bool",
             DefaultValue = "false",
-            Description = "Enables multi-file select & upload."
+            Description = "Enables multi-file selection."
         },
         new()
         {
@@ -461,74 +468,64 @@ public partial class BitFileUploadDemo
 private string UploadUrl = $""/Upload"";";
 
     private readonly string example2RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               AutoUpload
-               MultiSelect
-               UploadUrl=""@UploadUrl"" />";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl"" Multiple />";
     private readonly string example2CsharpCode = @"
 private string UploadUrl = $""/Upload"";";
 
     private readonly string example3RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               AutoUpload
-               MultiSelect
-               UploadUrl=""@UploadUrl""
-               MaxSize=""1024 * 1024 * 1"" />";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl"" AutoUpload />";
     private readonly string example3CsharpCode = @"
 private string UploadUrl = $""/Upload"";";
 
     private readonly string example4RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               MultiSelect
-               UploadUrl=""@UploadUrl""
-               AllowedExtensions=""@(new List<string> { "".gif"","".jpg"","".mp4"" })"" />";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl"" AutoReset />";
     private readonly string example4CsharpCode = @"
 private string UploadUrl = $""/Upload"";";
 
     private readonly string example5RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               MultiSelect
-               ShowRemoveButton
-               UploadUrl=""@UploadUrl""
-               RemoveUrl=""@RemoveUrl"" />";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl"" MaxSize=""1024 * 1024 * 1"" />";
     private readonly string example5CsharpCode = @"
-private string UploadUrl = $""/Upload"";
-private string RemoveUrl = $""/Remove"";";
+private string UploadUrl = $""/Upload"";";
 
     private readonly string example6RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               AutoUpload
-               MultiSelect
-               UploadUrl=""@UploadUrl""
-               OnAllUploadsComplete=""@(() => onAllUploadsCompleteText = ""All File Uploaded"")""
-               OnUploading=""@(info => info.HttpHeaders = new Dictionary<string, string> { {""key1"", ""value1""} })"" />
-
-<div>@onAllUploadsCompleteText</div>";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl""
+               AllowedExtensions=""@(new List<string> { "".gif"","".jpg"","".mp4"" })"" />";
     private readonly string example6CsharpCode = @"
-private string UploadUrl = $""/Upload"";
-private string onAllUploadsCompleteText = ""No File"";";
+private string UploadUrl = $""/Upload"";";
 
     private readonly string example7RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               MultiSelect
-               UploadUrl=""@UploadUrl""
-               RemoveUrl=""@RemoveUrl""
-               UploadRequestQueryStrings=""@(new Dictionary<string, string>{ {""qs1"", ""qsValue1"" } })""
-               UploadRequestHttpHeaders=""@(new Dictionary<string, string>{ {""header1"", ""value1"" } })""
-               RemoveRequestQueryStrings=""@(new Dictionary<string, string>{ {""qs2"", ""qsValue2"" } })""
-               RemoveRequestHttpHeaders=""@(new Dictionary<string, string>{ {""header2"", ""value2"" } })"" />";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl""
+               ShowRemoveButton RemoveUrl=""@RemoveUrl"" />";
     private readonly string example7CsharpCode = @"
 private string UploadUrl = $""/Upload"";
 private string RemoveUrl = $""/Remove"";";
 
     private readonly string example8RazorCode = @"
-<BitFileUpload Label=""Select or drag and drop files""
-               ChunkedUpload
-               UploadUrl=""@ChunkedUploadUrl"" />";
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl""
+               OnAllUploadsComplete=""@(() => onAllUploadsCompleteText = ""All File Uploaded"")""
+               OnUploading=""@(info => info.HttpHeaders = new Dictionary<string, string> { {""key1"", ""value1""} })"" />
+
+<div>@onAllUploadsCompleteText</div>";
     private readonly string example8CsharpCode = @"
-private string ChunkedUploadUrl = $""/ChunkedUpload"";";
+private string UploadUrl = $""/Upload"";
+private string onAllUploadsCompleteText = ""No File"";";
 
     private readonly string example9RazorCode = @"
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@UploadUrl"" RemoveUrl=""@RemoveUrl""
+               UploadRequestQueryStrings=""@(new Dictionary<string, string>{ {""qs1"", ""qsValue1"" } })""
+               UploadRequestHttpHeaders=""@(new Dictionary<string, string>{ {""header1"", ""value1"" } })""
+               RemoveRequestQueryStrings=""@(new Dictionary<string, string>{ {""qs2"", ""qsValue2"" } })""
+               RemoveRequestHttpHeaders=""@(new Dictionary<string, string>{ {""header2"", ""value2"" } })"" />";
+    private readonly string example9CsharpCode = @"
+private string UploadUrl = $""/Upload"";
+private string RemoveUrl = $""/Remove"";";
+
+    private readonly string example10RazorCode = @"
+<BitFileUpload Label=""Select or drag and drop files"" UploadUrl=""@ChunkedUploadUrl"" ChunkedUpload />";
+    private readonly string example10CsharpCode = @"
+private string ChunkedUploadUrl = $""/ChunkedUpload"";";
+
+    private readonly string example11RazorCode = @"
 <style>
     .browse-file {
         border: 1px solid #D2D2D7;
@@ -672,14 +669,7 @@ private string ChunkedUploadUrl = $""/ChunkedUpload"";";
 </style>
 
 
-<BitFileUpload @ref=""bitFileUpload""
-               Label=""""
-               UploadUrl=""@UploadUrl""
-               RemoveUrl=""@RemoveUrl""
-               MaxSize=""1024 * 1024 * 2""
-               SuccessfulUploadMessage=""File upload succeeded""
-               NotAllowedExtensionErrorMessage=""File type not supported""
-               AllowedExtensions=""@(new List<string> { "".jpeg"", "".jpg"", "".png"", "".bpm"" })"">
+<BitFileUpload @ref=""bitFileUpload"" UploadUrl=""@UploadUrl"" RemoveUrl=""@RemoveUrl"">
     <LabelTemplate>
         @if (FileUploadIsEmpty())
         {
@@ -752,7 +742,7 @@ private string ChunkedUploadUrl = $""/ChunkedUpload"";";
 </BitFileUpload>
 
 <BitButton OnClick=""HandleUploadOnClick"">Upload</BitButton>";
-    private readonly string example9CsharpCode = @"
+    private readonly string example11CsharpCode = @"
 [Inject] public IJSRuntime JSRuntime { get; set; } = default!;
 
 private string UploadUrl => ""/Upload"";
@@ -823,14 +813,14 @@ private bool IsFileTypeNotAllowed(BitFileInfo file)
     return bitFileUpload.AllowedExtensions.Count > 0 && bitFileUpload.AllowedExtensions.All(ext => ext != ""*"") && bitFileUpload.AllowedExtensions.All(ext => ext != extension);
 }";
 
-    private readonly string example10RazorCode = @"
+    private readonly string example12RazorCode = @"
 <BitFileUpload @ref=""bitFileUploadWithBrowseFile""
                Label=""""
                UploadUrl=""@UploadUrl""
                RemoveUrl=""@RemoveUrl"" />
 
 <BitButton OnClick=""HandleBrowseFileOnClick"">Browse file</BitButton>";
-    private readonly string example10CsharpCode = @"
+    private readonly string example12CsharpCode = @"
 private string UploadUrl = ""/Upload"";
 private string RemoveUrl = ""/Remove"";
 private BitFileUpload bitFileUploadWithBrowseFile;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/PopularComponents.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/PopularComponents.razor
@@ -73,7 +73,7 @@
                 else if (SelectedComponent?.Name == "FileUpload")
                 {
                     <BitFileUpload AutoUpload
-                                   MultiSelect 
+                                   Multiple 
                                    ChunkedUpload
                                    Label="Select files"
                                    UploadUrl="@UploadUrl"
@@ -144,7 +144,7 @@
                 {
                     <pre class="code">
                     <code class="language-cshtml">&ltBitFileUpload AutoUpload
-               MultiSelect 
+               Multiple
                ChunkedUpload
                Label="Select files"
                UploadUrl="@@UploadUrl"


### PR DESCRIPTION
closes #9221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced an `AutoReset` parameter for automatic resetting of file uploads.
	- Added new example boxes in the demo to showcase features like "MaxSize" and "AllowedExtensions."

- **Improvements**
	- Updated parameter names from `MultiSelect` to `Multiple` for consistency.
	- Enhanced interaction model for file uploads, including changes in label handling and file input attributes.

- **Documentation**
	- Refined descriptions in the demo to clarify functionality and usage of the `BitFileUpload` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->