### PR TITLE
Add ForceBreak and missing demo samples to BitText (#10699)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Text/BitText.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Text/BitText.cs
@@ -15,7 +15,7 @@ public partial class BitText : BitComponentBase
     public BitTextAlign? Align { get; set; }
 
     /// <summary>
-    /// The content of the Text.
+    /// The content of the text.
     /// </summary>
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
@@ -29,6 +29,12 @@ public partial class BitText : BitComponentBase
     /// The custom html element used for the root node.
     /// </summary>
     [Parameter] public string? Element { get; set; }
+
+    /// <summary>
+    /// Forces the text to always break at the end.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public bool ForceBreak { get; set; }
 
     /// <summary>
     /// The kind of the foreground color of the text.
@@ -50,7 +56,7 @@ public partial class BitText : BitComponentBase
     public bool NoWrap { get; set; }
 
     /// <summary>
-    /// The typography of the Text.
+    /// The typography of the text.
     /// </summary>
     [Parameter, ResetClassBuilder]
     public BitTypography? Typography { get; set; }
@@ -95,6 +101,8 @@ public partial class BitText : BitComponentBase
             BitColorKind.Transparent => "bit-txt-rfg",
             _ => string.Empty
         });
+
+        ClassBuilder.Register(() => ForceBreak ? "bit-txt-fbr" : string.Empty);
     }
 
     protected override void RegisterCssStyles()

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Text/BitText.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Text/BitText.scss
@@ -213,3 +213,8 @@
 .bit-txt-gutter {
     margin-bottom: $tg-gutter-size;
 }
+
+.bit-txt-fbr {
+    word-break: break-all;
+    white-space: break-spaces;
+}

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Utilities/Text/BitTextDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Utilities/Text/BitTextDemo.razor
@@ -12,6 +12,8 @@
           GitHubUrl="Utilities/Text/BitText.cs"
           GitHubDemoUrl="Utilities/Text/BitTextDemo.razor">
     <DemoExample Title="Basic" RazorCode="@example1RazorCode" Id="example1">
+        <BitText>11111111111111111111111111111111111111111111111111111111</BitText>
+        <br /><br />
         <BitText>This is default (Subtitle1)</BitText>
         <br /><br />
         <BitText Typography="BitTypography.H1">H1. Heading</BitText>
@@ -43,7 +45,18 @@
         <BitText Typography="BitTypography.Overline">Overline. this is overline text.</BitText>
     </DemoExample>
 
-    <DemoExample Title="Align" RazorCode="@example2RazorCode" Id="example2">
+    <DemoExample Title="Wrapping" RazorCode="@example2RazorCode" Id="example2">
+        <b>Normal wrap (default):</b><br />
+        <BitText Style="width:250px">Once upon a time, stories wove connections between people, a symphony of voices crafting shared dreams.</BitText>
+        <br /><br /><br />
+        <b>NoWrap:</b><br />
+        <BitText Style="width:250px" NoWrap>Once upon a time, stories wove connections between people, a symphony of voices crafting shared dreams.</BitText>
+        <br /><br /><br />
+        <b>ForceBreak:</b><br />
+        <BitText Style="width:250px" ForceBreak>1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</BitText>
+    </DemoExample>
+
+    <DemoExample Title="Align" RazorCode="@example3RazorCode" Id="example3">
         <BitText Align="BitTextAlign.Start">Start</BitText>
         <br />
         <BitText Align="BitTextAlign.Center">Center</BitText>
@@ -51,7 +64,7 @@
         <BitText Align="BitTextAlign.End">End</BitText>
     </DemoExample>
 
-    <DemoExample Title="Foreground" RazorCode="@example3RazorCode" Id="example3">
+    <DemoExample Title="Foreground" RazorCode="@example4RazorCode" Id="example4">
         <BitText Foreground="BitColorKind.Primary">Primary foreground</BitText>
         <br />
         <BitText Foreground="BitColorKind.Secondary">Secondary foreground</BitText>
@@ -63,7 +76,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="Color" RazorCode="@example4RazorCode" Id="example4">
+    <DemoExample Title="Color" RazorCode="@example5RazorCode" Id="example5">
         <BitText Color="BitColor.Primary">Primary color</BitText>
         <br />
         <BitText Color="BitColor.Secondary">Secondary color</BitText>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Utilities/Text/BitTextDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Utilities/Text/BitTextDemo.razor
@@ -12,8 +12,6 @@
           GitHubUrl="Utilities/Text/BitText.cs"
           GitHubDemoUrl="Utilities/Text/BitTextDemo.razor">
     <DemoExample Title="Basic" RazorCode="@example1RazorCode" Id="example1">
-        <BitText>11111111111111111111111111111111111111111111111111111111</BitText>
-        <br /><br />
         <BitText>This is default (Subtitle1)</BitText>
         <br /><br />
         <BitText Typography="BitTypography.H1">H1. Heading</BitText>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Utilities/Text/BitTextDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Utilities/Text/BitTextDemo.razor.cs
@@ -30,6 +30,13 @@ public partial class BitTextDemo
         },
         new()
         {
+            Name = "ForceBreak",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Forces the text to always break at the end.",
+        },
+        new()
+        {
             Name = "Foreground",
             Type = "BitColorKind?",
             DefaultValue = "null",
@@ -257,11 +264,18 @@ public partial class BitTextDemo
 <BitText Typography=""BitTypography.Overline"">Overline. this is overline text.</BitText>";
 
     private string example2RazorCode = @"
+<BitText Style=""width:250px"">Once upon a time, stories wove connections between people, a symphony of voices crafting shared dreams.</BitText>
+
+<BitText Style=""width:250px"" NoWrap>Once upon a time, stories wove connections between people, a symphony of voices crafting shared dreams.</BitText>
+
+<BitText Style=""width:250px"" ForceBreak>1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</BitText>";
+
+    private string example3RazorCode = @"
 <BitText Align=""BitTextAlign.Start"">Start</BitText>
 <BitText Align=""BitTextAlign.Center"">Center</BitText>
 <BitText Align=""BitTextAlign.End"">End</BitText>";
 
-    private string example3RazorCode = @"
+    private string example4RazorCode = @"
 <BitText Foreground=""BitColorKind.Primary"">Primary foreground</BitText>
 <BitText Foreground=""BitColorKind.Secondary"">Secondary foreground</BitText>
 <BitText Foreground=""BitColorKind.Tertiary"">Tertiary foreground</BitText>
@@ -270,7 +284,7 @@ public partial class BitTextDemo
     <BitText Foreground=""BitColorKind.Transparent"">Transparent foreground</BitText>
 </div>";
 
-    private string example4RazorCode = @"
+    private string example5RazorCode = @"
 <BitText Color=""BitColor.Primary"">Primary color</BitText>
 <BitText Color=""BitColor.Secondary"">Secondary color</BitText>
 <BitText Color=""BitColor.Tertiary"">Tertiary color</BitText>


### PR DESCRIPTION
closes #10699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to force text wrapping in the BitText component, allowing text to always break at the end.
  - Updated the demo page to showcase the new text wrapping behavior alongside existing wrapping and alignment options.

- **Style**
  - Added a new style for forced text breaking to visually support the new feature.

- **Documentation**
  - Enhanced demo examples and updated documentation to reflect the new text wrapping and alignment capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->