### PR TITLE
Fix validatorRef null check issue on singin page of Boilerplate (#9667)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
@@ -122,7 +122,7 @@ public partial class SignInPage : IDisposable
 
             CleanModel();
 
-            if ((validatorRef?.EditContext.Validate() ?? false) is false) return;
+            if (validatorRef?.EditContext.Validate() is false) return;
 
             model.DeviceInfo = telemetryContext.Platform;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
@@ -212,13 +212,16 @@ public partial class SignInPage : IDisposable
         if (currentSignInPanelTab is SignInPanelTab.Email)
         {
             model.PhoneNumber = null;
-            validatorRef?.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.PhoneNumber)));
-        }
+            if (validatorRef is null) return;
 
-        if (currentSignInPanelTab is SignInPanelTab.Phone)
+            validatorRef.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.PhoneNumber)));
+        }
+        else
         {
             model.Email = null;
-            validatorRef?.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.Email)));
+            if (validatorRef is null) return;
+
+            validatorRef.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.Email)));
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
@@ -36,7 +36,7 @@ public partial class SignInPage : IDisposable
     private bool requiresTwoFactor;
     private SignInPanelTab currentSignInPanelTab;
     private readonly SignInRequestDto model = new();
-    private AppDataAnnotationsValidator validatorRef = default!;
+    private AppDataAnnotationsValidator? validatorRef;
     private Action unsubscribeIdentityHeaderBackLinkClicked = default!;
 
 
@@ -122,7 +122,7 @@ public partial class SignInPage : IDisposable
 
             CleanModel();
 
-            if (validatorRef.EditContext.Validate() is false) return;
+            if ((validatorRef?.EditContext.Validate() ?? false) is false) return;
 
             model.DeviceInfo = telemetryContext.Platform;
 
@@ -212,13 +212,13 @@ public partial class SignInPage : IDisposable
         if (currentSignInPanelTab is SignInPanelTab.Email)
         {
             model.PhoneNumber = null;
-            validatorRef.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.PhoneNumber)));
+            validatorRef?.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.PhoneNumber)));
         }
 
         if (currentSignInPanelTab is SignInPanelTab.Phone)
         {
             model.Email = null;
-            validatorRef.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.Email)));
+            validatorRef?.EditContext.NotifyFieldChanged(validatorRef.EditContext.Field(nameof(SignInRequestDto.Email)));
         }
     }
 


### PR DESCRIPTION
closes #9664 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for sign-in page validation
  - Added null safety checks in sign-in page component to prevent potential null reference exceptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->