### PR TITLE
Move up BitModalContainer in MainLayout for modals to have access to cascading parameters in Boilerplate (#9944)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor
@@ -46,6 +46,7 @@
                                 }
                             </main>
                         </BitAppShell>
+                        <BitModalContainer ModalParameters="modalParameters" />
                     </CascadingValue>
                 </CascadingValue>
             </CascadingValue>
@@ -55,6 +56,5 @@
 
 <SnackBar />
 <DiagnosticModal />
-<BitModalContainer ModalParameters="modalParameters" />
 
 <JsBridge />


### PR DESCRIPTION
closes #9944