### PR TITLE
Add missing general Size parameters to BitScrollablePane (#10454)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/ScrollablePane/BitScrollablePane.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/ScrollablePane/BitScrollablePane.razor.cs
@@ -22,6 +22,12 @@ public partial class BitScrollablePane : BitComponentBase
     public bool AutoHeight { get; set; }
 
     /// <summary>
+    /// Makes both height and width of the pane auto.
+    /// </summary>
+    [Parameter, ResetStyleBuilder]
+    public bool AutoSize { get; set; }
+
+    /// <summary>
     /// Makes the width of the pane auto.
     /// </summary>
     [Parameter, ResetStyleBuilder]
@@ -39,6 +45,12 @@ public partial class BitScrollablePane : BitComponentBase
     public bool FitHeight { get; set; }
 
     /// <summary>
+    /// Makes both height and width of the pane fit-content.
+    /// </summary>
+    [Parameter, ResetStyleBuilder]
+    public bool FitSize { get; set; }
+
+    /// <summary>
     /// Makes the width of the pane fit-content.
     /// </summary>
     [Parameter, ResetStyleBuilder]
@@ -51,7 +63,13 @@ public partial class BitScrollablePane : BitComponentBase
     public bool FullHeight { get; set; }
 
     /// <summary>
-    /// Makes the width of the pane auto.
+    /// Makes both height and width of the pane 100%.
+    /// </summary>
+    [Parameter, ResetStyleBuilder]
+    public bool FullSize { get; set; }
+
+    /// <summary>
+    /// Makes the width of the pane 100%.
     /// </summary>
     [Parameter, ResetStyleBuilder]
     public bool FullWidth { get; set; }
@@ -136,12 +154,15 @@ public partial class BitScrollablePane : BitComponentBase
 
         StyleBuilder.Register(() => AutoWidth ? $"width:auto" : string.Empty);
         StyleBuilder.Register(() => AutoHeight ? $"height:auto" : string.Empty);
+        StyleBuilder.Register(() => AutoSize ? $"height:auto;width:auto" : string.Empty);
 
         StyleBuilder.Register(() => FitWidth ? $"width:fit-content" : string.Empty);
         StyleBuilder.Register(() => FitHeight ? $"height:fit-content" : string.Empty);
+        StyleBuilder.Register(() => FitSize ? $"height:fit-content;width:fit-content" : string.Empty);
 
         StyleBuilder.Register(() => FullWidth ? $"width:100%" : string.Empty);
         StyleBuilder.Register(() => FullHeight ? $"height:100%" : string.Empty);
+        StyleBuilder.Register(() => FullSize ? $"height:100%;width:100%" : string.Empty);
 
         // Auto is the default value which is already set on the root element
         StyleBuilder.Register(register =>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/ScrollablePane/BitScrollablePaneDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/ScrollablePane/BitScrollablePaneDemo.razor.cs
@@ -20,6 +20,13 @@ public partial class BitScrollablePaneDemo
         },
         new()
         {
+            Name = "AutoSize",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Makes both height and width of the pane auto.",
+        },
+        new()
+        {
             Name = "AutoWidth",
             Type = "bool",
             DefaultValue = "false",
@@ -41,6 +48,13 @@ public partial class BitScrollablePaneDemo
         },
         new()
         {
+            Name = "FitSize",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Makes both height and width of the pane fit-content.",
+        },
+        new()
+        {
             Name = "FitWidth",
             Type = "bool",
             DefaultValue = "false",
@@ -52,6 +66,13 @@ public partial class BitScrollablePaneDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Makes the height of the pane 100%.",
+        },
+        new()
+        {
+            Name = "FullSize",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Makes both height and width of the pane 100%.",
         },
         new()
         {


### PR DESCRIPTION
closes #10454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new options to set both the height and width of the scrollable pane at once: auto, fit-content, or 100%.
- **Documentation**
  - Updated demo and descriptions to include the new sizing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->