### PR TITLE
Made ReadUserSessionLogs stream logs with IAsyncEnumerable

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/UsersPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/UsersPage.razor.cs
@@ -191,10 +191,12 @@ public partial class UsersPage
     /// </summary>
     private async Task ReadUserSessionLogs(Guid userSessionId)
     {
-        var logs = await hubConnection.InvokeAsync<DiagnosticLogDto[]>("GetUserSessionLogs", userSessionId);
-
         DiagnosticLogger.Store.Clear();
-        foreach (var log in logs)
+
+        await foreach (var log in hubConnection.StreamAsync<DiagnosticLogDto>(
+            "GetUserSessionLogs",
+            userSessionId,
+            cancellationToken: CurrentCancellationToken))
         {
             DiagnosticLogger.Store.Enqueue(log);
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Diagnostics.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.Diagnostics.cs
@@ -1,0 +1,71 @@
+﻿//+:cnd:noEmit
+using Boilerplate.Shared.Dtos.Diagnostic;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Boilerplate.Server.Api.SignalR;
+
+public partial class AppHub
+{
+    /// <summary>
+    /// Adds the admin caller to a temp group and requests the target client to upload logs.
+    /// Returns a correlationId (group name) or null if target not connected.
+    /// </summary>
+    [Authorize(Policy = AppFeatures.System.ManageLogs)]
+    public async Task<string?> BeginUserSessionLogs(
+        Guid userSessionId,
+        [FromServices] AppDbContext dbContext)
+    {
+        var targetConnId = await dbContext.UserSessions
+            .Where(us => us.Id == userSessionId)
+            .Select(us => us.SignalRConnectionId)
+            .FirstOrDefaultAsync();
+
+        if (string.IsNullOrEmpty(targetConnId))
+            return null;
+
+        var correlationId = Guid.NewGuid().ToString("N");
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, correlationId, Context.ConnectionAborted);
+
+        await Clients.Client(targetConnId)
+            .SendAsync(SignalRMethods.REQUEST_UPLOAD_DIAGNOSTIC_LOGGER_BATCH, correlationId, Context.ConnectionAborted);
+
+        return correlationId;
+    }
+
+    [Authorize(Policy = AppFeatures.System.ManageLogs)]
+    public Task EndUserSessionLogs(string correlationId)
+        => Groups.RemoveFromGroupAsync(Context.ConnectionId, correlationId);
+
+    /// <summary>
+    /// Target client -> Hub: streams its logs once; hub forwards each item to the admin correlation group.
+    /// Handles completion, cancellation and errors.
+    /// </summary>
+    [HubMethodName(SignalRMethods.UPLOAD_DIAGNOSTIC_LOGGER_STREAM)]
+    public async Task UploadDiagnosticLoggerStream(
+        string correlationId,
+        IAsyncEnumerable<DiagnosticLogDto> logs)
+    {
+        try
+        {
+            await foreach (var log in logs)
+            {
+                await Clients.Group(correlationId)
+                    .SendAsync(SignalRMethods.UPLOAD_DIAGNOSTIC_LOGGER_STORE, log);
+            }
+
+            await Clients.Group(correlationId)
+                .SendAsync(SignalRMethods.DIAGNOSTIC_LOGS_COMPLETE, correlationId);
+        }
+        catch (OperationCanceledException)
+        {
+            await Clients.Group(correlationId)
+                .SendAsync(SignalRMethods.DIAGNOSTIC_LOGS_ABORTED, correlationId);
+        }
+        catch
+        {
+            await Clients.Group(correlationId)
+                .SendAsync(SignalRMethods.DIAGNOSTIC_LOGS_ERROR, correlationId);
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/SignalR/AppHub.cs
@@ -1,7 +1,4 @@
 ﻿//+:cnd:noEmit
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-using System.Threading.Channels;
 using Boilerplate.Server.Api.Controllers.Identity;
 using Boilerplate.Server.Api.Models.Identity;
 using Boilerplate.Shared.Dtos.Diagnostic;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/SharedPubSubMessages.cs
@@ -44,5 +44,21 @@ public static partial class SignalRMethods
     /// Uploading these logs for display in the support staff's diagnostic modal log viewer aids in pinpointing the root cause of user issues during live troubleshooting.
     /// Another benefit of having this feature is in dev environment when you wanna see your Android, iOS logs on your desktop wide screen.
     /// </summary>
+    public const string REQUEST_UPLOAD_DIAGNOSTIC_LOGGER_BATCH = nameof(REQUEST_UPLOAD_DIAGNOSTIC_LOGGER_BATCH);
+
+    /// <summary>
+    /// Client > Server: uploads a batch of diagnostic logs (use with a small, safe batch size).
+    /// </summary>
+    public const string UPLOAD_DIAGNOSTIC_LOGGER_BATCH = nameof(UPLOAD_DIAGNOSTIC_LOGGER_BATCH);
+
+    // Target client -> Hub: stream logs
+    public const string UPLOAD_DIAGNOSTIC_LOGGER_STREAM = nameof(UPLOAD_DIAGNOSTIC_LOGGER_STREAM);
+
+    // Hub -> Admin: deliver each log item
     public const string UPLOAD_DIAGNOSTIC_LOGGER_STORE = nameof(UPLOAD_DIAGNOSTIC_LOGGER_STORE);
+
+    // Hub -> Admin: lifecycle events
+    public const string DIAGNOSTIC_LOGS_COMPLETE = nameof(DIAGNOSTIC_LOGS_COMPLETE);
+    public const string DIAGNOSTIC_LOGS_ABORTED = nameof(DIAGNOSTIC_LOGS_ABORTED);
+    public const string DIAGNOSTIC_LOGS_ERROR = nameof(DIAGNOSTIC_LOGS_ERROR);
 }


### PR DESCRIPTION
closes #11480 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Diagnostic logs now stream incrementally, providing faster initial response times when retrieving user session logs.
  * Added cancellation support for log retrieval operations, enabling users to stop ongoing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->