### PR TITLE
Use projects relative paths for aspire (#11508)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Boilerplate.Server.AppHost.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Boilerplate.Server.AppHost.csproj
@@ -6,6 +6,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
         <IsAspireHost>true</IsAspireHost>
+        <EntryPointAccessibility>public</EntryPointAccessibility>
         <UserSecretsId>AC87AA5B-4B37-4E52-8468-2D5DF24AF256</UserSecretsId>
     </PropertyGroup>
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
@@ -1,5 +1,4 @@
 ﻿//+:cnd:noEmit
-using Projects;
 using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/TestsInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/TestsInitializer.cs
@@ -46,7 +46,7 @@ public partial class TestsInitializer
     private static async Task RunAspireHost(TestContext testContext)
     {
         var aspireBuilder = await DistributedApplicationTestingBuilder
-            .CreateAsync<Projects.Boilerplate_Server_AppHost>(testContext.CancellationToken);
+            .CreateAsync<Program>(testContext.CancellationToken);
 
         foreach (var res in aspireBuilder.Resources.OfType<ProjectResource>().ToList())
             aspireBuilder.Resources.Remove(res);


### PR DESCRIPTION
closes #11508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project registration configuration to use explicit file paths instead of generic type-based references for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->