### PR TITLE
Fix undefined canvas element issues in BitPdfReader (#9479)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/PdfReader/BitPdfReader.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/PdfReader/BitPdfReader.ts
@@ -95,6 +95,8 @@ namespace BitBlazorUI {
                     canvas = document.getElementById(`${config.id}-${pageNumber}`) as HTMLCanvasElement;
                 }
 
+                if (!canvas) return;
+
                 const context = canvas.getContext('2d')!;
                 canvas.width = viewport.width;
                 canvas.height = viewport.height;


### PR DESCRIPTION
closes #9479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the PDF reader by ensuring rendering only occurs when a canvas element is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->