### PR TITLE
Use cloudflare headers if cloudflare is enabled in bit Boilerplate (#11357)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/SystemPromptsPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/SystemPromptsPage.razor.cs
@@ -18,7 +18,9 @@ public partial class SystemPromptsPage
 
         try
         {
-            systemPrompts = await chatbotController.GetSystemPrompts(CurrentCancellationToken);
+            systemPrompts = await chatbotController
+                .WithQuery($"$orderby={nameof(SystemPromptDto.PromptKind)}")
+                .GetSystemPrompts(CurrentCancellationToken);
         }
         finally
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
@@ -194,9 +194,11 @@ public partial class IdentityController : AppControllerBase, IIdentityController
             UserId = userId,
             StartedOn = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             IP = HttpContext.Connection.RemoteIpAddress?.ToString(),
+            //#if (cloudflare == true)
             // Relying on Cloudflare cdn to retrieve address.
             // https://developers.cloudflare.com/rules/transform/managed-transforms/reference/#add-visitor-location-headers
             Address = $"{Request.Headers["cf-ipcountry"]}, {Request.Headers["cf-ipcity"]}"
+            //#endif
         };
 
         await UpdateUserSessionPrivilegeStatus(userSession, cancellationToken);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Chatbot.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Chatbot.cs
@@ -27,12 +27,15 @@ public partial class AppHub
         // While processing a user message, a new message may arrive.
         // To handle this, we cancel the ongoing message processing using `messageSpecificCancellationTokenSrc` and start processing the new message.
 
-        CultureInfo? culture;
+        CultureInfo? culture = null;
         string? supportSystemPrompt;
 
         try
         {
-            culture = CultureInfo.GetCultureInfo(request.CultureId);
+            if (CultureInfoManager.InvariantGlobalization is false)
+            {
+                culture = CultureInfo.GetCultureInfo(request.CultureId);
+            }
 
             await using var scope = serviceProvider.CreateAsyncScope();
 
@@ -42,7 +45,7 @@ public partial class AppHub
                     .SystemPrompts.FirstOrDefaultAsync(p => p.PromptKind == PromptKind.Support, cancellationToken))?.Markdown ?? throw new ResourceNotFoundException();
 
             supportSystemPrompt = supportSystemPrompt
-                .Replace("{{UserCulture}}", culture.NativeName)
+                .Replace("{{UserCulture}}", culture?.NativeName ?? "")
                 .Replace("{{DeviceInfo}}", request.DeviceInfo);
         }
         catch (Exception exp)


### PR DESCRIPTION
closes #11357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * System Prompts list is now sorted by prompt type for easier scanning and consistent ordering across sessions.
  * Optional Address enrichment from Cloudflare headers when the Cloudflare option is enabled; disabled by default to preserve current behavior.

* Bug Fixes
  * Chatbot now safely handles invariant globalization: user culture is optional and placeholders render empty when unavailable, preventing errors and avoiding crashes.

* Chores
  * No changes to public APIs or signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->