### PR TITLE
Remove duplicate submission of x-app-* headers through signalr client (#11515)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Extensions/IClientCoreServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Extensions/IClientCoreServiceCollectionExtensions.cs
@@ -167,11 +167,6 @@ public static partial class IClientCoreServiceCollectionExtensions
                 .WithAutomaticReconnect(sp.GetRequiredService<IRetryPolicy>())
                 .WithUrl(new Uri(absoluteServerAddressProvider.GetAddress(), "app-hub"), options =>
                 {
-                    var telemetryContext = sp.GetRequiredService<ITelemetryContext>();
-
-                    options.Headers.Add("X-App-Version", telemetryContext.AppVersion!);
-                    options.Headers.Add("X-App-Platform", AppPlatform.Type.ToString());
-
                     options.SkipNegotiation = false; // Required for Azure SignalR.
                     options.Transports = HttpTransportType.WebSockets;
                     // Avoid enabling long polling or Server-Sent Events. Focus on resolving the issue with WebSockets instead.


### PR DESCRIPTION
closes #11515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed application version and platform headers from SignalR connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->