### PR TITLE
Fix Boilerplate issue with opening page url on notification tap (#10765)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/app.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/app.ts
@@ -81,7 +81,7 @@ class App {
 window.addEventListener('message', handleMessage);
 window.addEventListener('load', handleLoad);
 window.addEventListener('resize', setCssWindowSizes);
-if (navigator.serviceWorker != null) {
+if ('serviceWorker' in navigator) {
     navigator.serviceWorker.addEventListener('message', handleMessage);
 }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/app.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/app.ts
@@ -81,9 +81,12 @@ class App {
 window.addEventListener('message', handleMessage);
 window.addEventListener('load', handleLoad);
 window.addEventListener('resize', setCssWindowSizes);
+if (navigator.serviceWorker != null) {
+    navigator.serviceWorker.addEventListener('message', handleMessage);
+}
 
 function handleMessage(e: MessageEvent) {
-    // Enable publishing messages from JavaScript's `window.postMessage` to the C# `PubSubService`.
+    // Enable publishing messages from JavaScript's `window.postMessage` or `client.postMessage` to the C# `PubSubService`.
     if (e.data.key === 'PUBLISH_MESSAGE') {
         App.publishMessage(e.data.message, e.data.payload);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/MainActivity.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/MainActivity.cs
@@ -62,6 +62,22 @@ public partial class MainActivity : MauiAppCompatActivity
             _ = Routes.OpenUniversalLink(new URL(url).File ?? Urls.HomePage);
         }
         //#if (notification == true)
+        var dataString = Intent?.GetStringExtra(LocalNotificationCenter.ReturnRequest);
+        if (string.IsNullOrEmpty(dataString) is false)
+        {
+            var request = JsonSerializer.Deserialize<NotificationRequest>(dataString, options: new()
+            {
+                NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
+            });
+            if (request?.ReturningData is not null)
+            {
+                var returningData = JsonSerializer.Deserialize<Dictionary<string, object>>(request.ReturningData);
+                if (returningData?.TryGetValue("pageUrl", out var pageUrl) is true)
+                {
+                    _ = Routes.OpenUniversalLink(pageUrl?.ToString() ?? Urls.AboutPage);
+                }
+            }
+        }
         PushNotificationService.IsPushNotificationSupported(default).ContinueWith(task =>
         {
             if (task.Result)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.js
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.js
@@ -25,7 +25,18 @@ self.addEventListener('notificationclick', function (event) {
     const pageUrl = event.notification.data.pageUrl;
     if (pageUrl != null) {
         event.waitUntil(
-            clients.openWindow(pageUrl)
+            clients
+                .matchAll({
+                    type: 'window',
+                    includeUncontrolled: true,
+                })
+                .then((clientList) => {
+                    for (const client of clientList) {
+                        client.postMessage({ key: 'PUBLISH_MESSAGE', message: 'NAVIGATE_TO', payload: pageUrl });
+                        return client.focus();
+                    }
+                    return clients.openWindow(pageUrl);
+                })
         );
     }
 });

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.js
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.js
@@ -32,6 +32,7 @@ self.addEventListener('notificationclick', function (event) {
                 })
                 .then((clientList) => {
                     for (const client of clientList) {
+                        if (!client.focus || !client.postMessage) continue;
                         client.postMessage({ key: 'PUBLISH_MESSAGE', message: 'NAVIGATE_TO', payload: pageUrl });
                         return client.focus();
                     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
@@ -30,6 +30,7 @@ self.addEventListener('notificationclick', function (event) {
                 })
                 .then((clientList) => {
                     for (const client of clientList) {
+                        if (!client.focus || !client.postMessage) continue;
                         client.postMessage({ key: 'PUBLISH_MESSAGE', message: 'NAVIGATE_TO', payload: pageUrl });
                         return client.focus();
                     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
@@ -23,7 +23,18 @@ self.addEventListener('notificationclick', function (event) {
     const pageUrl = event.notification.data.pageUrl;
     if (pageUrl != null) {
         event.waitUntil(
-            clients.openWindow(pageUrl)
+            clients
+                .matchAll({
+                    type: 'window',
+                    includeUncontrolled: true,
+                })
+                .then((clientList) => {
+                    for (const client of clientList) {
+                        client.postMessage({ key: 'PUBLISH_MESSAGE', message: 'NAVIGATE_TO', payload: pageUrl });
+                        return client.focus();
+                    }
+                    return clients.openWindow(pageUrl);
+                })
         );
     }
 });


### PR DESCRIPTION
closes #10765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved notification click handling to prioritize reusing and focusing existing app windows when a notification is clicked, instead of always opening a new window.
  - Enhanced support for navigating to specific pages from local notifications on Android devices.

- **Documentation**
  - Clarified comments regarding the sources of messages handled within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->