### PR TITLE
Add PanelPosition parameter to BitDropdown component (#11118)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.razor.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace Bit.BlazorUI;
+﻿namespace Bit.BlazorUI;
 
 /// <summary>
 /// DropMenu component is a versatile dropdown menu used in Blazor applications. It allows you to create a button that, when clicked, opens a callout or dropdown menu.
@@ -57,6 +55,11 @@ public partial class BitDropMenu : BitComponentBase
     /// The callback is called when the drop menu is dismissed.
     /// </summary>
     [Parameter] public EventCallback OnDismiss { get; set; }
+
+    /// <summary>
+    /// The position of the responsive panel to show on the screen.
+    /// </summary>
+    [Parameter] public BitPanelPosition? PanelPosition { get; set; }
 
     /// <summary>
     /// The id of the element which needs to be scrollable in the content of the callout of the drop menu.
@@ -163,7 +166,7 @@ public partial class BitDropMenu : BitComponentBase
         await _js.BitSwipesSetup(
             id: _calloutId,
             trigger: 0.25m,
-            position: BitPanelPosition.End,
+            position: PanelPosition ?? BitPanelPosition.End,
             isRtl: Dir is BitDir.Rtl,
             orientationLock: BitSwipeOrientation.Horizontal,
             dotnetObj: _dotnetObj,
@@ -243,6 +246,15 @@ public partial class BitDropMenu : BitComponentBase
         {
             classes.Add("bit-drm-res");
         }
+
+        classes.Add(PanelPosition switch
+        {
+            BitPanelPosition.Start => "bit-drm-sta",
+            BitPanelPosition.End => "bit-drm-end",
+            BitPanelPosition.Top => "bit-drm-top",
+            BitPanelPosition.Bottom => "bit-drm-btm",
+            _ => "bit-drm-end"
+        });
 
         return string.Join(' ', classes).Trim();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.scss
@@ -8,6 +8,11 @@
     font-weight: $tg-font-weight;
     background-color: $clr-bg-pri;
     border-radius: $shp-border-radius;
+    --bit-drm-transform-factor: 1;
+
+    &.bit-rtl {
+        --bit-drm-transform-factor: -1;
+    }
 
     @media (hover: hover) {
         &:hover {
@@ -83,26 +88,41 @@
 
 .bit-drm-res {
     @include lt-sm {
-        top: 0;
-        right: 0;
         opacity: 0;
         height: 100%;
         display: block;
         overflow: hidden;
         max-height: unset;
         animation-name: unset;
-        transform: translateX(100%);
         box-shadow: $box-shadow-callout;
         transition: transform 200ms ease-out, opacity 100ms linear;
-    }
-}
 
-.bit-rtl {
-    .bit-drm-res {
-        @include lt-sm {
-            left: 0;
-            right: unset;
-            transform: translateX(-100%);
+        &.bit-drm-sta {
+            inset-block: 0;
+            inset-inline-start: 0;
+            transform: translateX(calc(var(--bit-drm-transform-factor) * -100%));
+        }
+
+        &.bit-drm-end {
+            inset-block: 0;
+            inset-inline-end: 0;
+            transform: translateX(calc(var(--bit-drm-transform-factor) * 100%));
+        }
+
+        &.bit-drm-top {
+            top: 0;
+            width: 100%;
+            max-width: 100%;
+            inset-inline: 0;
+            transform: translateY(-100%);
+        }
+
+        &.bit-drm-btm {
+            bottom: 0;
+            width: 100%;
+            max-width: 100%;
+            inset-inline: 0;
+            transform: translateY(100%);
         }
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
@@ -189,8 +189,8 @@
                         const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
                         const isScrollAtRight = Math.abs(scrollContainer!.scrollLeft) + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
 
-                        if ((isRtl && position === BitSwipePosition.End) || (!isRtl && position === BitSwipePosition.End)) { if (isScrollAtLeft) return; }
-                        if ((isRtl && position === BitSwipePosition.Start) || (!isRtl && position === BitSwipePosition.Start)) { if (isScrollAtRight) return; }
+                        if (position === BitSwipePosition.End && isScrollAtLeft) return;
+                        if (position === BitSwipePosition.Start && isScrollAtRight) return;
 
                         e.stopPropagation();
                     });

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
@@ -121,8 +121,7 @@
                     if (!e.cancelable) return;
 
                     if (touchOnScrollContainer) {
-                        const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
-                        const isScrollAtRight = Math.abs(scrollContainer!.scrollLeft) + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
+                        const [isScrollAtLeft, isScrollAtRight] = calcScrolls();
 
                         if (diffX < 0 && (isRtl ? isScrollAtRight : isScrollAtLeft)) return;
                         if (diffX > 0 && (isRtl ? isScrollAtLeft : isScrollAtRight)) return;
@@ -135,6 +134,7 @@
 
             const onEnd = async (e: TouchEvent | PointerEvent): Promise<void> => {
                 touchOnScrollContainer = false;
+
                 if (startX === -1 || startY === -1) return;
 
                 startX = startY = -1;
@@ -186,8 +186,7 @@
                     scrollContainer.addEventListener('touchstart', e => {
                         touchOnScrollContainer = true;
 
-                        const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
-                        const isScrollAtRight = Math.abs(scrollContainer!.scrollLeft) + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
+                        const [isScrollAtLeft, isScrollAtRight] = calcScrolls();
 
                         if (position === BitSwipePosition.End && isScrollAtLeft) return;
                         if (position === BitSwipePosition.Start && isScrollAtRight) return;
@@ -219,6 +218,13 @@
                 }
             });
             Swipes._swipes.push(swipe);
+
+            const calcScrolls = () => {
+                const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
+                const isScrollAtRight = Math.abs(scrollContainer!.scrollLeft) + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
+
+                return [isScrollAtLeft, isScrollAtRight];
+            }
         }
 
         public static dispose(id: string) {

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
@@ -122,7 +122,7 @@
 
                     if (touchOnScrollContainer) {
                         const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
-                        const isScrollAtRight = scrollContainer!.scrollLeft + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
+                        const isScrollAtRight = Math.abs(scrollContainer!.scrollLeft) + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
 
                         if (diffX < 0 && (isRtl ? isScrollAtRight : isScrollAtLeft)) return;
                         if (diffX > 0 && (isRtl ? isScrollAtLeft : isScrollAtRight)) return;
@@ -186,13 +186,11 @@
                     scrollContainer.addEventListener('touchstart', e => {
                         touchOnScrollContainer = true;
 
-                        console.log(scrollContainer.scrollLeft, scrollContainer.scrollWidth, scrollContainer.clientWidth);
+                        const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
+                        const isScrollAtRight = Math.abs(scrollContainer!.scrollLeft) + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
 
-                        //const edge = (isRtl && position === BitSwipePosition.Start || !isRtl && position === BitSwipePosition.End) ? Math.abs(scrollContainer.scrollLeft)
-                        //    : (isRtl && position === BitSwipePosition.Start || !isRtl && position === BitSwipePosition.End) ? Math.abs(scrollContainer.scrollLeft)
-                        //        : 0;
-
-                        //if (edge <= 2) return;
+                        if ((isRtl && position === BitSwipePosition.End) || (!isRtl && position === BitSwipePosition.End)) { if (isScrollAtLeft) return; }
+                        if ((isRtl && position === BitSwipePosition.Start) || (!isRtl && position === BitSwipePosition.Start)) { if (isScrollAtRight) return; }
 
                         e.stopPropagation();
                     });

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Swipes.ts
@@ -123,7 +123,7 @@
                     if (touchOnScrollContainer) {
                         const isScrollAtLeft = Math.abs(scrollContainer!.scrollLeft) <= 2;
                         const isScrollAtRight = scrollContainer!.scrollLeft + scrollContainer!.clientWidth >= (scrollContainer!.scrollWidth - 2);
-                        
+
                         if (diffX < 0 && (isRtl ? isScrollAtRight : isScrollAtLeft)) return;
                         if (diffX > 0 && (isRtl ? isScrollAtLeft : isScrollAtRight)) return;
                     }
@@ -186,7 +186,13 @@
                     scrollContainer.addEventListener('touchstart', e => {
                         touchOnScrollContainer = true;
 
-                        if (Math.abs(scrollContainer.scrollLeft) <= 2) return;
+                        console.log(scrollContainer.scrollLeft, scrollContainer.scrollWidth, scrollContainer.clientWidth);
+
+                        //const edge = (isRtl && position === BitSwipePosition.Start || !isRtl && position === BitSwipePosition.End) ? Math.abs(scrollContainer.scrollLeft)
+                        //    : (isRtl && position === BitSwipePosition.Start || !isRtl && position === BitSwipePosition.End) ? Math.abs(scrollContainer.scrollLeft)
+                        //        : 0;
+
+                        //if (edge <= 2) return;
 
                         e.stopPropagation();
                     });

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
@@ -54,7 +54,7 @@
     <DemoExample Title="Responsive" RazorCode="@example3RazorCode" Id="example3">
         <div>Rendering the callout in responsive mode on small screens.</div><br />
         
-        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con1" PanelPosition="BitPanelPosition.End">
+        <BitDropMenu Text="End PanelPosition" Responsive ScrollContainerId="sc-con1" PanelPosition="BitPanelPosition.End">
             <div style="max-width:200px;overflow:auto" id="sc-con1">
                 <BitStack FitWidth Gap="1rem" Style="padding:0.5rem">
                     <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content This is the content This is the content</BitText>
@@ -64,10 +64,8 @@
                 </BitStack>
             </div>
         </BitDropMenu>
-
-        <br /><br />
-
-        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con2" PanelPosition="BitPanelPosition.Start">
+        <br />
+        <BitDropMenu Text="Start PanelPosition" Responsive ScrollContainerId="sc-con2" PanelPosition="BitPanelPosition.Start">
             <div style="max-width:200px;overflow:auto" id="sc-con2">
                 <BitStack FitWidth Gap="1rem" Style="padding:0.5rem">
                     <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content This is the content This is the content</BitText>
@@ -156,7 +154,7 @@
                 </BitStack>
             </BitDropMenu>
             <br />
-            <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl1">
+            <BitDropMenu Text="ریسپانسیو منو در انتها" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl1">
                 <div style="max-width:200px;overflow:auto" id="sc-con-rtl1">
                     <BitStack Gap="1rem" Style="padding:0.5rem">
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>
@@ -166,7 +164,7 @@
                 </div>
             </BitDropMenu>
             <br />
-            <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl2" PanelPosition="BitPanelPosition.Start">
+            <BitDropMenu Text="ریسپانسیو منو در ابتدا" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl2" PanelPosition="BitPanelPosition.Start">
                 <div style="max-width:200px;overflow:auto" id="sc-con-rtl2">
                     <BitStack Gap="1rem" Style="padding:0.5rem">
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
@@ -53,7 +53,7 @@
 
     <DemoExample Title="Responsive" RazorCode="@example3RazorCode" Id="example3">
         <div>Rendering the callout in responsive mode on small screens.</div><br />
-        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con">
+        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con" PanelPosition="BitPanelPosition.Start">
             <div style="max-width:200px;overflow:auto" id="sc-con">
                 <BitStack Gap="1rem" Style="padding:0.5rem">
                     <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content This is the content This is the content</BitText>
@@ -142,7 +142,7 @@
                 </BitStack>
             </BitDropMenu>
             <br />
-            <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl">
+            @* <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl">
                 <div style="max-width:200px;overflow:auto" id="sc-con-rtl">
                     <BitStack Gap="1rem" Style="padding:0.5rem">
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>
@@ -150,7 +150,7 @@
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد</BitText>
                     </BitStack>
                 </div>
-            </BitDropMenu>
+            </BitDropMenu> *@
         </div>
     </DemoExample>
 </DemoPage>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
@@ -53,9 +53,23 @@
 
     <DemoExample Title="Responsive" RazorCode="@example3RazorCode" Id="example3">
         <div>Rendering the callout in responsive mode on small screens.</div><br />
-        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con" PanelPosition="BitPanelPosition.Start">
-            <div style="max-width:200px;overflow:auto" id="sc-con">
-                <BitStack Gap="1rem" Style="padding:0.5rem">
+        
+        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con1" PanelPosition="BitPanelPosition.End">
+            <div style="max-width:200px;overflow:auto" id="sc-con1">
+                <BitStack FitWidth Gap="1rem" Style="padding:0.5rem">
+                    <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content This is the content This is the content</BitText>
+                    <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content</BitText>
+                    <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content</BitText>
+                    <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content</BitText>
+                </BitStack>
+            </div>
+        </BitDropMenu>
+
+        <br /><br />
+
+        <BitDropMenu Text="Responsive" Responsive ScrollContainerId="sc-con2" PanelPosition="BitPanelPosition.Start">
+            <div style="max-width:200px;overflow:auto" id="sc-con2">
+                <BitStack FitWidth Gap="1rem" Style="padding:0.5rem">
                     <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content This is the content This is the content</BitText>
                     <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content</BitText>
                     <BitText Typography="BitTypography.Subtitle1" NoWrap>This is the content</BitText>
@@ -142,15 +156,25 @@
                 </BitStack>
             </BitDropMenu>
             <br />
-            @* <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl">
-                <div style="max-width:200px;overflow:auto" id="sc-con-rtl">
+            <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl1">
+                <div style="max-width:200px;overflow:auto" id="sc-con-rtl1">
                     <BitStack Gap="1rem" Style="padding:0.5rem">
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد</BitText>
                         <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد</BitText>
                     </BitStack>
                 </div>
-            </BitDropMenu> *@
+            </BitDropMenu>
+            <br />
+            <BitDropMenu Text="ریسپانسیو منو" Dir="BitDir.Rtl" Responsive ScrollContainerId="sc-con-rtl2" PanelPosition="BitPanelPosition.Start">
+                <div style="max-width:200px;overflow:auto" id="sc-con-rtl2">
+                    <BitStack Gap="1rem" Style="padding:0.5rem">
+                        <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>
+                        <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد</BitText>
+                        <BitText Typography="BitTypography.Subtitle1" NoWrap>این یک محتوای تستی می باشد</BitText>
+                    </BitStack>
+                </div>
+            </BitDropMenu>
         </div>
     </DemoExample>
 </DemoPage>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor.samples.cs
@@ -41,13 +41,24 @@ public partial class BitDropMenuDemo
 </BitDropMenu>";
 
     private readonly string example3RazorCode = @"
-<BitDropMenu Text=""Responsive"" Responsive ScrollContainerId=""sc-con"">
-    <div style=""max-width:200px;overflow:auto"" id=""sc-con"">
-        <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
+<BitDropMenu Text=""End PanelPosition"" Responsive ScrollContainerId=""sc-con1"" PanelPosition=""BitPanelPosition.End"">
+    <div style=""max-width:200px;overflow:auto"" id=""sc-con1"">
+        <BitStack FitWidth Gap=""1rem"" Style=""padding:0.5rem"">
             <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content This is the content This is the content</BitText>
-            <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
-            <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
-            <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content</BitText>
+        </BitStack>
+    </div>
+</BitDropMenu>
+
+<BitDropMenu Text=""Start PanelPosition"" Responsive ScrollContainerId=""sc-con2"" PanelPosition=""BitPanelPosition.Start"">
+    <div style=""max-width:200px;overflow:auto"" id=""sc-con2"">
+        <BitStack FitWidth Gap=""1rem"" Style=""padding:0.5rem"">
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content This is the content This is the content</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>This is the content</BitText>
         </BitStack>
     </div>
 </BitDropMenu>";
@@ -150,8 +161,18 @@ private int clickCounter;";
     </BitStack>
 </BitDropMenu>
 
-<BitDropMenu Text=""ریسپانسیو منو"" Dir=""BitDir.Rtl"" Responsive ScrollContainerId=""sc-con-rtl"">
-    <div style=""max-width:200px;overflow:auto"" id=""sc-con-rtl"">
+<BitDropMenu Text=""ریسپانسیو منو در انتها"" Dir=""BitDir.Rtl"" Responsive ScrollContainerId=""sc-con-rtl1"">
+    <div style=""max-width:200px;overflow:auto"" id=""sc-con-rtl1"">
+        <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>این یک محتوای تستی می باشد</BitText>
+            <BitText Typography=""BitTypography.Subtitle1"" NoWrap>این یک محتوای تستی می باشد</BitText>
+        </BitStack>
+    </div>
+</BitDropMenu>
+
+<BitDropMenu Text=""ریسپانسیو منو در ابتدا"" Dir=""BitDir.Rtl"" Responsive ScrollContainerId=""sc-con-rtl2"" PanelPosition=""BitPanelPosition.Start"">
+    <div style=""max-width:200px;overflow:auto"" id=""sc-con-rtl2"">
         <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
             <BitText Typography=""BitTypography.Subtitle1"" NoWrap>این یک محتوای تستی می باشد این یک محتوای تستی می باشد این یک محتوای تستی می باشد</BitText>
             <BitText Typography=""BitTypography.Subtitle1"" NoWrap>این یک محتوای تستی می باشد</BitText>


### PR DESCRIPTION
closes #11118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the position of the responsive panel in the drop menu component, allowing placement at the start, end, top, or bottom of the screen.
  * Enhanced demo examples to showcase multiple drop menus with distinct panel positions and improved right-to-left (RTL) layout support.

* **Style**
  * Improved styling for responsive drop menus, including dynamic direction handling and modularized position classes for better RTL and layout adaptability.

* **Bug Fixes**
  * Refined swipe gesture handling to ensure more accurate boundary detection and prevent interference with native scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->