### PR TITLE
Remove redundant Immediate parameter from usages of BitOtpInput (#10007)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/OtpInput/BitOtpInputDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/OtpInput/BitOtpInputDemo.razor
@@ -88,7 +88,7 @@
         <BitOtpInput Label="OnChange" OnChange="v => onChangeValue = v" />
         <div>OnChange value: @onChangeValue</div>
         <br /><br />
-        <BitOtpInput Label="OnFill" OnFill="v => onFillValue = v" Immediate />
+        <BitOtpInput Label="OnFill" OnFill="v => onFillValue = v" />
         <div>OnFill value: @onFillValue</div>
         <br /><br />
         <BitOtpInput Label="OnFocusIn" OnFocusIn="args => onFocusInArgs = args" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
@@ -24,7 +24,6 @@
                 {
                     <BitOtpInput @bind-Value="value"
                                  AutoFocus
-                                 Immediate
                                  Length="6"
                                  Size="BitSize.Large"
                                  Type="BitInputType.Number"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangeEmailSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangeEmailSection.razor
@@ -56,7 +56,6 @@
 
                     <BitOtpInput @bind-Value="changeModel.Token"
                                  AutoFocus
-                                 Immediate
                                  Length="6"
                                  Size="BitSize.Large"
                                  Type="BitInputType.Number"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangePhoneNumberSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/ChangePhoneNumberSection.razor
@@ -56,7 +56,6 @@
 
                     <BitOtpInput @bind-Value="changeModel.Token"
                                  AutoFocus
-                                 Immediate
                                  Length="6"
                                  Size="BitSize.Large"
                                  Type="BitInputType.Number"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/OtpPanel.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/OtpPanel.razor
@@ -18,7 +18,6 @@
             <BitStack HorizontalAlign="BitAlignment.Center">
                 <BitOtpInput @bind-Value="Model.Otp"
                              AutoFocus
-                             Immediate
                              Length="6"
                              Size="BitSize.Large"
                              Type="BitInputType.Number"


### PR DESCRIPTION
closes #10007