### PR TITLE
Add required open telemetry usages to bit Boilerplate (#11265)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -27,7 +27,7 @@
         <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.90" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.90" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="9.0.90" />
-        <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
+        <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3405.78" />
         <PackageVersion Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.2" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />
@@ -46,21 +46,21 @@
         <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="9.0.8" />
         <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="9.0.8" />
         <!--/+:msbuild-conditional:noEmit -->
-        <PackageVersion Condition=" '$(aspire)' == 'true' OR '$(aspire)' == '' " Include="Aspire.Hosting.AppHost" Version="9.4.0" />
-        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Aspire.Hosting.SqlServer" Version="9.4.0" />
+        <PackageVersion Condition=" '$(aspire)' == 'true' OR '$(aspire)' == '' " Include="Aspire.Hosting.AppHost" Version="9.4.1" />
+        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Aspire.Hosting.SqlServer" Version="9.4.1" />
         <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="CommunityToolkit.Aspire.Hosting.SqlServer.Extensions" Version="9.7.0" />
-        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'PostgreSQL' OR '$(database)' == '') " Include="Aspire.Hosting.PostgreSQL" Version="9.4.0" />
-        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'MySql' OR '$(database)' == '') " Include="Aspire.Hosting.MySql" Version="9.4.0" />
-        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '') " Include="Aspire.Hosting.Azure.Storage" Version="9.4.0" />
+        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'PostgreSQL' OR '$(database)' == '') " Include="Aspire.Hosting.PostgreSQL" Version="9.4.1" />
+        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(database)' == 'MySql' OR '$(database)' == '') " Include="Aspire.Hosting.MySql" Version="9.4.1" />
+        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '') " Include="Aspire.Hosting.Azure.Storage" Version="9.4.1" />
         <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(filesStorage)' == 'S3' OR '$(filesStorage)' == '') " Include="CommunityToolkit.Aspire.Hosting.Minio" Version="9.7.0" />
-        <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
-        <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.0" />
+        <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0" />
+        <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.1" />
         <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
         <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
-        <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.20" />
+        <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.21" />
         <PackageVersion Include="Hangfire.EntityFrameworkCore" Version="0.7.0" />
         <PackageVersion Condition=" '$(sentry)' == 'true' OR '$(sentry)' == '' " Include="Sentry.AspNetCore" Version="5.13.0" />
         <PackageVersion Condition=" '$(sentry)' == 'true' OR '$(sentry)' == '' " Include="Sentry.Extensions.Logging" Version="5.13.0" />
@@ -73,7 +73,7 @@
         <PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Bit.Besql" Version="9.11.3" />
         <PackageVersion Condition=" '$(signalR)' == 'true' OR '$(signalR)' == ''" Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
         <PackageVersion Condition=" '$(signalR)' == 'true' OR '$(signalR)' == ''" Include="Microsoft.Azure.SignalR" Version="1.31.0" />
-        <PackageVersion Condition=" ('$(signalR)' == 'true' OR '$(signalR)' == '') OR ('$(database)' == 'PostgreSQL' OR '$(database)' == '') OR ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Microsoft.Extensions.AI" Version="9.7.1" />
+        <PackageVersion Condition=" ('$(signalR)' == 'true' OR '$(signalR)' == '') OR ('$(database)' == 'PostgreSQL' OR '$(database)' == '') OR ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Microsoft.Extensions.AI" Version="9.8.0" />
         <PackageVersion Condition=" ('$(signalR)' == 'true' OR '$(signalR)' == '') OR ('$(database)' == 'PostgreSQL' OR '$(database)' == '') OR ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Microsoft.Extensions.AI.OpenAI" Version="9.7.1-preview.1.25365.4" />
         <PackageVersion Condition=" ('$(signalR)' == 'true' OR '$(signalR)' == '') OR ('$(database)' == 'PostgreSQL' OR '$(database)' == '') OR ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.7.1-preview.1.25365.4" />
         <PackageVersion Condition=" ('$(database)' == 'PostgreSQL' OR '$(database)' == '') " Include="Pgvector.EntityFrameworkCore" Version="0.2.2" />
@@ -103,7 +103,7 @@
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-        <PackageVersion Include="Microsoft.Identity.Web" Version="3.12.0" />
+        <PackageVersion Include="Microsoft.Identity.Web" Version="3.13.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.8" />
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="9.0.8" />
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.8" />
@@ -122,7 +122,7 @@
         <PackageVersion Include="FakeItEasy" Version="8.3.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.54.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="3.10.0" />
-        <PackageVersion Include="MSTest.TestFramework" Version="3.10.0" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="3.10.2" />
+        <PackageVersion Include="MSTest.TestFramework" Version="3.10.2" />
     </ItemGroup>
 </Project>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/AttachmentController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/AttachmentController.cs
@@ -36,7 +36,7 @@ public partial class AttachmentController : AppControllerBase, IAttachmentContro
     [AutoInject] private IConfiguration configuration = default!;
 
     // For open telemetry metrics
-    private static readonly Histogram<double> updateResizeDurationHistogram = AppActivitySource.CurrentMeter.CreateHistogram<double>("attachment.upload_resize_duration");
+    private static readonly Histogram<double> updateResizeDurationHistogram = AppActivitySource.CurrentMeter.CreateHistogram<double>("attachment.resize_duration");
 
     [HttpPost]
     [RequestSizeLimit(11 * 1024 * 1024 /*11MB*/)]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/AttachmentController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/AttachmentController.cs
@@ -36,7 +36,7 @@ public partial class AttachmentController : AppControllerBase, IAttachmentContro
     [AutoInject] private IConfiguration configuration = default!;
 
     // For open telemetry metrics
-    private static readonly Histogram<double> updateResizeDurationHistogram = AppActivitySource.CurrentMeter.CreateHistogram<double>("attachment.resize_duration");
+    private static readonly Histogram<double> updateResizeDurationHistogram = AppActivitySource.CurrentMeter.CreateHistogram<double>("attachment.resize_duration", "ms", "Elapsed time to resize and persist an uploaded image");
 
     [HttpPost]
     [RequestSizeLimit(11 * 1024 * 1024 /*11MB*/)]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Chatbot.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Chatbot.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.ComponentModel;
 using System.Threading.Channels;
+using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.SignalR;
 using System.Runtime.CompilerServices;
 using Boilerplate.Shared.Dtos.Chatbot;
@@ -12,6 +13,9 @@ namespace Boilerplate.Server.Api.SignalR;
 public partial class AppHub
 {
     [AutoInject] private IConfiguration configuration = default!;
+
+    // For open telemetry metrics.
+    private static readonly UpDownCounter<long> ongoingConversationsCount = AppActivitySource.CurrentMeter.CreateUpDownCounter<long>("appHub.ongoing_conversations_count", "Number of ongoing conversations in the chatbot hub.");
 
     public async IAsyncEnumerable<string> Chatbot(
         StartChatbotRequest request,
@@ -164,8 +168,6 @@ public partial class AppHub
         }
 
         _ = ReadIncomingMessages();
-
-        var ongoingConversationsCount = AppActivitySource.CurrentMeter.CreateUpDownCounter<long>("appHub.ongoing_conversations_count", "Number of ongoing conversations in the chatbot hub.");
 
         try
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Chatbot.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Chatbot.cs
@@ -71,6 +71,7 @@ public partial class AppHub
             finally
             {
                 messageSpecificCancellationTokenSrc?.Dispose();
+                channel.Writer.Complete();
             }
 
             async Task HandleIncomingMessage(string incomingMessage, CancellationToken messageSpecificCancellationToken)
@@ -85,11 +86,16 @@ public partial class AppHub
                         Tools = [
                                 AIFunctionFactory.Create(async (string emailAddress, string conversationHistory) =>
                                 {
+                                    if (messageSpecificCancellationToken.IsCancellationRequested)
+                                        return;
+
                                     await using var scope = serviceProvider.CreateAsyncScope();
+
                                     // Ideally, store these in a CRM or app database,
                                     // but for now, we'll log them!
                                     scope.ServiceProvider.GetRequiredService<ILogger<IChatClient>>()
                                         .LogError("Chat reported issue: User email: {emailAddress}, Conversation history: {conversationHistory}", emailAddress, conversationHistory);
+
                                 }, name: "SaveUserEmailAndConversationHistory", description: "Saves the user's email address and the conversation history for future reference. Use this tool when the user provides their email address during the conversation. Parameters: emailAddress (string), conversationHistory (string)"),
                                 //#if (module == "Sales")
                                 AIFunctionFactory.Create(async ([Description("Concise summary of these user requirements")] string userNeeds,
@@ -159,9 +165,20 @@ public partial class AppHub
 
         _ = ReadIncomingMessages();
 
-        await foreach (var str in channel.Reader.ReadAllAsync(cancellationToken).WithCancellation(cancellationToken))
+        var ongoingConversationsCount = AppActivitySource.CurrentMeter.CreateUpDownCounter<long>("appHub.ongoing_conversations_count", "Number of ongoing conversations in the chatbot hub.");
+
+        try
         {
-            yield return str;
+            ongoingConversationsCount.Add(1);
+
+            await foreach (var str in channel.Reader.ReadAllAsync(cancellationToken).WithCancellation(cancellationToken))
+            {
+                yield return str;
+            }
+        }
+        finally
+        {
+            ongoingConversationsCount.Add(-1);
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/.config/dotnet-tools.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
     "tools": {
         "aspire.cli": {
-            "version": "9.4.0",
+            "version": "9.4.1",
             "commands": [
                 "aspire"
             ]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Extensions/IDistributedApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Extensions/IDistributedApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ public static class IDistributedApplicationBuilderExtensions
         if (builder.ExecutionContext.IsPublishMode)
         {
             // The name aspire-dashboard is special cased and excluded from the default
-            var dashboard = builder.AddContainer("dashboard", "mcr.microsoft.com/dotnet/aspire-dashboard:9.3")
+            var dashboard = builder.AddContainer("dashboard", "mcr.microsoft.com/dotnet/aspire-dashboard:9.4")
                    .WithHttpEndpoint(targetPort: 18888)
                    .WithHttpEndpoint(name: "otlp", targetPort: 18889);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Extensions/WebApplicationBuilderExtensions.cs
@@ -124,6 +124,8 @@ public static class WebApplicationBuilderExtensions
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation();
+
+                metrics.AddMeter(AppActivitySource.CurrentMeter.Name);
             })
             .WithTracing(tracing =>
             {
@@ -144,6 +146,8 @@ public static class WebApplicationBuilderExtensions
                     .AddHttpClientInstrumentation()
                     .AddEntityFrameworkCoreInstrumentation(options => options.Filter = (providerName, command) => command?.CommandText?.Contains("Hangfire") is false /* Ignore Hangfire */)
                     .AddHangfireInstrumentation();
+
+                tracing.AddSource(AppActivitySource.CurrentActivity.Name);
             })
             .ConfigureResource(resource =>
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppActivitySource.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppActivitySource.cs
@@ -7,7 +7,7 @@ namespace Boilerplate.Shared.Services;
 /// </summary>
 public class AppActivitySource
 {
-    public static ActivitySource CurrentActivity = new("Boilerplate", typeof(AppActivitySource).Assembly.GetName().Version!.ToString());
+    public static readonly ActivitySource CurrentActivity = new("Boilerplate", typeof(AppActivitySource).Assembly.GetName().Version!.ToString());
 
-    public static Meter CurrentMeter = new("Boilerplate", typeof(AppActivitySource).Assembly.GetName().Version!.ToString());
+    public static readonly Meter CurrentMeter = new("Boilerplate", typeof(AppActivitySource).Assembly.GetName().Version!.ToString());
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppActivitySource.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppActivitySource.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.Metrics;
+
+namespace Boilerplate.Shared.Services;
+
+/// <summary>
+/// Open telemetry activity source for the application.
+/// </summary>
+public class AppActivitySource
+{
+    public static ActivitySource CurrentActivity = new("Boilerplate", typeof(AppActivitySource).Assembly.GetName().Version!.ToString());
+
+    public static Meter CurrentMeter = new("Boilerplate", typeof(AppActivitySource).Assembly.GetName().Version!.ToString());
+}


### PR DESCRIPTION
closes #11265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added built-in telemetry: application activity/meter sources and OpenTelemetry wiring.
  * Introduced metrics for image resize duration and ongoing chatbot conversations.

* Bug Fixes
  * Improved streaming cleanup by completing chat channels after use.
  * Respects per-message cancellation in chatbot actions to prevent unnecessary work.

* Chores
  * Updated multiple dependencies and tools (Aspire, Microsoft.Extensions.*, Hangfire, MSTest, Microsoft.Identity.Web, WebView2).
  * Updated Aspire Dashboard container image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->