### PR TITLE
Rename PreserveCalloutWidh parameter to FixedCalloutWidth in callouts (#11507)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/MenuButton/BitMenuButton.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/MenuButton/BitMenuButton.razor.cs
@@ -593,7 +593,7 @@ public partial class BitMenuButton<TItem> : BitComponentBase where TItem : class
             headerId: "",
             footerId: "",
             setCalloutWidth: true,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/CircularTimePicker/BitCircularTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/CircularTimePicker/BitCircularTimePicker.razor.cs
@@ -551,7 +551,7 @@ public partial class BitCircularTimePicker : BitInputBase<TimeSpan?>
             headerId: "",
             footerId: "",
             setCalloutWidth: false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DatePicker/BitDatePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DatePicker/BitDatePicker.razor.cs
@@ -1416,7 +1416,7 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
             headerId: "",
             footerId: "",
             setCalloutWidth: false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: MAX_WIDTH);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DateRangePicker/BitDateRangePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DateRangePicker/BitDateRangePicker.razor.cs
@@ -1939,7 +1939,7 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
             headerId: "",
             footerId: "",
             setCalloutWidth: false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: MAX_WIDTH);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -1187,7 +1187,7 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             headerId: CalloutHeaderTemplate is not null ? _headerId : "",
             footerId: CalloutFooterTemplate is not null ? _footerId : "",
             setCalloutWidth: PreserveCalloutWidth is false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/SearchBox/BitSearchBox.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/SearchBox/BitSearchBox.razor.cs
@@ -535,7 +535,7 @@ public partial class BitSearchBox : BitTextInputBase<string?>
             headerId: string.Empty,
             footerId: string.Empty,
             setCalloutWidth: false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TimePicker/BitTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TimePicker/BitTimePicker.razor.cs
@@ -447,7 +447,7 @@ public partial class BitTimePicker : BitInputBase<TimeSpan?>
             headerId: string.Empty,
             footerId: string.Empty,
             setCalloutWidth: true,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor.cs
@@ -622,7 +622,7 @@ public partial class BitBreadcrumb<TItem> : BitComponentBase where TItem : class
             headerId: "",
             footerId: "",
             setCalloutWidth: false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.razor.cs
@@ -218,7 +218,7 @@ public partial class BitDropMenu : BitComponentBase
             headerId: "",
             footerId: "",
             setCalloutWidth: false,
-            preserveCalloutWidth: false,
+            fixedCalloutWidth: false,
             maxWindowWidth: 0);
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Callout/BitCallout.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Callout/BitCallout.razor.cs
@@ -51,6 +51,11 @@ public partial class BitCallout : BitComponentBase
     [Parameter] public BitDropDirection? Direction { get; set; }
 
     /// <summary>
+    /// Forces the callout to preserve its component's original width.
+    /// </summary>
+    [Parameter] public bool FixedCalloutWidth { get; set; }
+
+    /// <summary>
     /// The id of the footer element that renders at the end of the scrolling container of the callout contnet.
     /// </summary>
     [Parameter] public string? FooterId { get; set; }
@@ -79,12 +84,7 @@ public partial class BitCallout : BitComponentBase
     [Parameter] public EventCallback<bool> OnToggle { get; set; }
 
     /// <summary>
-    /// Forces the callout to preserve its component's original width.
-    /// </summary>
-    [Parameter] public bool PreserveCalloutWidth { get; set; }
-
-    /// <summary>
-    /// Forces the callout to set its content container width while openning based on the available space and actual content.
+    /// Forces the callout to set its content container width while opening based on the available space and actual content.
     /// </summary>
     [Parameter] public bool SetCalloutWidth { get; set; }
 
@@ -205,7 +205,7 @@ public partial class BitCallout : BitComponentBase
             headerId: HeaderId ?? "",
             footerId: FooterId ?? "",
             setCalloutWidth: SetCalloutWidth,
-            preserveCalloutWidth: PreserveCalloutWidth,
+            fixedCalloutWidth: FixedCalloutWidth,
             maxWindowWidth: MaxWindowWidth ?? 0);
 
         await OnToggle.InvokeAsync(IsOpen);

--- a/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/CalloutsJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/CalloutsJsRuntimeExtensions.cs
@@ -20,26 +20,27 @@ internal static class CalloutsJsRuntimeExtensions
         string headerId,
         string footerId,
         bool setCalloutWidth,
-        bool preserveCalloutWidth,
+        bool fixedCalloutWidth,
         int maxWindowWidth) where T : class
     {
-        return jsRuntime.Invoke<bool>("BitBlazorUI.Callouts.toggle",
-                                      dotnetObj,
-                                      componentId,
-                                      component,
-                                      calloutId,
-                                      callout,
-                                      isCalloutOpen,
-                                      responsiveMode,
-                                      dropDirection,
-                                      isRtl,
-                                      scrollContainerId,
-                                      scrollOffset,
-                                      headerId,
-                                      footerId,
-                                      setCalloutWidth,
-                                      preserveCalloutWidth,
-                                      maxWindowWidth);
+        return jsRuntime.Invoke<bool>(
+            "BitBlazorUI.Callouts.toggle",
+            dotnetObj,
+            componentId,
+            component,
+            calloutId,
+            callout,
+            isCalloutOpen,
+            responsiveMode,
+            dropDirection,
+            isRtl,
+            scrollContainerId,
+            scrollOffset,
+            headerId,
+            footerId,
+            setCalloutWidth,
+            fixedCalloutWidth,
+            maxWindowWidth);
     }
 
     internal static ValueTask BitCalloutClearCallout(this IJSRuntime jsRuntime, string calloutId)

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
@@ -19,7 +19,7 @@ namespace BitBlazorUI {
             headerId: string,
             footerId: string,
             setCalloutWidth: boolean,
-            preserveCalloutWidth: boolean,
+            fixedCalloutWidth: boolean,
             maxWindowWidth: number,
         ) {
             component ??= document.getElementById(componentId);
@@ -95,7 +95,7 @@ namespace BitBlazorUI {
                 callout.style.width = width + 'px';
                 calloutWidth = width;
             }
-            if (preserveCalloutWidth) {
+            if (fixedCalloutWidth) {
                 let width = Math.min(componentWidth, calloutWidth);
                 callout.style.width = width + 'px';
                 calloutWidth = width;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Callout/BitCalloutDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Callout/BitCalloutDemo.razor.cs
@@ -59,6 +59,13 @@ public partial class BitCalloutDemo
         },
         new()
         {
+            Name = "FixedCalloutWidth",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Forces the callout to preserve its component's original width."
+        },
+        new()
+        {
             Name = "FooterId",
             Type = "string?",
             DefaultValue = "null",
@@ -94,17 +101,10 @@ public partial class BitCalloutDemo
         },
         new()
         {
-            Name = "PreserveCalloutWidth",
-            Type = "bool",
-            DefaultValue = "false",
-            Description = "Forces the callout to preserve its component's original width."
-        },
-        new()
-        {
             Name = "SetCalloutWidth",
             Type = "bool",
             DefaultValue = "false",
-            Description = "Forces the callout to set its content container width while openning based on the available space and actual content."
+            Description = "Forces the callout to set its content container width while opening based on the available space and actual content."
         },
         new()
         {


### PR DESCRIPTION
closes #11507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the `PreserveCalloutWidth` parameter to `FixedCalloutWidth` in Callout and related dropdown/menu components. Update your code if currently using this parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->