### PR TITLE
Update project dependencies (#9512)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="bunit.web" Version="1.36.0" />
+		<PackageReference Include="bunit.web" Version="1.37.7" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.6.4" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -9,7 +9,7 @@
         <PackageVersion Include="Bit.Bswup" Version="9.1.1" />
         <PackageVersion Include="Bit.CodeAnalyzers" Version="9.1.1" />
         <PackageVersion Include="Bit.SourceGenerators" Version="9.1.1" />
-        <PackageVersion Include="libphonenumber-csharp" Version="8.13.51" />
+        <PackageVersion Include="libphonenumber-csharp" Version="8.13.52" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
@@ -92,7 +92,7 @@
         <PackageVersion Include="FakeItEasy" Version="8.3.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.49.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
-        <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.4" />
+        <PackageVersion Include="MSTest.TestFramework" Version="3.6.4" />
     </ItemGroup>
 </Project>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages8.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages8.props
@@ -9,7 +9,7 @@
         <PackageVersion Include="Bit.Bswup" Version="9.1.1" />
         <PackageVersion Include="Bit.CodeAnalyzers" Version="9.1.1" />
         <PackageVersion Include="Bit.SourceGenerators" Version="9.1.1" />
-        <PackageVersion Include="libphonenumber-csharp" Version="8.13.51" />
+        <PackageVersion Include="libphonenumber-csharp" Version="8.13.52" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.11" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.11" />
@@ -92,7 +92,7 @@
         <PackageVersion Include="FakeItEasy" Version="8.3.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.49.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
-        <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.4" />
+        <PackageVersion Include="MSTest.TestFramework" Version="3.6.4" />
     </ItemGroup>
 </Project>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Statistics/StatisticsController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Statistics/StatisticsController.cs
@@ -11,6 +11,7 @@ public partial class StatisticsController : AppControllerBase, IStatisticsContro
 
     [AllowAnonymous]
     [HttpGet("{packageId}")]
+    [ResponseCache(Duration = 1 * 24 * 3600, Location = ResponseCacheLocation.Any)]
     public async Task<NugetStatsDto> GetNugetStats(string packageId, CancellationToken cancellationToken)
     {
         return await nugetHttpClient.GetPackageStats(packageId, cancellationToken);


### PR DESCRIPTION
closes #9512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced caching for NuGet statistics retrieval, improving response times.
  
- **Bug Fixes**
	- Updated package versions for improved stability and performance:
		- `bunit.web` from `1.36.0` to `1.37.7`
		- `libphonenumber-csharp` from `8.13.51` to `8.13.52`
		- `MSTest.TestAdapter` and `MSTest.TestFramework` from `3.6.3` to `3.6.4`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->