### PR TITLE
Add missing parameters to Verify method of WebAuthn API in Butil (#10652)

### DIFF
--- a/src/Butil/Bit.Butil/Publics/WebAuthn.cs
+++ b/src/Butil/Bit.Butil/Publics/WebAuthn.cs
@@ -76,11 +76,14 @@ public class WebAuthn(IJSRuntime js, LocalStorage localStorage)
     /// Tries to get a valid credential using the minimum required options to expose a native verification feature.
     /// </summary>
     /// <param name="forceCreate">Forces the verification to be performed using the create credential approach.</param>
+    /// <param name="platform">Forces authenticator selection to be platform, otherwise it will be cross-platform (like hardware authenticators)</param>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyAllowCredential))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyAuthenticatorSelection))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyPubKeyCredParam))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyRp))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyUser))]
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebAuthnVerifyPubKeyCredParam))]
-    public async Task<bool> Verify(bool forceCreate = false)
+    public async Task<bool> Verify(bool forceCreate = false, bool platform = false)
     {
         try
         {
@@ -90,13 +93,14 @@ public class WebAuthn(IJSRuntime js, LocalStorage localStorage)
                 var result = await CreateCredential(new WebAuthnVerifyOptions
                 {
                     Challenge = "Butil Verify Challenge",
+                    Attestation = "direct",
                     Rp = new() { Name = "Butil Verify" },
                     User = new() { Id = "ButilVerifyUserId", Name = "ButilVerifyUser", DisplayName = "ButilVerifyUser" },
-                    AuthenticatorSelection = new() { AuthenticatorAttachment = "platform" },
-                    PubKeyCredParams = [new WebAuthnVerifyPubKeyCredParam() { Alg = -7, Type = "public-key" }]
+                    AuthenticatorSelection = new() { AuthenticatorAttachment = platform ? "platform" : "cross-platform" },
+                    PubKeyCredParams = [new() { Alg = -7, Type = "public-key" }, new() { Alg = -8, Type = "public-key" }, new() { Alg = -257, Type = "public-key" }]
                 });
                 var rawId = result.GetProperty("rawId").ToString();
-                
+
                 if (string.IsNullOrWhiteSpace(rawId)) return false;
 
                 await localStorage.SetItem(STORAGE_KEY, rawId);

--- a/src/Butil/Bit.Butil/Publics/WebAuthn/WebAuthnVerifyOptions.cs
+++ b/src/Butil/Bit.Butil/Publics/WebAuthn/WebAuthnVerifyOptions.cs
@@ -3,6 +3,7 @@
 public class WebAuthnVerifyOptions
 {
     public required string Challenge { get; set; }
+    public string? Attestation { get; set; }
     public WebAuthnVerifyRp? Rp { get; set; }
     public WebAuthnVerifyUser? User { get; set; }
     public WebAuthnVerifyAuthenticatorSelection? AuthenticatorSelection { get; set; }

--- a/src/Butil/Demo/Bit.Butil.Demo.Core/Pages/WebAuthnPage.razor
+++ b/src/Butil/Demo/Bit.Butil.Demo.Core/Pages/WebAuthnPage.razor
@@ -63,7 +63,7 @@
 
     private async Task Verify()
     {
-        var result = await webAuthn.Verify();
+        var result = await webAuthn.Verify(platform: true);
         await console.Log("Verify result:", result);
     }
 }


### PR DESCRIPTION
closes #10652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for choosing between platform and cross-platform authenticators during WebAuthn verification.
	- Expanded algorithm support for public key credentials.
	- Added an option to specify attestation type during credential creation.

- **Enhancements**
	- Improved flexibility for WebAuthn verification in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->