### PR TITLE
Use BitErrorBoundary in Boilerplate (#9687)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor
@@ -1,36 +1,5 @@
-﻿@inherits ErrorBoundaryBase
+﻿@inherits AppComponentBase
 
-@if (CurrentException is null)
-{
-    @ChildContent
-}
-else if (ErrorContent is not null)
-{
-    @ErrorContent(CurrentException)
-}
-else
-{
-    <main>
-        <BitStack Alignment="BitAlignment.Center">
-            <BitImage Src="_content/Boilerplate.Client.Core/images/icons/error-triangle.svg" />
-
-            <BitText Color="BitColor.Error" Typography="BitTypography.H3">
-                @localizer[nameof(AppStrings.SomethingWentWrong)]
-            </BitText>
-
-            @if (showException)
-            {
-                <div class="exception">
-                    @CurrentException?.ToString()
-                </div>
-            }
-
-            <BitStack Horizontal Alignment="BitAlignment.Center" AutoHeight>
-                <BitButton OnClick="Refresh">@localizer[nameof(AppStrings.Refresh)]</BitButton>
-                <BitButton OnClick="GoHome" Variant="BitVariant.Outline">@localizer[nameof(AppStrings.Home)]</BitButton>
-                <BitButton OnClick="Recover" Variant="BitVariant.Outline">@localizer[nameof(AppStrings.Recover)]</BitButton>
-                <BitButton OnClick="ShowDiagnostic" Variant="BitVariant.Text" IconOnly IconName="@BitIconName.Diagnostic" />
-            </BitStack>
-        </BitStack>
-    </main>
-}
+<BitErrorBoundary>
+    <BitButton OnClick="ShowDiagnostic" Variant="BitVariant.Text" IconOnly IconName="@BitIconName.Diagnostic" />
+</BitErrorBoundary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor
@@ -1,5 +1,17 @@
 ﻿@inherits AppComponentBase
 
-<BitErrorBoundary>
-    <BitButton OnClick="ShowDiagnostic" Variant="BitVariant.Text" IconOnly IconName="@BitIconName.Diagnostic" />
+<BitErrorBoundary @ref="boundaryRef"
+                  HomeUrl="@Urls.HomePage"
+                  ShowException="AppEnvironment.IsDev()"
+                  OnError="e => exceptionHandler.Handle(e)"
+                  HomeText="@localizer[nameof(AppStrings.Home)]"
+                  RefreshText="@localizer[nameof(AppStrings.Refresh)]"
+                  RecoverText="@localizer[nameof(AppStrings.Recover)]"
+                  Title="@localizer[nameof(AppStrings.SomethingWentWrong)]">
+    <AdditionalButtons>
+        <BitButton OnClick="ShowDiagnostic" Variant="BitVariant.Text" IconOnly IconName="@BitIconName.Diagnostic" />
+    </AdditionalButtons>
+    <Body>
+        @ChildContent
+    </Body>
 </BitErrorBoundary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor.cs
@@ -14,29 +14,19 @@ public partial class AppErrorBoundary
     [AutoInject] private NavigationManager navigationManager = default!;
     [AutoInject] private IStringLocalizer<AppStrings> localizer = default!;
 
-    protected override void OnInitialized()
+    protected override void OnInit()
     {
         showException = AppEnvironment.IsDev();
     }
 
-    protected override async Task OnErrorAsync(Exception exception)
+    private async Task OnErrorAsync(Exception exception)
     {
         exceptionHandler.Handle(exception);
     }
 
-    private void Refresh()
-    {
-        navigationManager.Refresh(forceReload: true);
-    }
-
-    private void GoHome()
-    {
-        navigationManager.NavigateTo(Urls.HomePage, forceLoad: true);
-    }
-
     private async Task ShowDiagnostic()
     {
-        Recover();
+        //Recover();
         await Task.Yield();
         pubSubService.Publish(ClientPubSubMessages.SHOW_DIAGNOSTIC_MODAL);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor.cs
@@ -1,32 +1,22 @@
-﻿//-:cnd:noEmit
+﻿namespace Boilerplate.Client.Core.Components.Layout;
 
-namespace Boilerplate.Client.Core.Components.Layout;
-
-/// <summary>
-/// https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors
-/// </summary>
 public partial class AppErrorBoundary
 {
-    private bool showException;
+    private BitErrorBoundary boundaryRef = default!;
+
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
 
     [AutoInject] private PubSubService pubSubService = default!;
     [AutoInject] private IExceptionHandler exceptionHandler = default!;
     [AutoInject] private NavigationManager navigationManager = default!;
     [AutoInject] private IStringLocalizer<AppStrings> localizer = default!;
 
-    protected override void OnInit()
-    {
-        showException = AppEnvironment.IsDev();
-    }
-
-    private async Task OnErrorAsync(Exception exception)
-    {
-        exceptionHandler.Handle(exception);
-    }
 
     private async Task ShowDiagnostic()
     {
-        //Recover();
+        boundaryRef.Recover();
         await Task.Yield();
         pubSubService.Publish(ClientPubSubMessages.SHOW_DIAGNOSTIC_MODAL);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppErrorBoundary.razor.scss
@@ -1,15 +1,1 @@
 ﻿@import '../../Styles/abstracts/_bit-css-variables.scss';
-
-main {
-    width: 100%;
-    height: 100%;
-    background-color: $bit-color-background-primary
-}
-
-.exception {
-    width: 90%;
-    margin: 1.5rem;
-    overflow: auto;
-    white-space: pre;
-    text-align: start;
-}


### PR DESCRIPTION
closes #9687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BitErrorBoundary` component for improved error handling
	- Enhanced error boundary with configurable parameters like home URL, error display, and recovery options

- **Refactor**
	- Completely restructured error handling mechanism
	- Replaced manual error rendering with a more structured component-based approach

- **Style**
	- Removed previous error-related CSS styles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->