### PR TITLE
Add skipWaiting public API to Bswup (#10919)

### DIFF
--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
@@ -96,7 +96,7 @@ BitBswup.version = window['bit-bswup version'] = '9.9.0-pre-02';
 
             if (e.data === 'CLIENTS_CLAIMED') {
                 Blazor.start().then(() => {
-                    blazorStartResolver(undefined);
+                    blazorStartResolver?.(undefined);
                     e.source.postMessage('BLAZOR_STARTED');
                 });
                 return;
@@ -240,6 +240,17 @@ BitBswup.forceRefresh = async () => {
     await Promise.all(regPromises);
 
     window.location.reload();
+}
+
+BitBswup.skipWaiting = async (): Promise<boolean> => {
+    const reg = await navigator.serviceWorker.getRegistration();
+
+    if (reg?.waiting) {
+        reg.waiting.postMessage('SKIP_WAITING');
+        return true;
+    }
+
+    return false;
 }
 
 const BswupMessage = {

--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.ts
@@ -216,17 +216,16 @@ BitBswup.version = window['bit-bswup version'] = '9.9.0-pre-02';
     }
 }());
 
-BitBswup.checkForUpdate = async () => {
+BitBswup.checkForUpdate = async (): Promise<void> => {
     if (!('serviceWorker' in navigator)) {
         return console.warn('no serviceWorker in navigator');
     }
 
     const reg = await navigator.serviceWorker.getRegistration();
-    const result = await reg.update();
-    return result;
+    await reg.update();
 }
 
-BitBswup.forceRefresh = async () => {
+BitBswup.forceRefresh = async (): Promise<void> => {
     if (!('serviceWorker' in navigator)) {
         return console.warn('no serviceWorker in navigator');
     }
@@ -243,6 +242,11 @@ BitBswup.forceRefresh = async () => {
 }
 
 BitBswup.skipWaiting = async (): Promise<boolean> => {
+    if (!('serviceWorker' in navigator)) {
+        console.warn('no serviceWorker in navigator');
+        return false;
+    }
+
     const reg = await navigator.serviceWorker.getRegistration();
 
     if (reg?.waiting) {


### PR DESCRIPTION
closes #10919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a method to allow skipping the waiting phase for service worker updates, enabling faster activation of new versions.

- **Bug Fixes**
  - Improved error handling to prevent issues if certain functions are undefined during message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->