### PR TITLE
Add NoShadow parameter to BitCard (#10740)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Card/BitCard.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Card/BitCard.razor.cs
@@ -40,6 +40,12 @@ public partial class BitCard : BitComponentBase
     [Parameter, ResetClassBuilder]
     public bool FullWidth { get; set; }
 
+    /// <summary>
+    /// Removes the default shadow around the card.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public bool NoShadow { get; set; }
+
 
 
     protected override string RootElementClass => "bit-crd";
@@ -66,5 +72,7 @@ public partial class BitCard : BitComponentBase
 
         ClassBuilder.Register(() => FullSize || FullHeight ? "bit-crd-fhe" : string.Empty);
         ClassBuilder.Register(() => FullSize || FullWidth ? "bit-crd-fwi" : string.Empty);
+
+        ClassBuilder.Register(() => NoShadow ? "bit-crd-nsd" : string.Empty);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Card/BitCard.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Card/BitCard.scss
@@ -27,13 +27,11 @@
 }
 
 .bit-crd-rbg {
-    box-shadow: none;
     background-color: transparent;
 }
 
 
 .bit-crd-brd {
-    box-shadow: none;
     border-width: $shp-border-width;
     border-style: $shp-border-style;
 }
@@ -61,4 +59,9 @@
 
 .bit-crd-fwi {
     width: 100%;
+}
+
+
+.bit-crd-nsd {
+    box-shadow: none;
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Card/BitCardDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Card/BitCardDemo.razor
@@ -22,7 +22,19 @@
         </BitCard>
     </DemoExample>
 
-    <DemoExample Title="Background" RazorCode="@example2RazorCode" CSharpCode="@example2CSharpCode" Id="example2">
+    <DemoExample Title="NoShadow" RazorCode="@example2RazorCode" Id="example2">
+        <BitCard NoShadow>
+            <BitStack HorizontalAlign="BitAlignment.Start">
+                <BitText Typography="BitTypography.H4">bit BlazorUI</BitText>
+                <BitText Typography="BitTypography.Body1">
+                    bit BlazorUI components are native, easy-to-customize, and ...
+                </BitText>
+                <BitLink Href="https://blazorui.bitplatform.dev" Target="_blank">Learn more</BitLink>
+            </BitStack>
+        </BitCard>
+    </DemoExample>
+
+    <DemoExample Title="Background" RazorCode="@example3RazorCode" CSharpCode="@example3CSharpCode" Id="example3">
         <BitChoiceGroup @bind-Value="backgroundColorKind" Horizontal
                         TItem="BitChoiceGroupOption<BitColorKind>" TValue="BitColorKind">
             <BitChoiceGroupOption Text="Primary" Value="BitColorKind.Primary" />
@@ -44,7 +56,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="Border" RazorCode="@example3RazorCode" CSharpCode="@example3CSharpCode" Id="example3">
+    <DemoExample Title="Border" RazorCode="@example4RazorCode" CSharpCode="@example4CSharpCode" Id="example4">
         <BitChoiceGroup @bind-Value="borderColorKind" Horizontal
                         TItem="BitChoiceGroupOption<BitColorKind>" TValue="BitColorKind">
             <BitChoiceGroupOption Text="Primary" Value="BitColorKind.Primary" />
@@ -64,7 +76,7 @@
         </BitCard>
     </DemoExample>
 
-    <DemoExample Title="FullSize" RazorCode="@example4RazorCode" CSharpCode="@example4CSharpCode" Id="example4">
+    <DemoExample Title="FullSize" RazorCode="@example5RazorCode" CSharpCode="@example5CSharpCode" Id="example5">
         <BitChoiceGroup @bind-Value="size" Horizontal
                         TItem="BitChoiceGroupOption<int>" TValue="int">
             <BitChoiceGroupOption Text="FullSize" Value="0" />

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Card/BitCardDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Card/BitCardDemo.razor.cs
@@ -54,7 +54,7 @@ public partial class BitCardDemo
         {
             Name = "NoShadow",
             Type = "bool",
-            DefaultValue = "null",
+            DefaultValue = "false",
             Description = "Removes the default shadow around the card.",
         },
     ];

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Card/BitCardDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Card/BitCardDemo.razor.cs
@@ -33,22 +33,29 @@ public partial class BitCardDemo
         {
             Name = "FullHeight",
             Type = "bool",
-            DefaultValue = "null",
+            DefaultValue = "false",
             Description = "Makes the card height 100% of its parent container.",
         },
         new()
         {
             Name = "FullSize",
             Type = "bool",
-            DefaultValue = "null",
+            DefaultValue = "false",
             Description = "Makes the card width and height 100% of its parent container.",
         },
         new()
         {
             Name = "FullWidth",
             Type = "bool",
-            DefaultValue = "null",
+            DefaultValue = "false",
             Description = "Makes the card width 100% of its parent container.",
+        },
+        new()
+        {
+            Name = "NoShadow",
+            Type = "bool",
+            DefaultValue = "null",
+            Description = "Removes the default shadow around the card.",
         },
     ];
 
@@ -109,6 +116,17 @@ public partial class BitCardDemo
 </BitCard>";
 
     private readonly string example2RazorCode = @"
+<BitCard NoShadow>
+    <BitStack HorizontalAlign=""BitAlignment.Start"">
+        <BitText Typography=""BitTypography.H4"">bit BlazorUI</BitText>
+        <BitText Typography=""BitTypography.Body1"">
+            bit BlazorUI components are native, easy-to-customize, and ...
+        </BitText>
+        <BitLink Href=""https://blazorui.bitplatform.dev"" Target=""_blank"">Learn more</BitLink>
+    </BitStack>
+</BitCard>";
+
+    private readonly string example3RazorCode = @"
 <BitChoiceGroup @bind-Value=""backgroundColorKind"" Horizontal
                 TItem=""BitChoiceGroupOption<BitColorKind>"" TValue=""BitColorKind"">
     <BitChoiceGroupOption Text=""Primary"" Value=""BitColorKind.Primary"" />
@@ -128,10 +146,10 @@ public partial class BitCardDemo
         </BitStack>
     </BitCard>
 </div>";
-    private readonly string example2CSharpCode = @"
+    private readonly string example3CSharpCode = @"
 private BitColorKind backgroundColorKind = BitColorKind.Primary;";
 
-    private readonly string example3RazorCode = @"
+    private readonly string example4RazorCode = @"
 <BitChoiceGroup @bind-Value=""borderColorKind"" Horizontal
                 TItem=""BitChoiceGroupOption<BitColorKind>"" TValue=""BitColorKind"">
     <BitChoiceGroupOption Text=""Primary"" Value=""BitColorKind.Primary"" />
@@ -149,10 +167,10 @@ private BitColorKind backgroundColorKind = BitColorKind.Primary;";
         <BitLink Href=""https://blazorui.bitplatform.dev"" Target=""_blank"">Learn more</BitLink>
     </BitStack>
 </BitCard>";
-    private readonly string example3CSharpCode = @"
+    private readonly string example4CSharpCode = @"
 private BitColorKind borderColorKind = BitColorKind.Primary;";
 
-    private readonly string example4RazorCode = @"
+    private readonly string example5RazorCode = @"
 <BitChoiceGroup @bind-Value=""size"" Horizontal
                 TItem=""BitChoiceGroupOption<int>"" TValue=""int"">
     <BitChoiceGroupOption Text=""FullSize"" Value=""0"" />
@@ -171,6 +189,6 @@ private BitColorKind borderColorKind = BitColorKind.Primary;";
         </BitStack>
     </BitCard>
 </div>";
-    private readonly string example4CSharpCode = @"
+    private readonly string example5CSharpCode = @"
 private int size = 0;";
 }


### PR DESCRIPTION
closes #10740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to display cards without a shadow.
  - Updated the demo page with an example showcasing the no-shadow card option.

- **Style**
  - Introduced a new style to remove the card shadow when the no-shadow option is enabled.

- **Documentation**
  - Updated demo documentation to reflect the new no-shadow card option and reorganized example order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->