### PR TITLE
Fix issue of clear button in BitDropdown when ItemsProvider is used (#11083)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -1143,6 +1143,8 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             if (InvalidValueBinding()) return;
 
             CurrentValue = default;
+
+            _selectedItems.Clear();
         }
 
         UpdateSelectedItemsFromValues();


### PR DESCRIPTION
closes #11083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where clearing a single-select dropdown did not fully reset the selected items, ensuring the selection is properly cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->