### PR TITLE
Improve .razor.css cleanup in boilerplate (#10955)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
@@ -78,17 +78,17 @@
         <Watch Remove="*.scss" />
     </ItemGroup>
 
-    <!-- Deletes razor.css files that lack a corresponding razor.scss file in the project before the build process.
+    <!-- Deletes *.razor.css files that lack a corresponding .razor file in the project before the build process.
          This is necessary in Blazor projects with Scoped CSS to prevent build errors caused by orphaned razor.css files,
-         which may remain after their source razor.scss files are deleted or renamed. For example, if a developer deletes
-         a razor.scss file and commits the change to Git, another developer who pulls the updated repository will have the
-         razor.scss file removed from their system, but the generated razor.css file may remain.
+         which may remain after their source razor files are deleted or renamed. For example, if a developer deletes
+         a razor, razor.cs and razor.scss files and commits the change to Git, another developer who pulls the updated repository will have the
+         razor, razor.cs and razor.scss file removed from their system, but the generated razor.css file may remain.
          This orphaned razor.css file can cause build errors in the ApplyCssScopes task.
          The following target ensures such files are deleted before the build, maintaining consistency and preventing errors. -->
     <Target Name="DeleteUnmatchedRazorCss" BeforeTargets="ComputeCssScope">
         <ItemGroup>
             <RazorCssFiles Include="**\*.razor.css" />
-            <UnmatchedRazorCssFiles Include="@(RazorCssFiles)" Condition="!Exists('%(RecursiveDir)%(FileName).scss')" />
+            <UnmatchedRazorCssFiles Include="@(RazorCssFiles)" Condition="!Exists('%(RecursiveDir)%(FileName)')" />
         </ItemGroup>
         <Delete Files="@(UnmatchedRazorCssFiles)" />
     </Target>


### PR DESCRIPTION
closes #10955 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of orphaned `.razor.css` files to prevent build errors by ensuring they are deleted when no matching `.razor` file exists.

- **Documentation**
  - Updated comments to clarify the behavior of deleting unmatched `.razor.css` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->