### PR TITLE
Start chatbot panel on SignalR reconnection only if it was started before (#10959)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.cs
@@ -88,6 +88,7 @@ public partial class AppAiChatPanel
 
     private async Task HubConnection_Reconnected(string? _)
     {
+        if (channel is null) return;
         await RestartChannel();
     }
 


### PR DESCRIPTION
closes #10959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability of the chat panel by preventing errors when reconnecting without an active channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->