### PR TITLE
Use get/set modifiers for BitNumberField value binding (#11926)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor
@@ -1,4 +1,4 @@
-﻿@namespace Bit.BlazorUI
+@namespace Bit.BlazorUI
 @inherits BitTextInputBase<TValue>
 @typeparam TValue
 
@@ -110,9 +110,10 @@
                    @onkeydown="HandleOnKeyDown"
                    @onfocusin="HandleOnFocusIn"
                    @onfocusout="HandleOnFocusOut"
-                   @onchange="HandleOnStringValueChangeAsync"
-                   @oninput="HandleOnStringValueInputAsync"
                    @onwheel="HandleOnMouseWheel"
+                   @bind-value:get="@CurrentValueAsString"
+                   @bind-value:set="@HandleOnStringValueSet"
+                   @bind-value:event="@(Immediate ? "oninput" : "onchange")"
                    form=""
                    min="@_min"
                    max="@_max"
@@ -126,7 +127,6 @@
                    inputmode="@_inputMode"
                    placeholder="@Placeholder"
                    aria-labelledby="@_labelId"
-                   value="@CurrentValueAsString"
                    disabled="@(IsEnabled is false)"
                    class="bit-nfl-inp@(Mode == BitSpinButtonMode.Spread ? " bit-nfl-cin" : "") @Classes?.Input"
                    autocomplete="@(AutoComplete ?? "off")"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -369,7 +369,14 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
         return base.HandleOnStringValueChangeAsync(e);
     }
 
-
+    async Task HandleOnStringValueSet(string? value)
+    {
+        var args = new ChangeEventArgs() { Value = value };
+        if (Immediate)
+            await HandleOnStringValueInputAsync(args);
+        else
+            await HandleOnStringValueChangeAsync(args);
+    }
 
     private async Task HandleOnKeyDown(KeyboardEventArgs e)
     {


### PR DESCRIPTION
closes #11926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved NumberField component's input value synchronization mechanism to use two-way binding, enhancing how the component handles value updates between immediate and change modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->