### PR TITLE
Fix parameter name in Alignment sample BitStack (#9521)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Layouts/Stack/BitStackDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Layouts/Stack/BitStackDemo.razor
@@ -73,8 +73,8 @@
         <ComponentExampleBox Title="Alignment" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
             <ExamplePreview>
                 <BitStack Horizontal Wrap Gap="2rem">
-                     <BitToggle @bind-Value="isHorizontal" DefaultText="Horizontal" />
-                     <BitToggle @bind-Value="isReversed" DefaultText="Reversed" />
+                     <BitToggle @bind-Value="isHorizontal" Text="Horizontal" />
+                     <BitToggle @bind-Value="isReversed" Text="Reversed" />
                  </BitStack>
                  <br />
                  <BitChoiceGroup Label="Direction"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Layouts/Stack/BitStackDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Layouts/Stack/BitStackDemo.razor.cs
@@ -281,8 +281,8 @@ private double gap = 1;
 </style>
 
 <BitStack Horizontal Wrap Gap=""2rem"">
-    <BitToggle @bind-Value=""isHorizontal"" DefaultText=""Horizontal"" />
-    <BitToggle @bind-Value=""isReversed"" DefaultText=""Reversed"" />
+    <BitToggle @bind-Value=""isHorizontal"" Text=""Horizontal"" />
+    <BitToggle @bind-Value=""isReversed"" Text=""Reversed"" />
 </BitStack>
 
 <BitChoiceGroup Label=""Direction""


### PR DESCRIPTION
This closes #9521 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated toggle labels in the "Alignment" example for improved clarity.
  
- **Bug Fixes**
	- Corrected the label assignment method for `BitToggle` components to enhance UI consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->