### PR TITLE
Add azure monitor profiler configuration to bit Boilerplate (#11419)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -90,6 +90,7 @@
         <PackageVersion Condition=" '$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '' " Include="FluentStorage.Azure.Blobs" Version="5.3.0" />
         <PackageVersion Condition=" '$(filesStorage)' == 'S3' OR '$(filesStorage)' == '' " Include="FluentStorage.AWS" Version="5.5.0" />
         <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
+        <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Azure.Monitor.OpenTelemetry.Profiler" Version="1.0.0-beta5" />
         <PackageVersion Condition=" '$(pipeline)' == 'GitHub' OR '$(pipeline)' == '' " Include="GitHubActionsTestLogger" Version="2.4.1" />
         <PackageVersion Condition=" '$(pipeline)' == 'Azure' " Include="AzurePipelines.TestLogger" Version="1.2.3" />
         <!--/-:msbuild-conditional:noEmit -->

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Boilerplate.Server.Shared.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Boilerplate.Server.Shared.csproj
@@ -19,6 +19,7 @@
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+        <PackageReference Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Azure.Monitor.OpenTelemetry.Profiler" />
         <PackageReference Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Extensions/WebApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using System.IO.Compression;
 using System.Net;
 //#if (appInsights == true)
+using Azure.Monitor.OpenTelemetry.Profiler;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 //#endif
 using Boilerplate.Server.Shared;
@@ -182,7 +183,7 @@ public static class WebApplicationBuilderExtensions
             builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
             {
                 builder.Configuration.Bind("ApplicationInsights", options);
-            });
+            }).AddAzureMonitorProfiler();
         }
         //#endif
 


### PR DESCRIPTION
closes #11419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Integrated Azure Monitor Profiler with OpenTelemetry when Application Insights is enabled, providing automatic runtime profiling for deeper performance diagnostics with minimal setup.
  - Enabled by default in new projects where Application Insights is on or unspecified; disable by turning off Application Insights.

- Chores
  - Updated telemetry dependencies to include support for the Azure Monitor Profiler, aligning with existing OpenTelemetry/Azure Monitor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->