### PR TITLE
Fix SkipIf and TakeIf extension methods issues in Boilerplate (#9598)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Categories/CategoryController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Categories/CategoryController.cs
@@ -29,8 +29,8 @@ public partial class CategoryController : AppControllerBase, ICategoryController
 
         var totalCount = await query.LongCountAsync(cancellationToken);
 
-        query = query.SkipIf(odataQuery.Skip is not null, odataQuery.Skip!.Value)
-                     .TakeIf(odataQuery.Top is not null, odataQuery.Top!.Value);
+        query = query.SkipIf(odataQuery.Skip is not null, odataQuery.Skip?.Value)
+                     .TakeIf(odataQuery.Top is not null, odataQuery.Top?.Value);
 
         return new PagedResult<CategoryDto>(await query.ToArrayAsync(cancellationToken), totalCount);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Products/ProductController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Products/ProductController.cs
@@ -29,8 +29,8 @@ public partial class ProductController : AppControllerBase, IProductController
 
         var totalCount = await query.LongCountAsync(cancellationToken);
 
-        query = query.SkipIf(odataQuery.Skip is not null, odataQuery.Skip!.Value)
-                     .TakeIf(odataQuery.Top is not null, odataQuery.Top!.Value);
+        query = query.SkipIf(odataQuery.Skip is not null, odataQuery.Skip?.Value)
+                     .TakeIf(odataQuery.Top is not null, odataQuery.Top?.Value);
 
         return new PagedResult<ProductDto>(await query.ToArrayAsync(cancellationToken), totalCount);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Todo/TodoItemController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Todo/TodoItemController.cs
@@ -23,8 +23,8 @@ public partial class TodoItemController : AppControllerBase, ITodoItemController
 
         var totalCount = await query.LongCountAsync(cancellationToken);
 
-        query = query.SkipIf(odataQuery.Skip is not null, odataQuery.Skip!.Value)
-                     .TakeIf(odataQuery.Top is not null, odataQuery.Top!.Value);
+        query = query.SkipIf(odataQuery.Skip is not null, odataQuery.Skip?.Value)
+                     .TakeIf(odataQuery.Top is not null, odataQuery.Top?.Value);
 
         return new PagedResult<TodoItemDto>(await query.ToArrayAsync(cancellationToken), totalCount);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Extensions/LinqExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Extensions/LinqExtensions.cs
@@ -31,6 +31,16 @@ public static partial class LinqExtensions
         return predicate ? query.Take(count) : query;
     }
 
+    public static IQueryable<T> SkipIf<T>(this IQueryable<T> query, bool predicate, int? count)
+    {
+        return (predicate && count.HasValue) ? query.Skip(count.Value) : query;
+    }
+
+    public static IQueryable<T> TakeIf<T>(this IQueryable<T> query, bool predicate, int? count)
+    {
+        return (predicate && count.HasValue) ? query.Take(count.Value) : query;
+    }
+
     public static IEnumerable<T> WhereIf<T>(this IEnumerable<T> source, bool predicate, Func<T, bool> itemPredicate)
     {
         return predicate ? source.Where(itemPredicate) : source;
@@ -54,5 +64,15 @@ public static partial class LinqExtensions
     public static IEnumerable<T> TakeIf<T>(this IEnumerable<T> source, bool predicate, int count)
     {
         return predicate ? source.Take(count) : source;
+    }
+
+    public static IEnumerable<T> SkipIf<T>(this IEnumerable<T> source, bool predicate, int? count)
+    {
+        return (predicate && count.HasValue) ? source.Skip(count.Value) : source;
+    }
+
+    public static IEnumerable<T> TakeIf<T>(this IEnumerable<T> source, bool predicate, int? count)
+    {
+        return (predicate && count.HasValue) ? source.Take(count.Value) : source;
     }
 }


### PR DESCRIPTION
closes #9598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved null handling in query parameter processing across multiple controllers
	- Enhanced safety when accessing optional query parameters

- **New Features**
	- Added conditional SignalR integration for product-related data changes
	- Introduced more flexible LINQ extension methods for conditional skipping and taking of query results

- **Refactor**
	- Updated code to use null-conditional operators for safer parameter access
	- Implemented more robust query parameter handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->