### PR TITLE
Use Uri.EscapeDataString instead of HttpUtility.UrlEncode in source generators (#9868)

### DIFF
--- a/src/SourceGenerators/Bit.SourceGenerators/HttpClientProxy/HttpClientProxySourceGenerator.cs
+++ b/src/SourceGenerators/Bit.SourceGenerators/HttpClientProxy/HttpClientProxySourceGenerator.cs
@@ -107,11 +107,11 @@ public static class IHttpClientServiceCollectionExtensions
 
 internal class AppControllerBase
 {{
-    System.Collections.Specialized.NameValueCollection queryString = HttpUtility.ParseQueryString(string.Empty);
+    QueryStringCollection queryString = new QueryStringCollection();
 
     public void AddQueryString(string existingQueryString)
     {{
-        queryString.Add(HttpUtility.ParseQueryString(existingQueryString));
+        queryString.Add(QueryStringCollection.Parse(existingQueryString));
     }}
 
     public void AddQueryString(string key, object? value)
@@ -129,19 +129,14 @@ internal class AppControllerBase
 
     protected string? GetDynamicQueryString()
     {{
-        if (queryString is not {{ Count: > 0 }})
+        if (queryString.IsEmpty)
             return null;
 
-        var collection = HttpUtility.ParseQueryString(string.Empty);
-
-        foreach (string key in queryString)
-        {{
-            collection.Add(key, queryString[key]);
-        }}
+        var result = queryString.ToString();
 
         queryString.Clear();
 
-        return collection.ToString();
+        return result;
     }}
 }}
 


### PR DESCRIPTION
closes #9868