### PR TITLE
Update bit packages download numbers (#10780)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![License](https://img.shields.io/github/license/bitfoundation/bitplatform.svg)
 ![CI Status](https://github.com/bitfoundation/bitplatform/actions/workflows/bit.ci.yml/badge.svg)
 ![NuGet version](https://img.shields.io/nuget/v/bit.blazorui.svg?logo=nuget)
-[![Nuget downloads](https://img.shields.io/badge/packages_download-6.2M-blue.svg?logo=nuget)](https://www.nuget.org/profiles/bit-foundation)
+[![Nuget downloads](https://img.shields.io/badge/packages_download-6.5M-blue.svg?logo=nuget)](https://www.nuget.org/profiles/bit-foundation)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/bitfoundation/bitplatform.svg)](http://isitmaintained.com/project/bitfoundation/bitplatform "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/bitfoundation/bitplatform.svg)](http://isitmaintained.com/project/bitfoundation/bitplatform "Percentage of issues still open")
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bitfoundation/bitplatform)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -22,7 +22,7 @@ public partial class BitMarkdownViewerDemo
 ![License](https://img.shields.io/github/license/bitfoundation/bitplatform.svg)
 ![CI Status](https://github.com/bitfoundation/bitplatform/actions/workflows/bit.ci.yml/badge.svg)
 ![NuGet version](https://img.shields.io/nuget/v/bit.blazorui.svg?logo=nuget)
-[![Nuget downloads](https://img.shields.io/badge/packages_download-6.2M-blue.svg?logo=nuget)](https://www.nuget.org/profiles/bit-foundation)
+[![Nuget downloads](https://img.shields.io/badge/packages_download-6.5M-blue.svg?logo=nuget)](https://www.nuget.org/profiles/bit-foundation)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/bitfoundation/bitplatform.svg)](http://isitmaintained.com/project/bitfoundation/bitplatform ""Average time to resolve an issue"")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/bitfoundation/bitplatform.svg)](http://isitmaintained.com/project/bitfoundation/bitplatform ""Percentage of issues still open"")
 
@@ -112,7 +112,7 @@ private string advancedMarkdown = @""![Header](https://user-images.githubusercon
 ![License](https://img.shields.io/github/license/bitfoundation/bitplatform.svg)
 ![CI Status](https://github.com/bitfoundation/bitplatform/actions/workflows/bit.ci.yml/badge.svg)
 ![NuGet version](https://img.shields.io/nuget/v/bit.blazorui.svg?logo=nuget)
-[![Nuget downloads](https://img.shields.io/badge/packages_download-6.2M-blue.svg?logo=nuget)](https://www.nuget.org/profiles/bit-foundation)
+[![Nuget downloads](https://img.shields.io/badge/packages_download-6.5M-blue.svg?logo=nuget)](https://www.nuget.org/profiles/bit-foundation)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/bitfoundation/bitplatform.svg)](http://isitmaintained.com/project/bitfoundation/bitplatform """"Average time to resolve an issue"""")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/bitfoundation/bitplatform.svg)](http://isitmaintained.com/project/bitfoundation/bitplatform """"Percentage of issues still open"""")
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Home/HomePage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Home/HomePage.razor
@@ -125,7 +125,7 @@
                     </BitStack>
                 </BitLink>
                 <BitLink Href="https://www.nuget.org/profiles/bit-foundation" Target="_blank" NoUnderline>
-                    <BitImage Src="https://img.shields.io/badge/packages_download-6.2M-blue.svg?logo=nuget" Alt="nuget downloads" />
+                    <BitImage Src="https://img.shields.io/badge/packages_download-6.5M-blue.svg?logo=nuget" Alt="nuget downloads" />
                 </BitLink>
             </BitStack>
         </BitCard>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/AboutUsPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/AboutUsPage.razor
@@ -46,7 +46,7 @@
 
     <section class="page-section download-section">
         <div class="page-section-content">
-            <BitText Typography="BitTypography.H3" Gutter>6.2M</BitText>
+            <BitText Typography="BitTypography.H3" Gutter>6.5M</BitText>
             <hr style="width:100%" />
             <a href="https://www.nuget.org/profiles/bit-foundation" target="_blank">
                 <BitText Typography="BitTypography.H5" Class="blue-txt">

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Lcnc/LcncPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Lcnc/LcncPage.razor
@@ -154,7 +154,7 @@
             <br />
             <BitText Typography="BitTypography.H5" Class="text-subtitle">
                 <div class="stats-container">
-                    <div>+6.2M NuGet downloads</div>
+                    <div>+6.5M NuGet downloads</div>
                     <div>+1K GitHub stars</div>
                     <div>+100 contributors</div>
                 </div>


### PR DESCRIPTION
closes #10780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated NuGet download badges and statistics across various pages and documentation to reflect the new total of 6.5 million downloads (previously 6.2 million). The visual count is now consistent throughout the app and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->