### PR TITLE
Make sure local http server is listening (#10859)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Services/MauiLocalHttpServer.cs
@@ -26,8 +26,10 @@ public partial class MauiLocalHttpServer : ILocalHttpServer
 
     public int EnsureStarted()
     {
-        if (port != -1)
-            return port;
+        if (localHttpServer?.State is WebServerState.Listening or WebServerState.Loading)
+            return port is -1 ? throw new InvalidOperationException() : port;
+
+        localHttpServer?.Dispose();
 
         port = GetAvailableTcpPort();
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Services/WindowsLocalHttpServer.cs
@@ -28,8 +28,10 @@ public partial class WindowsLocalHttpServer : ILocalHttpServer
 
     public int EnsureStarted()
     {
-        if (port != -1)
-            return port;
+        if (localHttpServer?.State is WebServerState.Listening or WebServerState.Loading)
+            return port is -1 ? throw new InvalidOperationException() : port;
+
+        localHttpServer?.Dispose();
 
         port = GetAvailableTcpPort();
 


### PR DESCRIPTION
closes #10859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when starting the local HTTP server by adding more robust state checks and handling for server restarts. This helps prevent server errors and ensures smoother server operation on both Maui and Windows clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->