### PR TITLE
Improve Boilerplate offline db context migration (#9724)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Offline/OfflineEditProfilePage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Offline/OfflineEditProfilePage.razor.cs
@@ -40,9 +40,6 @@ public partial class OfflineEditProfilePage
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(CurrentCancellationToken);
 
-        // Only for the first time, we need to migrate the database
-        await dbContext.Database.MigrateAsync(CurrentCancellationToken);
-
         return await dbContext.Users.FirstAsync(CurrentCancellationToken);
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Extensions/IClientCoreServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Extensions/IClientCoreServiceCollectionExtensions.cs
@@ -96,7 +96,7 @@ public static partial class IClientCoreServiceCollectionExtensions
         {
             AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue31751", true);
         }
-        services.AddBesqlDbContextFactory<OfflineDbContext>((optionsBuilder) =>
+        services.AddBesqlDbContextFactory<OfflineDbContext>((sp, optionsBuilder) =>
         {
             var isRunningInsideDocker = Directory.Exists("/container_volume"); // Blazor Server - Docker (It's supposed to be a mounted volume named /container_volume)
             var dirPath = isRunningInsideDocker ? "/container_volume"
@@ -121,7 +121,8 @@ public static partial class IClientCoreServiceCollectionExtensions
 
             optionsBuilder.EnableSensitiveDataLogging(AppEnvironment.IsDev())
                     .EnableDetailedErrors(AppEnvironment.IsDev());
-        });
+
+        }, dbContextInitializer: async (sp, dbContext) => await dbContext.Database.MigrateAsync());
         //#endif
 
         //#if (appInsights == true)


### PR DESCRIPTION
closes #9724

Instead of calling `dbContext.Database.MigrateAsync` multiple times (such as in `Program.cs` for Blazor Server, Blazor WASM, and Blazor Hybrid) or invoking it in every page, you now have a centralized method to handle it. This approach ensures migrations are performed only when the `DbContext` is first used, avoiding delays during application startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated database context initialization method to support dependency injection
	- Added asynchronous database migration during context initialization

- **Bug Fixes**
	- Removed manual database migration step from offline edit profile page
	- Improved database migration handling during application startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->