### PR TITLE
Fix UI style issues of SystemPrompt page of Boilerplate (#10503)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Chatbot/SystemPromptsPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Chatbot/SystemPromptsPage.razor
@@ -5,32 +5,33 @@
 
 <AppPageData Title="@Localizer[nameof(AppStrings.SystemPromptsTitle)]"
              SubTitle="@Localizer[nameof(AppStrings.SystemPromptsSubTitle)]" />
-
-<CascadingValue Value=BitDir.Ltr>
-    @if (isLoading)
-    {
-        <BitEllipsisLoading CustomSize="32" />
-    }
-    else
-    {
-        <AuthorizeView Roles="@AppRoles.SUPER_ADMIN">
-            <Authorized>
-                <BitSticky Top="4rem" Style="margin-bottom:8px">
-                    <BitButton IconName="@BitIconName.Save" OnClick="WrapHandled(SaveChanges)" AutoLoading>
-                        Save prompt
-                    </BitButton>
-                </BitSticky>
-            </Authorized>
-            <NotAuthorized>
-                <BitText Typography="BitTypography.H4" Color="BitColor.Warning">You don't have access to change the system prompts.</BitText>
-            </NotAuthorized>
-        </AuthorizeView>
-
-        <BitStack VerticalAlign="BitAlignment.Stretch" Horizontal>
+<section>
+    <CascadingValue Value=BitDir.Ltr>
+        @if (isLoading)
+        {
+            <BitEllipsisLoading CustomSize="32" />
+        }
+        else
+        {
             <AuthorizeView Roles="@AppRoles.SUPER_ADMIN">
-                <BitMarkdownEditor @bind-Value="systemPromptMarkdown" Style="height:auto" />
+                <Authorized>
+                    <BitSticky Top="5rem" Style="margin-bottom:8px">
+                        <BitButton IconName="@BitIconName.Save" OnClick="WrapHandled(SaveChanges)" AutoLoading>
+                            Save prompt
+                        </BitButton>
+                    </BitSticky>
+                </Authorized>
+                <NotAuthorized>
+                    <BitText Typography="BitTypography.H4" Color="BitColor.Warning">You don't have access to change the system prompts.</BitText>
+                </NotAuthorized>
             </AuthorizeView>
-            <BitMarkdownViewer Markdown="@systemPromptMarkdown" Style="word-break:break-all" />
-        </BitStack>
-    }
-</CascadingValue>
+
+            <BitStack VerticalAlign="BitAlignment.Stretch" Horizontal>
+                <AuthorizeView Roles="@AppRoles.SUPER_ADMIN">
+                    <BitMarkdownEditor @bind-Value="systemPromptMarkdown" Class="md-editor" />
+                </AuthorizeView>
+                <BitMarkdownViewer Markdown="@systemPromptMarkdown" Style="word-break:break-all" />
+            </BitStack>
+        }
+    </CascadingValue>
+</section>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Chatbot/SystemPromptsPage.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Chatbot/SystemPromptsPage.razor.scss
@@ -1,0 +1,13 @@
+section {
+    width: 100%;
+}
+
+::deep {
+    .md-editor {
+        height: auto;
+        
+        textarea {
+            font-size: 1rem;
+        }
+    }
+}


### PR DESCRIPTION
closes #10503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout and visual consistency for the System Prompts page, including updated section structure and markdown editor styling.
- **Refactor**
  - Enhanced role-based visibility, ensuring only SUPER_ADMIN users can edit system prompts while all users can view them. 
  - Streamlined page structure for clearer authorization and content separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->