### PR TITLE
Fix `ScssCompilerService` issue with host process termination (#10561)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -14,6 +14,7 @@
         <PackageVersion Include="Fido2.Models" Version="4.0.0-beta.16" />
         <PackageVersion Include="HtmlSanitizer" Version="9.0.876" />
         <PackageVersion Include="libphonenumber-csharp" Version="9.0.3" />
+        <PackageVersion Include="Meziantou.Framework.Win32.Jobs" Version="3.4.3" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.4" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.4" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Boilerplate.Server.Web.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Boilerplate.Server.Web.csproj
@@ -11,7 +11,7 @@
         <PublishReadyToRun>true</PublishReadyToRun>
         <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="NWebsec.AspNetCore.Middleware" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
@@ -29,6 +29,14 @@
 
     <ItemGroup>
         <Using Include="Boilerplate.Shared.Enums" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Environment)' == 'Development'">
+        <!-- Checkout ScssCompilerService.cs source code. -->
+        <PackageReference Include="Meziantou.Framework.Win32.Jobs" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(Environment)' != 'Development'">
+        <Compile Remove="Services\ScssCompilerService.cs" />
     </ItemGroup>
 
     <!--

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Services/ScssCompilerService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Services/ScssCompilerService.cs
@@ -16,6 +16,9 @@ public class ScssCompilerService
         if (Environment.GetEnvironmentVariable("IN_APP_SCSS_COMPILER_ENABLED") is not "true")
             return; // Checkout Visual Studio's launchSettings.json
 
+        if (AppPlatform.IsWindows is false)
+            return;
+
         var clientCorePath = Path.Combine(Environment.CurrentDirectory, "../../Client/Boilerplate.Client.Core");
 
         var logger = app.Services.GetRequiredService<ILogger<ScssCompilerService>>();


### PR DESCRIPTION
closes #10561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved SCSS file watching during development by consolidating multiple watchers into a single, more efficient process.
  - Enhanced process management to ensure the SCSS watcher terminates automatically when the application stops in development environments.

- **Chores**
  - Updated development dependencies to include a new package for better process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->