### PR TITLE
Force start Blazor when SW is not supported (#10709)

### DIFF
--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
@@ -36,6 +36,7 @@ BitBswup.forceRefresh = async () => {
 
     function runBswup() {
         if (!('serviceWorker' in navigator)) {
+            startBlazor(true);
             return warn('no serviceWorker in navigator');
         }
 


### PR DESCRIPTION
closes #10709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured Blazor starts automatically on browsers that do not support service workers, improving compatibility and user experience on unsupported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->