### PR TITLE
Replace 2024 with 2025 (#9561)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 bit platform
+Copyright (c) 2025 bit platform
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Bit.Build.props
+++ b/src/Bit.Build.props
@@ -8,7 +8,7 @@
 		<Product>bit platform</Product>
 		<Title>$(MSBuildProjectName)</Title>
 		<Description>$(MSBuildProjectName)</Description>
-		<Copyright>Copyright © bit platform 2024</Copyright>
+		<Copyright>Copyright © bit platform 2025</Copyright>
 
 		<!-- Repo -->
 		<RepositoryUrl>https://github.com/bitfoundation/bitplatform</RepositoryUrl>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Shared/Footer.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Shared/Footer.razor
@@ -40,7 +40,7 @@
                 <a class="social-link youtube-link" target="_blank" href="https://www.youtube.com/channel/UCtk33NQ91f3GOJG0HAdkdog"></a>
                 <a class="social-link linkedin-link" target="_blank" href="https://www.linkedin.com/company/bitplatformhq"></a>
             </div>
-            <div class="copy-right-txt">Copyright © 2024 bit platform | All Rights Reserved </div>
+            <div class="copy-right-txt">Copyright © 2025 bit platform | All Rights Reserved </div>
         </div>
     </section>
 </footer>

--- a/src/Templates/BlazorEmpty/Bit.BlazorEmpty.ProjectTemplate.csproj
+++ b/src/Templates/BlazorEmpty/Bit.BlazorEmpty.ProjectTemplate.csproj
@@ -15,7 +15,7 @@
         <Title>bit BlazorEmpty</Title>
         <PackageDescription>A template for creating an empty Blazor app using the bit platform products</PackageDescription>
         <PackageTags>Bit;c#;asp.net;core;template;web;blazor</PackageTags>
-        <PackageCopyright>Copyright © bit platform 2024</PackageCopyright>
+        <PackageCopyright>Copyright © bit platform 2025</PackageCopyright>
         <PackageIcon>bit-icon-512.png</PackageIcon>
         
     </PropertyGroup>

--- a/src/Templates/BlazorEmpty/Bit.BlazorEmpty/BlazorEmpty/Components/Layout/Footer.razor
+++ b/src/Templates/BlazorEmpty/Bit.BlazorEmpty/BlazorEmpty/Components/Layout/Footer.razor
@@ -1,3 +1,3 @@
 ﻿<footer>
-    <BitLabel>Copyright © 2024 bit Blazor Empty</BitLabel>
+    <BitLabel>Copyright © 2025 bit Blazor Empty</BitLabel>
 </footer>

--- a/src/Templates/Boilerplate/Bit.Boilerplate.ProjectTemplate.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate.ProjectTemplate.csproj
@@ -15,7 +15,7 @@
         <Title>bit Boilerplate</Title>
         <PackageDescription>A template for creating a full featured app using the bit platform products</PackageDescription>
         <PackageTags>bit;c#;asp;template;web;blazor;ef;api;rest;maui;</PackageTags>
-        <PackageCopyright>Copyright © bit platform 2024</PackageCopyright>
+        <PackageCopyright>Copyright © bit platform 2025</PackageCopyright>
         <PackageIcon>bit-icon-512.png</PackageIcon>
         
     </PropertyGroup>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/Footer.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/Footer.razor
@@ -50,7 +50,7 @@
                 <a class="social-link youtube-link" target="_blank" href="@Urls.YouTube"></a>
                 <a class="social-link linkedin-link" target="_blank" href="@Urls.Linkedin"></a>
             </div>
-            <div class="copyright-txt">Copyright © 2024 bit platform | All Rights Reserved </div>
+            <div class="copyright-txt">Copyright © 2025 bit platform | All Rights Reserved </div>
         </div>
     </section>
 </footer>

--- a/src/Websites/Sales/src/Bit.Websites.Sales.Client/Shared/Footer.razor
+++ b/src/Websites/Sales/src/Bit.Websites.Sales.Client/Shared/Footer.razor
@@ -25,5 +25,5 @@
             </div>
         </div>
     </div>
-    <div class="copyright">Copyright © 2001 - 2024 bit Inc. All Rights Reserved</div>
+    <div class="copyright">Copyright © 2001 - 2025 bit Inc. All Rights Reserved</div>
 </footer>


### PR DESCRIPTION
closes #9561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year from 2024 to 2025 across multiple files, including:
		- LICENSE
		- Build properties
		- Project templates
		- Footer components in various Blazor applications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->