### PR TITLE
Update platform website docs to .NET 10 version of the bitplatform products (#11476)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor
@@ -99,7 +99,7 @@
                             {
                                 <br />
                                 <BitAccordion Title="Ubuntu instructions">
-                                <CodeBox>wget https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.305/dotnet-sdk-9.0.305-linux-x64.tar.gz -O $HOME/dotnet.tar.gz
+                                <CodeBox>wget https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-rc.1.25451.107/dotnet-sdk-10.0.100-rc.1.25451.107-linux-x64.tar.gz -O $HOME/dotnet.tar.gz
 mkdir -p $HOME/.dotnet
 tar zxf $HOME/dotnet.tar.gz -C "$HOME/.dotnet"
 echo 'PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc
@@ -153,7 +153,7 @@ rm $HOME/dotnet.tar.gz</CodeBox>
                         </li>
                         <li>
                             <div style="margin-bottom:8px">Install <a href="https://www.nuget.org/packages/Bit.Boilerplate" target="_blank">Bit Boilerplate</a> project template</div>
-                            <CodeBox>dotnet new install Bit.Boilerplate</CodeBox>
+							<CodeBox>dotnet new install Bit.Boilerplate::10.0.0-pre-02</CodeBox>
                         </li>
                         @if (showCrossPlatform && devOS is "Windows")
                         {
@@ -202,7 +202,7 @@ rm $HOME/dotnet.tar.gz</CodeBox>
                             <div class="section-card-txt">
                                 <ul>
                                     <li>
-                                        <a href="https://visualstudio.microsoft.com/downloads/" target="_blank">Microsoft Visual Studio</a> 2022 - Version 17.13 or higher
+                                        <a href="https://visualstudio.microsoft.com/downloads/" target="_blank">Microsoft Visual Studio</a> 2026 - Version 18.0 or higher
                                         <ul dir="auto">
                                             <li>
                                                 Workloads:

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor.cs
@@ -25,7 +25,7 @@ public partial class Templates03GettingStartedPage
             command:"$progressPreference = 'silentlyContinue'; Install-PackageProvider -Name NuGet -Force | Out-Null; Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null; Repair-WinGetPackageManager -AllUsers;"),
 
             (text:@"echo 'Install .NET SDK https://dotnet.microsoft.com/en-us/download';",
-            command: $"winget install Microsoft.DotNet.SDK.9 --accept-source-agreements --accept-package-agreements;"),
+            command: $"winget install Microsoft.DotNet.SDK.Preview --accept-source-agreements --accept-package-agreements;"),
             
             (text:@"echo 'Install Microsoft DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows#install';",
             command: $"winget install Microsoft.devtunnel --accept-source-agreements --accept-package-agreements;"),
@@ -40,7 +40,7 @@ public partial class Templates03GettingStartedPage
             command:"dotnet nuget add source \"https://api.nuget.org/v3/index.json\" --name \"nuget.org\"; dotnet workload install wasm-tools;"),
 
             (text:@"echo 'Install the Bit.Boilerplate project template https://www.nuget.org/packages/Boilerplate.Templates';",
-            command:"dotnet new install Bit.Boilerplate;")
+            command:"dotnet new install Bit.Boilerplate::10.0.0-pre-02;")
         ];
 
         if (enableVirtualization)
@@ -104,9 +104,6 @@ public partial class Templates03GettingStartedPage
                 (text: @"echo 'Install the Docker extension for Visual Studio Code https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker';",
                 command: "code --install-extension ms-azuretools.vscode-docker;"),
 
-                (text: @"echo 'Install the RESX Editor extension for Visual Studio Code https://marketplace.visualstudio.com/items?itemName=DominicVonk.vscode-resx-editor';",
-                command: "code --install-extension DominicVonk.vscode-resx-editor;"),
-
                 (text: @"echo 'Install Dev Containers extension for Visual Studio Code https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers';",
                 command: "code --install-extension ms-vscode-remote.remote-containers;"),
 
@@ -120,8 +117,8 @@ public partial class Templates03GettingStartedPage
 
         if (installVs)
         {
-            result.Add((text: @"echo 'Install Visual Studio 2022 Community Edition https://visualstudio.microsoft.com/downloads/';",
-                command: $"winget install --id Microsoft.VisualStudio.2022.Community --exact --silent --custom \"--add Microsoft.VisualStudio.Workload.NetWeb{(enableCrossPlatform ? " --add Microsoft.VisualStudio.Workload.NetCrossPlat --add Component.Android.SDK.MAUI" : "")}\" --accept-source-agreements --accept-package-agreements --disable-interactivity;"));
+            result.Add((text: @"echo 'Install Visual Studio 2026 Community Edition https://visualstudio.microsoft.com/downloads/';",
+                command: $"winget install --id Microsoft.VisualStudio.Community.Insiders --exact --silent --custom \"--add Microsoft.VisualStudio.Workload.NetWeb{(enableCrossPlatform ? " --add Microsoft.VisualStudio.Workload.NetCrossPlat --add Component.Android.SDK.MAUI" : "")}\" --accept-source-agreements --accept-package-agreements --disable-interactivity;"));
         }
 
         return result;

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates05CreateProjectPage.razor
@@ -61,7 +61,7 @@
                     break;
                 case "SqlServer":
                     <div>
-                        You can use Sql Server LocalDb 2022 for development purposes.
+                        You can use Sql Server LocalDb 2025 for development purposes.
                         <br />
                         It gets installed within Visual Studio by default, but you can either download it from <a href="https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SqlLocalDB.msi" target="_blank">here</a> or install it using PowerShell:
                         <CodeBox>$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SqlLocalDB.msi -OutFile SqlLocalDB.msi; msiexec /i SqlLocalDB.msi /quiet</CodeBox>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Server/Bit.Websites.Platform.Server.csproj
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Server/Bit.Websites.Platform.Server.csproj
@@ -26,7 +26,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.AI" Version="9.9.1" />
         <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.9.1-preview.1.25474.6" />
-        <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.1" />
+        <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
         <PackageReference Include="AspNetCore.HealthChecks.System" Version="9.0.0" />
         <PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />


### PR DESCRIPTION
closes #11476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started to use .NET 10 preview SDK and clarified Ubuntu PATH setup.
  * Raised Visual Studio requirement to 2026 (v18.0+) and adjusted installation guidance.
  * Pinned Bit Boilerplate template to a specific pre-release version.
  * Removed RESX Editor from the recommended VS Code extensions.
  * Updated SQL Server LocalDb guidance text from 2022 to 2025.

* **Chores**
  * Upgraded a server-side dependency to the latest preview version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->