### PR TITLE
Show missing required asterisk in BitTimePicker's label (#9893)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.razor
@@ -33,6 +33,7 @@
                        name="@Name"
                        role="combobox"
                        id="@_inputId"
+                       required="@Required"
                        tabindex="@TabIndex"
                        aria-haspopup="dialog"
                        aria-label="@AriaLabel"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.razor.cs
@@ -315,6 +315,8 @@ public partial class BitTimePicker : BitInputBase<TimeSpan?>, IAsyncDisposable
         ClassBuilder.Register(() => Standalone ? "bit-tpc-sta" : string.Empty);
 
         ClassBuilder.Register(() => _hasFocus ? $"bit-tpc-foc {Classes?.Focused}" : string.Empty);
+
+        ClassBuilder.Register(() => IsEnabled && Required ? "bit-tpc-req" : string.Empty);
     }
 
     protected override void RegisterCssStyles()

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/_Pickers/TimePicker/BitTimePicker.scss
@@ -375,6 +375,14 @@
     }
 }
 
+.bit-tpc-req {
+    .bit-tpc-lbl::after {
+        content: "*";
+        color: $clr-req;
+        margin-inline-start: spacing(0.625);
+    }
+}
+
 .bit-tpc-res {
     @include lt-sm {
         top: 0;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TimePicker/BitTimePickerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TimePicker/BitTimePickerDemo.razor
@@ -18,6 +18,8 @@
             <br /><br />
             <BitTimePicker Label="Disabled" IsEnabled="false" />
             <br /><br />
+            <BitTimePicker Label="Required" Required />
+            <br /><br />
             <BitTimePicker Label="Placeholder" Placeholder="Select a time..." />
         </div>
     </DemoSection>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TimePicker/BitTimePickerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TimePicker/BitTimePickerDemo.razor.cs
@@ -588,9 +588,8 @@ public partial class BitTimePickerDemo
 
     private readonly string example1RazorCode = @"
 <BitTimePicker Label=""Basic TimePicker"" />
-
 <BitTimePicker Label=""Disabled"" IsEnabled=""false"" />
-
+<BitTimePicker Label=""Required"" Required />
 <BitTimePicker Label=""Placeholder"" Placeholder=""Select a time..."" />";
 
     private readonly string example2RazorCode = @"


### PR DESCRIPTION
This closes #9893 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a conditional "required" option to the time input component, ensuring user input when enabled.
  - Added a visual cue (asterisk) on the field label to indicate mandatory input.
  - Updated demonstration examples to showcase the new required functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->