### PR TITLE
fix forwarded headers options's allowed hosts with trusted origins (#10916)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/HttpRequestExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/HttpRequestExtensions.cs
@@ -1,4 +1,4 @@
-using Boilerplate.Server.Api;
+﻿using Boilerplate.Server.Api;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http;
@@ -16,7 +16,7 @@ public static partial class HttpRequestExtensions
         if (origin is null)
             return serverUrl; // Assume that web app and server are hosted in one place.
 
-        if (origin == serverUrl || settings.IsAllowedOrigin(origin))
+        if (origin == serverUrl || settings.IsTrustedOrigin(origin))
             return origin;
 
         throw new BadRequestException($"Invalid origin {origin}");

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
@@ -20,7 +20,7 @@ public static partial class Program
         var forwardedHeadersOptions = settings.ForwardedHeaders;
         if (forwardedHeadersOptions != null)
         {
-            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Host))];
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Port.HasValue ? $"{origin.Host}:{origin.Port}" : origin.Host))];
 
             if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
@@ -16,13 +16,17 @@ public static partial class Program
 
         ServerApiSettings settings = new();
         configuration.Bind(settings);
-        var forwardedHeadersOptions = settings.ForwardedHeaders;
 
-        if (forwardedHeadersOptions is not null
-            && (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any()))
+        var forwardedHeadersOptions = settings.ForwardedHeaders;
+        if (forwardedHeadersOptions != null)
         {
-            // If the list is empty then all hosts are allowed. Failing to restrict this these values may allow an attacker to spoof links generated for reset password etc.
-            app.UseForwardedHeaders(forwardedHeadersOptions);
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.ToString()))];
+
+            if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
+            {
+                // If the list is empty then all hosts are allowed. Failing to restrict this these values may allow an attacker to spoof links generated for reset password etc.
+                app.UseForwardedHeaders(forwardedHeadersOptions);
+            }
         }
 
         if (CultureInfoManager.InvariantGlobalization is false)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
@@ -20,7 +20,7 @@ public static partial class Program
         var forwardedHeadersOptions = settings.ForwardedHeaders;
         if (forwardedHeadersOptions != null)
         {
-            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Port.HasValue ? $"{origin.Host}:{origin.Port}" : origin.Host))];
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Host))];
 
             if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
@@ -20,7 +20,7 @@ public static partial class Program
         var forwardedHeadersOptions = settings.ForwardedHeaders;
         if (forwardedHeadersOptions != null)
         {
-            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.ToString()))];
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Host))];
 
             if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -150,7 +150,7 @@ public static partial class Program
                 ServerApiSettings settings = new();
                 configuration.Bind(settings);
 
-                policy.SetIsOriginAllowed(origin => Uri.TryCreate(origin, UriKind.Absolute, out var uri) && settings.IsAllowedOrigin(uri))
+                policy.SetIsOriginAllowed(origin => Uri.TryCreate(origin, UriKind.Absolute, out var uri) && settings.IsTrustedOrigin(uri))
                       .AllowAnyHeader()
                       .AllowAnyMethod()
                       .WithExposedHeaders(HeaderNames.RequestId, "Age", "App-Cache-Response");

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
@@ -43,16 +43,16 @@ public partial class ServerApiSettings : SharedSettings
 
     public ForwardedHeadersOptions? ForwardedHeaders { get; set; }
 
+    /// <summary>
+    /// Specifies the allowed origins for CORS requests, URLs returned after social sign-in and email confirmation, and permitted origins for Web Auth, as well as forwarded headers middleware in ASP.NET Core.
+    /// </summary>
+    public Uri[] TrustedOrigins { get; set; } = [];
+
     //#if (cloudflare == true)
     public CloudflareOptions? Cloudflare { get; set; }
     //#endif
 
     public ResponseCachingOptions? ResponseCaching { get; set; }
-
-    /// <summary>
-    /// Lists the permitted origins for CORS requests, return URLs following social sign-in and email confirmation, etc., along with allowed origins for Web Auth.
-    /// </summary>
-    public Uri[] TrustedOrigins { get; set; } = [];
 
     //#if (module == "Admin" || module == "Sales")
     [Required]
@@ -132,7 +132,7 @@ public partial class ServerApiSettings : SharedSettings
         return validationResults;
     }
 
-    internal bool IsAllowedOrigin(Uri origin)
+    internal bool IsTrustedOrigin(Uri origin)
     {
         return TrustedOrigins.Any(trustedOrigin => trustedOrigin == origin)
             || TrustedOriginsRegex().IsMatch(origin.ToString());

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -174,8 +174,7 @@
         "ForwardedHeaders_Comment": "These values apply only if your backend is hosted behind a CDN (such as `Cloudflare`).",
         "ForwardedHostHeaderName": "X-Forwarded-Host",
         "ForwardedHostHeaderName_Comment": "For Cloudflare, use X-Host instead of X-Forwarded-Host.",
-        "AllowedHosts": [ "" ],
-        "AllowedHosts_Comment": "If you're using a CDN like Cloudflare in front of your server, make sure to add your domain name to the `ForwardedHeaders:AllowedHosts` setting."
+        "AllowedHosts": [ "" ]
     },
     //#if (cloudflare == true)
     "Cloudflare": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -30,13 +30,17 @@ public static partial class Program
 
         ServerWebSettings settings = new();
         configuration.Bind(settings);
-        var forwardedHeadersOptions = settings.ForwardedHeaders;
 
-        if (forwardedHeadersOptions is not null
-            && (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any()))
+        var forwardedHeadersOptions = settings.ForwardedHeaders;
+        if (forwardedHeadersOptions != null)
         {
-            // If the list is empty then all hosts are allowed. Failing to restrict this these values may allow an attacker to spoof links generated for reset password etc.
-            app.UseForwardedHeaders(forwardedHeadersOptions);
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.ToString()))];
+
+            if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
+            {
+                // If the list is empty then all hosts are allowed. Failing to restrict this these values may allow an attacker to spoof links generated for reset password etc.
+                app.UseForwardedHeaders(forwardedHeadersOptions);
+            }
         }
 
         if (CultureInfoManager.InvariantGlobalization is false)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -34,7 +34,7 @@ public static partial class Program
         var forwardedHeadersOptions = settings.ForwardedHeaders;
         if (forwardedHeadersOptions != null)
         {
-            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Port.HasValue ? $"{origin.Host}:{origin.Port}" : origin.Host))];
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Host))];
 
             if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -34,7 +34,7 @@ public static partial class Program
         var forwardedHeadersOptions = settings.ForwardedHeaders;
         if (forwardedHeadersOptions != null)
         {
-            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.ToString()))];
+            forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(origin => origin.Port.HasValue ? $"{origin.Host}:{origin.Port}" : origin.Host))];
 
             if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/ServerWebSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/ServerWebSettings.cs
@@ -10,6 +10,11 @@ public partial class ServerWebSettings : ClientWebSettings
 {
     public ForwardedHeadersOptions? ForwardedHeaders { get; set; } = default!;
 
+    /// <summary>
+    /// Specifies the allowed origins for CORS requests, URLs returned after social sign-in and email confirmation, and permitted origins for Web Auth, as well as forwarded headers middleware in ASP.NET Core.
+    /// </summary>
+    public Uri[] TrustedOrigins { get; set; } = [];
+
     public ResponseCachingOptions? ResponseCaching { get; set; } = default!;
 
     [Required]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -141,8 +141,7 @@
         "ForwardedHeaders_Comment": "These values apply only if your backend is hosted behind a CDN (such as `Cloudflare`).",
         "ForwardedHostHeaderName": "X-Forwarded-Host",
         "ForwardedHostHeaderName_Comment": "For Cloudflare, use X-Host instead of X-Forwarded-Host.",
-        "AllowedHosts": [ "" ],
-        "AllowedHosts_Comment": "If you're using a CDN like Cloudflare in front of your server, make sure to add your domain name to the `ForwardedHeaders:AllowedHosts` setting."
+        "AllowedHosts": [ "" ]
     },
     "ResponseCaching": {
         "EnableOutputCaching": false,

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -134,11 +134,8 @@
         "MinimumSupportedWebAppVersion": "1.0.0"
     },
     //#endif
-    "ResponseCaching": {
-        "EnableOutputCaching": false,
-        "EnableCdnEdgeCaching": false
-    },
-    "AllowedHosts": "*",
+    "TrustedOrigins": [],
+    "TrustedOrigins_Comment": "Lists the permitted origins for CORS requests, return URLs following social sign-in and email confirmation, etc., along with allowed origins for Web Auth.",
     "ForwardedHeaders": {
         "ForwardedHeaders": "All",
         "ForwardedHeaders_Comment": "These values apply only if your backend is hosted behind a CDN (such as `Cloudflare`).",
@@ -147,6 +144,11 @@
         "AllowedHosts": [ "" ],
         "AllowedHosts_Comment": "If you're using a CDN like Cloudflare in front of your server, make sure to add your domain name to the `ForwardedHeaders:AllowedHosts` setting."
     },
+    "ResponseCaching": {
+        "EnableOutputCaching": false,
+        "EnableCdnEdgeCaching": false
+    },
+    "AllowedHosts": "*",
     "WebAppRender": {
         "BlazorMode": "BlazorServer",
         "BlazorMode_Comment": "BlazorServer, BlazorWebAssembly and BlazorAuto.",


### PR DESCRIPTION
closes ##10916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for specifying trusted origins, enhancing control over allowed origins for CORS, Web Authentication, and social sign-in redirections.

- **Improvements**
	- Updated internal logic to validate origins based on the new trusted origins setting.
	- Enhanced documentation for configuration properties related to trusted origins.
	- Improved handling of forwarded headers and allowed hosts by integrating trusted origins into middleware setup.

- **Configuration**
	- Added a "TrustedOrigins" array to the configuration file for clearer management of allowed origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->