### PR TITLE
Add ThrowIfContainsExpiredAccessToken method to Boilerplate (#10951)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/PushNotification/PushNotificationController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/PushNotification/PushNotificationController.cs
@@ -14,13 +14,7 @@ public partial class PushNotificationController : AppControllerBase, IPushNotifi
     [HttpPost]
     public async Task Subscribe([Required] PushNotificationSubscriptionDto subscription, CancellationToken cancellationToken)
     {
-        if (User.IsAuthenticated() is false && Request.Headers.Authorization.Any() is true)
-        {
-            // PushNotificationController allows anonymous notification subscriptions. However, if an Authorization is included
-            // and the user is not authenticated, it indicates the client has sent an invalid or expired access token.
-            // In this scenario, we should refresh the access token and attempt to re-send the api request.
-            throw new UnauthorizedException();
-        }
+        HttpContext.ThrowIfContainsExpiredAccessToken();
 
         await pushNotificationService.Subscribe(subscription, cancellationToken);
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/HttpContextExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/HttpContextExtensions.cs
@@ -1,4 +1,4 @@
-//+:cnd:noEmit
+﻿//+:cnd:noEmit
 
 using Microsoft.AspNetCore.Components.Endpoints;
 
@@ -22,5 +22,27 @@ internal static class HttpContextExtensions
         return context.GetEndpoint()?.Metadata?.OfType<ComponentTypeMetadata>()?.Any() is true;
     }
     //#endif
+
+    /// <summary>
+    /// Validates the authentication status of an incoming HTTP request in an API endpoint that supports anonymous access.
+    /// If the request is unauthenticated (i.e., no valid user is associated with the context) but an Authorization header
+    /// is present, it is assumed that the provided access token is likely expired. In this case, the method throws an
+    /// <see cref="UnauthorizedException"/> to signal the client to refresh the access token and retry the request. This behavior ensures
+    /// that clients with potentially expired tokens are prompted to re-authenticate while still allowing anonymous api call.
+    /// This way, API can act differently based on the authentication status of the request, while still allowing anonymous access to certain endpoints.
+    /// </summary>
+    public static void ThrowIfContainsExpiredAccessToken(this HttpContext context)
+    {
+        if (context.ContainsExpiredAccessToken())
+            throw new UnauthorizedException();
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="ThrowIfContainsExpiredAccessToken(HttpContext)"/>/>
+    /// </summary>
+    public static bool ContainsExpiredAccessToken(this HttpContext context)
+    {
+        return context.User.IsAuthenticated() is false && context.Request.Headers.Authorization.Any() is true;
+    }
 }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.cs
@@ -27,16 +27,8 @@ public partial class AppHub : Hub
 
     public override async Task OnConnectedAsync()
     {
-        if (Context.User.IsAuthenticated() is false)
-        {
-            if (Context.GetHttpContext()?.Request.Headers.Authorization.Any() is true)
-            {
-                // AppHub allows anonymous connections. However, if an Authorization is included
-                // and the user is not authenticated, it indicates the client has sent an invalid or expired access token.
-                // In this scenario, we should refresh the access token and attempt to reconnect.
-                throw new HubException(nameof(AppStrings.UnauthorizedException)).WithData("ConnectionId", Context.ConnectionId);
-            }
-        }
+        if (Context.GetHttpContext()?.ContainsExpiredAccessToken() is true)
+            throw new HubException(nameof(AppStrings.UnauthorizedException)).WithData("ConnectionId", Context.ConnectionId);
 
         await ChangeAuthenticationStateImplementation(Context.User);
 


### PR DESCRIPTION
closes #10951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling of expired access tokens for API and real-time connections, resulting in more consistent and centralized authentication checks.
- **Bug Fixes**
  - Enhanced detection of expired or invalid tokens, allowing the system to better prompt users to refresh authentication when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->