### PR TITLE
Removed unlimited privileged sessions feature (#10856)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/SessionsSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Authorized/Settings/SessionsSection.razor
@@ -15,10 +15,7 @@
         }
         @if (currentSession is not null)
         {
-            @if (maxPrivilegedSessionsCount != -1) // -1 means unlimited
-            {
-                <BitText Element="pre" Style="word-break:break-all;white-space:break-spaces" Typography="BitTypography.Body1">@Localizer[nameof(AppStrings.PrivilegedDeviceLimitMessage), maxPrivilegedSessionsCount, currentPrivilegedCount]</BitText>
-            }
+            <BitText Element="pre" Style="word-break:break-all;white-space:break-spaces" Typography="BitTypography.Body1">@Localizer[nameof(AppStrings.PrivilegedDeviceLimitMessage), maxPrivilegedSessionsCount.ToString("N0"), currentPrivilegedCount.ToString("N0")]</BitText>
 
             <BitText>@Localizer[nameof(AppStrings.CurrentSession)]</BitText>
             <BitCard FullWidth>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
@@ -215,8 +215,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
         var maxPrivilegedSessionsCount = await userClaimsService.GetUserClaimValue<int?>(userId, AppClaimTypes.MAX_PRIVILEGED_SESSIONS, cancellationToken)
              ?? AppSettings.Identity.MaxPrivilegedSessionsCount;
 
-        var isPrivileged = maxPrivilegedSessionsCount == -1 || // -1 means no limit
-            userSession.Privileged is true || // Once session gets privileged, it stays privileged until gets deleted.
+        var isPrivileged = userSession.Privileged is true || // Once session gets privileged, it stays privileged until gets deleted.
             await DbContext.UserSessions.CountAsync(us => us.UserId == userSession.UserId && us.Privileged == true, cancellationToken) < maxPrivilegedSessionsCount;
 
         userClaimsPrincipalFactory.SessionClaims.Add(new(AppClaimTypes.PRIVILEGED_SESSION, isPrivileged ? "true" : "false"));

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Data/Configurations/Identity/RoleClaimConfiguration.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Data/Configurations/Identity/RoleClaimConfiguration.cs
@@ -15,7 +15,7 @@ public partial class RoleClaimConfiguration : IEntityTypeConfiguration<RoleClaim
         {
             Id = 1,
             ClaimType = AppClaimTypes.MAX_PRIVILEGED_SESSIONS,
-            ClaimValue = "-1",
+            ClaimValue = "99",
             RoleId = superAdminRoleId
         });
 


### PR DESCRIPTION
closes #10856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Privileged device limit message is now always displayed in the settings section, regardless of session limits.
- **Improvements**
	- Numeric values for privileged session limits are now shown with localized formatting for better readability.
- **Changes**
	- The maximum privileged sessions for the super admin role has been updated from unlimited to 99.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->