### PR TITLE
Remove dictionary conversion from SetParametersAsync source generator (#9682)

### DIFF
--- a/src/SourceGenerators/Bit.SourceGenerators/Blazor/BlazorSetParametersSourceGenerator.cs
+++ b/src/SourceGenerators/Bit.SourceGenerators/Blazor/BlazorSetParametersSourceGenerator.cs
@@ -56,10 +56,9 @@ namespace {namespaceName}
         //{
         //    source.AppendLine($"            {property.PropertySymbol.Name}HasBeenSet = false;");
         //} 
-        source.AppendLine("            var parametersDictionary = parameters.ToDictionary() as Dictionary<string, object>;");
-        source.AppendLine("            foreach (var parameter in parametersDictionary!)");
+        source.AppendLine("            foreach (var parameter in parameters)");
         source.AppendLine("            {");
-        source.AppendLine("                switch (parameter.Key)");
+        source.AppendLine("                switch (parameter.Name)");
         source.AppendLine("                {");
 
         // create cases for each property

--- a/src/SourceGenerators/Bit.SourceGenerators/Blazor/BlazorSetParametersSourceGenerator.cs
+++ b/src/SourceGenerators/Bit.SourceGenerators/Blazor/BlazorSetParametersSourceGenerator.cs
@@ -71,7 +71,6 @@ namespace {namespaceName}
             //    source.AppendLine($"                       {bitProperty.PropertySymbol.Name}HasBeenSet = true;");
             //}
             source.AppendLine($"                       {bitProperty.PropertySymbol.Name} = parameter.Value is null ? default! : ({bitProperty.PropertySymbol.Type.ToDisplayString()})parameter.Value;");
-            source.AppendLine("                       parametersDictionary.Remove(parameter.Key);");
             source.AppendLine("                       break;");
         }
 
@@ -84,7 +83,7 @@ namespace {namespaceName}
         }
         else
         {
-            source.AppendLine("            return base.SetParametersAsync(ParameterView.FromDictionary(parametersDictionary as IDictionary<string, object?>));");
+            source.AppendLine("            return base.SetParametersAsync(parameters);");
         }
 
         source.AppendLine("        }");


### PR DESCRIPTION
closes #9682 

## Behaviour after this change:
This PR implements the changes we previously discussed with maintainers. Here is a brief of the implemented solution:
- The generated `SetParametersAsync` method, initializes parameters defined within the enclosing class (does not initialize properties inherited from base type, or properties of the runtime type, that are not available in current type) and then calls the base implementation of `SetParametersAsync` method.
- In case the base class is of type `Microsoft.AspNetCore.Components.ComponentBase`, the generated `SetParametersAsync` passes an empty `ParameterView` to base implementation, This is correct because parameters defined in derived types are already initialized during the call chains and the `ComponentBase` itself has nothing to initialize using the `ParameterView`
- In case the base class is not `Microsoft.AspNetCore.Components.ComponentBase`, the generated `SetParametersAsyn` passes the same `ParameterView` it receives to its parent class if the parent class is not `ComponentBase`. (Does not delete values already assigned to parameters from the `ParameterView` anymore)

## We prevented slow code, with one exception:
Our intention was to prevent the execution of reflectoin-based initializations which may happen if `Microsoft.AspNetCore.Components.ComponentBase` receives a **not empty** `ParameterView` in its `SetParametersAsync`.  
There is only one scenario in which that slow code gets executed. If our component is neither directly inheriting from `Microsoft.AspNetCore.Components.ComponentBase` nor is covered by our source generator (maybe because it is not in our assembly), then that slow reflection based initialization is going to execute. The following shows an example of such scenario:
```mermaid
classDiagram
    ComponentBase <|-- ExternalComponent
    ExternalComponent <|-- MyComponent
```
MyComponent is covered by source generator.
ExternalComponent is in a third-party assembly and not covered by source generator.
ComponentBase is `Microsoft.AspNetCore.Components.ComponentBase`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced component parameter processing to improve stability and responsiveness during updates by streamlining how parameter information is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->