### PR TITLE
Use Bswup.skipWaiting in force-update process of Boilerplate (#10922)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/app.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/app.ts
@@ -75,9 +75,14 @@ class App {
     };
     //#endif
 
-    public static forceUpdate() {
-        (window as any).BitBswupProgress.config({ autoReload: true });
-        (window as any).BitBswup.checkForUpdate();
+    public static async forceUpdate() {
+        const bswup = (window as any).BitBswup;
+        const bswupProgress = (window as any).BitBswupProgress;
+
+        if (await bswup.skipWaiting()) return;
+
+        bswupProgress.config({ autoReload: true });
+        bswup.checkForUpdate();
     }
 }
 


### PR DESCRIPTION
closes #10922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the update process to handle updates more reliably and ensure smoother application reloads when updates are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->