### PR TITLE
Fix font size in the small size of BitButton (#9802)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/BitButton/BitButton.scss
@@ -311,7 +311,7 @@
 
 .bit-btn-sm {
     --bit-btn-spn-size: #{spacing(1.75)};
-    --bit-btn-lbl-fontsize: #{spacing(1.75)};
+    --bit-btn-lbl-fontsize: #{spacing(1.25)};
     --bit-btn-prt-fontsize: #{spacing(1.50)};
     --bit-btn-sct-fontsize: #{spacing(1.25)};
     --bit-btn-icn-fontsize: #{spacing(1.50)};


### PR DESCRIPTION
This closes #9802 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of small buttons by reducing the label font size for a more compact and refined look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->