### PR TITLE
Log warning - error for get requests with body in Boilerplate (#10821)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/HttpMessageHandlers/LoggingDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Services/HttpMessageHandlers/LoggingDelegatingHandler.cs
@@ -1,4 +1,4 @@
-//+:cnd:noEmit
+﻿//+:cnd:noEmit
 using System.Web;
 using System.Diagnostics;
 
@@ -9,6 +9,11 @@ internal class LoggingDelegatingHandler(ILogger<HttpClient> logger, HttpMessageH
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        if (request.Method == HttpMethod.Get && request.Content is not null)
+        {
+            logger.Log(AppPlatform.IsBrowser ? LogLevel.Error : LogLevel.Warning, "Request with body will not work in Blazor WebAssembly. Request: {Request}", request.ToString());
+        }
+
         logger.LogInformation("Sending HTTP request {Method} {Uri}", request.Method, HttpUtility.UrlDecode(request.RequestUri?.ToString()));
         request.Options.Set(new(RequestOptionNames.LogLevel), LogLevel.Warning);
         request.Options.Set(new(RequestOptionNames.LogScopeData), new Dictionary<string, object?>());


### PR DESCRIPTION
closes #10821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a warning message when a GET request with a body is detected, helping users identify unsupported scenarios in Blazor WebAssembly. The message is shown as an error in browser environments and as a warning elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->