### PR TITLE
maintain return-url during email confirmation re-send in Boilerplate (#10083)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ConfirmPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ConfirmPage.razor.cs
@@ -99,7 +99,7 @@ public partial class ConfirmPage
 
         await WrapRequest(async () =>
         {
-            await identityController.SendConfirmEmailToken(new() { Email = emailModel.Email }, CurrentCancellationToken);
+            await identityController.SendConfirmEmailToken(new() { Email = emailModel.Email, ReturnUrl = ReturnUrlQueryString }, CurrentCancellationToken);
         });
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.EmailConfirmation.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.EmailConfirmation.cs
@@ -19,7 +19,7 @@ public partial class IdentityController
         if (await userManager.IsEmailConfirmedAsync(user))
             throw new BadRequestException(Localizer[nameof(AppStrings.EmailAlreadyConfirmed)]).WithData("UserId", user.Id);
 
-        await SendConfirmEmailToken(user, returnUrl: null, cancellationToken);
+        await SendConfirmEmailToken(user, request.ReturnUrl, cancellationToken);
     }
 
     [HttpPost, Produces<TokenResponseDto>()]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Dtos/Identity/SendEmailTokenRequestDto.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Dtos/Identity/SendEmailTokenRequestDto.cs
@@ -8,4 +8,6 @@ public partial class SendEmailTokenRequestDto
     [EmailAddress(ErrorMessage = nameof(AppStrings.EmailAddressAttribute_ValidationError))]
     [Display(Name = nameof(AppStrings.Email))]
     public string? Email { get; set; }
+
+    public string? ReturnUrl { get; set; }
 }


### PR DESCRIPTION
closes #10083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the email confirmation process so that after confirming their account, users are now redirected to the intended page automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->