### PR TITLE
Configure default decimal precision in bit Boilerplate (#11975)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Data/AppOfflineDbContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Data/AppOfflineDbContext.cs
@@ -18,6 +18,9 @@ public partial class AppOfflineDbContext(DbContextOptions<AppOfflineDbContext> o
         configurationBuilder.Properties<DateTimeOffset>().HaveConversion<DateTimeOffsetToBinaryConverter>();
         configurationBuilder.Properties<DateTimeOffset?>().HaveConversion<DateTimeOffsetToBinaryConverter>();
 
+        configurationBuilder.Properties<decimal>().HavePrecision(18, 3);
+        configurationBuilder.Properties<decimal?>().HavePrecision(18, 3);
+
         base.ConfigureConventions(configurationBuilder);
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Data/AppDbContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Data/AppDbContext.cs
@@ -187,6 +187,9 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options)
         }
         //#endif
 
+        configurationBuilder.Properties<decimal>().HavePrecision(18, 3);
+        configurationBuilder.Properties<decimal?>().HavePrecision(18, 3);
+
         base.ConfigureConventions(configurationBuilder);
     }
 


### PR DESCRIPTION
closes #11975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database context configuration to enforce consistent decimal precision (18,3) for all decimal fields, ensuring standardized data storage and handling across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->