### PR TITLE
Use readonly inputs for current values of Email and PhoneNumber on settings page of Boilerplate (#9601)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangeEmailSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangeEmailSection.razor
@@ -10,7 +10,7 @@
                 <BitStack FillContent>
                     @if (Email is not null)
                     {
-                        <BitTag Variant="BitVariant.Outline" Text="@Email" Color="BitColor.Info" />
+                        <BitTextField ReadOnly Value="@Email" />
                     }
 
                     <BitTextField @bind-Value="sendModel.Email"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangePhoneNumberSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangePhoneNumberSection.razor
@@ -10,7 +10,7 @@
                 <BitStack FillContent>
                     @if (PhoneNumber is not null)
                     {
-                        <BitTag Variant="BitVariant.Outline" Text="@PhoneNumber" Color="BitColor.Info" />
+                        <BitTextField ReadOnly Value="@PhoneNumber" />
                     }
 
                     <BitTextField @bind-Value="sendModel.PhoneNumber"


### PR DESCRIPTION
closes #9601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Updated email display in settings to use a read-only text field instead of a tag
	- Updated phone number display in settings to use a read-only text field instead of a tag

The changes enhance the visual presentation of user contact information while maintaining the existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->