### PR TITLE
Use xcode 26.2 across projects (#11900)

### DIFF
--- a/.github/workflows/admin-sample.cd.yml
+++ b/.github/workflows/admin-sample.cd.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Upload server web artifact
       uses: actions/upload-artifact@v5
       with:
-        name: AdminPanelWeb
+        name: AdminPanel
         path: server-web
         include-hidden-files: true # Required for wwwroot/.well-known folder
 
@@ -293,7 +293,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.2'
 
     - uses: actions/setup-node@v6
       with:

--- a/.github/workflows/blazorui.demo.cd.yml
+++ b/.github/workflows/blazorui.demo.cd.yml
@@ -164,7 +164,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.2'
 
     - uses: actions/setup-node@v6
       with:

--- a/.github/workflows/todo-sample.cd.yml
+++ b/.github/workflows/todo-sample.cd.yml
@@ -458,7 +458,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.2'
 
     - name: Create project from Boilerplate
       run: |

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/cd-template.yml
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/cd-template.yml
@@ -219,7 +219,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: '26.1'
+          xcode-version: '26.2'
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
closes #11900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment workflows to utilize Xcode 26.2 for iOS and macOS builds, ensuring the latest development toolchain is used and maintaining compatibility across platforms.
  * Standardized build artifact naming conventions in deployment workflows for improved consistency across the CI/CD pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->