### PR TITLE
Fix build error by removing none exist namespace (#10881)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/iOS/AppDelegate.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/iOS/AppDelegate.cs
@@ -1,6 +1,9 @@
 ﻿//+:cnd:noEmit
 using UIKit;
 using Foundation;
+//#if (notification == true)
+using Boilerplate.Client.Maui.Platforms.iOS.Services;
+//#endif
 
 namespace Boilerplate.Client.Maui.Platforms.iOS;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/iOS/AppDelegate.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/iOS/AppDelegate.cs
@@ -1,7 +1,6 @@
 ﻿//+:cnd:noEmit
 using UIKit;
 using Foundation;
-using Boilerplate.Client.Maui.Platforms.iOS.Services;
 
 namespace Boilerplate.Client.Maui.Platforms.iOS;
 


### PR DESCRIPTION
closes #10881 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused reference to improve code cleanliness. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->