### PR TITLE
Add AutoDismissTime parameter to BitMessage (#11426)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Message/BitMessage.razor.cs
@@ -21,6 +21,11 @@ public partial class BitMessage : BitComponentBase
     public BitAlignment? Alignment { get; set; }
 
     /// <summary>
+    /// Enables the auto-dismiss feature and sets the time to automatically call the OnDismiss callback.
+    /// </summary>
+    [Parameter] public TimeSpan? AutoDismissTime { get; set; }
+
+    /// <summary>
     /// The content of message.
     /// </summary>
     [Parameter] public RenderFragment? ChildContent { get; set; }
@@ -175,6 +180,28 @@ public partial class BitMessage : BitComponentBase
             BitSize.Medium => "bit-msg-md",
             BitSize.Large => "bit-msg-lg",
             _ => "bit-msg-md"
+        });
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender is false || AutoDismissTime is null || OnDismiss.HasDelegate is false) return;
+
+        await Task.Run(async () =>
+        {
+            await Task.Delay(AutoDismissTime.Value);
+
+            await InvokeAsync(async () =>
+            {
+                if (OnDismiss.HasDelegate)
+                {
+                    await OnDismiss.InvokeAsync();
+
+                    StateHasChanged();
+                }
+            });
         });
     }
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor
@@ -151,6 +151,19 @@
         {
             <BitButton OnClick="() => isDismissed = false">Dismissed, click to reset</BitButton>
         }
+
+        <br/><br/>
+        
+        @if (isAutoDismissed is false)
+        {
+            <BitMessage AutoDismissTime="TimeSpan.FromSeconds(5)" OnDismiss="() => isAutoDismissed = true">
+                Auto-Dismiss option enabled by adding the <strong>AutoDismissTime</strong> parameter alongside OnDismiss.
+            </BitMessage>
+        }
+        else
+        {
+            <BitButton OnClick="() => isAutoDismissed = false">Auto-Dismissed, click to reset</BitButton>
+        }
     </DemoExample>
 
     <DemoExample Title="Actions" RazorCode="@example9RazorCode" Id="example9">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor.cs
@@ -22,6 +22,13 @@ public partial class BitMessageDemo
         },
         new()
         {
+            Name = "AutoDismissTime",
+            Type = "TimeSpan?",
+            DefaultValue = "null",
+            Description = "Enables the auto-dismiss feature and sets the time to automatically call the OnDismiss callback.",
+        },
+        new()
+        {
             Name = "ChildContent",
             Type = "RenderFragment?",
             DefaultValue = "null",
@@ -474,6 +481,8 @@ public partial class BitMessageDemo
 
 
     private bool isDismissed;
+    private bool isAutoDismissed;
+
     private double elevation = 7;
     private bool isErrorDismissed;
     private bool isWarningDismissed;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Message/BitMessageDemo.razor.samples.cs
@@ -106,9 +106,21 @@ private double elevation = 7;";
 else
 {
     <BitButton OnClick=""() => isDismissed = false"">Dismissed, click to reset</BitButton>
+}
+
+@if (isAutoDismissed is false)
+{
+    <BitMessage AutoDismissTime=""TimeSpan.FromSeconds(5)"" OnDismiss=""() => isAutoDismissed = true"">
+        Auto-Dismiss option enabled by adding <strong>AutoDismissTime</strong> parameter alongside of OnDismiss.
+    </BitMessage>
+}
+else
+{
+    <BitButton OnClick=""() => isAutoDismissed = false"">Auto-Dismissed, click to reset</BitButton>
 }";
     private readonly string example8CsharpCode = @"
-private bool isDismissed;";
+private bool isDismissed;
+private bool isAutoDismissed;";
 
     private readonly string example9RazorCode = @"
 <BitMessage>


### PR DESCRIPTION
closes #11426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - BitMessage now supports automatic dismissal after a configurable duration via AutoDismissTime.
- Documentation
  - Updated BitMessage demo to showcase auto-dismiss behavior with a 5-second example and reset flow.
  - Added parameter description for AutoDismissTime in the demo to clarify usage and timing with OnDismiss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->