### PR TITLE
fix external js runner close issue in Boilerplate (#10316)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/settings.VisualStudio.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/settings.VisualStudio.json
@@ -1,6 +1,7 @@
 ﻿/* Visual Studio Settings File */
 {
-    "debugging.general.disableJITOptimization": true,
-    "environment.documents.saveWithSpecificEncoding": true,
-    "environment.documents.saveEncoding": "utf-8;65001"
+  "languages.defaults.general.lineNumbers": true,
+  "debugging.general.disableJITOptimization": true,
+  "environment.documents.saveWithSpecificEncoding": true,
+  "environment.documents.saveEncoding": "utf-8;65001"
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPage.razor.cs
@@ -152,7 +152,7 @@ public partial class SignInPage
     {
         try
         {
-            var port = localHttpServer.ShouldUseForSocialSignIn() ? localHttpServer.EnsureStarted() : -1;
+            var port = localHttpServer.EnsureStarted();
 
             var redirectUrl = await identityController.GetSocialSignInUri(provider, ReturnUrlQueryString, port is -1 ? null : port, CurrentCancellationToken);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUp/SignUpPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUp/SignUpPage.razor.cs
@@ -75,7 +75,7 @@ public partial class SignUpPage
     {
         try
         {
-            var port = localHttpServer.ShouldUseForSocialSignIn() ? localHttpServer.EnsureStarted() : -1;
+            var port = localHttpServer.EnsureStarted();
 
             var redirectUrl = await identityController.GetSocialSignInUri(provider, ReturnUrlQueryString, port is -1 ? null : port, CurrentCancellationToken);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
@@ -12,6 +12,7 @@ class ExternalJsRunner {
                 } else if (request.type == 'createCredential') {
                     result = await WebAuthn.createCredential(request.options);
                 } else if (request.type == 'close') {
+                    localWebSocket.close();
                     window.location.assign('/close-browser');
                     return;
                 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
@@ -1,4 +1,4 @@
-// Checkout external-js-runner.html
+﻿// Checkout external-js-runner.html
 class ExternalJsRunner {
     public static async run() {
         const host = window.origin.replace('http://', '');

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
@@ -12,11 +12,11 @@ class ExternalJsRunner {
                 } else if (request.type == 'createCredential') {
                     result = await WebAuthn.createCredential(request.options);
                 } else if (request.type == 'close') {
-                    result = {};
                     localWebSocket.close();
                     setTimeout(() => {
                         window.close();
                     }, 100);
+                    return;
                 }
                 localWebSocket.send(JSON.stringify({ body: result }));
             }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
@@ -13,6 +13,7 @@ class ExternalJsRunner {
                     result = await WebAuthn.createCredential(request.options);
                 } else if (request.type == 'close') {
                     localWebSocket.close();
+                    window.close();
                     window.location.assign('/close-browser');
                     return;
                 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/ExternalJsRunner.ts
@@ -12,10 +12,7 @@ class ExternalJsRunner {
                 } else if (request.type == 'createCredential') {
                     result = await WebAuthn.createCredential(request.options);
                 } else if (request.type == 'close') {
-                    localWebSocket.close();
-                    setTimeout(() => {
-                        window.close();
-                    }, 100);
+                    window.location.assign('/close-browser');
                     return;
                 }
                 localWebSocket.send(JSON.stringify({ body: result }));

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/Contracts/ILocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/Contracts/ILocalHttpServer.cs
@@ -7,16 +7,4 @@ public interface ILocalHttpServer : IAsyncDisposable
     int Port { get; }
 
     string? Origin { get; }
-
-    /// <summary>
-    /// Social sign-in on the web version of the app uses simple redirects. However, for Android, iOS, Windows, and macOS, social sign-in requires an in-app or external browser.
-    /// 
-    /// # Navigating Back to the App After Social Sign-In
-    /// 1. **Universal Deep Links**: Allow the app to directly handle specific web links (for iOS and Android apps).
-    /// 2. **Local HTTP Server**: Works similarly to how `git.exe` manages sign-ins with services like GitHub (supported on iOS, Android, Windows, and macOS).
-    ///
-    /// - **iOS, Windows, and macOS**: Use local HTTP server implementations in MAUI and Windows projects.
-    /// - **Android**: Use universal links.
-    /// </summary>
-    bool ShouldUseForSocialSignIn();
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/HttpMessageHandlers/RequestHeadersDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/HttpMessageHandlers/RequestHeadersDelegatingHandler.cs
@@ -12,7 +12,7 @@ public partial class RequestHeadersDelegatingHandler(ITelemetryContext telemetry
         request.SetBrowserRequestCredentials(BrowserRequestCredentials.Omit);
         request.SetBrowserResponseStreamingEnabled(true);
 
-        request.Version = HttpVersion.Version30;
+        request.Version = HttpVersion.Version20;
         request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
 
         if (request.Headers.UserAgent.Any() is false)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/NoopLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/NoopLocalHttpServer.cs
@@ -8,10 +8,5 @@ public partial class NoOpLocalHttpServer : ILocalHttpServer
 
     public int Port => -1;
 
-    /// <summary>
-    /// <inheritdoc cref="ILocalHttpServer.ShouldUseForSocialSignIn"/>
-    /// </summary>
-    public bool ShouldUseForSocialSignIn() => false;
-
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/MainActivity.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/MainActivity.cs
@@ -37,7 +37,7 @@ namespace Boilerplate.Client.Maui.Platforms.Android;
                         AutoVerify = true,
                         Categories = [Intent.ActionView, Intent.CategoryDefault, Intent.CategoryBrowsable])]
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask,
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleInstance,
     ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public partial class MainActivity : MauiAppCompatActivity
     //#if (notification == true)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/MainActivity.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/MainActivity.cs
@@ -37,7 +37,7 @@ namespace Boilerplate.Client.Maui.Platforms.Android;
                         AutoVerify = true,
                         Categories = [Intent.ActionView, Intent.CategoryDefault, Intent.CategoryBrowsable])]
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleInstance,
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask,
     ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public partial class MainActivity : MauiAppCompatActivity
     //#if (notification == true)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
@@ -74,7 +74,7 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
                     await MainThread.InvokeOnMainThreadAsync(() =>
                     {
                         var intent = new Android.Content.Intent(Platform.AppContext, typeof(Platforms.Android.MainActivity));
-                        intent.SetFlags(Android.Content.ActivityFlags.NewTask | Android.Content.ActivityFlags.SingleTop);
+                        intent.SetFlags(Android.Content.ActivityFlags.NewTask | Android.Content.ActivityFlags.ClearTop);
                         Platform.AppContext.StartActivity(intent);
                     });
 #endif
@@ -84,6 +84,7 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
             {
                 try
                 {
+                    ctx.Response.ContentType = "text/html";
                     await using var file = Assembly.Load("Boilerplate.Client.Maui").GetManifestResourceStream("Boilerplate.Client.Maui.wwwroot.external-js-runner.html")!;
                     await file.CopyToAsync(ctx.Response.OutputStream, ctx.CancellationToken);
                 }
@@ -96,6 +97,7 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
             {
                 try
                 {
+                    ctx.Response.ContentType = "application/javascript";
                     await using var file = Assembly.Load("Boilerplate.Client.Maui").GetManifestResourceStream("Boilerplate.Client.Maui.wwwroot.scripts.app.js")!;
                     await file.CopyToAsync(ctx.Response.OutputStream, ctx.CancellationToken);
                 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
@@ -33,23 +33,7 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
             {
                 try
                 {
-                    // Redirect to SocialSignedInPage.razor that will close the browser window.
-                    var url = new Uri(absoluteServerAddress, $"/api/Identity/SocialSignedIn?culture={CultureInfo.CurrentUICulture.Name}").ToString();
-                    ctx.Redirect(url);
-
-                    if (AppPlatform.IsIOS)
-                    {
-                        // SocialSignedInPage.razor's `window.close()` does NOT work on iOS's in app browser.
-                        await MainThread.InvokeOnMainThreadAsync(() =>
-                        {
-#if iOS
-                            if (UIKit.UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentedViewController is SafariServices.SFSafariViewController controller)
-                            {
-                                controller.DismissViewController(animated: true, completionHandler: null);
-                            }
-#endif
-                        });
-                    }
+                    ctx.Redirect("/close-browser");
 
                     _ = Task.Delay(1)
                     .ContinueWith(async _ =>
@@ -63,6 +47,26 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
                 catch (Exception exp)
                 {
                     exceptionHandler.Handle(exp);
+                }
+            }))
+            .WithModule(new ActionModule("/close-browser", HttpVerbs.Get, async ctx =>
+            {
+                // Redirect to CloseBrowserPage.razor that will close the browser window.
+                var url = new Uri(absoluteServerAddress, $"/api/Identity/CloseBrowserPage?culture={CultureInfo.CurrentUICulture.Name}").ToString();
+                ctx.Redirect(url);
+
+                if (AppPlatform.IsIOS)
+                {
+                    // CloseBrowserPage.razor's `window.close()` does NOT work on iOS's in app browser.
+                    await MainThread.InvokeOnMainThreadAsync(() =>
+                    {
+#if iOS
+                            if (UIKit.UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentedViewController is SafariServices.SFSafariViewController controller)
+                            {
+                                controller.DismissViewController(animated: true, completionHandler: null);
+                            }
+#endif
+                    });
                 }
             }))
             .WithModule(new ActionModule("/external-js-runner.html", HttpVerbs.Get, async ctx =>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
@@ -61,12 +61,23 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
                     await MainThread.InvokeOnMainThreadAsync(() =>
                     {
 #if iOS
-                            if (UIKit.UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentedViewController is SafariServices.SFSafariViewController controller)
-                            {
-                                controller.DismissViewController(animated: true, completionHandler: null);
-                            }
+                        if (UIKit.UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentedViewController is SafariServices.SFSafariViewController controller)
+                        {
+                            controller.DismissViewController(animated: true, completionHandler: null);
+                        }
 #endif
                     });
+                }
+                else if (AppPlatform.IsAndroid)
+                {
+#if Android
+                    await MainThread.InvokeOnMainThreadAsync(() =>
+                    {
+                        var intent = new Android.Content.Intent(Platform.AppContext, typeof(Platforms.Android.MainActivity));
+                        intent.SetFlags(Android.Content.ActivityFlags.NewTask | Android.Content.ActivityFlags.SingleTop);
+                        Platform.AppContext.StartActivity(intent);
+                    });
+#endif
                 }
             }))
             .WithModule(new ActionModule("/external-js-runner.html", HttpVerbs.Get, async ctx =>
@@ -130,11 +141,4 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
         localHttpServer?.Dispose();
     }
 
-    /// <summary>
-    /// <inheritdoc cref="ILocalHttpServer.ShouldUseForSocialSignIn"/>
-    /// </summary>
-    public bool ShouldUseForSocialSignIn()
-    {
-        return AppPlatform.IsAndroid is false;
-    }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiWebAuthnService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiWebAuthnService.cs
@@ -26,7 +26,7 @@ public partial class MauiWebAuthnService : WebAuthnServiceBase
 
     private static async Task CloseExternalBrowser()
     {
-        await MauiExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
+        _ = MauiExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
 
         if (AppPlatform.IsIOS)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiWebAuthnService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiWebAuthnService.cs
@@ -24,23 +24,9 @@ public partial class MauiWebAuthnService : WebAuthnServiceBase
         }
     }
 
-    private static async Task CloseExternalBrowser()
+    private async Task CloseExternalBrowser()
     {
         _ = MauiExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
-
-        if (AppPlatform.IsIOS)
-        {
-            // SocialSignedInPage.razor's `window.close()` does NOT work on iOS's in app browser.
-            await MainThread.InvokeOnMainThreadAsync(() =>
-            {
-#if iOS
-                if (UIKit.UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentedViewController is SafariServices.SFSafariViewController controller)
-                {
-                    controller.DismissViewController(animated: true, completionHandler: null);
-                }
-#endif
-            });
-        }
     }
 
     public override async ValueTask<AuthenticatorAttestationRawResponse> CreateWebAuthnCredential(CredentialCreateOptions options)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiWebAuthnService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiWebAuthnService.cs
@@ -24,7 +24,7 @@ public partial class MauiWebAuthnService : WebAuthnServiceBase
         }
     }
 
-    private async Task CloseExternalBrowser()
+    private static async Task CloseExternalBrowser()
     {
         _ = MauiExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/external-js-runner.html
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/external-js-runner.html
@@ -1,11 +1,16 @@
-<html>
+﻿<html>
 <head>
     <base href="/" />
     <title>&#128274; Passwordless login</title>
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
     <style>
-        body {
-            background-color: #FFFFFF;
+
+        html, body, main {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #FFFFFF;
         }
 
         .fluent-button {
@@ -14,7 +19,7 @@
             font-size: 50px;
             border-radius: 2px;
             padding: 12px 24px;
-            background-color: #FFFFFF;
+            background: #FFFFFF;
         }
 
         .container {
@@ -26,11 +31,11 @@
 
         @media (prefers-color-scheme: dark) {
             body {
-                background-color: #010409;
+                background: #010409;
             }
 
             .fluent-button {
-                background-color: #010409;
+                background: #010409;
             }
         }
     </style>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/external-js-runner.html
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/external-js-runner.html
@@ -8,20 +8,20 @@
             background-color: #FFFFFF;
         }
 
-        .fluent {
-            color: #010409;
+        .fluent-button {
             border: none;
-            padding: 12px 24px;
-            border-radius: 2px;
             cursor: pointer;
-            font-size: 18px;
+            font-size: 50px;
+            border-radius: 2px;
+            padding: 12px 24px;
+            background-color: #FFFFFF;
         }
 
         .container {
             display: flex;
-            justify-content: center;
-            align-items: center;
             height: 100vh;
+            align-items: center;
+            justify-content: center;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -29,8 +29,8 @@
                 background-color: #010409;
             }
 
-            .fluent {
-                color: #FFFFFF;
+            .fluent-button {
+                background-color: #010409;
             }
         }
     </style>
@@ -41,7 +41,7 @@
     -->
 
     <div class="container">
-        <button class="primary" onclick="window.close()">&#x1F519;</button>
+        <button class="fluent-button" onclick="window.close()">&#x1F519;</button>
     </div>
 
     <script src="app.js"></script>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/external-js-runner.html
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/wwwroot/external-js-runner.html
@@ -1,7 +1,7 @@
 ﻿<html>
 <head>
     <base href="/" />
-    <title>&#128274; Passwordless login</title>
+    <title>Boilerplate</title>
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
     <style>
 
@@ -18,7 +18,6 @@
             cursor: pointer;
             font-size: 50px;
             border-radius: 2px;
-            padding: 12px 24px;
             background: #FFFFFF;
         }
 
@@ -46,7 +45,7 @@
     -->
 
     <div class="container">
-        <button class="fluent-button" onclick="window.close()">&#x1F519;</button>
+        <button class="fluent-button" onclick="window.close();">&#x1F519;</button>
     </div>
 
     <script src="app.js"></script>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
@@ -63,6 +63,7 @@ public partial class WindowsLocalHttpServer : ILocalHttpServer
             {
                 try
                 {
+                    ctx.Response.ContentType = "text/html";
                     await using var fileStream = File.OpenRead("wwwroot/external-js-runner.html");
                     await fileStream.CopyToAsync(ctx.Response.OutputStream, ctx.CancellationToken);
                 }
@@ -75,6 +76,7 @@ public partial class WindowsLocalHttpServer : ILocalHttpServer
             {
                 try
                 {
+                    ctx.Response.ContentType = "application/javascript";
                     var filePath = Path.Combine(AppContext.BaseDirectory, @"wwwroot\_content\Boilerplate.Client.Core\scripts\app.js");
                     if (File.Exists(filePath) is false)
                     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
@@ -35,17 +35,11 @@ public partial class WindowsLocalHttpServer : ILocalHttpServer
             {
                 try
                 {
-                    var url = new Uri(absoluteServerAddress, $"/api/Identity/SocialSignedIn?culture={CultureInfo.CurrentUICulture.Name}").ToString();
-
-                    ctx.Redirect(url);
+                    ctx.Redirect("/close-browser");
 
                     _ = Task.Delay(1)
                         .ContinueWith(async _ =>
                         {
-                            Application.OpenForms[0]!.Invoke(() =>
-                            {
-                                Application.OpenForms[0]!.Activate();
-                            });
                             await Routes.OpenUniversalLink(ctx.Request.Url.PathAndQuery, replace: true);
                         });
                 }
@@ -53,6 +47,17 @@ public partial class WindowsLocalHttpServer : ILocalHttpServer
                 {
                     exceptionHandler.Handle(exp);
                 }
+            }))
+            .WithModule(new ActionModule("/close-browser", HttpVerbs.Get, async ctx =>
+            {
+                // Redirect to CloseBrowserPage.razor that will close the browser window.
+                var url = new Uri(absoluteServerAddress, $"/api/Identity/CloseBrowserPage?culture={CultureInfo.CurrentUICulture.Name}").ToString();
+                ctx.Redirect(url);
+
+                Application.OpenForms[0]!.Invoke(() =>
+                {
+                    Application.OpenForms[0]!.Activate();
+                });
             }))
             .WithModule(new ActionModule("/external-js-runner.html", HttpVerbs.Get, async ctx =>
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
@@ -111,12 +111,6 @@ public partial class WindowsLocalHttpServer : ILocalHttpServer
         return port;
     }
 
-    /// <summary>
-    /// <inheritdoc cref="ILocalHttpServer.ShouldUseForSocialSignIn"/>
-    /// </summary>
-
-    public bool ShouldUseForSocialSignIn() => true;
-
     public async ValueTask DisposeAsync()
     {
         localHttpServer?.Dispose();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsWebAuthnService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsWebAuthnService.cs
@@ -27,11 +27,6 @@ public partial class WindowsWebAuthnService : WebAuthnServiceBase
     private static async Task CloseExternalBrowser()
     {
         _ = WindowsExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
-
-        Application.OpenForms[0]!.Invoke(() =>
-        {
-            Application.OpenForms[0]!.Activate();
-        });
     }
 
     public override async ValueTask<AuthenticatorAttestationRawResponse> CreateWebAuthnCredential(CredentialCreateOptions options)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsWebAuthnService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsWebAuthnService.cs
@@ -26,7 +26,7 @@ public partial class WindowsWebAuthnService : WebAuthnServiceBase
 
     private static async Task CloseExternalBrowser()
     {
-        await WindowsExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
+        _ = WindowsExternalJsRunner.RequestToBeSent!.Invoke(JsonSerializer.SerializeToDocument(new { Type = "close" }, JsonSerializerOptions.Web));
 
         Application.OpenForms[0]!.Invoke(() =>
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Components/CloseBrowserPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Components/CloseBrowserPage.razor
@@ -7,13 +7,15 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
     <title>@Localizer[nameof(AppStrings.CloseBrowserMessageTitle)]</title>
     <style>
-        html, body, main {
+        html, body {
             margin: 0;
             padding: 0;
             height: 100%;
+            color: #161B22;
+            background: #E8E8E8;
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         }
 
@@ -24,8 +26,13 @@
             justify-content: center;
         }
 
-        div {
-            margin-bottom: 1rem;
+        .fluent-button {
+            border: none;
+            cursor: pointer;
+            font-size: 50px;
+            border-radius: 2px;
+            padding: 12px 24px;
+            background-color: transparent;
         }
 
         @@media (prefers-color-scheme: dark) {
@@ -38,6 +45,9 @@
 </head>
 
 <body>
+    <script type="text/javascript">
+        window.close();
+    </script>
     <main>
         <div>
             <h1>@Localizer[nameof(AppStrings.CloseBrowserMessageTitle)]</h1>
@@ -45,10 +55,8 @@
         <div>
             <h3>@Localizer[nameof(AppStrings.CloseBrowserMessageBody)]</h3>
         </div>
+        <button class="fluent-button" onclick="window.close()">&#x1F519;</button>
     </main>
-    <script type="text/javascript">
-        window.close();
-    </script>
 </body>
 
 </html>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Components/CloseBrowserPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Components/CloseBrowserPage.razor
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-    <title>@Localizer[nameof(AppStrings.SocialSignedInTitle)]</title>
+    <title>@Localizer[nameof(AppStrings.CloseBrowserMessageTitle)]</title>
     <style>
         html, body, main {
             margin: 0;
@@ -40,10 +40,10 @@
 <body>
     <main>
         <div>
-            <h1>@Localizer[nameof(AppStrings.SocialSignedInMessageTitle)]</h1>
+            <h1>@Localizer[nameof(AppStrings.CloseBrowserMessageTitle)]</h1>
         </div>
         <div>
-            <h3>@Localizer[nameof(AppStrings.SocialSignedInMessageBody)]</h3>
+            <h3>@Localizer[nameof(AppStrings.CloseBrowserMessageBody)]</h3>
         </div>
     </main>
     <script type="text/javascript">

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Components/CloseBrowserPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Components/CloseBrowserPage.razor
@@ -55,7 +55,7 @@
         <div>
             <h3>@Localizer[nameof(AppStrings.CloseBrowserMessageBody)]</h3>
         </div>
-        <button class="fluent-button" onclick="window.close()">&#x1F519;</button>
+        <button class="fluent-button" onclick="window.close();">&#x1F519;</button>
     </main>
 </body>
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
@@ -404,10 +404,10 @@ public partial class IdentityController : AppControllerBase, IIdentityController
 
     [HttpGet]
     [AppResponseCache(SharedMaxAge = 3600 * 24 * 7, MaxAge = 60 * 5)]
-    public async Task<ActionResult> SocialSignedIn()
+    public async Task<ActionResult> CloseBrowserPage()
     {
         var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
-                    (await htmlRenderer.RenderComponentAsync<SocialSignedInPage>()).ToHtmlString());
+                    (await htmlRenderer.RenderComponentAsync<CloseBrowserPage>()).ToHtmlString());
 
         return Content(html, "text/html");
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
@@ -672,13 +672,10 @@
     <data name="Continue" xml:space="preserve">
     <value>ادامه</value>
   </data>
-    <data name="SocialSignedInTitle" xml:space="preserve">
-    <value>ورود سوشال</value>
+    <data name="CloseBrowserMessageTitle" xml:space="preserve">
+    <value>بازگشت به برنامه</value>
   </data>
-    <data name="SocialSignedInMessageTitle" xml:space="preserve">
-    <value>ورود سوشال انجام شد</value>
-  </data>
-    <data name="SocialSignedInMessageBody" xml:space="preserve">
+    <data name="CloseBrowserMessageBody" xml:space="preserve">
     <value>حالا میتوانید به برنامه بازگردید</value>
   </data>
     <data name="GoogleSignInButtonText" xml:space="preserve">

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
@@ -669,17 +669,14 @@
     <data name="SignInPanelSubtitle" xml:space="preserve">
     <value>Log in bij jouw account met</value>
   </data>
-    <data name="SocialSignedInTitle" xml:space="preserve">
-    <value>Aangemeld bij social media</value>
+    <data name="CloseBrowserMessageTitle" xml:space="preserve">
+    <value>Ga terug naar de app</value>
+  </data>
+    <data name="CloseBrowserMessageBody" xml:space="preserve">
+    <value>U kunt nu teruggaan naar de applicatie</value>
   </data>
     <data name="Continue" xml:space="preserve">
     <value>Verzenden</value>
-  </data>
-    <data name="SocialSignedInMessageTitle" xml:space="preserve">
-    <value>De sociale aanmelding is voltooid</value>
-  </data>
-    <data name="SocialSignedInMessageBody" xml:space="preserve">
-    <value>U kunt nu teruggaan naar de applicatie</value>
   </data>
     <data name="GoogleSignInButtonText" xml:space="preserve">
     <value>Inloggen met Google</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -672,13 +672,10 @@
     <data name="Continue" xml:space="preserve">
     <value>Continue</value>
   </data>
-    <data name="SocialSignedInTitle" xml:space="preserve">
-    <value>Social signed in</value>
+    <data name="CloseBrowserMessageTitle" xml:space="preserve">
+    <value>Go back to app</value>
   </data>
-    <data name="SocialSignedInMessageTitle" xml:space="preserve">
-    <value>The social sign-in is done</value>
-  </data>
-    <data name="SocialSignedInMessageBody" xml:space="preserve">
+    <data name="CloseBrowserMessageBody" xml:space="preserve">
     <value>You can go back to the application now</value>
   </data>
     <data name="GoogleSignInButtonText" xml:space="preserve">


### PR DESCRIPTION
closes #10316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the handling of external session closures across platforms to use non-blocking operations. This adjustment improves responsiveness by allowing subsequent actions to proceed without waiting for the external interaction to finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->