### PR TITLE
Clean parameter before set in variable in BitNumberField (#10614)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -610,7 +610,8 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private void OnSetMin()
     {
-        if (BindConverter.TryConvertTo(Min, CultureInfo.InvariantCulture, out TValue? result))
+        var min = CleanValue(Min);
+        if (BindConverter.TryConvertTo(min, CultureInfo.InvariantCulture, out TValue? result))
         {
             _min = result ?? GetTypeMinValue();
         }
@@ -622,7 +623,8 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private void OnSetMax()
     {
-        if (BindConverter.TryConvertTo(Max, CultureInfo.InvariantCulture, out TValue? result))
+        var max = CleanValue(Max);
+        if (BindConverter.TryConvertTo(max, CultureInfo.InvariantCulture, out TValue? result))
         {
             _max = result ?? GetTypeMaxValue();
         }
@@ -634,7 +636,8 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private void OnSetStep()
     {
-        if (BindConverter.TryConvertTo(Step, CultureInfo.InvariantCulture, out TValue? result))
+        var step = CleanValue(Step);
+        if (BindConverter.TryConvertTo(step, CultureInfo.InvariantCulture, out TValue? result))
         {
             _step = result ?? ((TValue)(object)1);
         }


### PR DESCRIPTION
This closes #10614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of minimum, maximum, and step values in number input fields to ensure more reliable and consistent behavior when entering values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->