### PR TITLE
Reset internal state after end events in BitPullToRefresh (#9440)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/PullToRefresh/BitPullToRefresh.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/PullToRefresh/BitPullToRefresh.ts
@@ -67,14 +67,18 @@
                 if (startY === -1 || refreshing) return;
                 startY = -1;
 
-                await dotnetObj.invokeMethodAsync('OnEnd', diff);
+                try {
+                    await dotnetObj.invokeMethodAsync('OnEnd', diff);
 
-                if (diff >= trigger) {
-                    refreshing = true;
-                    await dotnetObj.invokeMethodAsync('Refresh');
+                    if (diff >= trigger) {
+                        refreshing = true;
+                        await dotnetObj.invokeMethodAsync('Refresh');
+                    }
+                } finally {
+                    diff = 0;
                     refreshing = false;
+                    loadingEl.style.minHeight = '0';
                 }
-                loadingEl.style.minHeight = '0';
             };
             const onLeave = (e: PointerEvent) => {
                 if (startY === -1) return;


### PR DESCRIPTION
closes #9440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the Pull to Refresh functionality, ensuring consistent UI behavior during asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->