### PR TITLE
Rename Toggled parameter in BitButtonGroup to Toggle (#9555)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButtonGroup/BitButtonGroup.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButtonGroup/BitButtonGroup.razor.cs
@@ -66,7 +66,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
     /// <summary>
     /// Display ButtonGroup with toggle mode enabled for each button.
     /// </summary>
-    [Parameter] public bool Toggled { get; set; }
+    [Parameter] public bool Toggle { get; set; }
 
     /// <summary>
     /// The visual variant of the button group.
@@ -186,7 +186,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
             }
         }
 
-        if (Toggled)
+        if (Toggle)
         {
             if (_toggleItem == item)
             {
@@ -226,7 +226,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
     {
         if (IconOnly) return null;
 
-        if (Toggled)
+        if (Toggle)
         {
             if (_toggleItem == item)
             {
@@ -251,7 +251,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
 
     private string? GetItemTitle(TItem? item)
     {
-        if (Toggled)
+        if (Toggle)
         {
             if (_toggleItem == item)
             {
@@ -276,7 +276,7 @@ public partial class BitButtonGroup<TItem> : BitComponentBase where TItem : clas
 
     private string? GetItemIconName(TItem? item)
     {
-        if (Toggled)
+        if (Toggle)
         {
             if (_toggleItem == item)
             {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/BitButtonGroupDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/BitButtonGroupDemo.razor.cs
@@ -67,7 +67,7 @@ public partial class BitButtonGroupDemo
         },
         new()
         {
-            Name = "Toggled",
+            Name = "Toggle",
             Type = "bool",
             DefaultValue = "false",
             Description = "Display ButtonGroup with toggle mode enabled for each button.",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor
@@ -140,7 +140,7 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Toggled" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+<ComponentExampleBox Title="Toggle" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
     <ExamplePreview>
         <div>The Toggle in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
         <br /><br />

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor
@@ -267,44 +267,50 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Toggled" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+<ComponentExampleBox Title="Toggle" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
     <ExamplePreview>
-        <div>The Toggled in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
+        <div>The Toggle in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
         <br /><br />
         <div class="example-content">
             <div>Fill (default)</div>
-            <BitButtonGroup Variant="BitVariant.Fill" Items="toggledCustoms"
+            <BitButtonGroup Toggle
+                            Items="toggledCustoms"
+                            Variant="BitVariant.Fill"
                             NameSelectors="@(new() { OnText = { Selector = i => i.OnName },
                                                      OffText = { Selector = i => i.OffName },
                                                      OnTitle = { Selector = i => i.OnTitle },
                                                      OffTitle = { Selector = i => i.OffTitle },
                                                      OnIconName = { Selector = i => i.OnIcon },
                                                      OffIconName = { Selector = i => i.OffIcon },
-                                                     ReversedIcon = { Selector = i => i.ReversedIcon } })" Toggled />
+                                                     ReversedIcon = { Selector = i => i.ReversedIcon } })" />
         </div>
         <br /><br />
         <div class="example-content">
             <div>Outline</div>
-            <BitButtonGroup Variant="BitVariant.Outline" Items="toggledCustoms"
+            <BitButtonGroup Toggle
+                            Items="toggledCustoms"
+                            Variant="BitVariant.Outline"
                             NameSelectors="@(new() { OnText = { Selector = i => i.OnName },
                                                      OffText = { Selector = i => i.OffName },
                                                      OnTitle = { Selector = i => i.OnTitle },
                                                      OffTitle = { Selector = i => i.OffTitle },
                                                      OnIconName = { Selector = i => i.OnIcon },
                                                      OffIconName = { Selector = i => i.OffIcon },
-                                                     ReversedIcon = { Selector = i => i.ReversedIcon } })" Toggled />
+                                                     ReversedIcon = { Selector = i => i.ReversedIcon } })" />
         </div>
         <br /><br />
         <div class="example-content">
             <div>Text</div>
-            <BitButtonGroup Variant="BitVariant.Text" Items="toggledCustoms"
+            <BitButtonGroup Toggle
+                            Items="toggledCustoms"
+                            Variant="BitVariant.Text"
                             NameSelectors="@(new() { OnText = { Selector = i => i.OnName },
                                                      OffText = { Selector = i => i.OffName },
                                                      OnTitle = { Selector = i => i.OnTitle },
                                                      OffTitle = { Selector = i => i.OffTitle },
                                                      OnIconName = { Selector = i => i.OnIcon },
                                                      OffIconName = { Selector = i => i.OffIcon },
-                                                     ReversedIcon = { Selector = i => i.ReversedIcon } })" Toggled />
+                                                     ReversedIcon = { Selector = i => i.ReversedIcon } })" />
         </div>
     </ExamplePreview>
 </ComponentExampleBox>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.cs
@@ -40,9 +40,9 @@ public partial class _BitButtonGroupCustomDemo
 
     private List<Operation> toggledCustoms =
     [
-        new() { OnName = "Back (2X)", OffName = "Back", OnIcon = BitIconName.RewindTwoX, OffIcon = BitIconName.Rewind },
+        new() { OnName = "Back (2X)", OffName = "Back (1X)", OnIcon = BitIconName.RewindTwoX, OffIcon = BitIconName.Rewind },
         new() { OnTitle = "Resume", OffTitle = "Play", OnIcon = BitIconName.PlayResume, OffIcon = BitIconName.Play },
-        new() { OnName = "Forward (2X)", OffName = "Forward", OnIcon = BitIconName.FastForwardTwoX, OffIcon = BitIconName.FastForward, ReversedIcon = true }
+        new() { OnName = "Forward (2X)", OffName = "Forward (1X)", OnIcon = BitIconName.FastForwardTwoX, OffIcon = BitIconName.FastForward, ReversedIcon = true }
     ];
 
     private List<Operation> eventsCustoms =

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.samples.cs
@@ -235,32 +235,38 @@ private List<Operation> reversedIconCustoms =
 ];";
 
     private readonly string example7RazorCode = @"
-<BitButtonGroup Variant=""BitVariant.Fill"" Items=""toggledCustoms""
+<BitButtonGroup Toggle 
+                Items=""toggledCustoms""
+                Variant=""BitVariant.Fill"" 
                 NameSelectors=""@(new() { OnText = { Selector = i => i.OnName },
                                           OffText = { Selector = i => i.OffName },
                                           OnTitle = { Selector = i => i.OnTitle },
                                           OffTitle = { Selector = i => i.OffTitle },
                                           OnIconName = { Selector = i => i.OnIcon },
                                           OffIconName = { Selector = i => i.OffIcon },
-                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggled />
+                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggle />
 
-<BitButtonGroup Variant=""BitVariant.Outline"" Items=""toggledCustoms""
+<BitButtonGroup Toggle
+                Items=""toggledCustoms""
+                Variant=""BitVariant.Outline"" 
                 NameSelectors=""@(new() { OnText = { Selector = i => i.OnName },
                                           OffText = { Selector = i => i.OffName },
                                           OnTitle = { Selector = i => i.OnTitle },
                                           OffTitle = { Selector = i => i.OffTitle },
                                           OnIconName = { Selector = i => i.OnIcon },
                                           OffIconName = { Selector = i => i.OffIcon },
-                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggled />
+                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggle />
 
-<BitButtonGroup Variant=""BitVariant.Text"" Items=""toggledCustoms""
+<BitButtonGroup Toggle
+                Items=""toggledCustoms""
+                Variant=""BitVariant.Text"" 
                 NameSelectors=""@(new() { OnText = { Selector = i => i.OnName },
                                           OffText = { Selector = i => i.OffName },
                                           OnTitle = { Selector = i => i.OnTitle },
                                           OffTitle = { Selector = i => i.OffTitle },
                                           OnIconName = { Selector = i => i.OnIcon },
                                           OffIconName = { Selector = i => i.OffIcon },
-                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggled />";
+                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" />";
     private readonly string example7CsharpCode = @"
 public class Operation
 {
@@ -275,9 +281,9 @@ public class Operation
 
 private List<Operation> toggledCustoms =
 [
-    new() { OnName = ""Back (2X)"", OffName = ""Back"", OnIcon = BitIconName.RewindTwoX, OffIcon = BitIconName.Rewind },
+    new() { OnName = ""Back (2X)"", OffName = ""Back (1X)"", OnIcon = BitIconName.RewindTwoX, OffIcon = BitIconName.Rewind },
     new() { OnTitle = ""Resume"", OffTitle = ""Play"", OnIcon = BitIconName.PlayResume, OffIcon = BitIconName.Play },
-    new() { OnName = ""Forward (2X)"", OffName = ""Forward"", OnIcon = BitIconName.FastForwardTwoX, OffIcon = BitIconName.FastForward, ReversedIcon = true }
+    new() { OnName = ""Forward (2X)"", OffName = ""Forward (1X)"", OnIcon = BitIconName.FastForwardTwoX, OffIcon = BitIconName.FastForward, ReversedIcon = true }
 ];";
 
     private readonly string example8RazorCode = @"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.samples.cs
@@ -151,7 +151,9 @@ private List<Operation> reversedIconCustoms =
 ];";
 
     private readonly string example6RazorCode = @"
-<BitButtonGroup Variant=""BitVariant.Fill"" Items=""toggledCustoms""
+<BitButtonGroup Toggle
+                Items=""toggledCustoms""
+                Variant=""BitVariant.Fill"" 
                 NameSelectors=""@(new() { OnText = { Selector = i => i.OnName },
                                           OffText = { Selector = i => i.OffName },
                                           OnTitle = { Selector = i => i.OnTitle },

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupCustomDemo.razor.samples.cs
@@ -158,7 +158,7 @@ private List<Operation> reversedIconCustoms =
                                           OffTitle = { Selector = i => i.OffTitle },
                                           OnIconName = { Selector = i => i.OnIcon },
                                           OffIconName = { Selector = i => i.OffIcon },
-                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggle />
+                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" />
 
 <BitButtonGroup Toggle
                 Items=""toggledCustoms""
@@ -169,7 +169,7 @@ private List<Operation> reversedIconCustoms =
                                           OffTitle = { Selector = i => i.OffTitle },
                                           OnIconName = { Selector = i => i.OnIcon },
                                           OffIconName = { Selector = i => i.OffIcon },
-                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggle />
+                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" />
 
 <BitButtonGroup Toggle
                 Items=""toggledCustoms""
@@ -180,7 +180,7 @@ private List<Operation> reversedIconCustoms =
                                           OffTitle = { Selector = i => i.OffTitle },
                                           OnIconName = { Selector = i => i.OnIcon },
                                           OffIconName = { Selector = i => i.OffIcon },
-                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" Toggled />";
+                                          ReversedIcon = { Selector = i => i.ReversedIcon } })"" />";
     private readonly string example6CsharpCode = @"
 public class Operation
 {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor
@@ -113,23 +113,23 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Toggled" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+<ComponentExampleBox Title="Toggle" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
     <ExamplePreview>
-        <div>The Toggled in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
+        <div>The Toggle in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
         <br /><br />
         <div class="example-content">
             <div>Fill (default)</div>
-            <BitButtonGroup Variant="BitVariant.Fill" Items="toggledItems" Toggled />
+            <BitButtonGroup Toggle Variant="BitVariant.Fill" Items="toggledItems" />
         </div>
         <br /><br />
         <div class="example-content">
             <div>Outline</div>
-            <BitButtonGroup Variant="BitVariant.Outline" Items="toggledItems" Toggled />
+            <BitButtonGroup Toggle Variant="BitVariant.Outline" Items="toggledItems" />
         </div>
         <br /><br />
         <div class="example-content">
             <div>Text</div>
-            <BitButtonGroup Variant="BitVariant.Text" Items="toggledItems" Toggled />
+            <BitButtonGroup Toggle Variant="BitVariant.Text" Items="toggledItems" />
         </div>
     </ExamplePreview>
 </ComponentExampleBox>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor
@@ -240,23 +240,23 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Toggled" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+<ComponentExampleBox Title="Toggle" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
     <ExamplePreview>
-        <div>The Toggled in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
+        <div>The Toggle in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
         <br /><br />
         <div class="example-content">
             <div>Fill (default)</div>
-            <BitButtonGroup Variant="BitVariant.Fill" Items="toggledItems" Toggled />
+            <BitButtonGroup Toggle Variant="BitVariant.Fill" Items="toggledItems" />
         </div>
         <br /><br />
         <div class="example-content">
             <div>Outline</div>
-            <BitButtonGroup Variant="BitVariant.Outline" Items="toggledItems" Toggled />
+            <BitButtonGroup Toggle Variant="BitVariant.Outline" Items="toggledItems" />
         </div>
         <br /><br />
         <div class="example-content">
             <div>Text</div>
-            <BitButtonGroup Variant="BitVariant.Text" Items="toggledItems" Toggled />
+            <BitButtonGroup Toggle Variant="BitVariant.Text" Items="toggledItems" />
         </div>
     </ExamplePreview>
 </ComponentExampleBox>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor.cs
@@ -38,9 +38,9 @@ public partial class _BitButtonGroupItemDemo
 
     private List<BitButtonGroupItem> toggledItems =
     [
-        new() { OnText = "Back (2X)", OffText = "Back", OnIconName = BitIconName.RewindTwoX, OffIconName = BitIconName.Rewind },
+        new() { OnText = "Back (2X)", OffText = "Back (1X)", OnIconName = BitIconName.RewindTwoX, OffIconName = BitIconName.Rewind },
         new() { OnTitle = "Resume", OffTitle = "Play", OnIconName = BitIconName.PlayResume, OffIconName = BitIconName.Play },
-        new() { OnText = "Forward (2X)", OffText = "Forward", OnIconName = BitIconName.FastForwardTwoX, OffIconName = BitIconName.FastForward, ReversedIcon = true }
+        new() { OnText = "Forward (2X)", OffText = "Forward (1X)", OnIconName = BitIconName.FastForwardTwoX, OffIconName = BitIconName.FastForward, ReversedIcon = true }
     ];
 
     private List<BitButtonGroupItem> eventsItems =

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor.samples.cs
@@ -158,15 +158,15 @@ private List<BitButtonGroupItem> reversedIconItems =
 ];";
 
     private readonly string example7RazorCode = @"
-<BitButtonGroup Variant=""BitVariant.Fill"" Items=""toggledItems"" Toggled />
-<BitButtonGroup Variant=""BitVariant.Outline"" Items=""toggledItems"" Toggled />
-<BitButtonGroup Variant=""BitVariant.Text"" Items=""toggledItems"" Toggled />";
+<BitButtonGroup Toggle Variant=""BitVariant.Fill"" Items=""toggledItems"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Outline"" Items=""toggledItems"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Text"" Items=""toggledItems"" />";
     private readonly string example7CsharpCode = @"
 private List<BitButtonGroupItem> toggledItems =
 [
-    new() { OnText = ""Back (2X)"", OffText = ""Back"", OnIconName = BitIconName.RewindTwoX, OffIconName = BitIconName.Rewind },
+    new() { OnText = ""Back (2X)"", OffText = ""Back (1X)"", OnIconName = BitIconName.RewindTwoX, OffIconName = BitIconName.Rewind },
     new() { OnTitle = ""Resume"", OffTitle = ""Play"", OnIconName = BitIconName.PlayResume, OffIconName = BitIconName.Play },
-    new() { OnText = ""Forward (2X)"", OffText = ""Forward"", OnIconName = BitIconName.FastForwardTwoX, OffIconName = BitIconName.FastForward, ReversedIcon = true }
+    new() { OnText = ""Forward (2X)"", OffText = ""Forward (1X)"", OnIconName = BitIconName.FastForwardTwoX, OffIconName = BitIconName.FastForward, ReversedIcon = true }
 ];";
 
     private readonly string example8RazorCode = @"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupItemDemo.razor.samples.cs
@@ -81,15 +81,15 @@ private List<BitButtonGroupItem> reversedIconItems =
 ];";
 
     private readonly string example6RazorCode = @"
-<BitButtonGroup Variant=""BitVariant.Fill"" Items=""toggledItems"" Toggled />
-<BitButtonGroup Variant=""BitVariant.Outline"" Items=""toggledItems"" Toggled />
-<BitButtonGroup Variant=""BitVariant.Text"" Items=""toggledItems"" Toggled />";
+<BitButtonGroup Toggle Variant=""BitVariant.Fill"" Items=""toggledItems"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Outline"" Items=""toggledItems"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Text"" Items=""toggledItems"" />";
     private readonly string example6CsharpCode = @"
 private List<BitButtonGroupItem> toggledItems =
 [
-    new() { OnText = ""Back (2X)"", OffText = ""Back"", OnIconName = BitIconName.RewindTwoX, OffIconName = BitIconName.Rewind },
+    new() { OnText = ""Back (2X)"", OffText = ""Back (1X)"", OnIconName = BitIconName.RewindTwoX, OffIconName = BitIconName.Rewind },
     new() { OnTitle = ""Resume"", OffTitle = ""Play"", OnIconName = BitIconName.PlayResume, OffIconName = BitIconName.Play },
-    new() { OnText = ""Forward (2X)"", OffText = ""Forward"", OnIconName = BitIconName.FastForwardTwoX, OffIconName = BitIconName.FastForward, ReversedIcon = true }
+    new() { OnText = ""Forward (2X)"", OffText = ""Forward (1X)"", OnIconName = BitIconName.FastForwardTwoX, OffIconName = BitIconName.FastForward, ReversedIcon = true }
 ];";
 
     private readonly string example7RazorCode = @"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor
@@ -412,34 +412,34 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Toggled" RazorCode="@example7RazorCode" Id="example7">
+<ComponentExampleBox Title="Toggle" RazorCode="@example7RazorCode" Id="example7">
     <ExamplePreview>
-        <div>The Toggled in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
+        <div>The Toggle in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
         <br /><br />
         <div class="example-content">
             <div>Fill (default)</div>
-            <BitButtonGroup Variant="BitVariant.Fill" TItem="BitButtonGroupOption" Toggled>
-                <BitButtonGroupOption OnText="Back (2X)" OffText="Back" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
+            <BitButtonGroup Toggle Variant="BitVariant.Fill" TItem="BitButtonGroupOption">
+                <BitButtonGroupOption OnText="Back (2X)" OffText="Back (1X)" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
                 <BitButtonGroupOption OnTitle="Resume" OffTitle="Play" OnIconName="@BitIconName.PlayResume" OffIconName="@BitIconName.Play" />
-                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
+                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward (1X)" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
             </BitButtonGroup>
         </div>
         <br /><br />
         <div class="example-content">
             <div>Outline</div>
-            <BitButtonGroup Variant="BitVariant.Outline" TItem="BitButtonGroupOption" Toggled>
-                <BitButtonGroupOption OnText="Back (2X)" OffText="Back" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
+            <BitButtonGroup Toggle Variant="BitVariant.Outline" TItem="BitButtonGroupOption">
+                <BitButtonGroupOption OnText="Back (2X)" OffText="Back (1X)" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
                 <BitButtonGroupOption OnTitle="Resume" OffTitle="Play" OnIconName="@BitIconName.PlayResume" OffIconName="@BitIconName.Play" />
-                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
+                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward (1X)" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
             </BitButtonGroup>
         </div>
         <br /><br />
         <div class="example-content">
             <div>Text</div>
-            <BitButtonGroup Variant="BitVariant.Text" TItem="BitButtonGroupOption" Toggled>
-                <BitButtonGroupOption OnText="Back (2X)" OffText="Back" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
+            <BitButtonGroup Toggle Variant="BitVariant.Text" TItem="BitButtonGroupOption">
+                <BitButtonGroupOption OnText="Back (2X)" OffText="Back (1X)" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
                 <BitButtonGroupOption OnTitle="Resume" OffTitle="Play" OnIconName="@BitIconName.PlayResume" OffIconName="@BitIconName.Play" />
-                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
+                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward (1X)" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
             </BitButtonGroup>
         </div>
     </ExamplePreview>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor
@@ -183,34 +183,34 @@
     </ExamplePreview>
 </ComponentExampleBox>
 
-<ComponentExampleBox Title="Toggled" RazorCode="@example6RazorCode" Id="example6">
+<ComponentExampleBox Title="Toggle" RazorCode="@example6RazorCode" Id="example6">
     <ExamplePreview>
-        <div>The Toggled in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
+        <div>The Toggle in BitButtonGroup allows you to control the active or inactive state of each button, providing clear visual feedback to users about which buttons are selected or currently in use.</div>
         <br /><br />
         <div class="example-content">
             <div>Fill (default)</div>
-            <BitButtonGroup Variant="BitVariant.Fill" TItem="BitButtonGroupOption" Toggled>
-                <BitButtonGroupOption OnText="Back (2X)" OffText="Back" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
+            <BitButtonGroup Toggle Variant="BitVariant.Fill" TItem="BitButtonGroupOption">
+                <BitButtonGroupOption OnText="Back (2X)" OffText="Back (1X)" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
                 <BitButtonGroupOption OnTitle="Resume" OffTitle="Play" OnIconName="@BitIconName.PlayResume" OffIconName="@BitIconName.Play" />
-                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
+                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward (1X)" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
             </BitButtonGroup>
         </div>
         <br /><br />
         <div class="example-content">
             <div>Outline</div>
-            <BitButtonGroup Variant="BitVariant.Outline" TItem="BitButtonGroupOption" Toggled>
-                <BitButtonGroupOption OnText="Back (2X)" OffText="Back" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
+            <BitButtonGroup Toggle Variant="BitVariant.Outline" TItem="BitButtonGroupOption">
+                <BitButtonGroupOption OnText="Back (2X)" OffText="Back (1X)" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
                 <BitButtonGroupOption OnTitle="Resume" OffTitle="Play" OnIconName="@BitIconName.PlayResume" OffIconName="@BitIconName.Play" />
-                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
+                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward (1X)" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
             </BitButtonGroup>
         </div>
         <br /><br />
         <div class="example-content">
             <div>Text</div>
-            <BitButtonGroup Variant="BitVariant.Text" TItem="BitButtonGroupOption" Toggled>
-                <BitButtonGroupOption OnText="Back (2X)" OffText="Back" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
+            <BitButtonGroup Toggle Variant="BitVariant.Text" TItem="BitButtonGroupOption">
+                <BitButtonGroupOption OnText="Back (2X)" OffText="Back (1X)" OnIconName="@BitIconName.RewindTwoX" OffIconName="@BitIconName.Rewind" />
                 <BitButtonGroupOption OnTitle="Resume" OffTitle="Play" OnIconName="@BitIconName.PlayResume" OffIconName="@BitIconName.Play" />
-                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
+                <BitButtonGroupOption OnText="Forward (2X)" OffText="Forward (1X)" OnIconName="@BitIconName.FastForwardTwoX" OffIconName="@BitIconName.FastForward" ReversedIcon />
             </BitButtonGroup>
         </div>
     </ExamplePreview>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor.samples.cs
@@ -118,22 +118,22 @@ public partial class _BitButtonGroupOptionDemo
 </BitButtonGroup>";
 
     private readonly string example6RazorCode = @"
-<BitButtonGroup Variant=""BitVariant.Fill"" TItem=""BitButtonGroupOption"" Toggled>
-    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Fill"" TItem=""BitButtonGroupOption"">
+    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back (1X)"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
     <BitButtonGroupOption OnTitle=""Resume"" OffTitle=""Play"" OnIconName=""@BitIconName.PlayResume"" OffIconName=""@BitIconName.Play"" />
-    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
+    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward (1X)"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
 </BitButtonGroup>
 
-<BitButtonGroup Variant=""BitVariant.Outline"" TItem=""BitButtonGroupOption"" Toggled>
-    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Outline"" TItem=""BitButtonGroupOption"">
+    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back (1X)"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
     <BitButtonGroupOption OnTitle=""Resume"" OffTitle=""Play"" OnIconName=""@BitIconName.PlayResume"" OffIconName=""@BitIconName.Play"" />
-    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
+    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward (1X)"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
 </BitButtonGroup>
 
-<BitButtonGroup Variant=""BitVariant.Text"" TItem=""BitButtonGroupOption"" Toggled>
-    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Text"" TItem=""BitButtonGroupOption"">
+    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back (1X)"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
     <BitButtonGroupOption OnTitle=""Resume"" OffTitle=""Play"" OnIconName=""@BitIconName.PlayResume"" OffIconName=""@BitIconName.Play"" />
-    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
+    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward (1X)"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
 </BitButtonGroup>";
 
     private readonly string example7RazorCode = @"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/_BitButtonGroupOptionDemo.razor.samples.cs
@@ -292,22 +292,22 @@ public partial class _BitButtonGroupOptionDemo
 </BitButtonGroup>";
 
     private readonly string example7RazorCode = @"
-<BitButtonGroup Variant=""BitVariant.Fill"" TItem=""BitButtonGroupOption"" Toggled>
-    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Fill"" TItem=""BitButtonGroupOption"">
+    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back (1X)"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
     <BitButtonGroupOption OnTitle=""Resume"" OffTitle=""Play"" OnIconName=""@BitIconName.PlayResume"" OffIconName=""@BitIconName.Play"" />
-    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
+    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward (1X)"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
 </BitButtonGroup>
 
-<BitButtonGroup Variant=""BitVariant.Outline"" TItem=""BitButtonGroupOption"" Toggled>
-    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Outline"" TItem=""BitButtonGroupOption"">
+    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back (1X)"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
     <BitButtonGroupOption OnTitle=""Resume"" OffTitle=""Play"" OnIconName=""@BitIconName.PlayResume"" OffIconName=""@BitIconName.Play"" />
-    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
+    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward (1X)"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
 </BitButtonGroup>
 
-<BitButtonGroup Variant=""BitVariant.Text"" TItem=""BitButtonGroupOption"" Toggled>
-    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
+<BitButtonGroup Toggle Variant=""BitVariant.Text"" TItem=""BitButtonGroupOption"">
+    <BitButtonGroupOption OnText=""Back (2X)"" OffText=""Back (1X)"" OnIconName=""@BitIconName.RewindTwoX"" OffIconName=""@BitIconName.Rewind"" />
     <BitButtonGroupOption OnTitle=""Resume"" OffTitle=""Play"" OnIconName=""@BitIconName.PlayResume"" OffIconName=""@BitIconName.Play"" />
-    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
+    <BitButtonGroupOption OnText=""Forward (2X)"" OffText=""Forward (1X)"" OnIconName=""@BitIconName.FastForwardTwoX"" OffIconName=""@BitIconName.FastForward"" ReversedIcon />
 </BitButtonGroup>";
 
     private readonly string example8RazorCode = @"


### PR DESCRIPTION
This closes #9555 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed `Toggled` parameter to `Toggle` in BitButtonGroup component
	- Enhanced toggle functionality with more descriptive state text

- **Documentation**
	- Updated demo and example code to reflect new `Toggle` parameter
	- Clarified button group toggle state descriptions

- **Style**
	- Refined button group text to include "(1X)" for clearer state representation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->