### PR TITLE
Update Fido2NetLib to beta.17 and fix breaking change in Boilerplate (#11045)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -10,8 +10,8 @@
         <PackageVersion Include="Bit.Bswup" Version="9.10.0-pre-01" />
         <PackageVersion Include="Bit.CodeAnalyzers" Version="9.10.0-pre-01" />
         <PackageVersion Include="Bit.SourceGenerators" Version="9.10.0-pre-01" />
-        <PackageVersion Include="Fido2.AspNet" Version="4.0.0-beta.16" />
-        <PackageVersion Include="Fido2.Models" Version="4.0.0-beta.16" />
+        <PackageVersion Include="Fido2.AspNet" Version="4.0.0-beta.17" />
+        <PackageVersion Include="Fido2.Models" Version="4.0.0-beta.17" />
         <PackageVersion Include="HtmlSanitizer" Version="9.0.886" />
         <PackageVersion Include="libphonenumber-csharp" Version="9.0.8" />
         <PackageVersion Include="Meziantou.Framework.Win32.Jobs" Version="3.4.3" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.WebAuthn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.WebAuthn.cs
@@ -105,7 +105,7 @@ public partial class IdentityController
         // since the TFA needs this option we won't remove it from cache manually and just wait for it to expire.
         // await cache.RemoveAsync(key, cancellationToken);
 
-        var credential = (await DbContext.WebAuthnCredential.FirstOrDefaultAsync(c => c.Id == clientResponse.Id, cancellationToken))
+        var credential = (await DbContext.WebAuthnCredential.FirstOrDefaultAsync(c => c.Id == clientResponse.RawId, cancellationToken))
                             ?? throw new ResourceNotFoundException();
 
         var verifyResult = await fido2.MakeAssertionAsync(new MakeAssertionParams

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/UserController.WebAuthn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/UserController.WebAuthn.cs
@@ -114,7 +114,7 @@ public partial class UserController
                     ?? throw new ResourceNotFoundException();
 
         var affectedRows = await DbContext.WebAuthnCredential
-            .Where(webAuthCred => webAuthCred.Id == assertionResponse.Id)
+            .Where(webAuthCred => webAuthCred.Id == assertionResponse.RawId)
             .ExecuteDeleteAsync(cancellationToken);
 
         if (affectedRows == 0)


### PR DESCRIPTION
closes #11045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of WebAuthn credential verification and deletion by updating how credentials are matched during authentication and removal processes.

* **Chores**
  * Updated dependencies for Fido2.AspNet and Fido2.Models to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->