### PR TITLE
Add height to FillContent settings of BitStack (#10427)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Layouts/Stack/BitStack.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Layouts/Stack/BitStack.cs
@@ -42,7 +42,7 @@ public partial class BitStack : BitComponentBase
     [Parameter] public string? Element { get; set; }
 
     /// <summary>
-    /// Expand the direct children to occupy all of the root element's width.
+    /// Expand the direct children to occupy all of the root element's width and height.
     /// </summary>
     [Parameter, ResetClassBuilder]
     public bool FillContent { get; set; }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Layouts/Stack/BitStack.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Layouts/Stack/BitStack.scss
@@ -11,5 +11,6 @@
 .bit-stc-fcn {
     > * {
         width: 100%;
+        height: 100%;
     }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Layouts/Stack/BitStackDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Layouts/Stack/BitStackDemo.razor.cs
@@ -52,7 +52,7 @@ public partial class BitStackDemo
             Name = "FillContent",
             Type = "bool",
             DefaultValue = "false",
-            Description = "Expand the direct children to occupy all of the root element's width."
+            Description = "Expand the direct children to occupy all of the root element's width and height."
         },
         new()
         {


### PR DESCRIPTION
closes #10427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated descriptions for a layout configuration, clarifying that child elements now occupy both the full width and height of their container.
  
- **Style**
  - Enhanced the layout styling to ensure child elements extend to fill the container's full height as well as its width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->