### PR TITLE
Use RenderInfo.IsInteractive instead of internal reflection in Boilerplate (#10250)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppComponentBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppComponentBase.cs
@@ -65,7 +65,7 @@ public partial class AppComponentBase : ComponentBase, IAsyncDisposable
         }
     }
 
-    protected bool InPrerenderSession => AppPlatform.IsBlazorHybrid is false && JSRuntime.IsInitialized() is false;
+    protected bool InPrerenderSession => AppPlatform.IsBlazorHybrid is false && RendererInfo.IsInteractive is false;
 
     protected sealed override void OnInitialized()
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor.cs
@@ -41,7 +41,7 @@ public partial class MainLayout : IAsyncDisposable
     {
         try
         {
-            var inPrerenderSession = jsRuntime.IsInitialized() is false;
+            var inPrerenderSession = RendererInfo.IsInteractive is false;
             isOnline = await prerenderStateService.GetValue<bool?>(nameof(isOnline), async () => isOnline ?? inPrerenderSession is true ? true : null);
             // During pre-rendering, if any API calls are made, the `isOnline` value will be set 
             // using PubSub's `ClientPubSubMessages.IS_ONLINE_CHANGED`, depending on the success 


### PR DESCRIPTION
closes #10250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for detecting the rendering mode during initialization, ensuring a more accurate switch between static and interactive states. This change may lead to more consistent component behavior during pre-rendering sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->