### PR TITLE
Add `--ads` parameter to platform website docs (#10622)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor
@@ -337,7 +337,7 @@
             <CodeBox>
                 @GetGoogleAdsCommand()
             </CodeBox>
-            Helps you earn money by displaying rewarded video ads. <a href="https://adminpanel.bitplatform.dev/settings/UpgradeAccount" target="_blank">Demo</a>
+            Helps you earn money by displaying reward-based Google ads. <a href="https://adminpanel.bitplatform.dev/settings/UpgradeAccount" target="_blank">Demo</a>
         </BitGridItem>
 
     </BitGrid>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor
@@ -125,6 +125,37 @@
             }
         </BitGridItem>
 
+        <BitGridItem Class="grid-item md">
+            <div class="row">
+                <BitText Typography="BitTypography.H6" Gutter>Pipeline</BitText>
+                <BitDropdown Placeholder="Choose pipeline" Items="@pipeline.Items" @bind-Value="@pipeline.Value" />
+            </div>
+            <br />
+            <CodeBox>
+                @GetPipelineCommand()
+            </CodeBox>
+            <br />
+            @switch (pipeline.Value)
+            {
+                case "None":
+                    <div>
+                        By selecting None, no CI/CD pipeline will be added.
+                    </div>
+                    break;
+                case "GitHub":
+                    <div>
+                        Ensure a rapid and reliable deployment by utilizing a pipeline.
+                        By selecting GitHub, CI/ CD pipelines will be set up using <a href="https://github.com/features/actions" target="_blank">Github Actions</a>.
+                    </div>
+                    break;
+                case "Azure":
+                    <div>
+                        By selecting Azure, CI/ CD pipelines will be set up using <a href="https://azure.microsoft.com/en-us/products/devops/pipelines" target="_blank">Azure Devops</a>.
+                    </div>
+                    break;
+            }
+        </BitGridItem>
+
         <BitGridItem Class="grid-item md" ColumnSpan="2">
             <div class="row">
                 <BitText Typography="BitTypography.H6" Gutter>API</BitText>
@@ -158,37 +189,6 @@
                 </div>
             }
 
-        </BitGridItem>
-
-        <BitGridItem Class="grid-item md">
-            <div class="row">
-                <BitText Typography="BitTypography.H6" Gutter>Pipeline</BitText>
-                <BitDropdown Placeholder="Choose pipeline" Items="@pipeline.Items" @bind-Value="@pipeline.Value" />
-            </div>
-            <br />
-            <CodeBox>
-                @GetPipelineCommand()
-            </CodeBox>
-            <br />
-            @switch (pipeline.Value)
-            {
-                case "None":
-                    <div>
-                        By selecting None, no CI/CD pipeline will be added.
-                    </div>
-                    break;
-                case "GitHub":
-                    <div>
-                        Ensure a rapid and reliable deployment by utilizing a pipeline.
-                        By selecting GitHub, CI/ CD pipelines will be set up using <a href="https://github.com/features/actions" target="_blank">Github Actions</a>.
-                    </div>
-                    break;
-                case "Azure":
-                    <div>
-                        By selecting Azure, CI/ CD pipelines will be set up using <a href="https://azure.microsoft.com/en-us/products/devops/pipelines" target="_blank">Azure Devops</a>.
-                    </div>
-                    break;
-            }
         </BitGridItem>
 
         <BitGridItem Class="grid-item md">
@@ -326,6 +326,18 @@
                 @GetCloudflareCommand()
             </CodeBox>
             Integrating Cloudflare and placing your backend behind the Cloudflare CDN will significantly enhance the app's performance while reducing server load.
+        </BitGridItem>
+
+        <BitGridItem Class="grid-item md">
+            <div class="row">
+                <BitText Typography="BitTypography.H6" Gutter>Google Ads</BitText>
+                <BitToggle @bind-Value="googleAds.Value" OnText="true" OffText="false" />
+            </div>
+            <br />
+            <CodeBox>
+                @GetGoogleAdsCommand()
+            </CodeBox>
+            Helps you earn money by displaying rewarded video ads. <a href="https://adminpanel.bitplatform.dev/settings/UpgradeAccount" target="_blank">Demo</a>
         </BitGridItem>
 
     </BitGrid>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
@@ -13,6 +13,7 @@ public partial class Templates05CreateProjectPage
     private Parameter<bool> notification = new() { Value = false, Default = false };
     private Parameter<bool> appInsight = new() { Value = false, Default = false };
     private Parameter<bool> signalR = new() { Value = false, Default = false };
+    private Parameter<bool> googleAds = new() { Value = false, Default = false };
 
     private Parameter<string> captcha = new()
     {
@@ -130,6 +131,11 @@ public partial class Templates05CreateProjectPage
             finalCommand.Append(GetSignalRCommand());
         }
 
+        if (googleAds.IsModified)
+        {
+            finalCommand.Append(GetGoogleAdsCommand());
+        }
+
         if (fileStorage.IsModified)
         {
             finalCommand.Append(GetFileStorageCommand());
@@ -226,6 +232,11 @@ public partial class Templates05CreateProjectPage
     private string GetSignalRCommand()
     {
         return $"--signalR{(signalR.Value ? string.Empty : " false")} ";
+    }
+
+    private string GetGoogleAdsCommand()
+    {
+        return $"--ads{(signalR.Value ? string.Empty : " false")} ";
     }
 
     private class Parameter<T>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
@@ -231,7 +231,7 @@ public partial class Templates05CreateProjectPage
 
     private string GetSignalRCommand()
     {
-        return $"--signalR{(signalR.Value ? string.Empty : " false")} ";
+        return $"--ads{(googleAds.Value ? string.Empty : " false")} ";
     }
 
     private string GetGoogleAdsCommand()

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
@@ -231,12 +231,12 @@ public partial class Templates05CreateProjectPage
 
     private string GetSignalRCommand()
     {
-        return $"--ads{(googleAds.Value ? string.Empty : " false")} ";
+        return $"--ads{(signalR.Value ? string.Empty : " false")} ";
     }
 
     private string GetGoogleAdsCommand()
     {
-        return $"--ads{(signalR.Value ? string.Empty : " false")} ";
+        return $"--ads{(googleAds.Value ? string.Empty : " false")} ";
     }
 
     private class Parameter<T>


### PR DESCRIPTION
closes #10622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Google Ads integration option with a toggle, code snippet display, and descriptive information, including a link to a demo page.

- **Refactor**
  - Simplified the form by removing a duplicated CI/CD Pipeline selection section and consolidating it into a single instance for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->