### PR TITLE
Add copy feature to Iconography page (#9333)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/IconographyPage.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/IconographyPage.razor
@@ -17,7 +17,10 @@
         </BitText>
     </section>
     <section class="page-section">
-        <BitText Typography="BitTypography.H4" Gutter>Available icons</BitText>
+        <BitText Typography="BitTypography.H4" Gutter>Icon list</BitText>
+        <BitText Typography="BitTypography.Caption1" Gutter Element="div">
+            <b>Note</b>: click on an icon to copy its name to clipboard.
+        </BitText>
         <BitSearchBox Immediate
                       DebounceTime="300"
                       OnClear="HandleClear"
@@ -36,7 +39,7 @@
             {
                 foreach (var icon in filteredIcons)
                 {
-                    <div class="icon-box">
+                    <div class="icon-box" @onclick="async () => await CopyToClipboard(icon)">
                         <i class="bit-icon bit-icon--iconography bit-icon--@icon"></i>
                         <span class="icon-name">@icon</span>
                     </div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/IconographyPage.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/IconographyPage.razor.cs
@@ -7,6 +7,12 @@ public partial class IconographyPage
     private List<string> allIcons = default!;
     private List<string> filteredIcons = default!;
 
+
+
+    [AutoInject] private IJSRuntime _js = default!;
+
+
+
     protected override void OnInitialized()
     {
         allIcons = typeof(BitIconName).GetFields(BindingFlags.Static | BindingFlags.Public)
@@ -15,6 +21,8 @@ public partial class IconographyPage
         HandleClear();
         base.OnInitialized();
     }
+
+
 
     private void HandleClear()
     {
@@ -27,5 +35,10 @@ public partial class IconographyPage
         if (string.IsNullOrEmpty(text)) return;
 
         filteredIcons = allIcons.FindAll(icon => string.IsNullOrEmpty(icon) is false && icon.Contains(text, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private async Task CopyToClipboard(string iconName)
+    {
+        await _js.CopyToClipboard(iconName);
     }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/IconographyPage.razor.scss
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/IconographyPage.razor.scss
@@ -23,11 +23,11 @@
 }
 
 .icon-box {
-    cursor: help;
+    cursor: copy;
     display: flex;
+    overflow: hidden;
     width: rem2(80px);
     margin: rem2(10px);
-    overflow: hidden;
     align-items: center;
     flex-flow: column nowrap;
     justify-content: flex-start;
@@ -56,7 +56,7 @@
     }
 
     .iconography-search-box {
+        margin-bottom: 1rem;
         max-width: rem2(300px);
-        margin-bottom: rem2(50px);
     }
 }


### PR DESCRIPTION
closes #9333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now click on an icon in the icon list to copy its name to the clipboard.
  * Added a caption below the icon list heading to inform users about the copy-to-clipboard functionality.

* **Style**
  * Updated the cursor to indicate the copy action when hovering over icons.
  * Adjusted spacing and overflow handling in the icon list and search box for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->