### PR TITLE
bit Boilerplate must always store auth method in jwt token (#11939)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/IdentityController.cs
@@ -239,6 +239,8 @@ public partial class IdentityController : AppControllerBase, IIdentityController
             if (refreshTicket?.Principal?.IsAuthenticated() is not true)
                 throw new UnauthorizedException();
 
+            HttpContext.Items[AppClaimTypes.METHOD] = refreshTicket.Principal.GetClaimValue<string?>(AppClaimTypes.METHOD);
+
             var securityStamp = refreshTicket.Principal.GetClaimValue<string?>("AspNet.Identity.SecurityStamp") ?? throw new UnauthorizedException();
 
             var currentSessionId = refreshTicket.Principal.GetSessionId();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/SignInManagerExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Extensions/SignInManagerExtensions.cs
@@ -65,6 +65,8 @@ public static partial class SignInManagerExtensions
             return (SignInResult.Failed, null);
         }
 
+        signInManager.Context.Items[AppClaimTypes.METHOD] = authenticationMethod;
+
         return (await SignInOrTwoFactorAsync(signInManager, user), authenticationMethod); // See SignInManager.SignInOrTwoFactorAsync in aspnetcore repo
     }
 
@@ -86,7 +88,7 @@ public static partial class SignInManagerExtensions
         if (updateResult.Succeeded is false)
             throw new ResourceValidationException(updateResult.Errors.Select(e => new LocalizedString(e.Code, e.Description)).ToArray()).WithData("UserId", user.Id);
 
-        await signInManager.SignInWithClaimsAsync(user!, isPersistent: false, [new Claim("amr", "otp")]);
+        await signInManager.SignInAsync(user!, isPersistent: false);
 
         return SignInResult.Success;
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Extensions/ISharedServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Extensions/ISharedServiceCollectionExtensions.cs
@@ -65,7 +65,6 @@ public static partial class ISharedServiceCollectionExtensions
 
         services.AddAuthorizationCore(options =>
         {
-            options.AddPolicy(AuthPolicies.TFA_ENABLED, x => x.RequireClaim("amr", "mfa"));
             options.AddPolicy(AuthPolicies.PRIVILEGED_ACCESS, x => x.RequireClaim(AppClaimTypes.PRIVILEGED_SESSION, "true"));
             options.AddPolicy(AuthPolicies.ELEVATED_ACCESS, x => x.RequireClaim(AppClaimTypes.ELEVATED_SESSION, "true"));
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppClaimTypes.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AppClaimTypes.cs
@@ -28,4 +28,10 @@ public class AppClaimTypes
     /// <see cref="AppFeatures"/>
     /// </summary>
     public const string FEATURES = "features";
+
+    /// <summary>
+    /// The method used for user authentication.
+    /// External (Social), Sms (Web-OTP), Email (Magic Link or 6 digit code), Push notification (6 digit code), WebAuthn (Face-Id, Fingerprint etc), Password.
+    /// </summary>
+    public const string METHOD = "method";
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AuthPolicies.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Services/AuthPolicies.cs
@@ -3,11 +3,6 @@
 public class AuthPolicies
 {
     /// <summary>
-    /// Having this policy means the user has enabled 2 factor authentication.
-    /// </summary>
-    public const string TFA_ENABLED = nameof(TFA_ENABLED);
-
-    /// <summary>
     /// Having this policy/claim in access token means the user is allowed to view pages that require privileged access.
     /// Currently, this policy applies only to the Todo and AdminPanel specific pages like dashboard page. 
     /// However, it can be extended to cover additional pages as needed. 


### PR DESCRIPTION
closes #11939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication method tracking throughout sign-in and token refresh flows to identify which method was used (External, SMS, Email, Push, WebAuthn, or Password).

* **Changes**
  * Keycloak identity claims are now conditionally retrieved only when external authentication method is used.
  * Removed the two-factor authentication enabled authorization policy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->