### PR TITLE
Add ExpandAll and AllExpanded to BitNav (#10685)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/BitNav.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/BitNav.razor.cs
@@ -199,8 +199,6 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
         if (SingleExpand) return;
 
         (item is null ? _items : [item]).ToList().ForEach(it => ToggleItemAndChildren(it, true));
-
-        //StateHasChanged();
     }
 
     /// <summary>

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/BitNav.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/BitNav.razor.cs
@@ -25,6 +25,11 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
     public BitColor? Accent { get; set; }
 
     /// <summary>
+    /// Expands all items on first render.
+    /// </summary>
+    [Parameter] public bool AllExpanded { get; set; }
+
+    /// <summary>
     /// The custom icon name of the chevron-down element of each nav item.
     /// </summary>
     [Parameter] public string? ChevronDownIcon { get; set; }
@@ -181,12 +186,21 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
     /// <summary>
     /// Collapses all items and children.
     /// </summary>
-    public void CollapseAll()
+    public void CollapseAll(TItem? item = null)
     {
-        foreach (var item in _items)
-        {
-            CollapseItemAndChildren(item);
-        }
+        (item is null ? _items : [item]).ToList().ForEach(it => ToggleItemAndChildren(it, false));
+    }
+
+    /// <summary>
+    /// Expands all items and children in non-SingleExpand mode.
+    /// </summary>
+    public void ExpandAll(TItem? item = null)
+    {
+        if (SingleExpand) return;
+
+        (item is null ? _items : [item]).ToList().ForEach(it => ToggleItemAndChildren(it, true));
+
+        //StateHasChanged();
     }
 
     /// <summary>
@@ -204,10 +218,7 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
                 {
                     ToggleItemAndParents(_items, _currentItem, false);
                 }
-            }
 
-            if (isExpanded)
-            {
                 ToggleItemAndParents(_items, Item, isExpanded);
             }
             else
@@ -766,15 +777,31 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
 
     internal void RegisterOption(BitNavOption option)
     {
-        _items.Add((option as TItem)!);
-        SetSelectedItemByCurrentUrl();
+        var item = (option as TItem)!;
+
+        _items.Add(item);
+
+        if (AllExpanded)
+        {
+            SetIsExpanded(item, true);
+        }
+
+        SetItemExpanded(item, GetIsExpanded(item) ?? false);
+
+        if (Mode == BitNavMode.Automatic)
+        {
+            SetSelectedItemByCurrentUrl();
+        }
+
         StateHasChanged();
     }
 
     internal void UnregisterOption(BitNavOption option)
     {
         _items.Remove((option as TItem)!);
+
         SetSelectedItemByCurrentUrl();
+
         StateHasChanged();
     }
 
@@ -845,12 +872,17 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
     {
         if (ChildContent is null && Items.Any())
         {
-            _items = Items.ToList();
+            _items = [.. Items];
             _oldItems = Items;
         }
 
         foreach (var item in Flatten(_items))
         {
+            if (AllExpanded)
+            {
+                SetIsExpanded(item, true);
+            }
+
             SetItemExpanded(item, GetIsExpanded(item) ?? false);
         }
 
@@ -907,13 +939,13 @@ public partial class BitNav<TItem> : BitComponentBase where TItem : class
         item.SetValueToProperty(NameSelectors.IsExpanded.Name, value);
     }
 
-    private void CollapseItemAndChildren(TItem item)
+    private void ToggleItemAndChildren(TItem item, bool isExpanded = false)
     {
-        SetIsExpanded(item, false);
+        SetIsExpanded(item, isExpanded);
 
         foreach (var child in GetChildItems(item))
         {
-            CollapseItemAndChildren(child);
+            ToggleItemAndChildren(child, isExpanded);
         }
     }
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Nav/BitNavDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Nav/BitNavDemo.razor.cs
@@ -15,6 +15,13 @@ public partial class BitNavDemo
         },
         new()
         {
+            Name = "AllExpanded",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Expands all items on first render."
+        },
+        new()
+        {
             Name = "ChevronDownIcon",
             Type = "string?",
             DefaultValue = "null",
@@ -224,8 +231,14 @@ public partial class BitNavDemo
         new()
         {
             Name = "CollapseAll",
-            Type = "Action",
+            Type = "Action<TItem? item>",
             Description = "Collapses all items and children.",
+        },
+        new()
+        {
+            Name = "ExpandAll",
+            Type = "Action<TItem? item>",
+            Description = "Expands all items and children in non-SingleExpand mode.",
         },
         new()
         {


### PR DESCRIPTION
closes #10685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to expand all navigation items on first render.
  - Added controls to programmatically expand or collapse all navigation items, with the ability to target specific items.

- **Refactor**
  - Improved and streamlined expand/collapse logic for navigation items, enhancing flexibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->