### PR TITLE
Add missing canonical link tag to BlazorUI demo pages (#11274)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/PageOutlet.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/PageOutlet.razor
@@ -17,6 +17,8 @@
     <meta name="twitter:title" content="@Title - bit BlazorUI" />
     <meta name="twitter:description" content="@Description" />
     <meta name="twitter:image" content="@ImageUrl" />
+
+    <link rel="canonical" href="https://blazorui.bitplatform.dev/@Url">
 </HeadContent>
 
 @code {


### PR DESCRIPTION
closes #11274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added canonical link tags to page headers to define the preferred URL for each page.
  - Canonical URLs are generated from the current page address and injected automatically.
  - Improves SEO by consolidating ranking signals, reducing duplicate-content indexing, and ensuring consistent link sharing previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->