### PR TITLE
Remove unused CSS class in TodoPage.razor (#9585)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Todo/TodoPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Todo/TodoPage.razor
@@ -26,9 +26,9 @@
         <BitStack Gap="0.25rem">
             <BitStack Horizontal VerticalAlign="BitAlignment.End" Gap="0.25rem" AutoHeight Class="todo-header">
                 <BitPivot SelectedKey="@selectedFilter" SelectedKeyChanged="FilterTodoItems" HeaderOnly>
-                    <BitPivotItem Key="@nameof(AppStrings.All)" Class="todo-pivot-tab" HeaderText="@Localizer[nameof(AppStrings.All)]" />
-                    <BitPivotItem Key="@nameof(AppStrings.Active)" Class="todo-pivot-tab" HeaderText="@Localizer[nameof(AppStrings.Active)]" />
-                    <BitPivotItem Key="@nameof(AppStrings.Completed)" Class="todo-pivot-tab" HeaderText="@Localizer[nameof(AppStrings.Completed)]" />
+                    <BitPivotItem Key="@nameof(AppStrings.All)" HeaderText="@Localizer[nameof(AppStrings.All)]" />
+                    <BitPivotItem Key="@nameof(AppStrings.Active)" HeaderText="@Localizer[nameof(AppStrings.Active)]" />
+                    <BitPivotItem Key="@nameof(AppStrings.Completed)" HeaderText="@Localizer[nameof(AppStrings.Completed)]" />
                 </BitPivot>
                 <BitSpacer />
                 <BitSearchBox @ref="searchBox"


### PR DESCRIPTION
This closes #9585 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified markup in TodoPage by removing unnecessary class attributes from pivot items
	- No functional changes to the component's behavior or appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->