### PR TITLE
Fix BitExtraServices registration (#9586)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Extensions/IServiceCollectionExtensions.cs
@@ -16,13 +16,13 @@ public static class IServiceCollectionExtensions
         if (trySingleton)
         {
             services.TryAddSingleton<BitModalService>();
-            services.TryAddSingleton<BitExtraServices>();
         }
         else
         {
             services.TryAddScoped<BitModalService>();
-            services.TryAddScoped<BitExtraServices>();
         }
+
+        services.TryAddScoped<BitExtraServices>();
 
         return services;
     }


### PR DESCRIPTION
closes #9586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated service registration logic to consistently register `BitExtraServices` as a scoped service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->