### PR TITLE
Enable sending null titles to header as page title in Boilerplate (#9581)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/AppPageBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/AppPageBase.cs
@@ -24,10 +24,7 @@ public abstract partial class AppPageBase : AppComponentBase
                 }
             }
 
-            if (string.IsNullOrEmpty(Title) is false)
-            {
-                PubSubService.Publish(ClientPubSubMessages.PAGE_TITLE_CHANGED, (Title, Subtitle), persistent: true);
-            }
+            PubSubService.Publish(ClientPubSubMessages.PAGE_TITLE_CHANGED, (Title, Subtitle), persistent: true);
         }
     }
 }


### PR DESCRIPTION
closes #9581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified page title event publishing logic to ensure consistent title change notifications, regardless of the title's state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->