### PR TITLE
User must be able to configure webAuthn in bit Boilerplate if passkey is no longer valid (#11947)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.Utils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.Utils.cs
@@ -123,16 +123,6 @@ public partial class AppDiagnosticModal
 
     private async Task ClearAppFiles()
     {
-        try
-        {
-            await userController.DeleteAllWebAuthnCredentials(CurrentCancellationToken);
-            // RemoveWebAuthnConfiguredUserId will be deleted using StorageService.Clear below.
-        }
-        catch (Exception exp)
-        {
-            logger.LogWarning(exp, "Failed to delete WebAuthn credentials during ClearAppStorage.");
-        }
-
         //#if (offlineDb == true)
         try
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs
@@ -81,14 +81,15 @@ public partial class PasswordlessTab
         }
         catch (Exception ex)
         {
-            // The browser itself would show a message dialog if the passkey is no longer valid.
+            // we can safely ignore the exception thrown here since it mostly because of a timeout or user cancelling the native ui.
+            // In case passkey is no longer valid, the browser would show a message dialog itself.
             ExceptionHandler.Handle(ex, ExceptionDisplayKind.None);
             return;
         }
         finally
         {
-            // Regardless of whether the user actively cancelled the operation or the passkey credential is no longer valid,
-            // the browser reports the same generic error in both cases.
+            // Regardless of whether the user actively cancelled the operation, it has timed out or the passkey is no longer valid,
+            // the browser throws the same generic error.
             // As a result, we cannot reliably distinguish the root cause of the failure.
             // To allow the user to attempt configuration again, we must clear the stored user ID here.
             await webAuthnService.RemoveWebAuthnConfiguredUserId(User.Id);
@@ -105,16 +106,6 @@ public partial class PasswordlessTab
 
         SnackBarService.Success(Localizer[nameof(AppStrings.DisablePasswordlessSucsessMessage)]);
     }
-
-    // Only for debugging purposes, uncomment the following lines and the corresponding lines in the razor file.
-    //private async Task DeleteAll()
-    //{
-    //    await userController.DeleteAllWebAuthnCredentials(CurrentCancellationToken);
-
-    //    await webAuthnService.RemoveWebAuthnConfigured();
-
-    //    isConfigured = false;
-    //}
 
     protected override async Task OnAfterFirstRenderAsync()
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/UserController.WebAuthn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Controllers/Identity/UserController.WebAuthn.cs
@@ -124,16 +124,6 @@ public partial class UserController
             throw new ResourceNotFoundException();
     }
 
-    [HttpDelete]
-    public async Task DeleteAllWebAuthnCredentials(CancellationToken cancellationToken)
-    {
-        var userId = User.GetUserId();
-        var user = await userManager.FindByIdAsync(userId.ToString())
-                    ?? throw new ResourceNotFoundException();
-
-        var affectedRows = await DbContext.WebAuthnCredential.Where(c => c.UserId == userId).ExecuteDeleteAsync(cancellationToken);
-    }
-
     private static string GetWebAuthnCacheKey(Guid userId) => $"WebAuthn_Options_{userId}";
 
     private async Task<bool> IsCredentialIdUniqueToUser(IsCredentialIdUniqueToUserParams args, CancellationToken cancellationToken)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Controllers/Identity/IUserController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Controllers/Identity/IUserController.cs
@@ -60,9 +60,6 @@ public interface IUserController : IAppController
     [HttpDelete]
     Task DeleteWebAuthnCredential(JsonElement clientResponse, CancellationToken cancellationToken) => default!;
 
-    [HttpDelete]
-    Task DeleteAllWebAuthnCredentials(CancellationToken cancellationToken);
-
     //#if (signalR == true || notification == true)
     [HttpPost("{userSessionId}")]
     Task<UserSessionNotificationStatus> ToggleNotification(Guid userSessionId, CancellationToken cancellationToken);


### PR DESCRIPTION
closes #11947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the passwordless authentication disable flow to ensure proper configuration cleanup and reset occur regardless of credential verification outcome, allowing users to successfully retry the operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->