### PR TITLE
Add VideDescription feature to ComponentDemo to display copyright info in BlazorUI demo pages (#9847)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/ComponentDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/ComponentDemo.razor
@@ -24,6 +24,11 @@
                 <div class="video-container">
                     <video src="@VideoUrl" controls />
                 </div>
+                @if (VideoDescription.HasValue())
+                {
+                    <br />
+                    <BitText Typography="BitTypography.Body2">@VideoDescription</BitText>
+                }
             </section>
         }
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/ComponentDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/ComponentDemo.razor.cs
@@ -6,6 +6,7 @@ public partial class ComponentDemo
     [Parameter] public string? ComponentDescription { get; set; }
     [Parameter] public string? Notes { get; set; }
     [Parameter] public string? VideoUrl { get; set; }
+    [Parameter] public string? VideoDescription { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public List<ComponentParameter> ComponentParameters { get; set; } = [];
     [Parameter] public List<ComponentSubClass> ComponentSubClasses { get; set; } = [];

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor
@@ -12,7 +12,8 @@
                    ComponentSubEnums="componentSubEnums"
                    ComponentPublicMembers="componentPublicMembers"
                    Notes="The BitDropdown is a Multi-API component which can accept the list of Items in 3 different ways: BitDropdownItem class, a custom Generic class, and BitDropdownOption component."
-                   VideoUrl="https://videos.bitplatform.dev/bit%20Dropdown.mp4">
+                   VideoUrl="https://videos.bitplatform.dev/bit%20Dropdown.mp4"
+                   VideoDescription="Music: Music Cocktails, Musician: AlexGuz, URL: https://open.spotify.com/artist/1u0Nlnljg2xGHJV6X7W4i1">
 
         <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })">
             <BitPivotItem HeaderText="Item">


### PR DESCRIPTION
close #9847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional video description capability that displays contextual text in the video section when provided.
	- Enhanced video components to support additional metadata for video content, including details about associated music such as title, artist, and related links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->