### PR TITLE
Add missing Provider parameters to BitFileUpload (#10592)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileInfo.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileInfo.cs
@@ -56,6 +56,6 @@ public class BitFileInfo
     /// <summary>
     /// The HTTP header at upload file.
     /// </summary>
-    [JsonIgnore] public IReadOnlyDictionary<string, string>? HttpHeaders { get; set; }
+    [JsonIgnore] public Dictionary<string, string>? HttpHeaders { get; set; }
     [JsonIgnore] internal DateTime? StartTimeUpload { get; set; }
 }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUploadJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/FileUpload/BitFileUploadJsRuntimeExtensions.cs
@@ -11,7 +11,7 @@ internal static class BitFileUploadJsRuntimeExtensions
                                                                      ElementReference element,
                                                                      bool append,
                                                                      string? uploadAddress,
-                                                                     IReadOnlyDictionary<string, string>? uploadRequestHttpHeaders)
+                                                                     Dictionary<string, string>? uploadRequestHttpHeaders)
     {
         return jsRuntime.Invoke<BitFileInfo[]>("BitBlazorUI.FileUpload.setup", id, dotnetObjectReference, element, append, uploadAddress, uploadRequestHttpHeaders);
     }
@@ -22,7 +22,7 @@ internal static class BitFileUploadJsRuntimeExtensions
                                                        long to,
                                                        int index,
                                                        string? uploadUrl,
-                                                       IReadOnlyDictionary<string, string>? httpHeaders)
+                                                       Dictionary<string, string>? httpHeaders)
     {
         return (httpHeaders is null ? jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.upload", id, from, to, index, uploadUrl)
                                     : jsRuntime.InvokeVoid("BitBlazorUI.FileUpload.upload", id, from, to, index, uploadUrl, httpHeaders));

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/FileUpload/BitFileUploadDemo.razor.cs
@@ -190,16 +190,30 @@ public partial class BitFileUploadDemo
         new()
         {
             Name = "RemoveRequestHttpHeaders",
-            Type = "IReadOnlyDictionary<string, string>?",
+            Type = "Dictionary<string, string>?",
             DefaultValue = "null",
             Description = "Custom http headers for remove request."
         },
         new()
         {
+            Name = "RemoveRequestHttpHeadersProvider",
+            Type = "Func<Task<Dictionary<string, string>>>?",
+            DefaultValue = "null",
+            Description = "The provider function to create the http headers for remove request."
+        },
+        new()
+        {
             Name = "RemoveRequestQueryStrings",
-            Type = "IReadOnlyDictionary<string, string>?",
+            Type = "Dictionary<string, string>?",
             DefaultValue = "null",
             Description = "Custom query strings for remove request."
+        },
+        new()
+        {
+            Name = "RemoveRequestQueryStringsProvider",
+            Type = "Func<Task<Dictionary<string, string>>>?",
+            DefaultValue = "null",
+            Description = "The provider function to create the query strings for remove request."
         },
         new()
         {
@@ -225,21 +239,28 @@ public partial class BitFileUploadDemo
         new()
         {
             Name = "UploadRequestHttpHeaders",
-            Type = "IReadOnlyDictionary<string, string>?",
+            Type = "Dictionary<string, string>?",
             DefaultValue = "null",
             Description = "Custom http headers for upload request."
         },
         new()
         {
+            Name = "UploadRequestHttpHeadersProvider",
+            Type = "Func<Task<Dictionary<string, string>>>?",
+            DefaultValue = "null",
+            Description = "The provider function to create the http headers for upload request."
+        },
+        new()
+        {
             Name = "UploadRequestQueryStrings",
-            Type = "IReadOnlyDictionary<string, string>?",
+            Type = "Dictionary<string, string>?",
             DefaultValue = "null",
             Description = "Custom query strings for upload request."
         },
         new()
         {
             Name = "UploadRequestQueryStringsProvider",
-            Type = "Func<Task<IReadOnlyDictionary<string, string>>>?",
+            Type = "Func<Task<Dictionary<string, string>>>?",
             DefaultValue = "null",
             Description = "The provider function to create the query strings for upload request."
         },
@@ -338,7 +359,7 @@ public partial class BitFileUploadDemo
                new()
                {
                    Name = "HttpHeaders",
-                   Type = "IReadOnlyDictionary<string, string>?",
+                   Type = "Dictionary<string, string>?",
                    DefaultValue = "null",
                    Description = "The HTTP header at upload file."
                }


### PR DESCRIPTION
closes #10592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for providing HTTP headers and query strings dynamically via asynchronous provider functions in file upload and removal operations.

- **Refactor**
  - Updated HTTP header and query string parameters from read-only to mutable dictionaries for file upload components and demos, allowing for more flexible manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->