### PR TITLE
Filter blazor events from open telemetry (#11523)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Services/AppOpenTelemetryProcessor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Services/AppOpenTelemetryProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using OpenTelemetry;
 
 namespace Boilerplate.Server.Shared.Services;
+
 public class AppOpenTelemetryProcessor : BaseProcessor<Activity>
 {
     public override void OnStart(Activity activity)
@@ -8,6 +9,10 @@ public class AppOpenTelemetryProcessor : BaseProcessor<Activity>
         if (activity.DisplayName.Contains("Microsoft.AspNetCore.Components.Server.ComponentHub"))
         {
             activity.IsAllDataRequested = false; // Prevents Blazor Server's SignalR from being exported
+        }
+        else if (activity.OperationName is "Microsoft.AspNetCore.Components.HandleEvent")
+        {
+            activity.IsAllDataRequested = false; // Prevents Blazor's events from being exported.
         }
     }
 }


### PR DESCRIPTION
closes #11523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved telemetry data collection by suppressing internal Blazor event handling from telemetry exports, reducing monitoring data noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->