### PR TITLE
Add missing .net 9 assemblies from blazor.boot.json to passive first boot mode of Bswup (#9606)

### DIFF
--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
@@ -233,7 +233,11 @@ async function createAssetsCache(ignoreProgressReport = false) {
             .concat(Object.keys(blazorBootJson.resources.runtime || {})) // before .NET 8
             .concat(Object.keys(blazorBootJson.resources.jsModuleNative || {})) // after .NET 8
             .concat(Object.keys(blazorBootJson.resources.jsModuleRuntime || {}))
-            .concat(Object.keys(blazorBootJson.resources.wasmNative || {}));
+            .concat(Object.keys(blazorBootJson.resources.wasmNative || {}))
+            .concat(Object.keys(blazorBootJson.resources.coreAssembly || {})) // after .NET 9
+            .concat(Object.keys(blazorBootJson.resources.icu || {}))
+            .concat(Object.keys(blazorBootJson.resources.jsModuleGlobalization || {}))
+            ;
         const blazorAssets = blazorResources.map(r => UNIQUE_ASSETS.find(a => a.url.endsWith(`/${r}`))).filter(a => !!a);
 
         diag('blazorBootAsset:', blazorBootAsset);

--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
@@ -236,8 +236,7 @@ async function createAssetsCache(ignoreProgressReport = false) {
             .concat(Object.keys(blazorBootJson.resources.wasmNative || {}))
             .concat(Object.keys(blazorBootJson.resources.coreAssembly || {})) // after .NET 9
             .concat(Object.keys(blazorBootJson.resources.icu || {}))
-            .concat(Object.keys(blazorBootJson.resources.jsModuleGlobalization || {}))
-            ;
+            .concat(Object.keys(blazorBootJson.resources.jsModuleGlobalization || {}));
         const blazorAssets = blazorResources.map(r => UNIQUE_ASSETS.find(a => a.url.endsWith(`/${r}`))).filter(a => !!a);
 
         diag('blazorBootAsset:', blazorBootAsset);


### PR DESCRIPTION
closes #9606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced service worker asset caching for .NET 9 applications
	- Added support for additional Blazor resource types including core assemblies and internationalization resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->