### PR TITLE
Add missing usage of Body parameter in BitAccordion (#9713)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Accordion/BitAccordion.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Accordion/BitAccordion.razor
@@ -41,7 +41,7 @@
              style="@Styles?.Content"
              class="bit-acd-con @(IsExpanded ? "bit-acd-cex" : "bit-acd-cco") @Classes?.Content"
              tabindex="@(IsEnabled ? 0 : -1)">
-            @ChildContent
+            @(ChildContent ?? Body)
         </div>
     </div>
 </div>


### PR DESCRIPTION
This closes #9713 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `BitAccordion` component with fallback content rendering when no child content is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->