### PR TITLE
Reset callouts opacity after closing in responsive mode (#10039)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
@@ -32,6 +32,7 @@ namespace BitBlazorUI {
 
             if (!isCalloutOpen) {
                 if (windowWidth < Utils.MAX_MOBILE_WIDTH && responsiveMode) {
+                    callout.style.opacity = '0';
                     callout.style.transform = '';
                 } else {
                     callout.style.display = 'none';


### PR DESCRIPTION
closes #10039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved callout behavior on mobile screens, where a smooth transition effect now makes the callout element gracefully fade out instead of disappearing abruptly when closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->