### PR TITLE
use large size of BitTag components in Demos page of Platform website (#10343)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/DemosPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/DemosPage.razor
@@ -26,24 +26,24 @@
 
             <BitStack Alignment="BitAlignment.Center">
                 <BitStack Horizontal Wrap Alignment="BitAlignment.Center" Style="max-width:800px">
-                    <BitTag Color="BitColor.Info">Free</BitTag>
-                    <BitTag Color="BitColor.Info">Open source</BitTag>
-                    <BitTag Color="BitColor.Info">Full stack</BitTag>
-                    <BitTag Color="BitColor.Info">Cross platform</BitTag>
-                    <BitTag Color="BitColor.Info">SEO friendly</BitTag>
-                    <BitTag Color="BitColor.Info">Localization</BitTag>
-                    <BitTag Color="BitColor.Info">OTP</BitTag>
-                    <BitTag Color="BitColor.Info">Magic link</BitTag>
-                    <BitTag Color="BitColor.Info">2FA</BitTag>
-                    <BitTag Color="BitColor.Info">Social sign-in</BitTag>
-                    <BitTag Color="BitColor.Info">EF core in browser</BitTag>
-                    <BitTag Color="BitColor.Info">reCAPTCHA</BitTag>
-                    <BitTag Color="BitColor.Info">PWA</BitTag>
-                    <BitTag Color="BitColor.Info">Dark/Light theme</BitTag>
-                    <BitTag Color="BitColor.Info">Logging</BitTag>
-                    <BitTag Color="BitColor.Info">Realtime dashboard</BitTag>
-                    <BitTag Color="BitColor.Info">In-app updates</BitTag>
-                    <BitTag Color="BitColor.Info">Super-optimized</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Free</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Open source</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Full stack</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Cross platform</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">SEO friendly</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Localization</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">OTP</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Magic link</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">2FA</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Social sign-in</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">EF core in browser</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">reCAPTCHA</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">PWA</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Dark/Light theme</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Logging</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Realtime dashboard</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">In-app updates</BitTag>
+                    <BitTag Size="BitSize.Large" Color="BitColor.Info">Super-optimized</BitTag>
                 </BitStack>
             </BitStack>
         </div>


### PR DESCRIPTION
closes #10343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the demos page by enhancing the visual presentation of tag elements with a larger display size for improved readability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->