### PR TITLE
Add digital ocean, hetzner and contabo sample to boilerplate (#11062)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.devcontainer/devcontainer.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.devcontainer/devcontainer.json
@@ -19,7 +19,9 @@
                 "DominicVonk.vscode-resx-editor",
                 "ms-dotnetools.csharp",
                 "ms-dotnettools.vscode-dotnet-runtime",
-                "ms-dotnettools.csdevkit"
+                "ms-dotnettools.csdevkit",
+                "GitHub.copilot-chat",
+                "GitHub.copilot"
             ]
         }
     },

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.vscode/extensions.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.vscode/extensions.json
@@ -5,6 +5,8 @@
         "ms-dotnettools.csdevkit",
         "DominicVonk.vscode-resx-editor",
         "ms-dotnettools.vscode-dotnet-runtime",
-        "kevin-chatham.aspnetcorerazor-html-css-class-completion"
+        "kevin-chatham.aspnetcorerazor-html-css-class-completion",
+        "GitHub.copilot-chat",
+        "GitHub.copilot"
     ]
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -73,7 +73,7 @@ public static partial class Program
         services.AddSingleton<IBlobStorage>(sp =>
         {
             //#if (filesStorage == "AzureBlobStorage" || filesStorage == "S3")
-            string GetValue(string connectionString, string key)
+            string GetValue(string connectionString, string key, string? defaultValue = null)
             {
                 var parts = connectionString.Split(';');
                 foreach (var part in parts)
@@ -81,7 +81,7 @@ public static partial class Program
                     if (part.StartsWith($"{key}="))
                         return part[$"{key}=".Length..];
                 }
-                throw new ArgumentException($"Invalid connection string: '{key}' not found.");
+                return defaultValue ?? throw new ArgumentException($"Invalid connection string: '{key}' not found.");
             }
             //#endif
 
@@ -98,11 +98,10 @@ public static partial class Program
                 : GetValue(azureBlobStorageConnectionString, "AccountKey");
             return StorageFactory.Blobs.AzureBlobStorageWithSharedKey(accountName, accountKey, blobServiceClient.Uri);
             //#elif (filesStorage == "S3")
-            // Checkout https://github.com/robinrodricks/FluentStorage for more S3 providers samples such as Digital Ocean's Spaces Object Storage, AWS, etc.
             // Run through docker using `docker run -d -p 9000:9000 -p 9001:9001 -e "MINIO_ROOT_USER=minioadmin" -e "MINIO_ROOT_PASSWORD=minioadmin" quay.io/minio/minio server /data --console-address ":9001"`
             // Open MinIO console at http://127.0.0.1:9001/browser
             var minIOConnectionString = configuration.GetConnectionString("MinIOS3ConnectionString")!;
-            return StorageFactory.Blobs.MinIO(GetValue(minIOConnectionString, "AccessKey"), GetValue(minIOConnectionString, "SecretKey"), "attachments", "us-east-1" /*Region doesn't matter for MinIO*/, GetValue(minIOConnectionString, "Endpoint"));
+            return StorageFactory.Blobs.MinIO(GetValue(minIOConnectionString, "AccessKey"), GetValue(minIOConnectionString, "SecretKey"), GetValue(minIOConnectionString, "BucketName", defaultValue: "files"), GetValue(minIOConnectionString, "Region", defaultValue: "us-east-1"), GetValue(minIOConnectionString, "Endpoint"));
             //#else
             throw new NotImplementedException("Install and configure any storage supported by fluent storage (https://github.com/robinrodricks/FluentStorage/wiki/Blob-Storage)");
             //#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -18,7 +18,8 @@
         //#if (filesStorage == "AzureBlobStorage")
         "AzureBlobStorageConnectionString": "UseDevelopmentStorage=true",
         //#elif (filesStorage == "S3")
-        "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin",
+        "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin;",
+        "MinIOS3ConnectionString__DigitalOceanObjectStorageSample": "Endpoint=https://ams3.digitaloceanspaces.com;BucketName=myBucketName;Region=ams3;AccessKey=XXX;SecretKey=XXX;",
         //#endif
         "ConnectionStrings_Comment": "The ConnectionStrings section contains database connection strings used by the application."
     },

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -21,7 +21,7 @@
         "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin;",
         "MinIOS3ConnectionString__ContaboSample": "Endpoint=https://eu2.contabostorage.com;BucketName=files;Region=eu2;AccessKey=XXX;SecretKey=XXX;",
         "MinIOS3ConnectionString__HetznerSample": "Endpoint=https://hel1.your-objectstorage.com;BucketName=files;Region=eu-central;AccessKey=XXX;SecretKey=XXX;",
-        "MinIOS3ConnectionString__DigitalOceanObjectStorageSample": "Endpoint=https://ams3.digitaloceanspaces.com;BucketName=myBucketName;Region=ams3;AccessKey=XXX;SecretKey=XXX;",
+        "MinIOS3ConnectionString__DigitalOceanSample": "Endpoint=https://ams3.digitaloceanspaces.com;BucketName=myBucketName;Region=ams3;AccessKey=XXX;SecretKey=XXX;",
         //#endif
         "ConnectionStrings_Comment": "The ConnectionStrings section contains database connection strings used by the application."
     },

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -20,6 +20,7 @@
         //#elif (filesStorage == "S3")
         "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin;",
         "MinIOS3ConnectionString__ContaboSample": "Endpoint=https://eu2.contabostorage.com;BucketName=files;Region=eu2;AccessKey=XXX;SecretKey=XXX;",
+        "MinIOS3ConnectionString__HetznerSample": "Endpoint=https://hel1.your-objectstorage.com;BucketName=files;Region=eu-central;AccessKey=XXX;SecretKey=XXX;",
         "MinIOS3ConnectionString__DigitalOceanObjectStorageSample": "Endpoint=https://ams3.digitaloceanspaces.com;BucketName=myBucketName;Region=ams3;AccessKey=XXX;SecretKey=XXX;",
         //#endif
         "ConnectionStrings_Comment": "The ConnectionStrings section contains database connection strings used by the application."

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -19,6 +19,7 @@
         "AzureBlobStorageConnectionString": "UseDevelopmentStorage=true",
         //#elif (filesStorage == "S3")
         "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin;",
+        "MinIOS3ConnectionString__ContaboSample": "Endpoint=https://eu2.contabostorage.com;BucketName=files;Region=eu2;AccessKey=XXX;SecretKey=XXX;",
         "MinIOS3ConnectionString__DigitalOceanObjectStorageSample": "Endpoint=https://ams3.digitaloceanspaces.com;BucketName=myBucketName;Region=ams3;AccessKey=XXX;SecretKey=XXX;",
         //#endif
         "ConnectionStrings_Comment": "The ConnectionStrings section contains database connection strings used by the application."

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -6,7 +6,7 @@
         "PostgreSQLConnectionString": "User ID=postgres;Password=postgres;Host=localhost;Database=BoilerplateDb;",
         "MySqlConnectionString": "Server=localhost;Port=3306;Database=BoilerplateDb;Uid=root;Pwd=123456;",
         "AzureBlobStorageConnectionString": "UseDevelopmentStorage=true",
-        "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin"
+        "MinIOS3ConnectionString": "Endpoint=http://localhost:9000;AccessKey=minioadmin;SecretKey=minioadmin;"
     },
     "Identity": {
         "JwtIssuerSigningKeySecret": "VeryLongJWTIssuerSiginingKeySecretThatIsMoreThan64BytesToEnsureCompatibilityWithHS512Algorithm",


### PR DESCRIPTION
closes #11062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing keys in MinIO connection strings, allowing default values for bucket name and region to be used when not specified.

* **Chores**
  * Updated configuration files to include sample connection strings and minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->