### PR TITLE
Add missing loading UI for products and categories in Boilerplate (#10736)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/SignOutConfirmDialog.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/SignOutConfirmDialog.razor
@@ -16,4 +16,4 @@
            OkText="@Localizer[nameof(AppStrings.SignOut)]"
            CancelText="@Localizer[nameof(AppStrings.Cancel)]"
            Message="@Localizer[nameof(AppStrings.SignOutPrompt)]"
-           Styles="@(new() { OkButton = "width:100%", CancelButton = "width:100%" })"/>
+           Styles="@(new() { OkButton = "width:100%", CancelButton = "width:100%" })" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor
@@ -9,10 +9,17 @@
 
 <section>
     <BitStack>
-        <BitButton IconName="@BitIconName.Add" ReversedIcon
-                   OnClick="CreateCategory">
-            @Localizer[nameof(AppStrings.AddCategory)]
-        </BitButton>
+        <BitStack Horizontal FitHeight>
+            <BitButton ReversedIcon
+                       OnClick="CreateCategory"
+                       IconName="@BitIconName.Add">
+                @Localizer[nameof(AppStrings.AddCategory)]
+            </BitButton>
+            @if (isLoading)
+            {
+                <BitSlickBarsLoading CustomSize="32" />
+            }
+        </BitStack>
         <BitStack Gap="0" FillContent>
             <div class="grid-container">
                 <BitDataGrid @ref="dataGrid"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor.cs
@@ -39,6 +39,7 @@ public partial class CategoriesPage
         categoriesProvider = async req =>
         {
             isLoading = true;
+            StateHasChanged();
 
             try
             {
@@ -66,7 +67,6 @@ public partial class CategoriesPage
             finally
             {
                 isLoading = false;
-
                 StateHasChanged();
             }
         };

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor.cs
@@ -6,16 +6,19 @@ namespace Boilerplate.Client.Core.Components.Pages.Categories;
 
 public partial class CategoriesPage
 {
-    [AutoInject] ICategoryController categoryController = default!;
-
     private bool isLoading;
     private bool isDeleteDialogOpen;
     private CategoryDto? deletingCategory;
     private AddOrEditCategoryModal? modal;
-    private BitDataGrid<CategoryDto>? dataGrid;
     private string categoryNameFilter = string.Empty;
+
+    private BitDataGrid<CategoryDto>? dataGrid;
     private BitDataGridItemsProvider<CategoryDto> categoriesProvider = default!;
     private BitDataGridPaginationState pagination = new() { ItemsPerPage = 10 };
+
+
+    [AutoInject] ICategoryController categoryController = default!;
+
 
     private string CategoryNameFilter
     {
@@ -27,12 +30,14 @@ public partial class CategoriesPage
         }
     }
 
+
     protected override async Task OnInitAsync()
     {
         await base.OnInitAsync();
 
         PrepareGridDataProvider();
     }
+
 
     private void PrepareGridDataProvider()
     {
@@ -43,7 +48,7 @@ public partial class CategoriesPage
 
             try
             {
-                var odataQ = new ODataQuery
+                var query = new ODataQuery
                 {
                     Top = req.Count ?? 10,
                     Skip = req.StartIndex,
@@ -52,11 +57,12 @@ public partial class CategoriesPage
 
                 if (string.IsNullOrEmpty(CategoryNameFilter) is false)
                 {
-                    odataQ.Filter = $"contains(tolower({nameof(CategoryDto.Name)}),'{CategoryNameFilter.ToLower()}')";
+                    query.Filter = $"contains(tolower({nameof(CategoryDto.Name)}),'{CategoryNameFilter.ToLower()}')";
                 }
-
-                var data = await categoryController.WithQuery(odataQ.ToString()).GetCategories(req.CancellationToken);
-
+                
+                var data = await categoryController.WithQuery(query.ToString())
+                                                   .GetCategories(req.CancellationToken);
+                
                 return BitDataGridItemsProviderResult.From(data!.Items!, (int)data!.TotalCount);
             }
             catch (Exception exp)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Categories/CategoriesPage.razor.scss
@@ -7,7 +7,7 @@ section {
 
 .grid-container {
     overflow: auto;
-    height: calc(#{$bit-env-height-available} - 14rem);
+    height: calc(#{$bit-env-height-available} - 12.1rem);
 
     @include lt-md {
         height: calc(#{$bit-env-height-available} - 17rem);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor
@@ -11,11 +11,20 @@
 
 <section>
     <BitStack>
-        <BitStack VerticalAlign="BitAlignment.Center" AutoHeight Horizontal="isSmallScreen is false">
-            <BitButton IconName="@BitIconName.Add" ReversedIcon
-                       OnClick="WrapHandled(CreateProduct)">
-                @Localizer[nameof(AppStrings.AddProduct)]
-            </BitButton>
+        <BitStack FitHeight 
+                  Gap="0.5rem"
+                  Horizontal="isSmallScreen is false">
+            <BitStack Horizontal FitHeight>
+                <BitButton ReversedIcon
+                           IconName="@BitIconName.Add" 
+                           OnClick="WrapHandled(CreateProduct)">
+                    @Localizer[nameof(AppStrings.AddProduct)]
+                </BitButton>
+                @if (isLoading)
+                {
+                    <BitSlickBarsLoading CustomSize="32" />
+                }
+            </BitStack>
             <BitSpacer />
             <BitSearchBox Underlined
                           ShowSearchButton
@@ -83,7 +92,7 @@
                         <BitButton Variant="BitVariant.Text"
                                    IconName="@BitIconName.Edit"
                                    Title="@Localizer[(nameof(AppStrings.Edit))]"
-                                   Href="@($"{PageUrls.AddOrEditProduct}/{product.Id}")"/>
+                                   Href="@($"{PageUrls.AddOrEditProduct}/{product.Id}")" />
                         <BitButton Color="BitColor.Error"
                                    Variant="BitVariant.Text"
                                    IconName="@BitIconName.Delete"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor.cs
@@ -55,6 +55,7 @@ public partial class ProductsPage
         productsProvider = async req =>
         {
             isLoading = true;
+            StateHasChanged();
 
             try
             {
@@ -90,7 +91,6 @@ public partial class ProductsPage
             finally
             {
                 isLoading = false;
-
                 StateHasChanged();
             }
         };

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor.cs
@@ -50,6 +50,7 @@ public partial class ProductsPage
         PrepareGridDataProvider();
     }
 
+
     private void PrepareGridDataProvider()
     {
         productsProvider = async req =>
@@ -59,7 +60,7 @@ public partial class ProductsPage
 
             try
             {
-                var odataQ = new ODataQuery
+                var query = new ODataQuery
                 {
                     Top = req.Count ?? 10,
                     Skip = req.StartIndex,
@@ -68,18 +69,18 @@ public partial class ProductsPage
 
                 if (string.IsNullOrEmpty(ProductNameFilter) is false)
                 {
-                    odataQ.Filter = $"contains(tolower({nameof(ProductDto.Name)}),'{ProductNameFilter.ToLower()}')";
+                    query.Filter = $"contains(tolower({nameof(ProductDto.Name)}),'{ProductNameFilter.ToLower()}')";
                 }
 
                 if (string.IsNullOrEmpty(CategoryNameFilter) is false)
                 {
-                    odataQ.AndFilter = $"contains(tolower({nameof(ProductDto.CategoryName)}),'{CategoryNameFilter.ToLower()}')";
+                    query.AndFilter = $"contains(tolower({nameof(ProductDto.CategoryName)}),'{CategoryNameFilter.ToLower()}')";
                 }
 
-                var queriedRequest = productController.WithQuery(odataQ.ToString());
+                var queriedRequest = productController.WithQuery(query.ToString());
                 var data = await (string.IsNullOrWhiteSpace(searchQuery)
-                                    ? queriedRequest.GetProducts(req.CancellationToken)
-                                    : queriedRequest.GetProductsBySearchQuery(searchQuery, req.CancellationToken));
+                            ? queriedRequest.GetProducts(req.CancellationToken)
+                            : queriedRequest.GetProductsBySearchQuery(searchQuery, req.CancellationToken));
 
                 return BitDataGridItemsProviderResult.From(data!.Items!, (int)data!.TotalCount);
             }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/ProductsPage.razor.scss
@@ -7,7 +7,7 @@ section {
 
 .grid-container {
     overflow: auto;
-    height: calc(#{$bit-env-height-available} - 14rem);
+    height: calc(#{$bit-env-height-available} - 12.1rem);
 
     @include lt-md {
         height: calc(#{$bit-env-height-available} - 17rem);


### PR DESCRIPTION
closes #10736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added loading indicators beside Add Category/Add Product buttons and in the category name filter.
  - Loading state now appears immediately on Categories and Products pages for clearer feedback during data fetches.
- Refactor
  - Reworked header/layout stacks on Products and Categories pages for improved alignment and responsiveness; no functional changes.
- Style
  - Minor markup formatting adjustments, including in the sign-out confirmation dialog; no behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->