### PR TITLE
Add InitialSelectedItems parameter to BitDorpdown (#9364)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -786,10 +786,7 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue>, IAsyncDi
         {
             if (ItemsProvider is not null && (InitialSelectedItems?.Any() ?? false))
             {
-                foreach (var item in InitialSelectedItems)
-                {
-                    _selectedItems.Add(item);
-                }
+                _selectedItems.AddRange(InitialSelectedItems);
 
                 if (ValuesHasBeenSet is false)
                 {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
@@ -132,6 +132,13 @@ public partial class BitDropdownDemo
         },
         new()
         {
+            Name = "InitialSelectedItems",
+            Type = "IEnumerable<TItem>?",
+            DefaultValue = "null",
+            Description = "The initial items that will be used to set selected items when using an ItemProvider.",
+        },
+        new()
+        {
             Name = "IsOpen",
             Type = "bool",
             DefaultValue = "false",


### PR DESCRIPTION
This closes #9364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new parameter `InitialSelectedItems` for the `BitDropdown` component, allowing users to specify initial selections when using an item provider.
	- Enhanced the `BitDropdownDemo` component to support the new `InitialSelectedItems` parameter, improving its configurability.

These updates improve the user experience by allowing better management of initial dropdown selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->