### PR TITLE
Fix error of BSWUP force-start when there is no SW available (#10767)

### DIFF
--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
@@ -193,7 +193,7 @@ const BswupMessage = {
                 return warn('no "autostart=false" found on the blazor script tag!');
             }
 
-            if (navigator.serviceWorker.controller || forceStart) {
+            if (navigator?.serviceWorker?.controller || forceStart) {
                 Blazor.start();
             }
         }


### PR DESCRIPTION
closes #10767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when starting Blazor by safely checking for service worker availability, reducing the risk of runtime errors in certain browsers or environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->