### PR TITLE
Add RTL sample for BitMessageBox demo page (#9673)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MessageBox/BitMessageBoxDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MessageBox/BitMessageBoxDemo.razor
@@ -1,4 +1,4 @@
-@page "/components/messagebox"
+﻿@page "/components/messagebox"
 
 <PageOutlet Url="components/messagebox"
             Title="MessageBox"
@@ -53,6 +53,18 @@
                     <BitMessageBox Title="It's a title"
                                    Body="It's a body."
                                    Classes="@(new() { Root = "custom-msg", OkButton = new() { Root = "custom-msg-btn" } })" />
+                </BitCard>
+            </div>
+        </ExamplePreview>
+    </ComponentExampleBox>
+
+    <ComponentExampleBox Title="RTL" RazorCode="@example6RazorCode" Id="example6">
+        <ExamplePreview>
+            <div>Use BitMessageBox in right-to-left (RTL).</div>
+            <br /><br />
+            <div dir="rtl">
+                <BitCard Style="padding:0">
+                    <BitMessageBox Dir="BitDir.Rtl" Title="عنوان پیام" Body="متن تست پیام..." OkText="تایید" />
                 </BitCard>
             </div>
         </ExamplePreview>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MessageBox/BitMessageBoxDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MessageBox/BitMessageBoxDemo.razor.samples.cs
@@ -76,4 +76,9 @@ private async Task ShowMessageBoxService()
                     Body=""It's a body.""
                     Classes=""@(new() { Root = ""custom-msg"", OkButton = new() { Root = ""custom-msg-btn"" } })"" />
 </BitCard>";
+
+    private readonly string example6RazorCode = @"
+<BitCard Style=""padding:0"">
+    <BitMessageBox Dir=""BitDir.Rtl"" Title=""عنوان پیام"" Body=""متن تست پیام..."" OkText=""تایید"" />
+</BitCard>";
 }


### PR DESCRIPTION
This closes #9673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new example demonstrating the `BitMessageBox` component in right-to-left (RTL) layout
	- Included localized text support for RTL languages

- **Documentation**
	- Expanded component demo with an RTL usage example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->