### PR TITLE
Add unit tests of BitFlag (#11730)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Tests/Components/Extras/Flag/BitFlagTests.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Tests/Components/Extras/Flag/BitFlagTests.cs
@@ -1,0 +1,110 @@
+﻿using Bunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.BlazorUI.Tests.Components.Extras.Flag;
+
+[TestClass]
+public class BitFlagTests : BunitTestContext
+{
+    [TestMethod,
+        DataRow(true),
+        DataRow(false)]
+    public void BitFlagShouldRespectIsEnabled(bool isEnabled)
+    {
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.IsEnabled, isEnabled);
+        });
+
+        var root = component.Find(".bit-flg");
+
+        if (isEnabled)
+        {
+            Assert.IsFalse(root.ClassList.Contains("bit-dis"));
+        }
+        else
+        {
+            Assert.IsTrue(root.ClassList.Contains("bit-dis"));
+        }
+    }
+
+    [TestMethod]
+    public void BitFlagShouldRespectTitle()
+    {
+        const string title = "Netherlands Flag";
+
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.Title, title);
+        });
+
+        var root = component.Find(".bit-flg");
+
+        Assert.AreEqual(title, root.GetAttribute("title"));
+    }
+
+    [TestMethod]
+    public void BitFlagShouldRenderFromCountry()
+    {
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.Country, BitCountries.Netherlands);
+        });
+
+        var style = component.Find(".bit-flg").GetAttribute("style") ?? string.Empty;
+
+        Assert.IsTrue(style.Contains("flags/NL-flat-16.webp"));
+    }
+
+    [TestMethod]
+    public void BitFlagShouldRenderFromIso2()
+    {
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.Iso2, "ca");
+        });
+
+        var style = component.Find(".bit-flg").GetAttribute("style") ?? string.Empty;
+
+        Assert.IsTrue(style.Contains("flags/CA-flat-16.webp"));
+    }
+
+    [TestMethod]
+    public void BitFlagShouldRenderFromIso3()
+    {
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.Iso3, "usa");
+        });
+
+        var style = component.Find(".bit-flg").GetAttribute("style") ?? string.Empty;
+
+        Assert.IsTrue(style.Contains("flags/US-flat-16.webp"));
+    }
+
+    [TestMethod]
+    public void BitFlagShouldRenderFromCode()
+    {
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.Code, "81"); // Japan
+        });
+
+        var style = component.Find(".bit-flg").GetAttribute("style") ?? string.Empty;
+
+        Assert.IsTrue(style.Contains("flags/JP-flat-16.webp"));
+    }
+
+    [TestMethod]
+    public void BitFlagShouldRenderEmptyWhenCountryNotFound()
+    {
+        var component = RenderComponent<BitFlag>(parameters =>
+        {
+            parameters.Add(p => p.Code, "0000");
+        });
+
+        var style = component.Find(".bit-flg").GetAttribute("style") ?? string.Empty;
+
+        Assert.IsFalse(style.Contains("background-image"));
+    }
+}


### PR DESCRIPTION
closes #11730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the BitFlag component, verifying enabled/disabled states, title attribute application, and flag rendering from various country code formats (Country enum, ISO 2/3 codes, and numeric codes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->