### PR TITLE
add configuration for response caching of Boilerplate (#9881)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/ODataQuery.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/ODataQuery.cs
@@ -26,7 +26,7 @@ public partial class ODataQuery
     public string? Expand { get; set; }
     public string? Search { get; set; }
 
-    public override string ToString()
+    public override string? ToString()
     {
         var qs = new AppQueryStringCollection();
 
@@ -68,5 +68,5 @@ public partial class ODataQuery
         return qs.ToString();
     }
 
-    public static implicit operator string(ODataQuery query) => query.ToString();
+    public static implicit operator string?(ODataQuery query) => query.ToString();
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
@@ -223,7 +223,7 @@ public class ResponseCachingOptions
     public bool EnableOutputCaching { get; set; }
 
     /// <summary>
-    /// Enables CDNs' edge servers caching
+    /// Enables CDN's edge servers caching
     /// </summary>
-    public bool EnableCDNsEdgeCaching { get; set; }
+    public bool EnableCdnEdgeCaching { get; set; }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
@@ -45,6 +45,8 @@ public partial class ServerApiSettings : SharedSettings
     public CloudflareOptions? Cloudflare { get; set; }
     //#endif
 
+    public ResponseCachingOptions ResponseCaching { get; set; } = default!;
+
     /// <summary>
     /// Defines the list of origins permitted for CORS access to the API. These origins are also valid for use as return URLs after social sign-ins and for generating URLs in emails.
     /// </summary>
@@ -81,6 +83,7 @@ public partial class ServerApiSettings : SharedSettings
         {
             Validator.TryValidateObject(ForwardedHeaders, new ValidationContext(ForwardedHeaders), validationResults, true);
         }
+        Validator.TryValidateObject(ResponseCaching, new ValidationContext(ResponseCaching), validationResults, true);
 
         if (AppEnvironment.IsDev() is false)
         {
@@ -210,4 +213,17 @@ public partial class SmsOptions
     public bool Configured => string.IsNullOrEmpty(FromPhoneNumber) is false &&
                               string.IsNullOrEmpty(TwilioAccountSid) is false &&
                               string.IsNullOrEmpty(TwilioAutoToken) is false;
+}
+
+public class ResponseCachingOptions
+{
+    /// <summary>
+    /// Enables ASP.NET Core's response output caching
+    /// </summary>
+    public bool EnableOutputCaching { get; set; }
+
+    /// <summary>
+    /// Enables CDNs' edge servers caching
+    /// </summary>
+    public bool EnableCDNsEdgeCaching { get; set; }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/AppResponseCachePolicy.cs
@@ -7,7 +7,7 @@ namespace Boilerplate.Server.Api.Services;
 /// <summary>
 /// An implementation of this interface can update how the current request is cached.
 /// </summary>
-public class AppResponseCachePolicy(IHostEnvironment env) : IOutputCachePolicy
+public class AppResponseCachePolicy(ServerApiSettings settings) : IOutputCachePolicy
 {
     /// <summary>
     /// Updates the <see cref="OutputCacheContext"/> before the cache middleware is invoked.
@@ -39,12 +39,13 @@ public class AppResponseCachePolicy(IHostEnvironment env) : IOutputCachePolicy
         var edgeCacheTtl = responseCacheAtt.SharedMaxAge;
         var outputCacheTtl = responseCacheAtt.SharedMaxAge;
 
-        if (env.IsDevelopment())
+        if (settings.ResponseCaching.EnableCDNsEdgeCaching is false)
         {
-            // To enhance the developer experience, return from here to make it easier for developers to debug cacheable responses.
             edgeCacheTtl = -1;
+        }
+        if (settings.ResponseCaching.EnableOutputCaching is false)
+        {
             outputCacheTtl = -1;
-            browserCacheTtl = -1;
         }
 
         if (context.HttpContext.User.IsAuthenticated() && responseCacheAtt.UserAgnostic is false)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/AppResponseCachePolicy.cs
@@ -39,7 +39,7 @@ public class AppResponseCachePolicy(ServerApiSettings settings) : IOutputCachePo
         var edgeCacheTtl = responseCacheAtt.SharedMaxAge;
         var outputCacheTtl = responseCacheAtt.SharedMaxAge;
 
-        if (settings.ResponseCaching.EnableCDNsEdgeCaching is false)
+        if (settings.ResponseCaching.EnableCdnEdgeCaching is false)
         {
             edgeCacheTtl = -1;
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/ResponseCacheService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Services/ResponseCacheService.cs
@@ -28,7 +28,7 @@ public partial class ResponseCacheService
         //#if (cloudflare == true)
         await PurgeCloudflareCache(relativePaths);
         //#else
-        // If you're using CDNs like GCore or others, make sure to purge the Edge Cache of your CDN.
+        // If you're using CDN like GCore or others, make sure to purge the Edge Cache of your CDN.
         // The Cloudflare Cache API is already integrated into the Boilerplate, but for other CDNs, 
         // you'll need to implement the caching logic yourself.
         if (httpContextAccessor.HttpContext!.Request.IsFromCDN())

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -150,7 +150,7 @@
     //#endif
     "ResponseCaching": {
         "EnableOutputCaching": false,
-        "EnableCDNsEdgeCaching": false
+        "EnableCdnEdgeCaching": false
     },
     "$schema": "https://json.schemastore.org/appsettings.json"
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -148,5 +148,9 @@
         "AdditionalDomains_Comment": "The ResponseCacheService clears the cache for the current domain by default. If multiple Cloudflare-hosted domains point to your backend, you will need to purge the cache for each of them individually."
     },
     //#endif
+    "ResponseCaching": {
+        "EnableOutputCaching": false,
+        "EnableCDNsEdgeCaching": false
+    },
     "$schema": "https://json.schemastore.org/appsettings.json"
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -87,7 +87,7 @@ public static partial class Program
             {
                 if (env.IsDevelopment() is false)
                 {
-                    // Caching static files on the Browser and CDNs' edge servers.
+                    // Caching static files on the Browser and CDN's edge servers.
                     if (context.Request.Query.Any(q => string.Equals(q.Key, "v", StringComparison.InvariantCultureIgnoreCase)) &&
                         env.WebRootFileProvider.GetFileInfo(context.Request.Path).Exists)
                     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -297,7 +297,7 @@ public static partial class Program
 
                     var qs = AppQueryStringCollection.Parse(httpContext.Request.QueryString.Value ?? string.Empty);
                     qs.Remove("try_refreshing_token");
-                    var returnUrl = UriHelper.BuildRelative(httpContext.Request.PathBase, httpContext.Request.Path, new QueryString($"?{qs}"));
+                    var returnUrl = UriHelper.BuildRelative(httpContext.Request.PathBase, httpContext.Request.Path, new QueryString(qs.ToString()));
                     httpContext.Response.Redirect($"{Urls.NotAuthorizedPage}?return-url={returnUrl}&isForbidden={(is403 ? "true" : "false")}");
                 }
                 else if (httpContext.Response.StatusCode is 404 &&

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/ServerWebSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/ServerWebSettings.cs
@@ -7,12 +7,29 @@ public partial class ServerWebSettings : ClientWebSettings
 {
     public ForwardedHeadersOptions ForwardedHeaders { get; set; } = default!;
 
+    public ResponseCachingOptions ResponseCaching { get; set; } = default!;
+
     public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         var validationResults = base.Validate(validationContext).ToList();
 
         Validator.TryValidateObject(ForwardedHeaders, new ValidationContext(ForwardedHeaders), validationResults, true);
 
+        Validator.TryValidateObject(ResponseCaching, new ValidationContext(ResponseCaching), validationResults, true);
+
         return validationResults;
     }
+}
+
+public class ResponseCachingOptions
+{
+    /// <summary>
+    /// Enables ASP.NET Core's response output caching
+    /// </summary>
+    public bool EnableOutputCaching { get; set; }
+
+    /// <summary>
+    /// Enables CDNs' edge servers caching
+    /// </summary>
+    public bool EnableCDNsEdgeCaching { get; set; }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/ServerWebSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/ServerWebSettings.cs
@@ -29,7 +29,7 @@ public class ResponseCachingOptions
     public bool EnableOutputCaching { get; set; }
 
     /// <summary>
-    /// Enables CDNs' edge servers caching
+    /// Enables CDN's edge servers caching
     /// </summary>
-    public bool EnableCDNsEdgeCaching { get; set; }
+    public bool EnableCdnEdgeCaching { get; set; }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Services/AppResponseCachePolicy.cs
@@ -39,7 +39,7 @@ public class AppResponseCachePolicy(ServerWebSettings settings) : IOutputCachePo
         var edgeCacheTtl = responseCacheAtt.SharedMaxAge;
         var outputCacheTtl = responseCacheAtt.SharedMaxAge;
 
-        if (settings.ResponseCaching.EnableCDNsEdgeCaching is false)
+        if (settings.ResponseCaching.EnableCdnEdgeCaching is false)
         {
             edgeCacheTtl = -1;
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Services/AppResponseCachePolicy.cs
@@ -7,7 +7,7 @@ namespace Boilerplate.Server.Web.Services;
 /// <summary>
 /// An implementation of this interface can update how the current request is cached.
 /// </summary>
-public class AppResponseCachePolicy(IHostEnvironment env) : IOutputCachePolicy
+public class AppResponseCachePolicy(ServerWebSettings settings) : IOutputCachePolicy
 {
     /// <summary>
     /// Updates the <see cref="OutputCacheContext"/> before the cache middleware is invoked.
@@ -39,12 +39,13 @@ public class AppResponseCachePolicy(IHostEnvironment env) : IOutputCachePolicy
         var edgeCacheTtl = responseCacheAtt.SharedMaxAge;
         var outputCacheTtl = responseCacheAtt.SharedMaxAge;
 
-        if (env.IsDevelopment())
+        if (settings.ResponseCaching.EnableCDNsEdgeCaching is false)
         {
-            // To enhance the developer experience, return from here to make it easier for developers to debug cacheable responses.
             edgeCacheTtl = -1;
+        }
+        if (settings.ResponseCaching.EnableOutputCaching is false)
+        {
             outputCacheTtl = -1;
-            browserCacheTtl = -1;
         }
 
         if (context.HttpContext.User.IsAuthenticated() && responseCacheAtt.UserAgnostic is false)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -101,6 +101,10 @@
         }
     },
     //#endif
+    "ResponseCaching": {
+        "EnableOutputCaching": false,
+        "EnableCDNsEdgeCaching": false
+    },
     "AllowedHosts": "*",
     "ForwardedHeaders": {
         "ForwardedHeaders": "All",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -103,7 +103,7 @@
     //#endif
     "ResponseCaching": {
         "EnableOutputCaching": false,
-        "EnableCDNsEdgeCaching": false
+        "EnableCdnEdgeCaching": false
     },
     "AllowedHosts": "*",
     "ForwardedHeaders": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppQueryStringCollection.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppQueryStringCollection.cs
@@ -7,8 +7,11 @@ namespace System;
 /// </summary>
 public class AppQueryStringCollection() : Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
 {
-    public override string ToString()
+    public override string? ToString()
     {
+        if (Count == 0)
+            return null;
+
         return string.Join("&", this.Select(kv => $"{Uri.EscapeDataString(Uri.UnescapeDataString(kv.Key))}={Uri.EscapeDataString(Uri.UnescapeDataString(kv.Value?.ToString() ?? ""))}"));
     }
 
@@ -29,8 +32,8 @@ public class AppQueryStringCollection() : Dictionary<string, object?>(StringComp
         {
             // Split the pair into key and value using '='.
             var parts = pair.Split(['='], 2);
-            string key = parts[0];
-            string value = parts.Length > 1 ? parts[1] : string.Empty;
+            string key = parts.ElementAt(0);
+            string value = parts.ElementAtOrDefault(1) ?? string.Empty;
             qsCollection.Add(key, value);
         }
 


### PR DESCRIPTION
closes #9881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced configurable response caching options that empower administrators to control response caching behavior.
	- Enhanced caching policies to determine cache durations based on explicit configuration settings rather than environment defaults.
	- Added new configuration sections that allow toggling of both output and CDN edge caching for improved performance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->