### PR TITLE
Add missing keywords meta tag to platform website (#11277)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/PageOutlet.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/PageOutlet.razor
@@ -3,6 +3,7 @@
 <HeadContent>
     <meta name="title" content="@Title - bit platform" />
     <meta name="description" content="@Description" />
+    <meta name="keywords" content=".NET development, Blazor tools, Blazor utilities, PWA tools, cross-platform .NET, .NET boilerplate, bit Boilerplate, bit Butil, bit Bswup, bit Besql, bit BlazorUI, .NET project template, low-code .NET, .NET DevTools, multi-platform apps, .NET developers, Blazor PWA, Entity Framework in browser, @Keywords" />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="bit platform" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/PageOutlet.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/PageOutlet.razor.cs
@@ -4,6 +4,7 @@ public partial class PageOutlet
 {
     [Parameter] public string? Title { get; set; }
     [Parameter] public string? Description { get; set; }
+    [Parameter] public string? Keywords { get; set; }
     [Parameter] public string? Url { get; set; }
     [Parameter] public string ImageUrl { get; set; } = "https://bitplatform.dev/images/og-image.webp";
 


### PR DESCRIPTION
closes #11277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable “keywords” meta tag to page head content.
  * Supports combining default keywords with page-specific values.
  * Allows setting keywords per page via a new parameter.
  * Existing head metadata (title, description, Open Graph, Twitter) remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->