### PR TITLE
Fix issues of SignOut confirm modal in Boilerplate (#10504)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor
@@ -1,9 +1,19 @@
 @inherits AppComponentBase
 
-<BitDialog @bind-IsOpen="IsOpen"
+@if (IsOpen)
+{
+    <!-- Close this dialog when navigation occurs instead of navigating away from the categories page -->
+    <NavigationLock OnBeforeInternalNavigation="@((args) => { args.PreventNavigation(); IsOpen = false; IsOpenChanged.InvokeAsync(false); })" />
+}
+
+<BitDialog IsBlocking="true"
+           @bind-IsOpen="IsOpen"
            OnDismiss="CloseModal"
+           ShowCloseButton="false"
            OnOk="WrapHandled(SignOut)"
+           ShowCancelButton="isSigningOut is false"
+           Title="@Localizer[nameof(AppStrings.SignOut)]"
            OkText="@Localizer[nameof(AppStrings.SignOut)]"
            CancelText="@Localizer[nameof(AppStrings.Cancel)]"
-           Title="@Localizer[nameof(AppStrings.SignOut)]"
-           Message="@Localizer[nameof(AppStrings.SignOutPrompt)]" />
+           Message="@Localizer[nameof(AppStrings.SignOutPrompt)]"
+           Styles="@(new() { OkButton = "width:100%", CancelButton = "width:100%" })"/>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor
@@ -2,7 +2,7 @@
 
 @if (IsOpen)
 {
-    <!-- Close this dialog when navigation occurs instead of navigating away from the categories page -->
+    <!-- Close this dialog when navigation occurs (click on the back button) instead of navigating away from the current page -->
     <NavigationLock OnBeforeInternalNavigation="@((args) => { args.PreventNavigation(); IsOpen = false; IsOpenChanged.InvokeAsync(false); })" />
 }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor
@@ -3,7 +3,7 @@
 @if (IsOpen)
 {
     <!-- Close this dialog when navigation occurs (click on the back button) instead of navigating away from the current page -->
-    <NavigationLock OnBeforeInternalNavigation="@((args) => { args.PreventNavigation(); IsOpen = false; IsOpenChanged.InvokeAsync(false); })" />
+    <NavigationLock OnBeforeInternalNavigation="HandleNavigation" />
 }
 
 <BitDialog IsBlocking="true"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor.cs
@@ -1,4 +1,6 @@
-﻿namespace Boilerplate.Client.Core.Components.Layout;
+﻿using Microsoft.AspNetCore.Components.Routing;
+
+namespace Boilerplate.Client.Core.Components.Layout;
 
 public partial class SignOutConfirmDialog
 {
@@ -34,5 +36,15 @@ public partial class SignOutConfirmDialog
         }
 
         await CloseModal();
+    }
+
+    private async Task HandleNavigation(LocationChangingContext context)
+    {
+        context.PreventNavigation();
+
+        if (isSigningOut) return;
+
+        IsOpen = false; 
+        await IsOpenChanged.InvokeAsync(false);
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/SignOutConfirmDialog.razor.cs
@@ -1,7 +1,10 @@
-namespace Boilerplate.Client.Core.Components.Layout;
+﻿namespace Boilerplate.Client.Core.Components.Layout;
 
 public partial class SignOutConfirmDialog
 {
+    private bool isSigningOut;
+
+
     [Parameter] public bool IsOpen { get; set; }
 
     [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
@@ -9,13 +12,26 @@ public partial class SignOutConfirmDialog
 
     private async Task CloseModal()
     {
+        if (isSigningOut) return;
+
         IsOpen = false;
         await IsOpenChanged.InvokeAsync(false);
     }
 
     private async Task SignOut()
     {
-        await AuthManager.SignOut(CurrentCancellationToken);
+        if (isSigningOut) return;
+
+        try
+        {
+            isSigningOut = true;
+
+            await AuthManager.SignOut(CurrentCancellationToken);
+        }
+        finally
+        {
+            isSigningOut = false;
+        }
 
         await CloseModal();
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Categories/AddOrEditCategoryModal.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Categories/AddOrEditCategoryModal.razor
@@ -2,7 +2,7 @@
 
 @if (isOpen)
 {
-    <!-- Close this dialog when navigation occures instead of navigating away from the categories page -->
+    <!-- Close this dialog when navigation occurs instead of navigating away from the categories page -->
     <NavigationLock OnBeforeInternalNavigation="@((args) => { args.PreventNavigation(); isOpen = false; })" />
 }
 


### PR DESCRIPTION
closes #10504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the sign-out confirmation dialog to prevent accidental navigation while open and ensure a smoother sign-out process.
- **Bug Fixes**
  - The sign-out dialog now properly disables actions and closes only when appropriate, preventing duplicate sign-out attempts.
- **Style**
  - Dialog buttons are now displayed at full width for better usability.
- **Documentation**
  - Corrected a spelling error in a comment for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->