### PR TITLE
Hide empty list message when no items provided (#10734)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
@@ -66,7 +66,7 @@
                 </div>
             }
 
-            @if (HideSearchBox is false)
+            @if (NoSearchBox is false)
             {
                 <BitSearchBox @ref="_searchBoxRef"
                               Underlined
@@ -92,7 +92,7 @@
                 }
             }
 
-            @if (_filteredNavItems.Any() is false)
+            @if (Items.Any() && _filteredNavItems.Any() is false)
             {
                 if (isToggled is false)
                 {
@@ -116,7 +116,7 @@
                         ChevronDownIcon="@ChevronDownIcon"
                         Classes="NavClasses"
                         Color="Color"
-                        DefaultSelectedItem="_filteredNavItems[0]"
+                        DefaultSelectedItem="_filteredNavItems.Any() ? _filteredNavItems[0] : null"
                         FullWidth
                         HeaderTemplate="HeaderTemplate"
                         HeaderTemplateRenderMode="HeaderTemplateRenderMode"

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -83,11 +83,6 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public BitNavItemTemplateRenderMode HeaderTemplateRenderMode { get; set; }
 
     /// <summary>
-    /// If true, the search box is hidden.
-    /// </summary>
-    [Parameter] public bool HideSearchBox { get; set; }
-
-    /// <summary>
     /// Renders an anchor wrapping the icon to navigate to the specified url.
     /// </summary>
     [Parameter] public string? IconNavUrl { get; set; }
@@ -165,6 +160,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// </summary>
     [Parameter, ResetClassBuilder]
     public bool NoPad { get; set; }
+
+    /// <summary>
+    /// Removes the search box from the nav panel.
+    /// </summary>
+    [Parameter] public bool NoSearchBox { get; set; }
 
     /// <summary>
     /// Disables the toggle feature of the nav panel.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
@@ -78,12 +78,12 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="HideSearchBox" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+        <DemoExample Title="NoSearchBox" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
             <div class="open-btn">
-                <BitToggleButton @bind-IsChecked="hideSearchBoxIsOpen" OnText="Close" OffText="Open" />
+                <BitToggleButton @bind-IsChecked="noSearchBoxIsOpen" OnText="Close" OffText="Open" />
             </div>
             <div style="width:240px">
-                <BitNavPanel @bind-IsOpen="hideSearchBoxIsOpen" Items="basicNavItems" HideSearchBox />
+                <BitNavPanel @bind-IsOpen="noSearchBoxIsOpen" Items="basicNavItems" NoSearchBox />
             </div>
         </DemoExample>
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -106,13 +106,6 @@ public partial class BitNavPanelDemo
         },
         new()
         {
-            Name = "HideSearchBox",
-            Type = "bool",
-            DefaultValue = "false",
-            Description = "If true, the search box is hidden.",
-        },
-        new()
-        {
             Name = "IconNavUrl",
             Type = "string?",
             DefaultValue = "null",
@@ -219,6 +212,13 @@ public partial class BitNavPanelDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Disables the padded mode of the nav panel.",
+        },
+        new()
+        {
+            Name = "NoSearchBox",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Removes the search box from the nav panel.",
         },
         new()
         {
@@ -581,7 +581,7 @@ public partial class BitNavPanelDemo
     private bool noToggleIsOpen;
     private bool iconUrlIsOpen;
     private bool searchBoxPlaceholderIsOpen;
-    private bool hideSearchBoxIsOpen;
+    private bool noSearchBoxIsOpen;
     private bool emptyListMessageIsOpen;
     private bool singleExpandIsOpen;
     private bool templateIsOpen;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.samples.cs
@@ -360,13 +360,13 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example7RazorCode = @"
-<BitToggleButton @bind-IsChecked=""hideSearchBoxIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""noSearchBoxIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div style=""width:222px"">
-    <BitNavPanel @bind-IsOpen=""hideSearchBoxIsOpen"" Items=""basicNavItems"" HideSearchBox />
+    <BitNavPanel @bind-IsOpen=""noSearchBoxIsOpen"" Items=""basicNavItems"" NoSearchBox />
 </div>";
     private readonly string example7CsharpCode = @"
-private bool hideSearchBoxIsOpen;
+private bool noSearchBoxIsOpen;
 
 private List<BitNavItem> basicNavItems =
 [


### PR DESCRIPTION
closes #10734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the parameter controlling the search box visibility in the navigation panel from "HideSearchBox" to "NoSearchBox" across the component and related demo pages.
  - Updated demo examples and related fields to use the new naming for consistency.
  - Improved logic for displaying empty list messages and handling default selections when no filtered items are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->