### PR TITLE
Make using of fast invoke methods optional and disabled by default (#9999)

### DIFF
--- a/src/Butil/Bit.Butil/BitButil.cs
+++ b/src/Butil/Bit.Butil/BitButil.cs
@@ -26,4 +26,16 @@ public static class BitButil
 
         return services;
     }
+
+    internal static bool FastInvokeEnabled { get; private set; }
+
+    public static void UseFastInvoke()
+    {
+        FastInvokeEnabled = true;
+    }
+
+    public static void UseNormalInvoke()
+    {
+        FastInvokeEnabled = false;
+    }
 }

--- a/src/Butil/Bit.Butil/Extensions/InternalJSRuntimeExtensions.cs
+++ b/src/Butil/Bit.Butil/Extensions/InternalJSRuntimeExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop;
+using static Bit.Butil.LinkerFlags;
+
+namespace Bit.Butil;
+
+internal static class InternalJSRuntimeExtensions
+{
+    internal static ValueTask InvokeVoid(this IJSRuntime jsRuntime, string identifier, params object?[]? args)
+    {
+        return InvokeVoid(jsRuntime, identifier, CancellationToken.None, args);
+    }
+
+    internal static ValueTask InvokeVoid(this IJSRuntime jsRuntime, string identifier, TimeSpan timeout, params object?[]? args)
+    {
+        using var cancellationTokenSource = timeout == Timeout.InfiniteTimeSpan ? null : new CancellationTokenSource(timeout);
+        var cancellationToken = cancellationTokenSource?.Token ?? CancellationToken.None;
+
+        return InvokeVoid(jsRuntime, identifier, cancellationToken, args);
+    }
+
+    internal static ValueTask InvokeVoid(this IJSRuntime jsRuntime, string identifier, CancellationToken cancellationToken, params object?[]? args)
+    {
+        return BitButil.FastInvokeEnabled
+            ? jsRuntime.FastInvokeVoidAsync(identifier, cancellationToken, args)
+            : jsRuntime.InvokeVoidAsync(identifier, cancellationToken, args);
+    }
+
+
+
+    internal static ValueTask<TValue> Invoke<[DynamicallyAccessedMembers(JsonSerialized)] TValue>(this IJSRuntime jsRuntime, string identifier, params object?[]? args)
+    {
+        return Invoke<TValue>(jsRuntime, identifier, CancellationToken.None, args);
+    }
+
+    internal static ValueTask<TValue> Invoke<[DynamicallyAccessedMembers(JsonSerialized)] TValue>(this IJSRuntime jsRuntime, string identifier, TimeSpan timeout, params object?[]? args)
+    {
+        using var cancellationTokenSource = timeout == Timeout.InfiniteTimeSpan ? null : new CancellationTokenSource(timeout);
+        var cancellationToken = cancellationTokenSource?.Token ?? CancellationToken.None;
+
+        return Invoke<TValue>(jsRuntime, identifier, cancellationToken, args);
+    }
+
+    internal static ValueTask<TValue> Invoke<[DynamicallyAccessedMembers(JsonSerialized)] TValue>(this IJSRuntime jsRuntime, string identifier, CancellationToken cancellationToken, params object?[]? args)
+    {
+        return BitButil.FastInvokeEnabled
+            ? jsRuntime.FastInvokeAsync<TValue>(identifier, cancellationToken, args)
+            : jsRuntime.InvokeAsync<TValue>(identifier, cancellationToken, args);
+    }
+}

--- a/src/Butil/Bit.Butil/Internals/JsInterops/EventsJsInterop.cs
+++ b/src/Butil/Bit.Butil/Internals/JsInterops/EventsJsInterop.cs
@@ -15,7 +15,7 @@ internal static class EventsJsInterop
         object? options = null,
         bool preventDefault = false,
         bool stopPropagation = false)
-        => await js.FastInvokeVoidAsync("BitButil.events.addEventListener",
+        => await js.InvokeVoid("BitButil.events.addEventListener",
             elementName,
             eventName,
             methodName,
@@ -30,7 +30,7 @@ internal static class EventsJsInterop
         string eventName,
         Guid[] listenerIds,
         object? options = null)
-        => await js.FastInvokeVoidAsync("BitButil.events.removeEventListener",
+        => await js.InvokeVoid("BitButil.events.removeEventListener",
             elementName,
             eventName,
             listenerIds,

--- a/src/Butil/Bit.Butil/Publics/Console.cs
+++ b/src/Butil/Bit.Butil/Publics/Console.cs
@@ -11,7 +11,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/assert_static">https://developer.mozilla.org/en-US/docs/Web/API/console/assert_static</see>
     /// </summary>
     public async Task Assert(bool? condition, params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.assert", [condition, .. args]);
+        => await js.InvokeVoid("BitButil.console.assert", [condition, .. args]);
 
     /// <summary>
     /// Clear the console.
@@ -19,7 +19,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/clear_static">https://developer.mozilla.org/en-US/docs/Web/API/console/clear_static</see>
     /// </summary>
     public async Task Clear()
-        => await js.FastInvokeVoidAsync("BitButil.console.clear");
+        => await js.InvokeVoid("BitButil.console.clear");
 
     /// <summary>
     /// Log the number of times this line has been called with the given label.
@@ -27,8 +27,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/count_static">https://developer.mozilla.org/en-US/docs/Web/API/console/count_static</see>
     /// </summary>
     public async Task Count(string? label = null)
-        => await (label is null ? js.FastInvokeVoidAsync("BitButil.console.count")
-                                : js.FastInvokeVoidAsync("BitButil.console.count", label));
+        => await (label is null ? js.InvokeVoid("BitButil.console.count")
+                                : js.InvokeVoid("BitButil.console.count", label));
 
     /// <summary>
     /// Resets the value of the counter with the given label.
@@ -36,8 +36,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/countreset_static">https://developer.mozilla.org/en-US/docs/Web/API/console/countreset_static</see>
     /// </summary>
     public async Task CountReset(string? label = null)
-        => await (label is null ? js.FastInvokeVoidAsync("BitButil.console.countReset")
-                                : js.FastInvokeVoidAsync("BitButil.console.countReset", label));
+        => await (label is null ? js.InvokeVoid("BitButil.console.countReset")
+                                : js.InvokeVoid("BitButil.console.countReset", label));
 
     /// <summary>
     /// Outputs a message to the console with the log level debug.
@@ -45,7 +45,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/debug_static">https://developer.mozilla.org/en-US/docs/Web/API/console/debug_static</see>
     /// </summary>
     public async Task Debug(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.debug", args);
+        => await js.InvokeVoid("BitButil.console.debug", args);
 
     /// <summary>
     /// Displays an interactive listing of the properties of a specified JavaScript object. 
@@ -54,7 +54,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/dir_static">https://developer.mozilla.org/en-US/docs/Web/API/console/dir_static</see>
     /// </summary>
     public async Task Dir(object? item, object? options = null)
-        => await js.FastInvokeVoidAsync("BitButil.console.dir", item, options);
+        => await js.InvokeVoid("BitButil.console.dir", item, options);
 
     /// <summary>
     /// Displays an XML/HTML Element representation of the specified object if possible 
@@ -63,7 +63,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/dirxml_static">https://developer.mozilla.org/en-US/docs/Web/API/console/dirxml_static</see>
     /// </summary>
     public async Task Dirxml(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.dirxml", args);
+        => await js.InvokeVoid("BitButil.console.dirxml", args);
 
     /// <summary>
     /// Outputs an error message. You may use string substitution and additional arguments with this method.
@@ -71,7 +71,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/error_static">https://developer.mozilla.org/en-US/docs/Web/API/console/error_static</see>
     /// </summary>
     public async Task Error(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.error", args);
+        => await js.InvokeVoid("BitButil.console.error", args);
 
     /// <summary>
     /// Creates a new inline group, indenting all following output by another level. 
@@ -80,7 +80,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/group_static">https://developer.mozilla.org/en-US/docs/Web/API/console/group_static</see>
     /// </summary>
     public async Task Group(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.group", args);
+        => await js.InvokeVoid("BitButil.console.group", args);
 
     /// <summary>
     /// Creates a new inline group, indenting all following output by another level. However, unlike console.group() 
@@ -90,7 +90,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/groupcollapsed_static">https://developer.mozilla.org/en-US/docs/Web/API/console/groupcollapsed_static</see>
     /// </summary>
     public async Task GroupCollapsed(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.groupCollapsed", args);
+        => await js.InvokeVoid("BitButil.console.groupCollapsed", args);
 
     /// <summary>
     /// Exits the current inline group.
@@ -98,7 +98,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/groupend_static">https://developer.mozilla.org/en-US/docs/Web/API/console/groupend_static</see>
     /// </summary>
     public async Task GroupEnd()
-        => await js.FastInvokeVoidAsync("BitButil.console.groupEnd");
+        => await js.InvokeVoid("BitButil.console.groupEnd");
 
     /// <summary>
     /// Informative logging of information. You may use string substitution and additional arguments with this method.
@@ -106,7 +106,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/info_static">https://developer.mozilla.org/en-US/docs/Web/API/console/info_static</see>
     /// </summary>
     public async Task Info(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.info", args);
+        => await js.InvokeVoid("BitButil.console.info", args);
 
     /// <summary>
     /// For general output of logging information. You may use string substitution and additional arguments with this method.
@@ -114,7 +114,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/log_static">https://developer.mozilla.org/en-US/docs/Web/API/console/log_static</see>
     /// </summary>
     public async Task Log(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.log", args);
+        => await js.InvokeVoid("BitButil.console.log", args);
 
     /// <summary>
     /// Starts the browser's built-in profiler (for example, the Firefox performance tool). 
@@ -123,8 +123,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/profile_static">https://developer.mozilla.org/en-US/docs/Web/API/console/profile_static</see>
     /// </summary>
     public async Task Profile(string? name = null)
-        => await (name is null ? js.FastInvokeVoidAsync("BitButil.console.profile")
-                               : js.FastInvokeVoidAsync("BitButil.console.profile", name));
+        => await (name is null ? js.InvokeVoid("BitButil.console.profile")
+                               : js.InvokeVoid("BitButil.console.profile", name));
 
     /// <summary>
     /// Stops the profiler. You can see the resulting profile in the browser's performance tool 
@@ -133,8 +133,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/profileend_static">https://developer.mozilla.org/en-US/docs/Web/API/console/profileend_static</see>
     /// </summary>
     public async Task ProfileEnd(string? name = null)
-        => await (name is null ? js.FastInvokeVoidAsync("BitButil.console.profileEnd")
-                               : js.FastInvokeVoidAsync("BitButil.console.profileEnd", name));
+        => await (name is null ? js.InvokeVoid("BitButil.console.profileEnd")
+                               : js.InvokeVoid("BitButil.console.profileEnd", name));
 
     /// <summary>
     /// Displays tabular data as a table.
@@ -142,8 +142,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/table_static">https://developer.mozilla.org/en-US/docs/Web/API/console/table_static</see>
     /// </summary>
     public async Task Table(object? data, object? properties = null)
-        => await (properties is null ? js.FastInvokeVoidAsync("BitButil.console.table", data)
-                                     : js.FastInvokeVoidAsync("BitButil.console.table", data, properties));
+        => await (properties is null ? js.InvokeVoid("BitButil.console.table", data)
+                                     : js.InvokeVoid("BitButil.console.table", data, properties));
 
     /// <summary>
     /// Starts a timer with a name specified as an input parameter. Up to 10,000 simultaneous timers can run on a given page.
@@ -151,8 +151,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/time_static">https://developer.mozilla.org/en-US/docs/Web/API/console/time_static</see>
     /// </summary>
     public async Task Time(string? label = null)
-        => await (label is null ? js.FastInvokeVoidAsync("BitButil.console.time")
-                                : js.FastInvokeVoidAsync("BitButil.console.time", label));
+        => await (label is null ? js.InvokeVoid("BitButil.console.time")
+                                : js.InvokeVoid("BitButil.console.time", label));
 
     /// <summary>
     /// Stops the specified timer and logs the elapsed time in milliseconds since it started.
@@ -160,8 +160,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/timeend_static">https://developer.mozilla.org/en-US/docs/Web/API/console/timeend_static</see>
     /// </summary>
     public async Task TimeEnd(string? label = null)
-        => await (label is null ? js.FastInvokeVoidAsync("BitButil.console.timeEnd")
-                                : js.FastInvokeVoidAsync("BitButil.console.timeEnd", label));
+        => await (label is null ? js.InvokeVoid("BitButil.console.timeEnd")
+                                : js.InvokeVoid("BitButil.console.timeEnd", label));
 
     /// <summary>
     /// Logs the value of the specified timer to the console.
@@ -169,8 +169,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/timelog_static">https://developer.mozilla.org/en-US/docs/Web/API/console/timelog_static</see>
     /// </summary>
     public async Task TimeLog(string? label = null, params object?[]? args)
-        => await (label is null ? js.FastInvokeVoidAsync("BitButil.console.timeLog")
-                                : js.FastInvokeVoidAsync("BitButil.console.timeLog", [label, .. args]));
+        => await (label is null ? js.InvokeVoid("BitButil.console.timeLog")
+                                : js.InvokeVoid("BitButil.console.timeLog", [label, .. args]));
 
     /// <summary>
     /// Adds a marker to the browser performance tool's timeline.
@@ -178,8 +178,8 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/timestamp_static">https://developer.mozilla.org/en-US/docs/Web/API/console/timestamp_static</see>
     /// </summary>
     public async Task TimeStamp(string? label = null)
-        => await (label is null ? js.FastInvokeVoidAsync("BitButil.console.timeStamp")
-                                : js.FastInvokeVoidAsync("BitButil.console.timeStamp", label));
+        => await (label is null ? js.InvokeVoid("BitButil.console.timeStamp")
+                                : js.InvokeVoid("BitButil.console.timeStamp", label));
 
     /// <summary>
     /// Outputs a stack trace.
@@ -187,7 +187,7 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/trace_static">https://developer.mozilla.org/en-US/docs/Web/API/console/trace_static</see>
     /// </summary>
     public async Task Trace(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.trace", args);
+        => await js.InvokeVoid("BitButil.console.trace", args);
 
     /// <summary>
     /// Outputs a warning message.
@@ -195,5 +195,5 @@ public class Console(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/console/warn_static">https://developer.mozilla.org/en-US/docs/Web/API/console/warn_static</see>
     /// </summary>
     public async Task Warn(params object?[]? args)
-        => await js.FastInvokeVoidAsync("BitButil.console.warn", args);
+        => await js.InvokeVoid("BitButil.console.warn", args);
 }

--- a/src/Butil/Bit.Butil/Publics/Cookie.cs
+++ b/src/Butil/Bit.Butil/Publics/Cookie.cs
@@ -17,7 +17,7 @@ public class Cookie(IJSRuntime js)
     /// </summary>
     public async Task<ButilCookie[]> GetAll()
     {
-        var cookie = await js.FastInvokeAsync<string>("BitButil.cookie.get");
+        var cookie = await js.Invoke<string>("BitButil.cookie.get");
         return cookie.Split(';').Select(ButilCookie.Parse).ToArray();
     }
 
@@ -62,5 +62,5 @@ public class Cookie(IJSRuntime js)
     /// Sets a cookie.
     /// </summary>
     public async Task Set(ButilCookie cookie)
-        => await js.FastInvokeVoidAsync("BitButil.cookie.set", cookie.ToString());
+        => await js.InvokeVoid("BitButil.cookie.set", cookie.ToString());
 }

--- a/src/Butil/Bit.Butil/Publics/Document.cs
+++ b/src/Butil/Bit.Butil/Publics/Document.cs
@@ -25,7 +25,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/characterSet">https://developer.mozilla.org/en-US/docs/Web/API/Document/characterSet</see>
     /// </summary>
     public async Task<string> GetCharacterSet()
-        => await js.FastInvokeAsync<string>("BitButil.document.characterSet");
+        => await js.Invoke<string>("BitButil.document.characterSet");
 
     /// <summary>
     /// Indicates whether the document is rendered in quirks or strict mode.
@@ -34,7 +34,7 @@ public class Document(IJSRuntime js)
     /// </summary>
     public async Task<CompatMode> GetCompatMode()
     {
-        var mode = await js.FastInvokeAsync<string>("BitButil.document.compatMode");
+        var mode = await js.Invoke<string>("BitButil.document.compatMode");
         return mode switch
         {
             "BackCompat" => CompatMode.BackCompat,
@@ -48,7 +48,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/contentType">https://developer.mozilla.org/en-US/docs/Web/API/Document/contentType</see>
     /// </summary>
     public async Task<string> GetContentType()
-        => await js.FastInvokeAsync<string>("BitButil.document.contentType");
+        => await js.Invoke<string>("BitButil.document.contentType");
 
     /// <summary>
     /// Returns the document location as a string.
@@ -56,7 +56,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/documentURI">https://developer.mozilla.org/en-US/docs/Web/API/Document/documentURI</see>
     /// </summary>
     public async Task<string> GetDocumentURI()
-        => await js.FastInvokeAsync<string>("BitButil.document.documentURI");
+        => await js.Invoke<string>("BitButil.document.documentURI");
 
     /// <summary>
     /// Gets ability to edit the whole document.
@@ -65,7 +65,7 @@ public class Document(IJSRuntime js)
     /// </summary>
     public async Task<DesignMode> GetDesignMode()
     {
-        var mode = await js.FastInvokeAsync<string>("BitButil.document.getDesignMode");
+        var mode = await js.Invoke<string>("BitButil.document.getDesignMode");
         return mode switch
         {
             "on" => DesignMode.On,
@@ -78,7 +78,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/designMode">https://developer.mozilla.org/en-US/docs/Web/API/Document/designMode</see>
     /// </summary>
     public async Task SetDesignMode(DesignMode mode)
-        => await js.FastInvokeVoidAsync("BitButil.document.setDesignMode", mode.ToString());
+        => await js.InvokeVoid("BitButil.document.setDesignMode", mode.ToString());
 
     /// <summary>
     /// Gets directionality (rtl/ltr) of the document.
@@ -87,7 +87,7 @@ public class Document(IJSRuntime js)
     /// </summary>
     public async Task<DocumentDir> GetDir()
     {
-        var mode = await js.FastInvokeAsync<string>("BitButil.document.getDir");
+        var mode = await js.Invoke<string>("BitButil.document.getDir");
         return mode switch
         {
             "rtl" => DocumentDir.Rtl,
@@ -100,7 +100,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/dir">https://developer.mozilla.org/en-US/docs/Web/API/Document/dir</see>
     /// </summary>
     public async Task SetDir(DocumentDir dir)
-        => await js.FastInvokeVoidAsync("BitButil.document.setDir", dir.ToString());
+        => await js.InvokeVoid("BitButil.document.setDir", dir.ToString());
 
     /// <summary>
     /// Returns the URI of the page that linked to this page.
@@ -108,7 +108,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer">https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer</see>
     /// </summary>
     public async Task<string> GetReferrer()
-        => await js.FastInvokeAsync<string>("BitButil.document.referrer");
+        => await js.Invoke<string>("BitButil.document.referrer");
 
     /// <summary>
     /// Gets the title of the current document.
@@ -116,14 +116,14 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/title">https://developer.mozilla.org/en-US/docs/Web/API/Document/title</see>
     /// </summary>
     public async Task<string> GetTitle()
-        => await js.FastInvokeAsync<string>("BitButil.document.getTitle");
+        => await js.Invoke<string>("BitButil.document.getTitle");
     /// <summary>
     /// Sets the title of the current document.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/title">https://developer.mozilla.org/en-US/docs/Web/API/Document/title</see>
     /// </summary>
     public async Task SetTitle(string title)
-        => await js.FastInvokeVoidAsync("BitButil.document.setTitle", title);
+        => await js.InvokeVoid("BitButil.document.setTitle", title);
 
     /// <summary>
     /// Returns the document location as a string.
@@ -131,7 +131,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/URL">https://developer.mozilla.org/en-US/docs/Web/API/Document/URL</see>
     /// </summary>
     public async Task<string> GetUrl()
-        => await js.FastInvokeAsync<string>("BitButil.document.URL");
+        => await js.Invoke<string>("BitButil.document.URL");
 
     /// <summary>
     /// Stops document's fullscreen element from being displayed fullscreen.
@@ -139,7 +139,7 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen">https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen</see>
     /// </summary>
     public async Task ExitFullscreen()
-        => await js.FastInvokeVoidAsync("BitButil.document.exitFullscreen");
+        => await js.InvokeVoid("BitButil.document.exitFullscreen");
 
     /// <summary>
     /// Release the pointer lock.
@@ -147,5 +147,5 @@ public class Document(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/exitPointerLock">https://developer.mozilla.org/en-US/docs/Web/API/Document/exitPointerLock</see>
     /// </summary>
     public async Task ExitPointerLock()
-        => await js.FastInvokeVoidAsync("BitButil.document.exitPointerLock");
+        => await js.InvokeVoid("BitButil.document.exitPointerLock");
 }

--- a/src/Butil/Bit.Butil/Publics/ElementReferenceExtensions.cs
+++ b/src/Butil/Bit.Butil/Publics/ElementReferenceExtensions.cs
@@ -37,7 +37,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur</see>
     /// </summary>
     public static ValueTask Blur(this ElementReference element)
-        => GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.blur", element);
+        => GetJSRuntime(element).InvokeVoid("BitButil.element.blur", element);
 
     /// <summary>
     /// Retrieves the value of the named attribute from the current node and returns it as a string.
@@ -45,7 +45,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute">https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute</see>
     /// </summary>
     public static ValueTask<string> GetAttribute(this ElementReference element, string name)
-        => GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getAttribute", element, name);
+        => GetJSRuntime(element).Invoke<string>("BitButil.element.getAttribute", element, name);
 
     /// <summary>
     /// Returns an array of attribute names from the current element.
@@ -53,7 +53,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames">https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames</see>
     /// </summary>
     public static async ValueTask<string[]> GetAttributeNames(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string[]>("BitButil.element.getAttributeNames", element);
+        => await GetJSRuntime(element).Invoke<string[]>("BitButil.element.getAttributeNames", element);
 
     /// <summary>
     /// Returns the size of an element and its position relative to the viewport.
@@ -61,7 +61,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect">https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect</see>
     /// </summary>
     public static async ValueTask<Rect> GetBoundingClientRect(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<Rect>("BitButil.element.getBoundingClientRect", element);
+        => await GetJSRuntime(element).Invoke<Rect>("BitButil.element.getBoundingClientRect", element);
 
     /// <summary>
     /// Returns a boolean value indicating if the element has the specified attribute or not.
@@ -69,7 +69,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttribute">https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttribute</see>
     /// </summary>
     public static async ValueTask<bool> HasAttribute(this ElementReference element, string name)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.hasAttribute", element, name);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.hasAttribute", element, name);
 
     /// <summary>
     /// Returns a boolean value indicating if the element has one or more HTML attributes present.
@@ -77,7 +77,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttributes">https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttributes</see>
     /// </summary>
     public static async ValueTask<bool> HasAttributes(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.hasAttributes", element);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.hasAttributes", element);
 
     /// <summary>
     /// Indicates whether the element on which it is invoked has pointer capture for the pointer identified by the given pointer ID.
@@ -85,7 +85,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture">https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture</see>
     /// </summary>
     public static async ValueTask<bool> HasPointerCapture(this ElementReference element, int pointerId)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.hasPointerCapture", element, pointerId);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.hasPointerCapture", element, pointerId);
 
     /// <summary>
     /// Returns a boolean value indicating whether or not the element would be selected by the specified selector string.
@@ -93,7 +93,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/matches">https://developer.mozilla.org/en-US/docs/Web/API/Element/matches</see>
     /// </summary>
     public static async ValueTask<bool> Matches(this ElementReference element, string selectors)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.matches", element, selectors);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.matches", element, selectors);
 
     /// <summary>
     /// Releases (stops) pointer capture that was previously set for a specific pointer event.
@@ -101,7 +101,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture">https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture</see>
     /// </summary>
     public static async ValueTask ReleasePointerCapture(this ElementReference element, int pointerId)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.releasePointerCapture", element, pointerId);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.releasePointerCapture", element, pointerId);
 
     /// <summary>
     /// Removes the element from the children list of its parent.
@@ -109,7 +109,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/remove">https://developer.mozilla.org/en-US/docs/Web/API/Element/remove</see>
     /// </summary>
     public static async ValueTask Remove(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.remove", element);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.remove", element);
 
     /// <summary>
     /// Removes the named attribute from the current node.
@@ -117,7 +117,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute">https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute</see>
     /// </summary>
     public static async ValueTask RemoveAttribute(this ElementReference element, string name)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.removeAttribute", element, name);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.removeAttribute", element, name);
 
     /// <summary>
     /// Asynchronously asks the browser to make the element fullscreen.
@@ -126,7 +126,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(FullScreenJsOptions))]
     public static async ValueTask RequestFullScreen(this ElementReference element, FullScreenOptions? options)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.requestFullScreen", element, options?.ToJsObject());
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.requestFullScreen", element, options?.ToJsObject());
 
     /// <summary>
     /// Allows to asynchronously ask for the pointer to be locked on the given element.
@@ -134,7 +134,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock">https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock</see>
     /// </summary>
     public static async ValueTask RequestPointerLock(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.requestPointerLock", element);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.requestPointerLock", element);
 
     /// <summary>
     /// Scrolls to a particular set of coordinates inside a given element.
@@ -143,14 +143,14 @@ public static class ElementReferenceExtensions
     /// </summary>
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ScrollJsOptions))]
     public static async ValueTask Scroll(this ElementReference element, ScrollOptions? options)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scroll", element, options?.ToJsObject(), null, null);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scroll", element, options?.ToJsObject(), null, null);
     /// <summary>
     /// Scrolls to a particular set of coordinates inside a given element.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll">https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll</see>
     /// </summary>
     public static async ValueTask Scroll(this ElementReference element, double? x, double? y)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scroll", element, null, x, y);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scroll", element, null, x, y);
 
     /// <summary>
     /// Scrolls an element by the given amount.
@@ -158,14 +158,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy</see>
     /// </summary>
     public static async ValueTask ScrollBy(this ElementReference element, ScrollOptions? options)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scrollBy", element, options?.ToJsObject(), null, null);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scrollBy", element, options?.ToJsObject(), null, null);
     /// <summary>
     /// Scrolls an element by the given amount.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy</see>
     /// </summary>
     public static async ValueTask ScrollBy(this ElementReference element, double? x, double? y)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scrollBy", element, null, x, y);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scrollBy", element, null, x, y);
 
     /// <summary>
     /// Scrolls the page until the element gets into the view.
@@ -173,14 +173,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView</see>
     /// </summary>
     public static async ValueTask ScrollIntoView(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scrollIntoView", element, null, null);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scrollIntoView", element, null, null);
     /// <summary>
     /// Scrolls the page until the element gets into the view.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView</see>
     /// </summary>
     public static async ValueTask ScrollIntoView(this ElementReference element, bool alignToTop)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scrollIntoView", element, alignToTop, null);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scrollIntoView", element, alignToTop, null);
     /// <summary>
     /// Scrolls the page until the element gets into the view.
     /// <br />
@@ -188,7 +188,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ScrollIntoViewJsOptions))]
     public static async ValueTask ScrollIntoView(this ElementReference element, ScrollIntoViewOptions options)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.scrollIntoView", element, null, options?.ToJsObject());
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.scrollIntoView", element, null, options?.ToJsObject());
 
     /// <summary>
     /// Sets the value of a named attribute of the current node.
@@ -196,7 +196,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute">https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute</see>
     /// </summary>
     public static async ValueTask SetAttribute(this ElementReference element, string name, string value)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setAttribute", element, name, value);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setAttribute", element, name, value);
 
     /// <summary>
     /// Designates a specific element as the capture target of future pointer events.
@@ -204,7 +204,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture">https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture</see>
     /// </summary>
     public static async ValueTask SetPointerCapture(this ElementReference element, int pointerId)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setPointerCapture", element, pointerId);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setPointerCapture", element, pointerId);
 
     /// <summary>
     /// Toggles a boolean attribute, removing it if it is present and adding it if it is not present, on the specified element.
@@ -212,7 +212,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute">https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute</see>
     /// </summary>
     public static async ValueTask<bool> ToggleAttribute(this ElementReference element, string name, bool? force)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.toggleAttribute", element, name, force);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.toggleAttribute", element, name, force);
 
     /// <summary>
     /// A string representing the access key assigned to the element.
@@ -220,14 +220,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey</see>
     /// </summary>
     public static async ValueTask<string> GetAccessKey(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getAccessKey", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.getAccessKey", element);
     /// <summary>
     /// A string representing the access key assigned to the element.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey</see>
     /// </summary>
     public static async ValueTask SetAccessKey(this ElementReference element, string key)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setAccessKey", element, key);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setAccessKey", element, key);
 
     /// <summary>
     /// A string representing the class of the element.
@@ -235,14 +235,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/className">https://developer.mozilla.org/en-US/docs/Web/API/Element/className</see>
     /// </summary>
     public static async ValueTask<string> GetClassName(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getClassName", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.getClassName", element);
     /// <summary>
     /// A string representing the class of the element.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/className">https://developer.mozilla.org/en-US/docs/Web/API/Element/className</see>
     /// </summary>
     public static async ValueTask SetClassName(this ElementReference element, string className)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setClassName", element, className);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setClassName", element, className);
 
     /// <summary>
     /// Returns a number representing the inner height of the element in px.
@@ -250,7 +250,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight">https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight</see>
     /// </summary>
     public static async ValueTask<float> GetClientHeight(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.clientHeight", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.clientHeight", element);
 
     /// <summary>
     /// Returns a number representing the width of the left border of the element in px.
@@ -258,7 +258,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft">https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft</see>
     /// </summary>
     public static async ValueTask<float> GetClientLeft(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.clientLeft", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.clientLeft", element);
 
     /// <summary>
     /// Returns a number representing the width of the top border of the element in px.
@@ -266,7 +266,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop">https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop</see>
     /// </summary>
     public static async ValueTask<float> GetClientTop(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.clientTop", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.clientTop", element);
 
     /// <summary>
     /// Returns a number representing the inner width of the element in px.
@@ -274,7 +274,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth">https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth</see>
     /// </summary>
     public static async ValueTask<float> GetClientWidth(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.clientWidth", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.clientWidth", element);
 
     /// <summary>
     /// A string representing the id of the element.
@@ -282,14 +282,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/id">https://developer.mozilla.org/en-US/docs/Web/API/Element/id</see>
     /// </summary>
     public static async ValueTask<string> GetId(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getId", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.getId", element);
     /// <summary>
     /// A string representing the id of the element.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/id">https://developer.mozilla.org/en-US/docs/Web/API/Element/id</see>
     /// </summary>
     public static async ValueTask SetId(this ElementReference element, string id)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setId", element, id);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setId", element, id);
 
     /// <summary>
     /// A string representing the markup of the element's content.
@@ -297,14 +297,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML">https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML</see>
     /// </summary>
     public static async ValueTask<string> GetInnerHtml(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getInnerHTML", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.getInnerHTML", element);
     /// <summary>
     /// A string representing the markup of the element's content.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML">https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML</see>
     /// </summary>
     public static async ValueTask SetInnerHtml(this ElementReference element, string innerHtml)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setInnerHTML", element, innerHtml);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setInnerHTML", element, innerHtml);
 
     /// <summary>
     /// A string representing the markup of the element including its content.
@@ -312,7 +312,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML">https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML</see>
     /// </summary>
     public static async ValueTask<string> GetOuterHtml(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getOuterHTML", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.getOuterHTML", element);
     /// <summary>
     /// A string representing the markup of the element including its content. When used as a setter, 
     /// replaces the element with nodes parsed from the given string.
@@ -320,7 +320,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML">https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML</see>
     /// </summary>
     public static async ValueTask SetOuterHtml(this ElementReference element, string outerHtml)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setOuterHTML", element, outerHtml);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setOuterHTML", element, outerHtml);
 
     /// <summary>
     /// Returns a number representing the scroll view height of an element.
@@ -328,7 +328,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight</see>
     /// </summary>
     public static async ValueTask<float> GetScrollHeight(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.scrollHeight", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.scrollHeight", element);
 
     /// <summary>
     /// A number representing the left scroll offset of the element.
@@ -336,7 +336,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft</see>
     /// </summary>
     public static async ValueTask<float> GetScrollLeft(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.scrollLeft", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.scrollLeft", element);
 
     /// <summary>
     /// A number representing number of pixels the top of the element is scrolled vertically.
@@ -344,7 +344,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop</see>
     /// </summary>
     public static async ValueTask<float> GetScrollTop(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.scrollTop", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.scrollTop", element);
 
     /// <summary>
     /// Returns a number representing the scroll view width of the element.
@@ -352,7 +352,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth">https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth</see>
     /// </summary>
     public static async ValueTask<float> GetScrollWidth(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.scrollWidth", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.scrollWidth", element);
 
     /// <summary>
     /// Returns a string with the name of the tag for the given element.
@@ -360,7 +360,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName">https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName</see>
     /// </summary>
     public static async ValueTask<string> GetTagName(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.tagName", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.tagName", element);
 
     /// <summary>
     /// The contentEditable property of the HTMLElement interface specifies whether or not the element is editable.
@@ -369,7 +369,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     public static async ValueTask<ContentEditable> GetContentEditable(this ElementReference element)
     {
-        var value = await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getContentEditable", element);
+        var value = await GetJSRuntime(element).Invoke<string>("BitButil.element.getContentEditable", element);
         return value switch
         {
             "true" => ContentEditable.True,
@@ -392,7 +392,7 @@ public static class ElementReferenceExtensions
             ContentEditable.PlainTextOnly => "plaintext-only",
             _ => "inherit",
         };
-        await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setContentEditable", element, v);
+        await GetJSRuntime(element).InvokeVoid("BitButil.element.setContentEditable", element, v);
     }
 
     /// <summary>
@@ -401,7 +401,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable</see>
     /// </summary>
     public static async ValueTask<bool> IsContentEditable(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.isContentEditable", element);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.isContentEditable", element);
 
     /// <summary>
     /// The HTMLElement.dir property gets or sets the text writing directionality of the content of the current element.
@@ -410,7 +410,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     public static async ValueTask<ElementDir> GetDir(this ElementReference element)
     {
-        var value = await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getDir", element);
+        var value = await GetJSRuntime(element).Invoke<string>("BitButil.element.getDir", element);
         return value switch
         {
             "ltr" => ElementDir.Ltr,
@@ -433,7 +433,7 @@ public static class ElementReferenceExtensions
             ElementDir.Auto => "auto",
             _ => "",
         };
-        await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setDir", element, v);
+        await GetJSRuntime(element).InvokeVoid("BitButil.element.setDir", element, v);
     }
 
     /// <summary>
@@ -444,7 +444,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     public static async ValueTask<EnterKeyHint> GetEnterKeyHint(this ElementReference element)
     {
-        var value = await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getEnterKeyHint", element);
+        var value = await GetJSRuntime(element).Invoke<string>("BitButil.element.getEnterKeyHint", element);
         return value switch
         {
             "enter" => EnterKeyHint.Enter,
@@ -476,7 +476,7 @@ public static class ElementReferenceExtensions
             EnterKeyHint.Send => "send",
             _ => "",
         };
-        await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setEnterKeyHint", element, v);
+        await GetJSRuntime(element).InvokeVoid("BitButil.element.setEnterKeyHint", element, v);
     }
 
     /// <summary>
@@ -486,7 +486,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     public static async ValueTask<Hidden> GetHidden(this ElementReference element)
     {
-        var value = await GetJSRuntime(element).FastInvokeAsync<object>("BitButil.element.getHidden", element);
+        var value = await GetJSRuntime(element).Invoke<object>("BitButil.element.getHidden", element);
         var v = value.ToString() switch
         {
             "True" => Hidden.True,
@@ -508,7 +508,7 @@ public static class ElementReferenceExtensions
             Hidden.UntilFound => "until-found",
             _ => false,
         };
-        await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setHidden", element, v);
+        await GetJSRuntime(element).InvokeVoid("BitButil.element.setHidden", element, v);
     }
 
     /// <summary>
@@ -519,7 +519,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert</see>
     /// </summary>
     public static async ValueTask<bool> GetInert(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<bool>("BitButil.element.getInert", element);
+        => await GetJSRuntime(element).Invoke<bool>("BitButil.element.getInert", element);
     /// <summary>
     /// The HTMLElement property inert reflects the value of the element's inert attribute. 
     /// It is a boolean value that, when present, makes the browser "ignore" user input events 
@@ -528,7 +528,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert</see>
     /// </summary>
     public static async ValueTask SetInert(this ElementReference element, bool value)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setInert", element, value);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setInert", element, value);
 
     /// <summary>
     /// The innerText property of the HTMLElement interface represents the rendered text content of a node and its descendants.
@@ -536,14 +536,14 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText</see>
     /// </summary>
     public static async ValueTask<string> GetInnerText(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getInnerText", element);
+        => await GetJSRuntime(element).Invoke<string>("BitButil.element.getInnerText", element);
     /// <summary>
     /// The innerText property of the HTMLElement interface represents the rendered text content of a node and its descendants.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText</see>
     /// </summary>
     public static async ValueTask SetInnerText(this ElementReference element, string value)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setInnerText", element, value);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setInnerText", element, value);
 
     /// <summary>
     /// The HTMLElement property inputMode reflects the value of the element's inputmode attribute.
@@ -552,7 +552,7 @@ public static class ElementReferenceExtensions
     /// </summary>
     public static async ValueTask<InputMode> GetInputMode(this ElementReference element)
     {
-        var value = await GetJSRuntime(element).FastInvokeAsync<string>("BitButil.element.getInputMode", element);
+        var value = await GetJSRuntime(element).Invoke<string>("BitButil.element.getInputMode", element);
         return value switch
         {
             "decimal" => InputMode.Decimal,
@@ -585,7 +585,7 @@ public static class ElementReferenceExtensions
             InputMode.Url => "url",
             _ => "",
         };
-        await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setInputMode", element, v);
+        await GetJSRuntime(element).InvokeVoid("BitButil.element.setInputMode", element, v);
     }
 
     /// <summary>
@@ -595,7 +595,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight</see>
     /// </summary>
     public static async ValueTask<float> GetOffsetHeight(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.offsetHeight", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.offsetHeight", element);
 
     /// <summary>
     /// The HTMLElement.offsetLeft read-only property returns the number of pixels that the upper left corner 
@@ -604,7 +604,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft</see>
     /// </summary>
     public static async ValueTask<float> GetOffsetLeft(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.offsetLeft", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.offsetLeft", element);
 
     /// <summary>
     /// The HTMLElement.offsetTop read-only property returns the distance from the outer border of the current element 
@@ -613,7 +613,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop</see>
     /// </summary>
     public static async ValueTask<float> GetOffsetTop(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.offsetTop", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.offsetTop", element);
 
     /// <summary>
     /// The layout width of an element in px.
@@ -621,7 +621,7 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth</see>
     /// </summary>
     public static async ValueTask<float> GetOffsetWidth(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<float>("BitButil.element.offsetWidth", element);
+        => await GetJSRuntime(element).Invoke<float>("BitButil.element.offsetWidth", element);
 
     /// <summary>
     /// A number representing the position of the element in the tabbing order.
@@ -629,12 +629,12 @@ public static class ElementReferenceExtensions
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex</see>
     /// </summary>
     public static async ValueTask<int> GetTabIndex(this ElementReference element)
-        => await GetJSRuntime(element).FastInvokeAsync<int>("BitButil.element.getTabIndex", element);
+        => await GetJSRuntime(element).Invoke<int>("BitButil.element.getTabIndex", element);
     /// <summary>
     /// A number representing the position of the element in the tabbing order.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex">https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex</see>
     /// </summary>
     public static async ValueTask SetTabIndex(this ElementReference element, int value)
-        => await GetJSRuntime(element).FastInvokeVoidAsync("BitButil.element.setTabIndex", element, value);
+        => await GetJSRuntime(element).InvokeVoid("BitButil.element.setTabIndex", element, value);
 }

--- a/src/Butil/Bit.Butil/Publics/History.cs
+++ b/src/Butil/Bit.Butil/Publics/History.cs
@@ -23,7 +23,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/History/length">https://developer.mozilla.org/en-US/docs/Web/API/History/length</see>
     /// </summary>
     public async Task<int> GetLength()
-        => await js.FastInvokeAsync<int>("BitButil.history.length");
+        => await js.Invoke<int>("BitButil.history.length");
 
     /// <summary>
     /// Gets default scroll restoration behavior on history navigation. This property can be either auto or manual.
@@ -32,7 +32,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     public async Task<ScrollRestoration> GetScrollRestoration()
     {
-        var value = await js.FastInvokeAsync<string>("BitButil.history.scrollRestoration");
+        var value = await js.Invoke<string>("BitButil.history.scrollRestoration");
         return value == "auto" ? ScrollRestoration.Auto : ScrollRestoration.Manual;
     }
 
@@ -43,7 +43,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/History/scrollRestoration">https://developer.mozilla.org/en-US/docs/Web/API/History/scrollRestoration</see>
     /// </summary>
     public async Task SetScrollRestoration(ScrollRestoration value)
-        => await js.FastInvokeVoidAsync("BitButil.history.setScrollRestoration", value.ToString().ToLowerInvariant());
+        => await js.InvokeVoid("BitButil.history.setScrollRestoration", value.ToString().ToLowerInvariant());
 
     /// <summary>
     /// Returns an any value representing the state at the top of the history stack.
@@ -51,7 +51,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/History/state">https://developer.mozilla.org/en-US/docs/Web/API/History/state</see>
     /// </summary>
     public async Task<object> GetState()
-        => await js.FastInvokeAsync<object>("BitButil.history.state");
+        => await js.Invoke<object>("BitButil.history.state");
 
     /// <summary>
     /// This asynchronous method goes to the previous page in session history, the same action as 
@@ -61,7 +61,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/History/back">https://developer.mozilla.org/en-US/docs/Web/API/History/back</see>
     /// </summary>
     public async Task GoBack()
-        => await js.FastInvokeVoidAsync("BitButil.history.back");
+        => await js.InvokeVoid("BitButil.history.back");
 
     /// <summary>
     /// This asynchronous method goes to the next page in session history, the same action as 
@@ -71,7 +71,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/History/forward">https://developer.mozilla.org/en-US/docs/Web/API/History/forward</see>
     /// </summary>
     public async Task GoForward()
-        => await js.FastInvokeVoidAsync("BitButil.history.forward");
+        => await js.InvokeVoid("BitButil.history.forward");
 
     /// <summary>
     /// Asynchronously loads a page from the session history, identified by its relative location 
@@ -81,7 +81,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/History/go">https://developer.mozilla.org/en-US/docs/Web/API/History/go</see>
     /// </summary>
     public async Task Go(int? delta = null)
-        => await js.FastInvokeVoidAsync("BitButil.history.go", delta);
+        => await js.InvokeVoid("BitButil.history.go", delta);
 
     /// <summary>
     /// Pushes the given data onto the session history stack with the specified title (and, if provided, URL).
@@ -92,7 +92,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <param name="url">The new history entry's URL. The new URL must be of the same origin as the current URL; 
     /// otherwise PushState throws an exception.</param>
     public async Task PushState(object? state = null, string? url = null)
-        => await js.FastInvokeVoidAsync("BitButil.history.pushState", state, string.Empty, url);
+        => await js.InvokeVoid("BitButil.history.pushState", state, string.Empty, url);
 
     /// <summary>
     /// Updates the most recent entry on the history stack to have the specified data, title, and, if provided, URL.
@@ -104,7 +104,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     /// <param name="url">The URL of the history entry. The new URL must be of the same origin as the current URL; 
     /// otherwise ReplaceState throws an exception.</param>
     public async Task ReplaceState(object? state = null, string? url = null)
-        => await js.FastInvokeVoidAsync("BitButil.history.replaceState", state, string.Empty, url);
+        => await js.InvokeVoid("BitButil.history.replaceState", state, string.Empty, url);
 
     /// <summary>
     /// The popstate event of the Window interface is fired when the active history entry changes while the user 
@@ -118,7 +118,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
         var listenerId = HistoryListenersManager.AddListener(handler);
         _handlers.TryAdd(listenerId, handler);
 
-        await js.FastInvokeVoidAsync("BitButil.history.addPopState", HistoryListenersManager.InvokeMethodName, listenerId);
+        await js.InvokeVoid("BitButil.history.addPopState", HistoryListenersManager.InvokeMethodName, listenerId);
 
         return listenerId;
     }
@@ -180,7 +180,7 @@ public class History(IJSRuntime js) : IAsyncDisposable
     {
         if (OperatingSystem.IsBrowser() is false) return;
 
-        await js.FastInvokeVoidAsync("BitButil.history.removePopState", ids);
+        await js.InvokeVoid("BitButil.history.removePopState", ids);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Butil/Bit.Butil/Publics/Keyboard.cs
+++ b/src/Butil/Bit.Butil/Publics/Keyboard.cs
@@ -17,7 +17,7 @@ public class Keyboard(IJSRuntime js) : IAsyncDisposable
         var listenerId = KeyboardListenersManager.AddListener(handler);
         _handlers.TryAdd(listenerId, handler);
 
-        await js.FastInvokeVoidAsync("BitButil.keyboard.add",
+        await js.InvokeVoid("BitButil.keyboard.add",
             KeyboardListenersManager.InvokeMethodName,
             listenerId,
             code,
@@ -77,7 +77,7 @@ public class Keyboard(IJSRuntime js) : IAsyncDisposable
     {
         if (OperatingSystem.IsBrowser() is false) return;
 
-        await js.FastInvokeVoidAsync("BitButil.keyboard.remove", ids);
+        await js.InvokeVoid("BitButil.keyboard.remove", ids);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Butil/Bit.Butil/Publics/Location.cs
+++ b/src/Butil/Bit.Butil/Publics/Location.cs
@@ -19,14 +19,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/href">https://developer.mozilla.org/en-US/docs/Web/API/Location/href</see>
     /// </summary>
     public async Task<string> GetHref()
-        => await js.FastInvokeAsync<string>("BitButil.location.getHref");
+        => await js.Invoke<string>("BitButil.location.getHref");
     /// <summary>
     /// Sets the href of the location andn then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/href">https://developer.mozilla.org/en-US/docs/Web/API/Location/href</see>
     /// </summary>
     public async Task SetHref(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setHref", value);
+        => await js.InvokeVoid("BitButil.location.setHref", value);
 
     /// <summary>
     /// A string containing the protocol scheme of the URL, including the final ':'.
@@ -34,14 +34,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol">https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol</see>
     /// </summary>
     public async Task<string> GetProtocol()
-        => await js.FastInvokeAsync<string>("BitButil.location.getProtocol");
+        => await js.Invoke<string>("BitButil.location.getProtocol");
     /// <summary>
     /// Sets the protocol scheme of the URL and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol">https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol</see>
     /// </summary>
     public async Task SetProtocol(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setProtocol", value);
+        => await js.InvokeVoid("BitButil.location.setProtocol", value);
 
     /// <summary>
     /// A string containing the host, that is the hostname, a ':', and the port of the URL.
@@ -49,14 +49,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/host">https://developer.mozilla.org/en-US/docs/Web/API/Location/host</see>
     /// </summary>
     public async Task<string> GetHost()
-        => await js.FastInvokeAsync<string>("BitButil.location.getHost");
+        => await js.Invoke<string>("BitButil.location.getHost");
     /// <summary>
     /// Sets the host of the location and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/host">https://developer.mozilla.org/en-US/docs/Web/API/Location/host</see>
     /// </summary>
     public async Task SetHost(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setHost", value);
+        => await js.InvokeVoid("BitButil.location.setHost", value);
 
     /// <summary>
     /// A string containing the domain of the URL.
@@ -64,14 +64,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hostname">https://developer.mozilla.org/en-US/docs/Web/API/Location/hostname</see>
     /// </summary>
     public async Task<string> GetHostname()
-        => await js.FastInvokeAsync<string>("BitButil.location.getHostname");
+        => await js.Invoke<string>("BitButil.location.getHostname");
     /// <summary>
     /// Sets the hostname of the location and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hostname">https://developer.mozilla.org/en-US/docs/Web/API/Location/hostname</see>
     /// </summary>
     public async Task SetHostname(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setHostname", value);
+        => await js.InvokeVoid("BitButil.location.setHostname", value);
 
     /// <summary>
     /// A string containing the port number of the URL.
@@ -79,14 +79,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/port">https://developer.mozilla.org/en-US/docs/Web/API/Location/port</see>
     /// </summary>
     public async Task<string> GetPort()
-        => await js.FastInvokeAsync<string>("BitButil.location.getPort");
+        => await js.Invoke<string>("BitButil.location.getPort");
     /// <summary>
     /// Sets the port of the location and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/port">https://developer.mozilla.org/en-US/docs/Web/API/Location/port</see>
     /// </summary>
     public async Task SetPort(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setPort", value);
+        => await js.InvokeVoid("BitButil.location.setPort", value);
 
     /// <summary>
     /// A string containing an initial '/' followed by the path of the URL, not including the query string or fragment.
@@ -94,14 +94,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname">https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname</see>
     /// </summary>
     public async Task<string> GetPathname()
-        => await js.FastInvokeAsync<string>("BitButil.location.getPathname");
+        => await js.Invoke<string>("BitButil.location.getPathname");
     /// <summary>
     /// Sets the pathname of the location and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname">https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname</see>
     /// </summary>
     public async Task SetPathname(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setPathname", value);
+        => await js.InvokeVoid("BitButil.location.setPathname", value);
 
     /// <summary>
     /// A string containing a '?' followed by the parameters or "querystring" of the URL.
@@ -109,14 +109,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/search">https://developer.mozilla.org/en-US/docs/Web/API/Location/search</see>
     /// </summary>
     public async Task<string> GetSearch()
-        => await js.FastInvokeAsync<string>("BitButil.location.getSearch");
+        => await js.Invoke<string>("BitButil.location.getSearch");
     /// <summary>
     /// Sets the search of the location and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/search">https://developer.mozilla.org/en-US/docs/Web/API/Location/search</see>
     /// </summary>
     public async Task SetSearch(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setSearch", value);
+        => await js.InvokeVoid("BitButil.location.setSearch", value);
 
     /// <summary>
     /// A string containing a '#' followed by the fragment identifier of the URL.
@@ -124,14 +124,14 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hash">https://developer.mozilla.org/en-US/docs/Web/API/Location/hash</see>
     /// </summary>
     public async Task<string> GetHash()
-        => await js.FastInvokeAsync<string>("BitButil.location.getHash");
+        => await js.Invoke<string>("BitButil.location.getHash");
     /// <summary>
     /// Sets the hash of the location and then the associated document navigates to the new page.
     /// <br />
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hash">https://developer.mozilla.org/en-US/docs/Web/API/Location/hash</see>
     /// </summary>
     public async Task SetHash(string value)
-        => await js.FastInvokeVoidAsync("BitButil.location.setHash", value);
+        => await js.InvokeVoid("BitButil.location.setHash", value);
 
     /// <summary>
     /// Returns a string containing the canonical form of the origin of the specific location.
@@ -139,7 +139,7 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/origin">https://developer.mozilla.org/en-US/docs/Web/API/Location/origin</see>
     /// </summary>
     public async Task<string> GetOrigin()
-        => await js.FastInvokeAsync<string>("BitButil.location.origin");
+        => await js.Invoke<string>("BitButil.location.origin");
 
     /// <summary>
     /// Loads the resource at the URL provided in parameter.
@@ -147,7 +147,7 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/assign">https://developer.mozilla.org/en-US/docs/Web/API/Location/assign</see>
     /// </summary>
     public async Task Assign(string url)
-        => await js.FastInvokeVoidAsync("BitButil.location.assign", url);
+        => await js.InvokeVoid("BitButil.location.assign", url);
 
     /// <summary>
     /// Reloads the current URL, like the Refresh button.
@@ -155,7 +155,7 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/reload">https://developer.mozilla.org/en-US/docs/Web/API/Location/reload</see>
     /// </summary>
     public async Task Reload()
-        => await js.FastInvokeVoidAsync("BitButil.location.reload");
+        => await js.InvokeVoid("BitButil.location.reload");
 
     /// <summary>
     /// Replaces the current resource with the one at the provided URL (redirects to the provided URL).
@@ -163,5 +163,5 @@ public class Location(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Location/replace">https://developer.mozilla.org/en-US/docs/Web/API/Location/replace</see>
     /// </summary>
     public async Task Replace(string url)
-        => await js.FastInvokeVoidAsync("BitButil.location.replace", url);
+        => await js.InvokeVoid("BitButil.location.replace", url);
 }

--- a/src/Butil/Bit.Butil/Publics/Navigator.cs
+++ b/src/Butil/Bit.Butil/Publics/Navigator.cs
@@ -17,7 +17,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory</see>
     /// </summary>
     public async Task<float> GetDeviceMemory()
-        => await js.FastInvokeAsync<float>("BitButil.navigator.deviceMemory");
+        => await js.Invoke<float>("BitButil.navigator.deviceMemory");
 
     /// <summary>
     /// Returns the number of logical processor cores available.
@@ -25,7 +25,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency</see>
     /// </summary>
     public async Task<float> GetHardwareConcurrency()
-        => await js.FastInvokeAsync<ushort>("BitButil.navigator.hardwareConcurrency");
+        => await js.Invoke<ushort>("BitButil.navigator.hardwareConcurrency");
 
     /// <summary>
     /// Returns a string representing the preferred language of the user, usually the language of the browser UI. 
@@ -34,7 +34,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language</see>
     /// </summary>
     public async Task<string> GetLanguage()
-        => await js.FastInvokeAsync<string>("BitButil.navigator.language");
+        => await js.Invoke<string>("BitButil.navigator.language");
 
     /// <summary>
     /// Returns an array of strings representing the languages known to the user, by order of preference.
@@ -42,7 +42,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages</see>
     /// </summary>
     public async Task<string[]> GetLanguages()
-        => await js.FastInvokeAsync<string[]>("BitButil.navigator.languages");
+        => await js.Invoke<string[]>("BitButil.navigator.languages");
 
     /// <summary>
     /// Returns the maximum number of simultaneous touch contact points are supported by the current device.
@@ -50,7 +50,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints</see>
     /// </summary>
     public async Task<byte> GetMaxTouchPoints()
-        => await js.FastInvokeAsync<byte>("BitButil.navigator.maxTouchPoints");
+        => await js.Invoke<byte>("BitButil.navigator.maxTouchPoints");
 
     /// <summary>
     /// Returns a boolean value indicating whether the browser is working online.
@@ -58,7 +58,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine</see>
     /// </summary>
     public async Task<bool> IsOnLine()
-        => await js.FastInvokeAsync<bool>("BitButil.navigator.onLine");
+        => await js.Invoke<bool>("BitButil.navigator.onLine");
 
     /// <summary>
     /// Returns true if the browser can display PDF files inline when navigating to them, and false otherwise.
@@ -66,7 +66,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/pdfViewerEnabled">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/pdfViewerEnabled</see>
     /// </summary>
     public async Task<bool> IsPdfViewerEnabled()
-        => await js.FastInvokeAsync<bool>("BitButil.navigator.pdfViewerEnabled");
+        => await js.Invoke<bool>("BitButil.navigator.pdfViewerEnabled");
 
     /// <summary>
     /// Returns the user agent string for the current browser.
@@ -74,7 +74,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent</see>
     /// </summary>
     public async Task<string> GetUserAgent()
-        => await js.FastInvokeAsync<string>("BitButil.navigator.userAgent");
+        => await js.Invoke<string>("BitButil.navigator.userAgent");
 
     /// <summary>
     /// Indicates whether the user agent is controlled by automation.
@@ -82,7 +82,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver</see>
     /// </summary>
     public async Task<bool> IsWebDriver()
-        => await js.FastInvokeAsync<bool>("BitButil.navigator.webdriver");
+        => await js.Invoke<bool>("BitButil.navigator.webdriver");
 
     /// <summary>
     /// Returns true if a call to Navigator.share() would succeed.
@@ -90,7 +90,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare</see>
     /// </summary>
     public async Task<bool> CanShare()
-        => await js.FastInvokeAsync<bool>("BitButil.navigator.canShare");
+        => await js.Invoke<bool>("BitButil.navigator.canShare");
 
     /// <summary>
     /// Clears a badge on the current app's icon and returns a Promise that resolves with undefined.
@@ -98,7 +98,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clearAppBadge">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clearAppBadge</see>
     /// </summary>
     public async Task ClearAppBadge()
-        => await js.FastInvokeVoidAsync("BitButil.navigator.clearAppBadge");
+        => await js.InvokeVoid("BitButil.navigator.clearAppBadge");
 
     /// <summary>
     /// Used to asynchronously transfer a small amount of data using HTTP from the User Agent to a web server.
@@ -106,7 +106,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon</see>
     /// </summary>
     public async Task<bool> SendBeacon()
-        => await js.FastInvokeAsync<bool>("BitButil.navigator.sendBeacon");
+        => await js.Invoke<bool>("BitButil.navigator.sendBeacon");
 
     /// <summary>
     /// Sets a badge on the icon associated with this app and returns a Promise that resolves with undefined.
@@ -114,7 +114,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/setAppBadge">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/setAppBadge</see>
     /// </summary>
     public async Task SetAppBadge()
-        => await js.FastInvokeVoidAsync("BitButil.navigator.setAppBadge");
+        => await js.InvokeVoid("BitButil.navigator.setAppBadge");
 
     /// <summary>
     /// Invokes the native sharing mechanism of the current platform.
@@ -122,7 +122,7 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share</see>
     /// </summary>
     public async Task Share(ShareData data)
-        => await js.FastInvokeVoidAsync("BitButil.navigator.share", data);
+        => await js.InvokeVoid("BitButil.navigator.share", data);
 
     /// <summary>
     /// Causes vibration on devices with support for it. Does nothing if vibration support isn't available.
@@ -130,5 +130,5 @@ public class Navigator(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate">https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate</see>
     /// </summary>
     public async Task<bool> Vibrate(int[] pattern)
-        => await js.FastInvokeAsync<bool>("BitButil.navigator.vibrate", pattern);
+        => await js.Invoke<bool>("BitButil.navigator.vibrate", pattern);
 }

--- a/src/Butil/Bit.Butil/Publics/Notification.cs
+++ b/src/Butil/Bit.Butil/Publics/Notification.cs
@@ -16,7 +16,7 @@ public class Notification(IJSRuntime js)
     /// </summary>
     public async ValueTask<bool> IsSupported()
     {
-        return await js.FastInvokeAsync<bool>("BitButil.notification.isSupported");
+        return await js.Invoke<bool>("BitButil.notification.isSupported");
     }
 
     /// <summary>
@@ -26,7 +26,7 @@ public class Notification(IJSRuntime js)
     /// </summary>
     public async ValueTask<NotificationPermission> GetPermission()
     {
-        var permission = await js.FastInvokeAsync<string>("BitButil.notification.getPermission");
+        var permission = await js.Invoke<string>("BitButil.notification.getPermission");
 
         return permission switch
         {
@@ -70,6 +70,6 @@ public class Notification(IJSRuntime js)
             opts = new(options);
         }
 
-        await js.FastInvokeVoidAsync("BitButil.notification.show", title, opts);
+        await js.InvokeVoid("BitButil.notification.show", title, opts);
     }
 }

--- a/src/Butil/Bit.Butil/Publics/Screen.cs
+++ b/src/Butil/Bit.Butil/Publics/Screen.cs
@@ -24,7 +24,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight">https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight</see>
     /// </summary>
     public async Task<float> GetAvailableHeight()
-        => await js.FastInvokeAsync<float>("BitButil.screen.availHeight");
+        => await js.Invoke<float>("BitButil.screen.availHeight");
 
     /// <summary>
     /// Returns the amount of horizontal space in pixels available to the window.
@@ -32,7 +32,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availWidth">https://developer.mozilla.org/en-US/docs/Web/API/Screen/availWidth</see>
     /// </summary>
     public async Task<float> GetAvailableWidth()
-        => await js.FastInvokeAsync<float>("BitButil.screen.availWidth");
+        => await js.Invoke<float>("BitButil.screen.availWidth");
 
     /// <summary>
     /// Returns the color depth of the screen.
@@ -40,7 +40,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/colorDepth">https://developer.mozilla.org/en-US/docs/Web/API/Screen/colorDepth</see>
     /// </summary>
     public async Task<byte> GetColorDepth()
-        => await js.FastInvokeAsync<byte>("BitButil.screen.colorDepth");
+        => await js.Invoke<byte>("BitButil.screen.colorDepth");
 
     /// <summary>
     /// Returns the height of the screen in pixels.
@@ -48,7 +48,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/height">https://developer.mozilla.org/en-US/docs/Web/API/Screen/height</see>
     /// </summary>
     public async Task<float> GetHeight()
-        => await js.FastInvokeAsync<float>("BitButil.screen.height");
+        => await js.Invoke<float>("BitButil.screen.height");
 
     /// <summary>
     /// Returns true if the user's device has multiple screens, and false if not.
@@ -56,7 +56,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/isExtended">https://developer.mozilla.org/en-US/docs/Web/API/Screen/isExtended</see>
     /// </summary>
     public async Task<bool> IsExtended()
-        => await js.FastInvokeAsync<bool>("BitButil.screen.isExtended");
+        => await js.Invoke<bool>("BitButil.screen.isExtended");
 
     /// <summary>
     /// Gets the bit depth of the screen.
@@ -64,7 +64,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/pixelDepth">https://developer.mozilla.org/en-US/docs/Web/API/Screen/pixelDepth</see>
     /// </summary>
     public async Task<byte> GetPixelDepth()
-        => await js.FastInvokeAsync<byte>("BitButil.screen.pixelDepth");
+        => await js.Invoke<byte>("BitButil.screen.pixelDepth");
 
     /// <summary>
     /// Returns the width of the screen.
@@ -72,7 +72,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/width">https://developer.mozilla.org/en-US/docs/Web/API/Screen/width</see>
     /// </summary>
     public async Task<float> GetWidth()
-        => await js.FastInvokeAsync<float>("BitButil.screen.width");
+        => await js.Invoke<float>("BitButil.screen.width");
 
     /// <summary>
     /// Fired on a specific screen when it changes in some way — width or height, 
@@ -86,7 +86,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
         var listenerId = ScreenListenersManager.AddListener(handler);
         _handlers.TryAdd(listenerId, handler);
 
-        await js.FastInvokeVoidAsync("BitButil.screen.addChange", ScreenListenersManager.InvokeMethodName, listenerId);
+        await js.InvokeVoid("BitButil.screen.addChange", ScreenListenersManager.InvokeMethodName, listenerId);
 
         return listenerId;
     }
@@ -148,7 +148,7 @@ public class Screen(IJSRuntime js) : IAsyncDisposable
     {
         if (OperatingSystem.IsBrowser() is false) return;
 
-        await js.FastInvokeVoidAsync("BitButil.screen.removeChange", ids);
+        await js.InvokeVoid("BitButil.screen.removeChange", ids);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Butil/Bit.Butil/Publics/ScreenOrientation.cs
+++ b/src/Butil/Bit.Butil/Publics/ScreenOrientation.cs
@@ -23,7 +23,7 @@ public class ScreenOrientation(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     public async Task<ScreenOrientationType> GetOrientationType()
     {
-        var type = await js.FastInvokeAsync<string>("BitButil.screenOrientation.type");
+        var type = await js.Invoke<string>("BitButil.screenOrientation.type");
 
         return type switch
         {
@@ -41,7 +41,7 @@ public class ScreenOrientation(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/angle">https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/angle</see>
     /// </summary>
     public async Task<ushort> GetAngle()
-        => await js.FastInvokeAsync<ushort>("BitButil.screenOrientation.angle");
+        => await js.Invoke<ushort>("BitButil.screenOrientation.angle");
 
     /// <summary>
     /// Locks the orientation of the containing document to the specified orientation.
@@ -64,7 +64,7 @@ public class ScreenOrientation(IJSRuntime js) : IAsyncDisposable
             _ => "any"
         };
 
-        await js.FastInvokeVoidAsync("BitButil.screenOrientation.lock", type);
+        await js.InvokeVoid("BitButil.screenOrientation.lock", type);
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public class ScreenOrientation(IJSRuntime js) : IAsyncDisposable
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock">https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock</see>
     /// </summary>
     public async Task Unlock()
-        => await js.FastInvokeVoidAsync("BitButil.screenOrientation.unlock");
+        => await js.InvokeVoid("BitButil.screenOrientation.unlock");
 
     /// <summary>
     /// The change event of the ScreenOrientation interface fires when the orientation of the 
@@ -87,7 +87,7 @@ public class ScreenOrientation(IJSRuntime js) : IAsyncDisposable
         var listenerId = ScreenOrientationListenersManager.AddListener(handler);
         _handlers.TryAdd(listenerId, handler);
 
-        await js.FastInvokeVoidAsync("BitButil.screenOrientation.addChange", ScreenOrientationListenersManager.InvokeMethodName, listenerId);
+        await js.InvokeVoid("BitButil.screenOrientation.addChange", ScreenOrientationListenersManager.InvokeMethodName, listenerId);
 
         return listenerId;
     }
@@ -149,7 +149,7 @@ public class ScreenOrientation(IJSRuntime js) : IAsyncDisposable
     {
         if (OperatingSystem.IsBrowser() is false) return;
 
-        await js.FastInvokeVoidAsync("BitButil.screenOrientation.removeChange", ids);
+        await js.InvokeVoid("BitButil.screenOrientation.removeChange", ids);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Butil/Bit.Butil/Publics/Storage/ButilStorage.cs
+++ b/src/Butil/Bit.Butil/Publics/Storage/ButilStorage.cs
@@ -17,7 +17,7 @@ public class ButilStorage(IJSRuntime js, string storageName)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/length">https://developer.mozilla.org/en-US/docs/Web/API/Storage/length</see>
     /// </summary>
     public async Task<int> GetLength()
-        => await js.FastInvokeAsync<int>("BitButil.storage.length", storageName);
+        => await js.Invoke<int>("BitButil.storage.length", storageName);
 
     /// <summary>
     /// When passed a number n, this method will return the name of the nth key in the storage.
@@ -25,7 +25,7 @@ public class ButilStorage(IJSRuntime js, string storageName)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/key">https://developer.mozilla.org/en-US/docs/Web/API/Storage/key</see>
     /// </summary>
     public async Task<string?> GetKey(int index)
-        => await js.FastInvokeAsync<string?>("BitButil.storage.key", storageName, index);
+        => await js.Invoke<string?>("BitButil.storage.key", storageName, index);
 
     /// <summary>
     /// When passed a key name, will return that key's value.
@@ -33,7 +33,7 @@ public class ButilStorage(IJSRuntime js, string storageName)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem">https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem</see>
     /// </summary>
     public async Task<string?> GetItem(string? key)
-        => await js.FastInvokeAsync<string?>("BitButil.storage.getItem", storageName, key);
+        => await js.Invoke<string?>("BitButil.storage.getItem", storageName, key);
 
     /// <summary>
     /// When passed a key name and value, will add that key to the storage, or update that key's value if it already exists.
@@ -41,7 +41,7 @@ public class ButilStorage(IJSRuntime js, string storageName)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem">https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem</see>
     /// </summary>
     public async Task SetItem(string? key, string? value)
-        => await js.FastInvokeVoidAsync("BitButil.storage.setItem", storageName, key, value);
+        => await js.InvokeVoid("BitButil.storage.setItem", storageName, key, value);
 
     /// <summary>
     /// When passed a key name, will remove that key from the storage.
@@ -49,7 +49,7 @@ public class ButilStorage(IJSRuntime js, string storageName)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/removeItem">https://developer.mozilla.org/en-US/docs/Web/API/Storage/removeItem</see>
     /// </summary>
     public async Task RemoveItem(string? key)
-        => await js.FastInvokeVoidAsync("BitButil.storage.removeItem", storageName, key);
+        => await js.InvokeVoid("BitButil.storage.removeItem", storageName, key);
 
     /// <summary>
     /// When invoked, will empty all keys out of the storage.
@@ -57,5 +57,5 @@ public class ButilStorage(IJSRuntime js, string storageName)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/clear">https://developer.mozilla.org/en-US/docs/Web/API/Storage/clear</see>
     /// </summary>
     public async Task Clear()
-        => await js.FastInvokeVoidAsync("BitButil.storage.clear", storageName);
+        => await js.InvokeVoid("BitButil.storage.clear", storageName);
 }

--- a/src/Butil/Bit.Butil/Publics/UserAgent.cs
+++ b/src/Butil/Bit.Butil/Publics/UserAgent.cs
@@ -16,6 +16,6 @@ public class UserAgent(IJSRuntime js)
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(UserAgentProperties))]
     public async ValueTask<UserAgentProperties> Extract()
     {
-        return await js.FastInvokeAsync<UserAgentProperties>("BitButil.userAgent.extract");
+        return await js.Invoke<UserAgentProperties>("BitButil.userAgent.extract");
     }
 }

--- a/src/Butil/Bit.Butil/Publics/VisualViewport.cs
+++ b/src/Butil/Bit.Butil/Publics/VisualViewport.cs
@@ -28,7 +28,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetOffsetLeft()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.offsetLeft");
+        => await js.Invoke<double>("BitButil.visualViewport.offsetLeft");
 
     /// <summary>
     /// Returns the offset of the top edge of the visual viewport from the top edge of 
@@ -38,7 +38,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetOffsetTop()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.offsetTop");
+        => await js.Invoke<double>("BitButil.visualViewport.offsetTop");
 
     /// <summary>
     /// Returns the x coordinate of the left edge of the visual viewport relative to the 
@@ -48,7 +48,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetPageLeft()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.pageLeft");
+        => await js.Invoke<double>("BitButil.visualViewport.pageLeft");
 
     /// <summary>
     /// Returns the y coordinate of the top edge of the visual viewport relative to the 
@@ -58,7 +58,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetPageTop()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.pageTop");
+        => await js.Invoke<double>("BitButil.visualViewport.pageTop");
 
     /// <summary>
     /// Returns the width of the visual viewport, in CSS pixels, or 0 if current document is not fully active.
@@ -67,7 +67,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetWidth()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.width");
+        => await js.Invoke<double>("BitButil.visualViewport.width");
 
     /// <summary>
     /// Returns the height of the visual viewport, in CSS pixels, or 0 if current document is not fully active.
@@ -76,7 +76,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetHeight()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.height");
+        => await js.Invoke<double>("BitButil.visualViewport.height");
 
     /// <summary>
     /// Returns the pinch-zoom scaling factor applied to the visual viewport, or 0 if current 
@@ -86,7 +86,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     /// </summary>
     /// <returns></returns>
     public async Task<double> GetScale()
-        => await js.FastInvokeAsync<double>("BitButil.visualViewport.scale");
+        => await js.Invoke<double>("BitButil.visualViewport.scale");
 
     /// <summary>
     /// Fired when the visual viewport is resized.
@@ -99,7 +99,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
         var listenerId = VisualViewportListenersManager.AddListener(handler);
         _handlers.TryAdd(listenerId, handler);
 
-        await js.FastInvokeVoidAsync("BitButil.visualViewport.addResize", VisualViewportListenersManager.InvokeMethodName, listenerId);
+        await js.InvokeVoid("BitButil.visualViewport.addResize", VisualViewportListenersManager.InvokeMethodName, listenerId);
 
         return listenerId;
     }
@@ -146,7 +146,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     {
         if (OperatingSystem.IsBrowser() is false) return;
 
-        await js.FastInvokeVoidAsync("BitButil.visualViewport.removeResize", ids);
+        await js.InvokeVoid("BitButil.visualViewport.removeResize", ids);
     }
 
     /// <summary>
@@ -160,7 +160,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
         var listenerId = VisualViewportListenersManager.AddListener(handler);
         _handlers.TryAdd(listenerId, handler);
 
-        await js.FastInvokeVoidAsync("BitButil.visualViewport.addScroll", VisualViewportListenersManager.InvokeMethodName, listenerId);
+        await js.InvokeVoid("BitButil.visualViewport.addScroll", VisualViewportListenersManager.InvokeMethodName, listenerId);
 
         return listenerId;
     }
@@ -205,7 +205,7 @@ public class VisualViewport(IJSRuntime js) : IAsyncDisposable
     {
         if (OperatingSystem.IsBrowser() is false) return;
 
-        await js.FastInvokeVoidAsync("BitButil.visualViewport.removeScroll", ids);
+        await js.InvokeVoid("BitButil.visualViewport.removeScroll", ids);
     }
 
 

--- a/src/Butil/Bit.Butil/Publics/Window.cs
+++ b/src/Butil/Bit.Butil/Publics/Window.cs
@@ -27,7 +27,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event">https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event</see>
     /// </summary>
     public async Task AddBeforeUnload()
-        => await js.FastInvokeVoidAsync("BitButil.window.addBeforeUnload");
+        => await js.InvokeVoid("BitButil.window.addBeforeUnload");
 
     /// <summary>
     /// The beforeunload event is fired when the current window, contained document, and associated resources are about to be unloaded. 
@@ -36,7 +36,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event">https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event</see>
     /// </summary>
     public async Task RemoveBeforeUnload()
-        => await js.FastInvokeVoidAsync("BitButil.window.removeBeforeUnload");
+        => await js.InvokeVoid("BitButil.window.removeBeforeUnload");
 
     /// <summary>
     /// Gets the height of the content area of the browser window in px including, if rendered, the horizontal scrollbar.
@@ -44,7 +44,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight">https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight</see>
     /// </summary>
     public async Task<float> GetInnerHeight()
-        => await js.FastInvokeAsync<float>("BitButil.window.innerHeight");
+        => await js.Invoke<float>("BitButil.window.innerHeight");
 
     /// <summary>
     /// Gets the width of the content area of the browser window in px including, if rendered, the vertical scrollbar.
@@ -52,7 +52,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth">https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth</see>
     /// </summary>
     public async Task<float> GetInnerWidth()
-        => await js.FastInvokeAsync<float>("BitButil.window.innerWidth");
+        => await js.Invoke<float>("BitButil.window.innerWidth");
 
     /// <summary>
     /// Returns a boolean indicating whether the current context is secure (true) or not (false).
@@ -60,7 +60,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/isSecureContext">https://developer.mozilla.org/en-US/docs/Web/API/isSecureContext</see>
     /// </summary>
     public async Task<bool> IsSecureContext()
-        => await js.FastInvokeAsync<bool>("BitButil.window.isSecureContext");
+        => await js.Invoke<bool>("BitButil.window.isSecureContext");
 
     /// <summary>
     /// Returns the locationbar object. For privacy and interoperability reasons, 
@@ -69,7 +69,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/locationbar">https://developer.mozilla.org/en-US/docs/Web/API/Window/locationbar</see>
     /// </summary>
     public async Task<BarProp> GetLocationBar()
-        => await js.FastInvokeAsync<BarProp>("BitButil.window.locationbar");
+        => await js.Invoke<BarProp>("BitButil.window.locationbar");
 
     /// <summary>
     /// Gets the name of the window.
@@ -77,14 +77,14 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/name">https://developer.mozilla.org/en-US/docs/Web/API/Window/name</see>
     /// </summary>
     public async Task<string> GetName()
-        => await js.FastInvokeAsync<string>("BitButil.window.getName");
+        => await js.Invoke<string>("BitButil.window.getName");
     /// <summary>
     /// Sets the name of the window.
     /// <br/>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/name">https://developer.mozilla.org/en-US/docs/Web/API/Window/name</see>
     /// </summary>
     public async Task SetName(string value)
-        => await js.FastInvokeVoidAsync("BitButil.window.setName", value);
+        => await js.InvokeVoid("BitButil.window.setName", value);
 
     /// <summary>
     /// Returns the global object's origin, serialized as a string.
@@ -92,7 +92,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/origin">https://developer.mozilla.org/en-US/docs/Web/API/origin</see>
     /// </summary>
     public async Task<string> GetOrigin()
-        => await js.FastInvokeAsync<string>("BitButil.window.origin");
+        => await js.Invoke<string>("BitButil.window.origin");
 
     /// <summary>
     /// Gets the height of the outside of the browser window in px.
@@ -100,7 +100,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight">https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight</see>
     /// </summary>
     public async Task<float> GetOuterHeight()
-        => await js.FastInvokeAsync<float>("BitButil.window.outerHeight");
+        => await js.Invoke<float>("BitButil.window.outerHeight");
 
     /// <summary>
     /// Gets the width of the outside of the browser window in px.
@@ -108,7 +108,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/outerWidth">https://developer.mozilla.org/en-US/docs/Web/API/Window/outerWidth</see>
     /// </summary>
     public async Task<float> GetOuterWidth()
-        => await js.FastInvokeAsync<float>("BitButil.window.outerWidth");
+        => await js.Invoke<float>("BitButil.window.outerWidth");
 
     /// <summary>
     /// Returns the horizontal distance in px from the left border of the user's browser viewport to the left side of the screen.
@@ -116,7 +116,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/screenX">https://developer.mozilla.org/en-US/docs/Web/API/Window/screenX</see>
     /// </summary>
     public async Task<float> GetScreenX()
-        => await js.FastInvokeAsync<float>("BitButil.window.screenX");
+        => await js.Invoke<float>("BitButil.window.screenX");
 
     /// <summary>
     /// Returns the vertical distance in px from the top border of the user's browser viewport to the top side of the screen.
@@ -124,7 +124,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/screenY">https://developer.mozilla.org/en-US/docs/Web/API/Window/screenY</see>
     /// </summary>
     public async Task<float> GetScreenY()
-        => await js.FastInvokeAsync<float>("BitButil.window.screenY");
+        => await js.Invoke<float>("BitButil.window.screenY");
 
     /// <summary>
     /// Returns the number of pixels that the document has already been scrolled horizontally.
@@ -132,7 +132,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX">https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX</see>
     /// </summary>
     public async Task<float> GetScrollX()
-        => await js.FastInvokeAsync<float>("BitButil.window.scrollX");
+        => await js.Invoke<float>("BitButil.window.scrollX");
 
     /// <summary>
     /// Returns the number of pixels that the document has already been scrolled vertically.
@@ -140,7 +140,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY">https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY</see>
     /// </summary>
     public async Task<float> GetScrollY()
-        => await js.FastInvokeAsync<float>("BitButil.window.scrollY");
+        => await js.Invoke<float>("BitButil.window.scrollY");
 
     /// <summary>
     /// Decodes a string of data which has been encoded using base-64 encoding.
@@ -148,7 +148,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/atob">https://developer.mozilla.org/en-US/docs/Web/API/atob</see>
     /// </summary>
     public async Task<string> Atob(string data)
-        => await js.FastInvokeAsync<string>("BitButil.window.atob", data);
+        => await js.Invoke<string>("BitButil.window.atob", data);
 
     /// <summary>
     /// Displays an alert dialog.
@@ -156,7 +156,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/alert">https://developer.mozilla.org/en-US/docs/Web/API/Window/alert</see>
     /// </summary>
     public async Task Alert(string? message = null)
-        => await js.FastInvokeVoidAsync("BitButil.window.alert", message);
+        => await js.InvokeVoid("BitButil.window.alert", message);
 
     /// <summary>
     /// Sets focus away from the window.
@@ -164,7 +164,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/blur">https://developer.mozilla.org/en-US/docs/Web/API/Window/blur</see>
     /// </summary>
     public async Task Blur()
-        => await js.FastInvokeVoidAsync("BitButil.window.blur");
+        => await js.InvokeVoid("BitButil.window.blur");
 
     /// <summary>
     /// Creates a base-64 encoded ASCII string from a string of binary data.
@@ -172,7 +172,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/btoa">https://developer.mozilla.org/en-US/docs/Web/API/btoa</see>
     /// </summary>
     public async Task<string> Btoa(string data)
-        => await js.FastInvokeAsync<string>("BitButil.window.btoa", data);
+        => await js.Invoke<string>("BitButil.window.btoa", data);
 
     /// <summary>
     /// Closes the current window.
@@ -180,7 +180,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/close">https://developer.mozilla.org/en-US/docs/Web/API/Window/close</see>
     /// </summary>
     public async Task Close()
-        => await js.FastInvokeVoidAsync("BitButil.window.close");
+        => await js.InvokeVoid("BitButil.window.close");
 
     /// <summary>
     /// Displays a dialog with a message that the user needs to respond to.
@@ -188,7 +188,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm">https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm</see>
     /// </summary>
     public async Task<bool> Confirm(string? message = null)
-        => await js.FastInvokeAsync<bool>("BitButil.window.confirm", message);
+        => await js.Invoke<bool>("BitButil.window.confirm", message);
 
     /// <summary>
     /// Searches for a given string in a window.
@@ -201,7 +201,7 @@ public class Window(IJSRuntime js)
         bool? wrapAround = null,
         bool? wholeWord = null,
         bool? searchInFrame = null)
-        => await js.FastInvokeAsync<bool>("BitButil.window.find", text, caseSensitive, backward, wrapAround, wholeWord, searchInFrame);
+        => await js.Invoke<bool>("BitButil.window.find", text, caseSensitive, backward, wrapAround, wholeWord, searchInFrame);
 
     /// <summary>
     /// Sets focus on the current window.
@@ -209,7 +209,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/focus">https://developer.mozilla.org/en-US/docs/Web/API/Window/focus</see>
     /// </summary>
     public async Task Focus()
-        => await js.FastInvokeVoidAsync("BitButil.window.focus");
+        => await js.InvokeVoid("BitButil.window.focus");
 
     /// <summary>
     /// Returns the selection text representing the selected item(s).
@@ -217,7 +217,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection">https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection</see>
     /// </summary>
     public async Task<string> GetSelection()
-        => await js.FastInvokeAsync<string>("BitButil.window.getSelection");
+        => await js.Invoke<string>("BitButil.window.getSelection");
 
     /// <summary>
     /// Returns a MediaQueryList object representing the specified media query string.
@@ -225,7 +225,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia">https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia</see>
     /// </summary>
     public async Task<MediaQueryList> MatchMedia(string query)
-        => await js.FastInvokeAsync<MediaQueryList>("BitButil.window.matchMedia", query);
+        => await js.Invoke<MediaQueryList>("BitButil.window.matchMedia", query);
 
     /// <summary>
     /// Opens a new window.
@@ -233,14 +233,14 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/open">https://developer.mozilla.org/en-US/docs/Web/API/Window/open</see>
     /// </summary>
     public async Task<bool> Open(string? url = null, string? target = null, string? windowFeatures = null)
-        => await js.FastInvokeAsync<bool>("BitButil.window.open", url, target, windowFeatures);
+        => await js.Invoke<bool>("BitButil.window.open", url, target, windowFeatures);
     /// <summary>
     /// Opens a new window.
     /// <br/>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/open">https://developer.mozilla.org/en-US/docs/Web/API/Window/open</see>
     /// </summary>
     public async Task<bool> Open(string? url = null, string? target = null, WindowFeatures? windowFeatures = null)
-        => await js.FastInvokeAsync<bool>("BitButil.window.open", url, target, windowFeatures?.ToString());
+        => await js.Invoke<bool>("BitButil.window.open", url, target, windowFeatures?.ToString());
 
     /// <summary>
     /// Opens the Print Dialog to print the current document.
@@ -248,7 +248,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/print">https://developer.mozilla.org/en-US/docs/Web/API/Window/print</see>
     /// </summary>
     public async Task Print()
-        => await js.FastInvokeVoidAsync("BitButil.window.print");
+        => await js.InvokeVoid("BitButil.window.print");
 
     /// <summary>
     /// Returns the text entered by the user in a prompt dialog.
@@ -256,7 +256,7 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt">https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt</see>
     /// </summary>
     public async Task<string> Prompt(string? message, string? defaultValue)
-        => await js.FastInvokeAsync<string>("BitButil.window.prompt", message, defaultValue);
+        => await js.Invoke<string>("BitButil.window.prompt", message, defaultValue);
 
     /// <summary>
     /// Scrolls the window to a particular place in the document.
@@ -264,14 +264,14 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll">https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll</see>
     /// </summary>
     public async Task Scroll(ScrollOptions? options)
-        => await js.FastInvokeVoidAsync("BitButil.window.scroll", options?.ToJsObject(), null, null);
+        => await js.InvokeVoid("BitButil.window.scroll", options?.ToJsObject(), null, null);
     /// <summary>
     /// Scrolls the window to a particular place in the document.
     /// <br/>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll">https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll</see>
     /// </summary>
     public async Task Scroll(float? x, float? y)
-        => await js.FastInvokeVoidAsync("BitButil.window.scroll", null, x, y);
+        => await js.InvokeVoid("BitButil.window.scroll", null, x, y);
 
     /// <summary>
     /// Scrolls the document in the window by the given amount.
@@ -279,14 +279,14 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy">https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy</see>
     /// </summary>
     public async Task ScrollBy(ScrollOptions? options)
-        => await js.FastInvokeVoidAsync("BitButil.window.scrollBy", options?.ToJsObject(), null, null);
+        => await js.InvokeVoid("BitButil.window.scrollBy", options?.ToJsObject(), null, null);
     /// <summary>
     /// Scrolls the document in the window by the given amount.
     /// <br/>
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy">https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy</see>
     /// </summary>
     public async Task ScrollBy(float? x, float? y)
-        => await js.FastInvokeVoidAsync("BitButil.window.scrollBy", null, x, y);
+        => await js.InvokeVoid("BitButil.window.scrollBy", null, x, y);
 
     /// <summary>
     /// This method stops window loading.
@@ -294,5 +294,5 @@ public class Window(IJSRuntime js)
     /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/stop">https://developer.mozilla.org/en-US/docs/Web/API/Window/stop</see>
     /// </summary>
     public async Task Stop()
-        => await js.FastInvokeVoidAsync("BitButil.window.stop");
+        => await js.InvokeVoid("BitButil.window.stop");
 }


### PR DESCRIPTION
closes #9999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the approach for invoking browser APIs across multiple components, ensuring more consistent and reliable interoperation.
  - Introduced new toggle options to adjust invocation behavior while maintaining backward compatibility with existing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->