### PR TITLE
Add quill container check before initialization on BitRichTextEditor setup (#10411)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.ts
@@ -45,6 +45,8 @@ namespace BitBlazorUI {
             toolbarStyle: string,
             toolbarClass: string) {
 
+            if (!editorContainer) return;
+
             const quill = new Quill(editorContainer, {
                 modules: {
                     toolbar: toolbarContainer || (fullToolbar ? RichTextEditor._toolbarFullOptions : RichTextEditor._toolbarMinOptions)


### PR DESCRIPTION
closes #10411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the Rich Text Editor's stability by ensuring it safely handles scenarios where a required element might be missing, leading to a smoother and more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->