### PR TITLE
Add ability to read other user logs by super users in Boilerplate (#10588)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/ClientAppCoordinator.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/ClientAppCoordinator.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 using BlazorApplicationInsights.Interfaces;
 //#endif
 using Microsoft.AspNetCore.Components.Routing;
+using Boilerplate.Client.Core.Services.DiagnosticLog;
 
 namespace Boilerplate.Client.Core.Components;
 
@@ -204,6 +205,11 @@ public partial class ClientAppCoordinator : AppComponentBase
         signalROnDisposables.Add(hubConnection.On<AppProblemDetails>(SignalREvents.EXCEPTION_THROWN, async (appProblemDetails) =>
         {
             ExceptionHandler.Handle(appProblemDetails, displayKind: ExceptionDisplayKind.NonInterrupting);
+        }));
+
+        signalROnDisposables.Add(hubConnection.On(SignalRMethods.UPLOAD_DIAGNOSTIC_LOGGER_STORE, async () =>
+        {
+            return DiagnosticLogger.Store.ToArray();
         }));
 
         hubConnection.Closed += HubConnectionStateChange;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor
@@ -36,11 +36,11 @@
             <BitStack Horizontal FitHeight Wrap>
                 <BitStack Horizontal Gap="4px" FitWidth AutoHeight>
                     <BitSearchBox FixedIcon
-                                  Immediate 
-                                  DebounceTime="500" 
+                                  Immediate
+                                  DebounceTime="500"
                                   @bind-Value="@searchText"
                                   OnChange="_ => FilterLogs()" />
-                    <BitToggleButton Variant="BitVariant.Text" 
+                    <BitToggleButton Variant="BitVariant.Text"
                                      Color="BitColor.Secondary"
                                      OnChange="_ => FilterLogs()"
                                      Style="width:2rem;height:2rem"
@@ -84,7 +84,7 @@
                 <BitButton IconOnly
                            Title="Clear logs"
                            OnClick="ClearLogs"
-                           IconName="@BitIconName.Delete" 
+                           IconName="@BitIconName.Delete"
                            Color="BitColor.SecondaryBackground" />
 
                 <BitButton IconOnly
@@ -105,12 +105,24 @@
                            Color="BitColor.SecondaryBackground"
                            IconName="@BitIconName.DeveloperTools" />
 
+                @*#if (signalR == true)*@
+                <AuthorizeView Roles="@AppRoles.SUPER_ADMIN">
+                    <Authorized>
+                        <BitButton IconOnly AutoLoading
+                                   OnClick="ReadAnotherUserLogs"
+                                   Title="Read another user logs"
+                                   Color="BitColor.SecondaryBackground"
+                                   IconName="@BitIconName.Download" />
+                    </Authorized>
+                </AuthorizeView>
+                @*#endif*@
+
                 @if (AppPlatform.IsBrowser is false)
                 {
                     <BitButton IconOnly
                                Title="Call GC"
                                OnClick="CallGC"
-                               IconName="@BitIconName.RecycleBin" 
+                               IconName="@BitIconName.RecycleBin"
                                Color="BitColor.SecondaryBackground" />
                 }
 
@@ -118,7 +130,7 @@
                            AutoLoading
                            Title="Clear cache"
                            OnClick="ClearCache"
-                           IconName="@BitIconName.RemoveFrom" 
+                           IconName="@BitIconName.RemoveFrom"
                            Color="BitColor.SecondaryBackground" />
             </BitStack>
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
@@ -147,7 +147,7 @@ public partial class AppDiagnosticModal
     /// </summary>
     private async Task ReadAnotherUserLogs()
     {
-        var userId = Guid.Parse((await promptService.Show("Enter the user id", "Read Another User Logs"))!);
+        var userId = Guid.Parse((await promptService.Show("Enter other user id:", "Get other user logs"))!);
         var logs = await hubConnection.InvokeAsync<DiagnosticLogDto[]>("GetUserDiagnosticLogs", userId, CurrentCancellationToken);
         foreach (var log in logs)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
@@ -142,6 +142,9 @@ public partial class AppDiagnosticModal
     }
 
     //#if (signalR == true)
+    /// <summary>
+    /// <inheritdoc cref="SignalRMethods.UPLOAD_DIAGNOSTIC_LOGGER_STORE"/>
+    /// </summary>
     private async Task ReadAnotherUserLogs()
     {
         var userId = Guid.Parse((await promptService.Show("Enter the user id", "Read Another User Logs"))!);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
@@ -147,13 +147,9 @@ public partial class AppDiagnosticModal
     /// </summary>
     private async Task ReadAnotherUserLogs()
     {
-        var userId = Guid.Parse((await promptService.Show("Enter other user id:", "Get other user logs"))!);
-        var logs = await hubConnection.InvokeAsync<DiagnosticLogDto[]>("GetUserDiagnosticLogs", userId, CurrentCancellationToken);
-        foreach (var log in logs)
-        {
-            DiagnosticLogger.Store.Enqueue(log);
-        }
-        ReloadLogs();
+        var userQuery = await promptService.Show("Enter `UserId`, `UserSessionId`, `Email` or `PhoneNumber`:", "Get other user logs");
+        var logs = await hubConnection.InvokeAsync<DiagnosticLogDto[]>("GetUserDiagnosticLogs", userQuery, CurrentCancellationToken);
+        LoadLogs(logs);
     }
     //#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.Utils.cs
@@ -149,6 +149,10 @@ public partial class AppDiagnosticModal
     {
         var userQuery = await promptService.Show("Enter `UserId`, `UserSessionId`, `Email` or `PhoneNumber`:", "Get other user logs");
         var logs = await hubConnection.InvokeAsync<DiagnosticLogDto[]>("GetUserDiagnosticLogs", userQuery, CurrentCancellationToken);
+
+        filterCategoryValues = null;
+        filterLogLevelValues = [LogLevel.Information, LogLevel.Warning, LogLevel.Error, LogLevel.Critical];
+
         LoadLogs(logs);
     }
     //#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.cs
@@ -117,19 +117,26 @@ public partial class AppDiagnosticModal
         ReloadLogs();
     }
 
-    private void ReloadLogs()
+    private void LoadLogs(IEnumerable<DiagnosticLogDto> logs)
     {
-        allLogs = [.. DiagnosticLogger.Store];
+        allLogs = logs;
 
-        var allCategories = allLogs.Select(l => l.Category ?? string.Empty)
-                                   .Where(c => string.IsNullOrWhiteSpace(c) is false)
-                                   .Distinct().Order();
+        var allCategories = allLogs.Where(c => string.IsNullOrEmpty(c.Category) is false)
+                                   .Select(l => l.Category!)
+                                   .Distinct()
+                                   .Order()
+                                   .ToArray();
 
         filterCategoryValues ??= [.. allCategories];
 
         allCategoryItems = [.. allCategories.Select(c => new BitDropdownItem<string>() { Text = c, Value = c })];
 
         FilterLogs();
+    }
+
+    private void ReloadLogs()
+    {
+        LoadLogs([.. DiagnosticLogger.Store]);
     }
 
     private void FilterLogs()

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 using Boilerplate.Shared.Controllers.Diagnostics;
 using Boilerplate.Client.Core.Services.DiagnosticLog;
 using System.Text.RegularExpressions;
+using Boilerplate.Shared.Dtos.Diagnostic;
 
 namespace Boilerplate.Client.Core.Components.Layout;
 
@@ -19,14 +20,14 @@ public partial class AppDiagnosticModal
     private bool enableRegExp;
     private string? searchText;
     private bool isLogModalOpen;
-    private DiagnosticLog? selectedLog;
+    private DiagnosticLogDto? selectedLog;
     private bool isDescendingSort = true;
     private Action unsubscribe = default!;
     private IEnumerable<string>? filterCategoryValues;
-    private IEnumerable<DiagnosticLog> allLogs = default!;
+    private IEnumerable<DiagnosticLogDto> allLogs = default!;
     private BitDropdownItem<string>[] allCategoryItems = [];
-    private IEnumerable<DiagnosticLog> filteredLogs = default!;
-    private BitBasicList<(DiagnosticLog, int)> logStackRef = default!;
+    private IEnumerable<DiagnosticLogDto> filteredLogs = default!;
+    private BitBasicList<(DiagnosticLogDto, int)> logStackRef = default!;
     private readonly BitDropdownItem<LogLevel>[] logLevelItems = Enum.GetValues<LogLevel>().Select(v => new BitDropdownItem<LogLevel>() { Value = v, Text = v.ToString() }).ToArray();
     private IEnumerable<LogLevel> filterLogLevelValues = AppEnvironment.IsDev()
                                                             ? [LogLevel.Information, LogLevel.Warning, LogLevel.Error, LogLevel.Critical]
@@ -68,25 +69,25 @@ public partial class AppDiagnosticModal
         await clipboard.WriteText(string.Join(Environment.NewLine, telemetryContext.ToDictionary().Select(c => $"{c.Key}: {c.Value}")));
     }
 
-    private async Task CopyException(DiagnosticLog? log)
+    private async Task CopyException(DiagnosticLogDto? log)
     {
         if (log is null) return;
 
         await clipboard.WriteText(GetContent(log));
     }
 
-    private async Task OpenLog(DiagnosticLog log)
+    private async Task OpenLog(DiagnosticLogDto log)
     {
         selectedLog = log;
         isLogModalOpen = true;
     }
 
-    private static string GetContent(DiagnosticLog? log)
+    private static string GetContent(DiagnosticLogDto? log)
     {
         if (log is null) return string.Empty;
 
         var stateToCopy = string.Join(Environment.NewLine, log.State?.Select(i => $"{i.Key}: {i.Value}") ?? []);
-        return $"{log.Category}{Environment.NewLine}{log.Message}{Environment.NewLine}{log.Exception?.ToString()}{Environment.NewLine}{stateToCopy}";
+        return $"{log.Category}{Environment.NewLine}{log.Message}{Environment.NewLine}{log.ExceptionString?.ToString()}{Environment.NewLine}{stateToCopy}";
     }
 
     private async Task GoTop()
@@ -149,7 +150,7 @@ public partial class AppDiagnosticModal
 
         StateHasChanged();
 
-        IEnumerable<DiagnosticLog> FilterSearchText(IEnumerable<DiagnosticLog> logs)
+        IEnumerable<DiagnosticLogDto> FilterSearchText(IEnumerable<DiagnosticLogDto> logs)
         {
             if (string.IsNullOrEmpty(searchText)) return logs;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppDiagnosticModal.razor.cs
@@ -113,7 +113,6 @@ public partial class AppDiagnosticModal
     private async Task ClearLogs()
     {
         DiagnosticLogger.Store.Clear();
-        filterCategoryValues = null;
         ReloadLogs();
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
@@ -32,7 +32,7 @@
                 }
                 else
                 {
-                    <BitTextField @bind-Value="value" AutoFocus />
+                    <BitTextField @bind-Value="value" AutoFocus OnEnter="WrapHandled(async (KeyboardEventArgs args) => OnOk?.Invoke(value))" />
                 }
             </BitStack>
         </div>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Prompt.razor
@@ -32,7 +32,10 @@
                 }
                 else
                 {
-                    <BitTextField @bind-Value="value" AutoFocus OnEnter="WrapHandled(async (KeyboardEventArgs args) => OnOk?.Invoke(value))" />
+                    <BitTextField @bind-Value="value"
+                                  AutoFocus
+                                  Immediate
+                                  OnEnter="WrapHandled(async (KeyboardEventArgs args) => OnOk?.Invoke(value))" />
                 }
             </BitStack>
         </div>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Todo/TodoPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Todo/TodoPage.razor
@@ -14,7 +14,7 @@
                           @bind-Value="newTodoTitle"
                           Immediate DebounceTime="300"
                           Placeholder="@Localizer[nameof(AppStrings.TodoAddPlaceholder)]"
-                          OnKeyDown="WrapHandled(async (KeyboardEventArgs args) => await OnInputKeyDown(args))" />
+                          OnEnter="WrapHandled(async (KeyboardEventArgs args) => await AddTodoItem())" />
 
             <BitButton AutoLoading
                        OnClick="WrapHandled(AddTodoItem)"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Todo/TodoPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Todo/TodoPage.razor.cs
@@ -1,4 +1,4 @@
-using Boilerplate.Shared.Controllers.Todo;
+﻿using Boilerplate.Shared.Controllers.Todo;
 using Boilerplate.Shared.Dtos.Todo;
 using Microsoft.AspNetCore.Components.Web;
 
@@ -139,14 +139,6 @@ public partial class TodoPage
 
         newTodoTitle = "";
         await newTodoInput.FocusAsync();
-    }
-
-    private async Task OnInputKeyDown(KeyboardEventArgs args)
-    {
-        if (args.Key == "Enter")
-        {
-            await AddTodoItem();
-        }
     }
 
     private async Task DeleteTodoItem()

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Extensions/IClientCoreServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Extensions/IClientCoreServiceCollectionExtensions.cs
@@ -150,6 +150,13 @@ public static partial class IClientCoreServiceCollectionExtensions
 
             var hubConnection = new HubConnectionBuilder()
                 .WithStatefulReconnect()
+                .AddJsonProtocol(options =>
+                {
+                    foreach (var chain in sp.GetRequiredService<JsonSerializerOptions>().TypeInfoResolverChain)
+                    {
+                        options.PayloadSerializerOptions.TypeInfoResolverChain.Add(chain);
+                    }
+                })
                 .WithAutomaticReconnect(sp.GetRequiredService<IRetryPolicy>())
                 .WithUrl(new Uri(absoluteServerAddressProvider.GetAddress(), "app-hub"), options =>
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/DiagnosticLog/DiagnosticLogger.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/DiagnosticLog/DiagnosticLogger.cs
@@ -1,8 +1,10 @@
+﻿using Boilerplate.Shared.Dtos.Diagnostic;
+
 namespace Boilerplate.Client.Core.Services.DiagnosticLog;
 
 public partial class DiagnosticLogger : ILogger, IDisposable
 {
-    public static ConcurrentQueue<DiagnosticLog> Store { get; } = [];
+    public static ConcurrentQueue<DiagnosticLogDto> Store { get; } = [];
 
     private IDictionary<string, object?>? currentState;
 
@@ -40,8 +42,8 @@ public partial class DiagnosticLogger : ILogger, IDisposable
             CreatedOn = DateTimeOffset.Now,
             Level = logLevel,
             Message = message,
-            Exception = exception,
             Category = Category,
+            ExceptionString = exception?.ToString(),
             State = currentState?.ToDictionary(i => i.Key, i => i.Value?.ToString())
         });
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.cs
@@ -220,6 +220,11 @@ public partial class AppHub : Hub
         catch { }
     }
 
+    /// <summary>
+    /// <inheritdoc cref="SignalRMethods.UPLOAD_DIAGNOSTIC_LOGGER_STORE"/>
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <returns></returns>
     [Authorize(Roles = AppRoles.SUPER_ADMIN)]
     public async Task<DiagnosticLogDto[]> GetUserDiagnosticLogs(Guid userId)
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Dtos/AppJsonContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Dtos/AppJsonContext.cs
@@ -19,6 +19,7 @@ using Boilerplate.Shared.Dtos.Chatbot;
 //#endif
 using Boilerplate.Shared.Dtos.Identity;
 using Boilerplate.Shared.Dtos.Statistics;
+using Boilerplate.Shared.Dtos.Diagnostic;
 
 namespace Boilerplate.Shared.Dtos;
 
@@ -64,6 +65,8 @@ namespace Boilerplate.Shared.Dtos;
 [JsonSerializable(typeof(WebAuthnAssertionOptionsRequestDto))]
 
 //#if (signalR == true)
+[JsonSerializable(typeof(DiagnosticLogDto[]))]
+[JsonSerializable(typeof(StartChatbotRequest))]
 [JsonSerializable(typeof(UpdateSystemPromptDto))]
 //#endif
 public partial class AppJsonContext : JsonSerializerContext

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Dtos/Diagnostic/DiagnosticLogDto.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Dtos/Diagnostic/DiagnosticLogDto.cs
@@ -1,6 +1,8 @@
-namespace Boilerplate.Client.Core.Services.DiagnosticLog;
+﻿using Microsoft.Extensions.Logging;
 
-public class DiagnosticLog
+namespace Boilerplate.Shared.Dtos.Diagnostic;
+
+public class DiagnosticLogDto
 {
     public DateTimeOffset CreatedOn { get; set; }
 
@@ -10,7 +12,7 @@ public class DiagnosticLog
 
     public string? Category { get; set; }
 
-    public Exception? Exception { get; set; }
+    public string? ExceptionString { get; set; }
 
     public IDictionary<string, string?>? State { get; set; }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
@@ -38,9 +38,9 @@ public static partial class SignalREvents
 public static partial class SignalRMethods
 {
     /// <summary>
-    /// Super admins can call this method to get all diagnostic logs of the currently opended session.
-    /// It's useful, because unlike Sentry, AppInsights and the rest of loggers in production that their
-    /// log level has been set to Warning by default to reduce the costs, this client side logger 
+    /// Allows super admins to retrieve all diagnostic logs for the active session.
+    /// Unlike production loggers (e.g., Sentry, AppInsights) set to Warning by default to minimize costs,
+    /// the diagnostic logger defaults to Information for detailed logging.
     /// </summary>
     public const string UPLOAD_DIAGNOSTIC_LOGGER_STORE = nameof(UPLOAD_DIAGNOSTIC_LOGGER_STORE);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
@@ -38,9 +38,10 @@ public static partial class SignalREvents
 public static partial class SignalRMethods
 {
     /// <summary>
-    /// Allows super admins to retrieve all diagnostic logs for the active session.
+    /// Allows super admins to retrieve all diagnostic logs for the active user session(s).
     /// Unlike production loggers (e.g., Sentry, AppInsights) set to Warning by default to minimize costs,
     /// the diagnostic logger defaults to Information for detailed logging.
+    /// This helps in debugging issues in production environments.
     /// </summary>
     public const string UPLOAD_DIAGNOSTIC_LOGGER_STORE = nameof(UPLOAD_DIAGNOSTIC_LOGGER_STORE);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
@@ -34,3 +34,13 @@ public static partial class SignalREvents
     /// </summary>
     public const string EXCEPTION_THROWN = nameof(EXCEPTION_THROWN);
 }
+
+public static partial class SignalRMethods
+{
+    /// <summary>
+    /// Super admins can call this method to get all diagnostic logs of the currently opended session.
+    /// It's useful, because unlike Sentry, AppInsights and the rest of loggers in production that their
+    /// log level has been set to Warning by default to reduce the costs, this client side logger 
+    /// </summary>
+    public const string UPLOAD_DIAGNOSTIC_LOGGER_STORE = nameof(UPLOAD_DIAGNOSTIC_LOGGER_STORE);
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
@@ -38,10 +38,10 @@ public static partial class SignalREvents
 public static partial class SignalRMethods
 {
     /// <summary>
-    /// Allows super admins to retrieve all diagnostic logs for the active user session(s).
-    /// Unlike production loggers (e.g., Sentry, AppInsights) set to Warning by default to minimize costs,
-    /// the diagnostic logger defaults to Information for detailed logging.
-    /// This helps in debugging issues in production environments.
+    /// Allows super admins and support staff to retrieve all diagnostic logs for active user sessions.
+    /// In contrast to production loggers (e.g., Sentry, AppInsights), which use a Warning level by default (except for specific categories at Information level) to reduce costs,
+    /// the diagnostic logger defaults to Information level to capture all logs, stored solely in the client device's memory.
+    /// Uploading these logs for display in the support staff's diagnostic modal log viewer aids in pinpointing the root cause of user issues during live troubleshooting.
     /// </summary>
     public const string UPLOAD_DIAGNOSTIC_LOGGER_STORE = nameof(UPLOAD_DIAGNOSTIC_LOGGER_STORE);
 }


### PR DESCRIPTION
closes #10588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Super admins can now remotely view diagnostic logs from other users' active sessions via a new button in the diagnostic modal.
  - Added the ability to fetch and display another user's diagnostic logs using a user ID prompt.
- **Improvements**
  - Diagnostic logs now use a new data format for improved consistency and clarity.
  - Exception details in logs are now shown as strings for better readability.
- **Access Control**
  - The new log retrieval feature is restricted to users with the SUPER_ADMIN role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->