### PR TITLE
Show missing required asterisk in BitCircularTimePicker's label (#9890)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.razor
@@ -33,6 +33,7 @@
                        name="@Name"
                        id="@_inputId"
                        role="combobox"
+                       required="@Required"
                        tabindex="@TabIndex"
                        aria-haspopup="dialog"
                        aria-label="@AriaLabel"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.razor.cs
@@ -278,6 +278,8 @@ public partial class BitCircularTimePicker : BitInputBase<TimeSpan?>, IAsyncDisp
         ClassBuilder.Register(() => Standalone ? "bit-ctp-sta" : string.Empty);
 
         ClassBuilder.Register(() => _hasFocus ? $"bit-ctp-foc {Classes?.Focused}" : string.Empty);
+
+        ClassBuilder.Register(() => IsEnabled && Required ? "bit-ctp-req" : string.Empty);
     }
 
     protected override void RegisterCssStyles()

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/CircularTimePicker/BitCircularTimePicker.scss
@@ -390,6 +390,14 @@
     }
 }
 
+.bit-ctp-req {
+    .bit-ctp-lbl::after {
+        content: "*";
+        color: $clr-req;
+        margin-left: spacing(0.625);
+    }
+}
+
 .bit-ctp-res {
     @include lt-sm {
         top: 0;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/CircularTimePicker/BitCircularTimePickerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/CircularTimePicker/BitCircularTimePickerDemo.razor
@@ -19,6 +19,8 @@
             <br /><br />
             <BitCircularTimePicker Label="Disabled" IsEnabled="false" />
             <br /><br />
+            <BitCircularTimePicker Label="Required" Required />
+            <br /><br />
             <BitCircularTimePicker Label="PlaceHolder" Placeholder="Select a time" />
             <br /><br />
             <BitCircularTimePicker Label="TimeFormat (AM/PM)" TimeFormat="BitTimeFormat.TwelveHours" />

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/CircularTimePicker/BitCircularTimePickerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/CircularTimePicker/BitCircularTimePickerDemo.razor.cs
@@ -575,6 +575,7 @@ public partial class BitCircularTimePickerDemo
     private readonly string example1RazorCode = @"
 <BitCircularTimePicker Label=""Basic CircularTimePicker"" />
 <BitCircularTimePicker Label=""Disabled"" IsEnabled=""false"" />
+<BitCircularTimePicker Label=""Required"" Required />
 <BitCircularTimePicker Label=""PlaceHolder"" Placeholder=""Select a time"" />
 <BitCircularTimePicker Label=""TimeFormat (AM/PM)"" TimeFormat=""BitTimeFormat.TwelveHours"" />
 <BitCircularTimePicker Label=""Custom icon"" IconName=""@BitIconName.Airplane"" />";


### PR DESCRIPTION
This closes #9890 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The time picker now enforces a required selection, ensuring users provide input before submitting forms.
  - Demo examples have been updated to showcase this enhanced validation, including improved feedback on form submissions.

- **Style**
  - A new visual indicator (an asterisk styled with a distinctive color) clearly marks fields as required, enhancing the overall user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->