### PR TITLE
Fix signalR command in Create Project's page (#10637)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor.cs
@@ -231,7 +231,7 @@ public partial class Templates05CreateProjectPage
 
     private string GetSignalRCommand()
     {
-        return $"--ads{(signalR.Value ? string.Empty : " false")} ";
+        return $"--signalR{(signalR.Value ? string.Empty : " false")} ";
     }
 
     private string GetGoogleAdsCommand()


### PR DESCRIPTION
This closes #10637 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the command-line argument for enabling SignalR, ensuring the correct feature flag is used when creating a project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->