### PR TITLE
Apply max-width to sign-in page of Boilerplate (#9407)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor
@@ -7,7 +7,7 @@
 
 <section>
     <BitStack HorizontalAlign="BitAlignment.Center" FillContent>
-        <EditForm Model="model" OnValidSubmit="WrapHandled(DoSignIn)" novalidate class="max-width">
+        <EditForm Model="model" OnValidSubmit="WrapHandled(DoSignIn)" novalidate>
             <AppDataAnnotationsValidator />
 
             <BitStack HorizontalAlign="BitAlignment.Center">

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.scss
@@ -4,3 +4,9 @@ section {
     width: 100%;
     height: 100%;
 }
+
+::deep {
+    form {
+        width: 304px;
+    }
+}


### PR DESCRIPTION
closes #9407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Introduced a new CSS rule to set the width of the sign-in form to 304 pixels, enhancing the layout of the sign-in page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->