### PR TITLE
Add missing keywords meta tag to BlazorUI demo (#11267)

### DIFF
--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
@@ -15,6 +15,7 @@
     <meta name="theme-color">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="bit BlazorUI components are native, easy-to-customize, and work seamlessly in all interactive Blazor modes (WASM, Server, Hybrid, pre-rendering), saving you time and making development enjoyable." />
+    <meta name="keywords" content="Blazor UI, Blazor components, Blazor WebAssembly UI, Blazor Server UI, Blazor Hybrid UI, .NET UI components, C# UI library, open source Blazor controls, Blazor toolkit, high performance Blazor, responsive Blazor components, Blazor PWA UI, BlazorUI documentation, Blazor WASM UI, Blazor SSR components, Blazor native UI, Bit BlazorUI" />
 
     <script>
         // disable auto-zoom of iOS Safari when focusing an input

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/PageOutlet.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/PageOutlet.razor
@@ -5,6 +5,7 @@
 <HeadContent>
     <meta name="title" content="@Title - bit BlazorUI" />
     <meta name="description" content="@Description" />
+    <meta name="keywords" content="@Keywords" />
 
     <meta property="og:url" content="https://blazorui.bitplatform.dev/@Url" />
     <meta property="og:type" content="website" />
@@ -32,7 +33,8 @@
         }
     }
 
-    [Parameter] public string? Description { get; set; }
     [Parameter] public string? Url { get; set; }
+    [Parameter] public string? Keywords { get; set; }
+    [Parameter] public string? Description { get; set; }
     [Parameter] public string ImageUrl { get; set; } = "https://blazorui.bitplatform.dev/images/og-image.svg";
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/HomePage.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/HomePage.razor
@@ -3,7 +3,8 @@
 
 <PageOutlet Url=""
             Title="Home"
-            Description="home page of the bit blazorui components" />
+            Description="home page of the bit blazorui components"
+            Keywords="Blazor UI, Blazor components, Blazor WebAssembly UI, Blazor Server UI, Blazor Hybrid UI, .NET UI components, C# UI library, open source Blazor controls, Blazor toolkit, high performance Blazor, responsive Blazor components, Blazor PWA UI, BlazorUI documentation, Blazor WASM UI, Blazor SSR components, Blazor native UI, Bit BlazorUI" />
 
 <div class="homepage-container">
     <section class="homepage-section hero-section">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/HomePage.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/HomePage.razor
@@ -3,8 +3,7 @@
 
 <PageOutlet Url=""
             Title="Home"
-            Description="home page of the bit blazorui components"
-            Keywords="Blazor UI, Blazor components, Blazor WebAssembly UI, Blazor Server UI, Blazor Hybrid UI, .NET UI components, C# UI library, open source Blazor controls, Blazor toolkit, high performance Blazor, responsive Blazor components, Blazor PWA UI, BlazorUI documentation, Blazor WASM UI, Blazor SSR components, Blazor native UI, Bit BlazorUI" />
+            Description="home page of the bit blazorui components" />
 
 <div class="homepage-container">
     <section class="homepage-section hero-section">


### PR DESCRIPTION
closes #11267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Keywords parameter to the PageOutlet component, enabling rendering of a keywords meta tag in the page head.
  * Page markup now includes a keywords meta tag when the parameter is provided.
  * Updated the Home page to supply a comprehensive keywords list via the new parameter, without altering existing title or description behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->