### PR TITLE
Limit Boilerplate diag logger's in memory entries to 1,000 (#9898)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/DiagnosticLog/DiagnosticLogger.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/DiagnosticLog/DiagnosticLogger.cs
@@ -2,7 +2,7 @@
 
 public partial class DiagnosticLogger : ILogger, IDisposable
 {
-    public static ConcurrentBag<DiagnosticLog> Store { get; } = [];
+    public static ConcurrentQueue<DiagnosticLog> Store { get; } = [];
 
     private IDictionary<string, object?>? currentState;
 
@@ -30,7 +30,12 @@ public partial class DiagnosticLogger : ILogger, IDisposable
 
         var message = formatter(state, exception);
 
-        Store.Add(new()
+        if (Store.Count >= 1_000)
+        {
+            Store.TryDequeue(out var _);
+        }
+
+        Store.Enqueue(new()
         {
             CreatedOn = DateTimeOffset.Now,
             Level = logLevel,


### PR DESCRIPTION
closes #9898