### PR TITLE
add hotReloadCssChanges to Boilerplate Visual Studio settings (#10677)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/settings.VisualStudio.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/settings.VisualStudio.json
@@ -6,5 +6,6 @@
     "environment.documents.saveEncoding": "utf-8-nobom;65001",
     "languages.defaults.tabs.tabSize": 4,
     "debugging.hotReload.enableHotReload": true,
-    "debugging.hotReload.enableForNoDebugLaunch": true
+    "debugging.hotReload.enableForNoDebugLaunch": true,
+    "projectsAndSolutions.aspNetCore.general.hotReloadCssChanges": true
 }


### PR DESCRIPTION
closes #10677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled hot reload for CSS changes in ASP.NET Core projects when using Visual Studio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->