### PR TITLE
Disable asset compression in development in Boilerplate (#10575)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
@@ -9,9 +9,9 @@
         <NoWarn>$(NoWarn);CS1998;CS1591</NoWarn>
         <WarningsAsErrors>$(WarningsAsErrors);CS0114;CS8785</WarningsAsErrors>
         <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-		
-		<!-- You have the flexibility to modify all of these properties using the -p parameters during the build process. -->
-		<!-- Examples: dotnet publish -c Release -p:InvariantGlobalization=true -->
+
+        <!-- You have the flexibility to modify all of these properties using the -p parameters during the build process. -->
+        <!-- Examples: dotnet publish -c Release -p:InvariantGlobalization=true -->
 
         <NeutralLanguage>en-US</NeutralLanguage>
         <InvariantGlobalization>false</InvariantGlobalization>
@@ -50,7 +50,7 @@
         <PackageReference Include="Bit.SourceGenerators" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <Using Include="System.Net.Http" />
         <Using Include="System.Text.Json" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
@@ -31,6 +31,7 @@
         <DefineConstants Condition=" '$(InvariantGlobalization)' == 'true' ">$(DefineConstants);InvariantGlobalization</DefineConstants>
         <DefineConstants>$(DefineConstants);$(Environment);$(Configuration)</DefineConstants>
         <DefineConstants Condition="$(Configuration.Contains('Debug'))">$(DefineConstants);DEBUG</DefineConstants>
+        <CompressionEnabled Condition="'$(Environment)' == 'Development'">false</CompressionEnabled>
     </PropertyGroup>
     <!--/+:msbuild-conditional:noEmit -->
 


### PR DESCRIPTION
closes #10575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting to control compression, which is disabled by default in development environments.

- **Style**
  - Improved consistency in whitespace and indentation within configuration comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->