### PR TITLE
Add Toggled property to ClassStyles of BitNavPanel (#10825)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
@@ -14,7 +14,7 @@
 <div @ref="RootElement" @attributes="HtmlAttributes"
      id="@_Id"
      style="@GetPanelStyle(isToggled)"
-     class="@ClassBuilder.Value @($"{(isToggled ? $"bit-npn-tgl {Classes?.ToggledRoot}" : "")}")"
+     class="@ClassBuilder.Value @($"{(isToggled ? $"bit-npn-tgl {Classes?.Toggled}" : "")}")"
      dir="@Dir?.ToString().ToLower()">
     <BitSwipeTrap Style="width:100%; height:100%"
                   Threshold="5"

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
@@ -13,8 +13,8 @@
 
 <div @ref="RootElement" @attributes="HtmlAttributes"
      id="@_Id"
-     style="@GetPanelStyle()"
-     class="@ClassBuilder.Value @($"{(isToggled ? "bit-npn-tgl" : "")}")"
+     style="@GetPanelStyle(isToggled)"
+     class="@ClassBuilder.Value @($"{(isToggled ? $"bit-npn-tgl {Classes?.ToggledRoot}" : "")}")"
      dir="@Dir?.ToString().ToLower()">
     <BitSwipeTrap Style="width:100%; height:100%"
                   Threshold="5"

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -366,12 +366,12 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 
     private string? GetPanelStyle(bool isToggled)
     {
-        if (IsOpen is false) return $"{StyleBuilder.Value};{(isToggled ? Styles?.ToggledRoot : string.Empty)}".Trim(';');
+        if (IsOpen is false) return $"{StyleBuilder.Value};{(isToggled ? Styles?.Toggled : string.Empty)}".Trim(';');
 
         var translate = ((Dir != BitDir.Rtl && diffXPanel < 0) || (Dir == BitDir.Rtl && diffXPanel > 0))
                             ? $"transform: translateX({diffXPanel}px)"
                             : string.Empty;
-        return $"{translate};{StyleBuilder.Value};{(isToggled ? Styles?.ToggledRoot : string.Empty)}".Trim(';');
+        return $"{translate};{StyleBuilder.Value};{(isToggled ? Styles?.Toggled : string.Empty)}".Trim(';');
     }
 
     private async Task OnItemsSet()

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -364,14 +364,14 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         }
     }
 
-    private string? GetPanelStyle()
+    private string? GetPanelStyle(bool isToggled)
     {
-        if (IsOpen is false) return StyleBuilder.Value;
+        if (IsOpen is false) return $"{StyleBuilder.Value};{(isToggled ? Styles?.ToggledRoot : string.Empty)}".Trim(';');
 
         var translate = ((Dir != BitDir.Rtl && diffXPanel < 0) || (Dir == BitDir.Rtl && diffXPanel > 0))
                             ? $"transform: translateX({diffXPanel}px)"
                             : string.Empty;
-        return $"{translate};{StyleBuilder.Value}".Trim(';');
+        return $"{translate};{StyleBuilder.Value};{(isToggled ? Styles?.ToggledRoot : string.Empty)}".Trim(';');
     }
 
     private async Task OnItemsSet()

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelClassStyles.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelClassStyles.cs
@@ -15,7 +15,7 @@ public class BitNavPanelClassStyles
     /// <summary>
     /// Custom CSS classes/styles for the root element of the BitNavPanel when toggled.
     /// </summary>
-    public string? ToggledRoot { get; set; }
+    public string? Toggled { get; set; }
 
     /// <summary>
     /// Custom CSS classes/styles for the container of the BitNavPanel.

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelClassStyles.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelClassStyles.cs
@@ -13,6 +13,11 @@ public class BitNavPanelClassStyles
     public string? Root { get; set; }
 
     /// <summary>
+    /// Custom CSS classes/styles for the root element of the BitNavPanel when toggled.
+    /// </summary>
+    public string? ToggledRoot { get; set; }
+
+    /// <summary>
     /// Custom CSS classes/styles for the container of the BitNavPanel.
     /// </summary>
     public string? Container { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -339,6 +339,13 @@ public partial class BitNavPanelDemo
                 },
                 new()
                 {
+                    Name = "ToggledRoot",
+                    Type = "string?",
+                    DefaultValue = "null",
+                    Description = "Custom CSS classes/styles for the root element of the BitNavPanel when toggled.",
+                },
+                new()
+                {
                     Name = "Container",
                     Type = "string?",
                     DefaultValue = "null",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -339,7 +339,7 @@ public partial class BitNavPanelDemo
                 },
                 new()
                 {
-                    Name = "ToggledRoot",
+                    Name = "Toggled",
                     Type = "string?",
                     DefaultValue = "null",
                     Description = "Custom CSS classes/styles for the root element of the BitNavPanel when toggled.",


### PR DESCRIPTION
This closes #10825 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for custom CSS classes and styles for the navigation panel when it is toggled, allowing for enhanced visual customization in the toggled state.
- **Documentation**
	- Updated demo component parameters to showcase the new toggled state styling option for the navigation panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->