### PR TITLE
Bind hangfire and azure monitor configurations in bit Boilerplate (#11207)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -472,6 +472,7 @@ public static partial class Program
         builder.Services.AddHangfireServer(options =>
         {
             options.SchedulePollingInterval = TimeSpan.FromSeconds(5);
+            configuration.Bind("Hangfire", options);
         });
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Extensions/WebApplicationBuilderExtensions.cs
@@ -179,7 +179,7 @@ public static class WebApplicationBuilderExtensions
         {
             builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
             {
-                options.ConnectionString = appInsightsConnectionString;
+                builder.Configuration.Bind("ApplicationInsights", options);
             });
         }
         //#endif


### PR DESCRIPTION
closes #11207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for loading Hangfire server settings and Azure Monitor OpenTelemetry exporter options from configuration, allowing more flexible and comprehensive configuration management.
* **Chores**
  * Improved configuration binding for background job processing and monitoring/exporter services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->