### PR TITLE
Use new dark bg, fg, and brd colors in BitToggleButton (#11210)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/ToggleButton/BitToggleButton.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/ToggleButton/BitToggleButton.scss
@@ -204,9 +204,9 @@
     --bit-tgb-clr: #{$clr-bg-pri};
     --bit-tgb-clr-hover: #{$clr-bg-pri-hover};
     --bit-tgb-clr-active: #{$clr-bg-pri-active};
-    --bit-tgb-clr-dark: #{$clr-bg-pri};
-    --bit-tgb-clr-dark-hover: #{$clr-bg-pri-hover};
-    --bit-tgb-clr-dark-active: #{$clr-bg-pri-active};
+    --bit-tgb-clr-dark: #{$clr-bg-pri-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-bg-pri-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-bg-pri-dark-active};
 }
 
 .bit-tgb-sbg {
@@ -214,9 +214,9 @@
     --bit-tgb-clr: #{$clr-bg-sec};
     --bit-tgb-clr-hover: #{$clr-bg-sec-hover};
     --bit-tgb-clr-active: #{$clr-bg-sec-active};
-    --bit-tgb-clr-dark: #{$clr-bg-sec};
-    --bit-tgb-clr-dark-hover: #{$clr-bg-sec-hover};
-    --bit-tgb-clr-dark-active: #{$clr-bg-sec-active};
+    --bit-tgb-clr-dark: #{$clr-bg-sec-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-bg-sec-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-bg-sec-dark-active};
 }
 
 .bit-tgb-tbg {
@@ -224,9 +224,9 @@
     --bit-tgb-clr: #{$clr-bg-ter};
     --bit-tgb-clr-hover: #{$clr-bg-ter-hover};
     --bit-tgb-clr-active: #{$clr-bg-ter-active};
-    --bit-tgb-clr-dark: #{$clr-bg-ter};
-    --bit-tgb-clr-dark-hover: #{$clr-bg-ter-hover};
-    --bit-tgb-clr-dark-active: #{$clr-bg-ter-active};
+    --bit-tgb-clr-dark: #{$clr-bg-ter-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-bg-ter-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-bg-ter-dark-active};
 }
 
 .bit-tgb-pfg {
@@ -234,9 +234,9 @@
     --bit-tgb-clr: #{$clr-fg-pri};
     --bit-tgb-clr-hover: #{$clr-fg-pri-hover};
     --bit-tgb-clr-active: #{$clr-fg-pri-active};
-    --bit-tgb-clr-dark: #{$clr-fg-pri};
-    --bit-tgb-clr-dark-hover: #{$clr-fg-pri-hover};
-    --bit-tgb-clr-dark-active: #{$clr-fg-pri-active};
+    --bit-tgb-clr-dark: #{$clr-fg-pri-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-fg-pri-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-fg-pri-dark-active};
 }
 
 .bit-tgb-sfg {
@@ -244,9 +244,9 @@
     --bit-tgb-clr: #{$clr-fg-sec};
     --bit-tgb-clr-hover: #{$clr-fg-sec-hover};
     --bit-tgb-clr-active: #{$clr-fg-sec-active};
-    --bit-tgb-clr-dark: #{$clr-fg-sec};
-    --bit-tgb-clr-dark-hover: #{$clr-fg-sec-hover};
-    --bit-tgb-clr-dark-active: #{$clr-fg-sec-active};
+    --bit-tgb-clr-dark: #{$clr-fg-sec-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-fg-sec-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-fg-sec-dark-active};
 }
 
 .bit-tgb-tfg {
@@ -254,9 +254,9 @@
     --bit-tgb-clr: #{$clr-fg-ter};
     --bit-tgb-clr-hover: #{$clr-fg-ter-hover};
     --bit-tgb-clr-active: #{$clr-fg-ter-active};
-    --bit-tgb-clr-dark: #{$clr-fg-ter};
-    --bit-tgb-clr-dark-hover: #{$clr-fg-ter-hover};
-    --bit-tgb-clr-dark-active: #{$clr-fg-ter-active};
+    --bit-tgb-clr-dark: #{$clr-fg-ter-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-fg-ter-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-fg-ter-dark-active};
 }
 
 .bit-tgb-pbr {
@@ -264,9 +264,9 @@
     --bit-tgb-clr: #{$clr-brd-pri};
     --bit-tgb-clr-hover: #{$clr-brd-pri-hover};
     --bit-tgb-clr-active: #{$clr-brd-pri-active};
-    --bit-tgb-clr-dark: #{$clr-brd-pri};
-    --bit-tgb-clr-dark-hover: #{$clr-brd-pri-hover};
-    --bit-tgb-clr-dark-active: #{$clr-brd-pri-active};
+    --bit-tgb-clr-dark: #{$clr-brd-pri-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-brd-pri-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-brd-pri-dark-active};
 }
 
 .bit-tgb-sbr {
@@ -274,9 +274,9 @@
     --bit-tgb-clr: #{$clr-brd-sec};
     --bit-tgb-clr-hover: #{$clr-brd-sec-hover};
     --bit-tgb-clr-active: #{$clr-brd-sec-active};
-    --bit-tgb-clr-dark: #{$clr-brd-sec};
-    --bit-tgb-clr-dark-hover: #{$clr-brd-sec-hover};
-    --bit-tgb-clr-dark-active: #{$clr-brd-sec-active};
+    --bit-tgb-clr-dark: #{$clr-brd-sec-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-brd-sec-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-brd-sec-dark-active};
 }
 
 .bit-tgb-tbr {
@@ -284,9 +284,9 @@
     --bit-tgb-clr: #{$clr-brd-ter};
     --bit-tgb-clr-hover: #{$clr-brd-ter-hover};
     --bit-tgb-clr-active: #{$clr-brd-ter-active};
-    --bit-tgb-clr-dark: #{$clr-brd-ter};
-    --bit-tgb-clr-dark-hover: #{$clr-brd-ter-hover};
-    --bit-tgb-clr-dark-active: #{$clr-brd-ter-active};
+    --bit-tgb-clr-dark: #{$clr-brd-ter-dark};
+    --bit-tgb-clr-dark-hover: #{$clr-brd-ter-dark-hover};
+    --bit-tgb-clr-dark-active: #{$clr-brd-ter-dark-active};
 }
 
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ToggleButton/BitToggleButtonDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ToggleButton/BitToggleButtonDemo.razor
@@ -167,7 +167,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="Color" RazorCode="@example9RazorCode" Id="example7">
+    <DemoExample Title="Color" RazorCode="@example9RazorCode" Id="example9">
         <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div><br />
         <div class="example-box">
             <BitToggleButton Variant="BitVariant.Fill" Color="BitColor.Primary">Primary</BitToggleButton>


### PR DESCRIPTION
closes #11210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode appearance for toggle buttons by updating color variables to use correct dark color references.

* **Chores**
  * Updated the identifier for a demo example to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->