### PR TITLE
Add missing Immediate parameter to BitOtpInpts across all projects (#9993)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/OtpInput/BitOtpInputDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/OtpInput/BitOtpInputDemo.razor
@@ -99,7 +99,7 @@
         <BitOtpInput Label="OnChange" OnChange="v => onChangeValue = v" />
         <div>OnChange value: @onChangeValue</div>
         <br /><br />
-        <BitOtpInput Label="OnFill" OnFill="v => onFillValue = v" />
+        <BitOtpInput Label="OnFill" OnFill="v => onFillValue = v" Immediate />
         <div>OnFill value: @onFillValue</div>
         <br /><br />
         <BitOtpInput Label="OnFocusIn" OnFocusIn="args => onFocusInArgs = args" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
@@ -24,6 +24,7 @@
                 {
                     <BitOtpInput @bind-Value="value"
                                  AutoFocus
+                                 Immediate
                                  Length="6"
                                  Size="BitSize.Large"
                                  Type="BitInputType.Number"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangeEmailSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangeEmailSection.razor
@@ -56,6 +56,7 @@
 
                     <BitOtpInput @bind-Value="changeModel.Token"
                                  AutoFocus
+                                 Immediate
                                  Length="6"
                                  Size="BitSize.Large"
                                  Type="BitInputType.Number"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangePhoneNumberSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangePhoneNumberSection.razor
@@ -56,6 +56,7 @@
 
                     <BitOtpInput @bind-Value="changeModel.Token"
                                  AutoFocus
+                                 Immediate
                                  Length="6"
                                  Size="BitSize.Large"
                                  Type="BitInputType.Number"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/OtpPanel.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/OtpPanel.razor
@@ -18,6 +18,7 @@
             <BitStack HorizontalAlign="BitAlignment.Center">
                 <BitOtpInput @bind-Value="Model.Otp"
                              AutoFocus
+                             Immediate
                              Length="6"
                              Size="BitSize.Large"
                              Type="BitInputType.Number"


### PR DESCRIPTION
closes #9993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- OTP input fields now trigger their events instantaneously, providing immediate feedback and responsiveness across authentication, demo, and account settings views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->