### PR TITLE
Use new bitplatform intro video in Demos page of Platform website (#10350)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/DemosPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/DemosPage.razor
@@ -56,10 +56,12 @@
         </BitText>
         <br />
         <div class="video-container">
-            <iframe src="https://www.youtube.com/embed/MCrF1iwN1h4"
-                    width="560" height="315" title="YouTube video player" frameborder="0" allowfullscreen
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share">
-            </iframe>
+            <video 
+                width="560"
+                height="315" 
+                controls 
+                title="bitplatform intro"
+                src="https://videos.bitplatform.dev/bitplatform-intro.mp4" />
         </div>
         <br />
         <BitText Typography="BitTypography.H6" Gutter>


### PR DESCRIPTION
closes #10350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replaced an external video embed with a self-hosted HTML5 video player, offering direct playback with standard controls for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->