### PR TITLE
Add missing important preload links to BlazorUI demo (#11330)

### DIFF
--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
@@ -15,27 +15,31 @@
     <meta name="theme-color">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
-    <script>
+    <Script>
         // disable auto-zoom of iOS Safari when focusing an input
         (/iPad|iPhone|iPod/.test(navigator.userAgent)) &&
         (document.querySelector('meta[name="viewport"]').content = 'width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0')
-    </script>
+    </Script>
 
-    <Link rel="icon" href="favicon.ico" type="image/x-icon" />
     <HeadOutlet @rendermode=renderMode />
-    <Link rel="apple-touch-icon" sizes="512x512" href="images/icons/bit-icon-512.png" />
-    <Link rel="manifest" href="manifest.json" />
+
+    <Link rel="manifest" Href="manifest.json" />
+    <Link rel="icon" Href="favicon.ico" type="image/x-icon" />
+    <Link rel="apple-touch-icon" sizes="512x512" Href="images/icons/bit-icon-512.png" />
+
+    <Link rel="preload" Href="_framework/dotnet.js" as="script" type="text/javascript" />
+    <Link rel="preload" Href="_framework/blazor.boot.json" as="fetch" type="application/json" />
 </head>
 
 <body class="@BitCss.Class.Color.Background.Primary @BitCss.Class.Color.Foreground.Primary bit-blazor-web">
 
-    <Link rel="stylesheet" href="_content/Bit.BlazorUI/styles/bit.blazorui.css" />
-    <Link rel="stylesheet" href="_content/Bit.BlazorUI.Extras/styles/bit.blazorui.extras.css" />
-    <Link rel="stylesheet" href="_content/Bit.BlazorUI.Icons/styles/bit.blazorui.icons.css" />
-    <Link rel="stylesheet" href="_content/Bit.BlazorUI.Assets/styles/bit.blazorui.assets.css" />
-    <Link rel="stylesheet" href="_content/Bit.BlazorUI.Demo.Client.Core/styles/app.css" />
-    <Link rel="stylesheet" href="Bit.BlazorUI.Demo.Server.styles.css" />
-    <Link rel="stylesheet" href="_content/Bit.BlazorUI.Demo.Client.Core/prism-1.28.0/prism-okaidia-bit.css" />
+    <Link rel="stylesheet" Href="_content/Bit.BlazorUI/styles/bit.blazorui.css" />
+    <Link rel="stylesheet" Href="_content/Bit.BlazorUI.Extras/styles/bit.blazorui.extras.css" />
+    <Link rel="stylesheet" Href="_content/Bit.BlazorUI.Icons/styles/bit.blazorui.icons.css" />
+    <Link rel="stylesheet" Href="_content/Bit.BlazorUI.Assets/styles/bit.blazorui.assets.css" />
+    <Link rel="stylesheet" Href="_content/Bit.BlazorUI.Demo.Client.Core/styles/app.css" />
+    <Link rel="stylesheet" Href="Bit.BlazorUI.Demo.Server.styles.css" />
+    <Link rel="stylesheet" Href="_content/Bit.BlazorUI.Demo.Client.Core/prism-1.28.0/prism-okaidia-bit.css" />
 
     @if (AppRenderMode.PrerenderEnabled is false || noPrerender)
     {


### PR DESCRIPTION
closes #11330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added web app manifest, favicon, and Apple touch icon for improved installability and branding.
  - Introduced preloading of core framework resources to speed up initial load times.

- Refactor
  - Consolidated and standardized head asset declarations for consistency across resources.

- Chores
  - Aligned asset paths and attributes for CSS and icon resources without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->