### PR TITLE
Reset otp requested on for two factor enabled users during otp sign-in (#10831)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/SignInManagerExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/SignInManagerExtensions.cs
@@ -81,7 +81,7 @@ public static partial class SignInManagerExtensions
         }
 
         await signInManager.UserManager.ResetAccessFailedCountAsync(user);
-        user.OtpRequestedOn = null; // invalidates the OTP
+        user.OtpRequestedOn = null; // invalidates the OTP. For those with 2fa, the OTP is invalidated when the user signs in successfully in TwoFactorSignIn method.
         var updateResult = await signInManager.UserManager.UpdateAsync(user);
         if (updateResult.Succeeded is false)
             throw new ResourceValidationException(updateResult.Errors.Select(e => new LocalizedString(e.Code, e.Description)).ToArray()).WithData("UserId", user.Id);


### PR DESCRIPTION
closes #10831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved two-factor authentication process to better handle recovery codes, phone, and authenticator app sign-ins, ensuring proper OTP invalidation and access reset after successful sign-in.

- **Documentation**
  - Enhanced comments to clarify the timing of OTP invalidation during two-factor authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->