### PR TITLE
Fix race conditions for simultaneous refresh token requests in Boilerplate (#9946)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/AuthManager.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/AuthManager.cs
@@ -213,6 +213,7 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        semaphore.Dispose();
         unsubscribe?.Invoke();
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/AuthManager.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/AuthManager.cs
@@ -89,6 +89,7 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
     /// <summary>
     /// To prevent multiple simultaneous refresh token requests.
     /// </summary>
+    private SemaphoreSlim semaphore = new(1, 1);
     private TaskCompletionSource<string?>? accessTokenTsc = null;
 
     public Task<string?> RefreshToken(string requestedBy, string? elevatedAccessToken = null)
@@ -103,41 +104,46 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
 
         async Task RefreshTokenImplementation()
         {
-            authLogger.LogInformation("Refreshing access token requested by {RequestedBy}", requestedBy);
-            string? refreshToken = await storageService.GetItem("refresh_token");
             try
             {
-                if (string.IsNullOrEmpty(refreshToken))
-                    throw new UnauthorizedException(localizer[nameof(AppStrings.YouNeedToSignIn)]);
+                await semaphore.WaitAsync();
+                authLogger.LogInformation("Refreshing access token requested by {RequestedBy}", requestedBy);
+                string? refreshToken = await storageService.GetItem("refresh_token");
+                try
+                {
+                    if (string.IsNullOrEmpty(refreshToken))
+                        throw new UnauthorizedException(localizer[nameof(AppStrings.YouNeedToSignIn)]);
 
-                var refreshTokenResponse = await identityController.Refresh(new()
-                {
-                    RefreshToken = refreshToken,
-                    DeviceInfo = telemetryContext.Platform,
-                    ElevatedAccessToken = elevatedAccessToken
-                }, default);
-                await StoreTokens(refreshTokenResponse);
-                accessTokenTsc.SetResult(refreshTokenResponse.AccessToken!);
-            }
-            catch (Exception exp)
-            {
-                exceptionHandler.Handle(exp, parameters: new()
-                {
-                    { "AdditionalData", "Refreshing access token failed." },
-                    { "RefreshTokenRequestedBy", requestedBy }
-                });
-
-                if (exp is UnauthorizedException // refresh token is also invalid.
-                    || exp is ReusedRefreshTokenException && refreshToken == await storageService.GetItem("refresh_token"))
-                {
-                    await ClearTokens();
+                    var refreshTokenResponse = await identityController.Refresh(new()
+                    {
+                        RefreshToken = refreshToken,
+                        DeviceInfo = telemetryContext.Platform,
+                        ElevatedAccessToken = elevatedAccessToken
+                    }, default);
+                    await StoreTokens(refreshTokenResponse);
+                    accessTokenTsc.SetResult(refreshTokenResponse.AccessToken!);
                 }
+                catch (Exception exp)
+                {
+                    exceptionHandler.Handle(exp, parameters: new()
+                    {
+                        { "AdditionalData", "Refreshing access token failed." },
+                        { "RefreshTokenRequestedBy", requestedBy }
+                    });
 
-                accessTokenTsc.SetResult(null);
+                    if (exp is UnauthorizedException // refresh token is also invalid.
+                        || exp is ReusedRefreshTokenException && refreshToken == await storageService.GetItem("refresh_token"))
+                    {
+                        await ClearTokens();
+                    }
+
+                    accessTokenTsc.SetResult(null);
+                }
             }
             finally
             {
                 accessTokenTsc = null;
+                semaphore.Release();
             }
         }
     }


### PR DESCRIPTION
closes #9946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the authentication refresh process to prevent overlapping refresh requests.
  - Streamlined error handling, contributing to a more stable and reliable sign-in experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->