### PR TITLE
Add new enableCacheControl config to Bswup (#11328)

### DIFF
--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
@@ -26,6 +26,7 @@ interface Window {
     enableFetchDiagnostics: any
     disableHashlessAssetsUpdate: any
     forcePrerender: any
+    enableCacheControl: any
 
     prerenderMode: any
 }
@@ -397,9 +398,14 @@ function createNewAssetRequest(asset: any) {
 
     const assetUrl = url.toString();
 
-    const requestInit: RequestInit = asset.hash && asset.hash.startsWith('sha') && self.enableIntegrityCheck
-        ? { cache: 'no-store', integrity: asset.hash, headers: [['cache-control', 'public, max-age=3153600']] }
-        : { cache: 'no-store', headers: [['cache-control', 'public, max-age=3153600']] };
+    const requestInit: RequestInit = {};
+    if (asset.hash?.startsWith('sha') && self.enableIntegrityCheck) {
+        requestInit.integrity = asset.hash;
+    }
+    if (self.enableCacheControl) {
+        requestInit.cache = 'no-store';
+        requestInit.headers = [['cache-control', 'public, max-age=3153600']];
+    }
 
     return new Request(assetUrl, requestInit);
 }

--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
@@ -49,7 +49,7 @@ const CACHE_NAME_PREFIX = 'bit-bswup';
 const CACHE_NAME = `${CACHE_NAME_PREFIX} - ${VERSION}`;
 
 switch (self.prerenderMode) {
-    case 'none': // like admin
+    case 'none': // like adminpanel
         self.defaultUrl ||= "/";
         self.isPassive ||= true;
         self.forcePrerender ||= false;
@@ -83,7 +83,7 @@ self.addEventListener('activate', e => e.waitUntil(handleActivate(e)));
 self.addEventListener('fetch', e => e.respondWith(handleFetch(e)));
 self.addEventListener('message', handleMessage);
 
-async function handleInstall(e) {
+async function handleInstall(e: any) {
     diag('installing version:', VERSION);
 
     sendMessage({ type: 'install', data: { version: VERSION, isPassive: self.isPassive } });
@@ -91,7 +91,7 @@ async function handleInstall(e) {
     createAssetsCache();
 }
 
-async function handleActivate(e) {
+async function handleActivate(e: any) {
     diag('activate version:', VERSION);
 
     //await deleteOldCaches();
@@ -143,7 +143,7 @@ diag('UNIQUE_ASSETS:', UNIQUE_ASSETS);
 
 diagGroupEnd();
 
-async function handleFetch(e) {
+async function handleFetch(e: any) {
     const req = e.request as Request;
 
     if (PROHIBITED_URLS.some(pattern => pattern.test(req.url))) {
@@ -212,7 +212,7 @@ async function handleFetch(e) {
     return response;
 }
 
-function handleMessage(e) {
+function handleMessage(e: MessageEvent<any>) {
     diag('handleMessage:', e);
 
     if (e.data === 'SKIP_WAITING') {
@@ -336,7 +336,7 @@ async function createAssetsCache(ignoreProgressReport = false) {
     diag('createAssetsCache ended.');
     diagGroupEnd();
 
-    async function addCache(report, asset) {
+    async function addCache(report: boolean, asset: any) {
         try {
             const request = createNewAssetRequest(asset);
             const responsePromise = fetch(request);
@@ -385,11 +385,6 @@ function createNewAssetRequest(asset: any) {
     const version = ((asset.hash || self.assetsManifest.version) as string).replaceAll('+', '-').replaceAll('/', '_');
     const trimmedVersion = encodeURIComponent(trimEnd(version, '='));
 
-    //let assetUrl = `${asset.url}?v=${trimmedVersion}`;
-    //if (asset.url === DEFAULT_URL && self.noPrerenderQuery) {
-    //    assetUrl += `&${self.noPrerenderQuery}`;
-    //}
-
     const url = new URL(asset.url, self.location.origin);
     url.searchParams.set('v', trimmedVersion);
     if (asset.url === DEFAULT_URL && self.noPrerenderQuery) {
@@ -404,7 +399,7 @@ function createNewAssetRequest(asset: any) {
     }
     if (self.enableCacheControl) {
         requestInit.cache = 'no-store';
-        requestInit.headers = [['cache-control', 'public, max-age=3153600']];
+        requestInit.headers = [['cache-control', 'no-cache']];
     }
 
     return new Request(assetUrl, requestInit);
@@ -416,7 +411,7 @@ async function deleteOldCaches() {
     return Promise.all(promises);
 }
 
-function uniqueAssets(assets) {
+function uniqueAssets(assets: any) {
     const unique = {};
     const distinct = [];
     for (let i = 0; i < assets.length; i++) {
@@ -430,13 +425,13 @@ function uniqueAssets(assets) {
     return distinct;
 }
 
-function sendMessage(message) {
+function sendMessage(message: any) {
     self.clients
         .matchAll({ includeUncontrolled: true })
-        .then(clients => (clients || []).forEach(client => client.postMessage(typeof message === 'string' ? message : JSON.stringify(message))));
+        .then((clients: any) => (clients || []).forEach((client: any) => client.postMessage(typeof message === 'string' ? message : JSON.stringify(message))));
 }
 
-function prepareExternalAssetsArray(value) {
+function prepareExternalAssetsArray(value: any) {
     const array = value ? (value instanceof Array ? value : [value]) : [];
 
     return array.map(asset => {
@@ -452,7 +447,7 @@ function prepareExternalAssetsArray(value) {
     }).filter(asset => asset !== null);
 }
 
-function prepareRegExpArray(value) {
+function prepareRegExpArray(value: any) {
     return value ? (value instanceof Array ? value : [value]).filter(p => p instanceof RegExp) : [];
 }
 

--- a/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
+++ b/src/Bswup/Bit.Bswup/Scripts/bit-bswup.sw.ts
@@ -131,8 +131,8 @@ diag('ASSETS_INCLUDE:', ASSETS_INCLUDE);
 diag('ASSETS_EXCLUDE:', ASSETS_EXCLUDE);
 
 const ALL_ASSETS = self.assetsManifest.assets
-    .filter(asset => ASSETS_INCLUDE.some(pattern => pattern.test(asset.url)))
-    .filter(asset => !ASSETS_EXCLUDE.some(pattern => pattern.test(asset.url)))
+    .filter((asset: any) => ASSETS_INCLUDE.some(pattern => pattern.test(asset.url)))
+    .filter((asset: any) => !ASSETS_EXCLUDE.some(pattern => pattern.test(asset.url)))
     .concat(EXTERNAL_ASSETS);
 
 diag('ALL_ASSETS:', ALL_ASSETS);
@@ -212,7 +212,7 @@ async function handleFetch(e: any) {
     return response;
 }
 
-function handleMessage(e: MessageEvent<any>) {
+function handleMessage(e: MessageEvent<string>) {
     diag('handleMessage:', e);
 
     if (e.data === 'SKIP_WAITING') {


### PR DESCRIPTION
closes #11328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a setting to enable cache-control for asset requests; when enabled, assets can be cached, otherwise they bypass cache.
  - Optional integrity verification for assets when supported and enabled, enhancing security without affecting others.
  - Smarter asset fetching applies headers only when relevant, reducing unnecessary request overhead.
  - Provides more predictable network behavior with configurable performance/security trade-offs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->