### PR TITLE
Replace login with sign-in in Boilerplate (#10352)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorize.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorize.razor.cs
@@ -5,16 +5,16 @@
 /// an appropriately encoded `redirect_uri`, and `state`.
 /// 
 /// The user can sign in (or sign up if necessary) using various authentication methods provided by project template, 
-/// such as social login, 2FA, magic link, and OTP. After authentication, the system redirects to the specified app 
+/// such as social sign-in, 2FA, magic link, and OTP. After authentication, the system redirects to the specified app 
 /// with an access token and other relevant authentication details.
 /// 
 /// Example Usage:
 /// Opening:
-///     http://localhost:5030/authorize?client_id=SampleClient&redirect_uri=https://sampleclient.azurewebsites.net/loginCallback&state=/carts
-///     http://localhost:5030/authorize?client_id=NopClient&redirect_uri=https%3A%2F%2Fsampleclient.azurewebsites.net%2FLoginCallback&state=%2Fcarts
+///     http://localhost:5030/authorize?client_id=SampleClient&redirect_uri=https://sampleclient.azurewebsites.net/signInCallback&state=/carts
+///     http://localhost:5030/authorize?client_id=NopClient&redirect_uri=https%3A%2F%2Fsampleclient.azurewebsites.net%2FsignInCallback&state=%2Fcarts
 /// 
 /// Redirects to:
-///     https://sampleclient.azurewebsites.net/loginCallback?access_token=di1d98cxh913fh29ufhnfunxw9&token_type=Bearer&expires_in=3600&state=/carts
+///     https://sampleclient.azurewebsites.net/signInCallback?access_token=di1d98cxh913fh29ufhnfunxw9&token_type=Bearer&expires_in=3600&state=/carts
 ///
 /// Note:
 /// This route is **disabled by default** for security reasons.  
@@ -34,7 +34,7 @@ public partial class Authorize
         {
             "SampleClient",
             [
-                "https://sampleclient.azurewebsites.net/loginCallback"
+                "https://sampleclient.azurewebsites.net/signInCallback"
             ]
         }
     };

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Resources/EmailStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Resources/EmailStrings.resx
@@ -158,16 +158,16 @@
     <value>Hello {0}</value>
   </data>
     <data name="OtpSubtitle" xml:space="preserve">
-    <value>Someone has requested an OTP to login to the app.</value>
+    <value>Someone has requested an OTP to sign-in to the app.</value>
   </data>
     <data name="OtpBody" xml:space="preserve">
     <value>If you did not request the OTP, you can ignore this email.</value>
   </data>
     <data name="OtpMessage" xml:space="preserve">
-    <value>You can copy the below OTP and enter it in the login page.</value>
+    <value>You can copy the below OTP and enter it in the sign-in page.</value>
   </data>
     <data name="OtpLinkMessage" xml:space="preserve">
-    <value>Or you can click on the following link to login.</value>
+    <value>Or you can click on the following link to sign-in.</value>
   </data>
     <data name="AppName" xml:space="preserve">
     <value>Boilerplate</value>
@@ -182,7 +182,7 @@
     <value>Hello dear {0}</value>
   </data>
     <data name="TfaTokenMessage" xml:space="preserve">
-    <value>Here is your new 2FA token to login:</value>
+    <value>Here is your new 2FA token to sign-in:</value>
   </data>
     <data name="ElevatedAccessTokenEmailSubject" xml:space="preserve">
     <value>Boilerplate {0} - Elevated access token</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -484,7 +484,7 @@
     <value>Your email address ({0}) has been confirmed.</value>
   </data>
     <data name="EmailConfirmationSuccessMessage" xml:space="preserve">
-    <value>You can now login with your account.</value>
+    <value>You can now sign-in with your account.</value>
   </data>
     <data name="ConfirmPhoneHeaderText" xml:space="preserve">
     <value>Phone Number</value>
@@ -520,7 +520,7 @@
     <value>Your phone number ({0}) has been confirmed.</value>
   </data>
     <data name="PhoneConfirmationSuccessMessage" xml:space="preserve">
-    <value>You can now login with your account.</value>
+    <value>You can now sign-in with your account.</value>
   </data>
     <data name="AccountTitle" xml:space="preserve">
     <value>Account</value>
@@ -652,7 +652,7 @@
     <value>Your password has been reset.</value>
   </data>
     <data name="ResetPasswordSuccessBody" xml:space="preserve">
-    <value>You can now login with your password.</value>
+    <value>You can now sign-in with your password.</value>
   </data>
     <data name="ResetPasswordMessageInForgot" xml:space="preserve">
     <value>Already have a reset password token?</value>
@@ -814,7 +814,7 @@
     <value>The 2fa token provided by the request was invalid. A valid 2fa token is required to enable 2fa.</value>
   </data>
     <data name="TfaProtectedSignInSubtitle" xml:space="preserve">
-    <value>Your login is protected with an authenticator app.</value>
+    <value>Your sign-in is protected with an authenticator app.</value>
   </data>
     <data name="TfaEnterCodeInSignInMessage" xml:space="preserve">
     <value>Enter your authenticator code:</value>
@@ -862,7 +862,7 @@
     <value>You have no recovery codes left.</value>
   </data>
     <data name="TfaRecoveryCodesZeroLeftSubtitle" xml:space="preserve">
-    <value>You must generate a new set of recovery codes before you can log in with a recovery code.</value>
+    <value>You must generate a new set of recovery codes before you can sign in with a recovery code.</value>
   </data>
     <data name="TfaRecoveryCodesOneLeftTitle" xml:space="preserve">
     <value>You have 1 recovery code left.</value>
@@ -1211,18 +1211,18 @@
     <value>Passwordless</value>
   </data>
     <data name="PasswordlessTitle" xml:space="preserve">
-    <value>Passwordless login</value>
+    <value>Passwordless sign-in</value>
   </data>
     <data name="EnablePasswordless" xml:space="preserve">
-    <value>Enable passwordless login</value>
+    <value>Enable passwordless sign-in</value>
   </data>
     <data name="EnablePasswordlessSucsessMessage" xml:space="preserve">
-    <value>Passwordless login enabled successfully</value>
+    <value>Passwordless sign-in enabled successfully</value>
   </data>
     <data name="DisablePasswordless" xml:space="preserve">
-    <value>Disable passwordless login</value>
+    <value>Disable passwordless sign-in</value>
   </data>
     <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
-    <value>Passwordless login disabled successfully</value>
+    <value>Passwordless sign-in disabled successfully</value>
   </data>
 </root>


### PR DESCRIPTION
closes #10352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all user-facing authentication messages and prompts to consistently use "sign-in" instead of "login," including email notifications, OTP instructions, and related texts for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->