### PR TITLE
Use non sticky followup suggestions list in ai chat panel (#11417)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor
@@ -63,7 +63,7 @@
                             }
                         }
 
-						<BitStack Alignment=" BitAlignment.Center" FitHeight FillContent Class="default-prompt-container">
+						<BitStack Alignment="BitAlignment.Center" FitHeight FillContent Class="default-prompt-container">
 
 							@foreach (var suggestion in followUpSuggestions)
 							{


### PR DESCRIPTION
closes #11417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Chat Panel now shows follow-up suggestions as a row of centered, clickable buttons for quicker prompt entry.
  * Selecting a suggestion immediately sends it as a prompt.
  * The suggestions area is consistently displayed to maintain layout stability, even when no suggestions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->