### PR TITLE
Apply bit Boilerplate api versioning on non source-generator based http api calls (#12062)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/AddOrEditProductPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Products/AddOrEditProductPage.razor.cs
@@ -123,7 +123,7 @@ public partial class AddOrEditProductPage
 
     private async Task<string> GetUploadUrl()
     {
-        var uploadUrl = new Uri(AbsoluteServerAddress, $"/api/Attachment/UploadProductPrimaryImage/{Id ?? product.Id}").ToString();
+        var uploadUrl = new Uri(AbsoluteServerAddress, $"/api/v1/Attachment/UploadProductPrimaryImage/{Id ?? product.Id}").ToString();
 
         if (CultureInfoManager.InvariantGlobalization is false)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/ProfileSection.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/ProfileSection.razor.cs
@@ -116,7 +116,7 @@ public partial class ProfileSection
 
     private async Task<string> GetUploadUrl()
     {
-        var uploadUrl = new Uri(AbsoluteServerAddress, $"/api/Attachment/UploadUserProfilePicture").ToString();
+        var uploadUrl = new Uri(AbsoluteServerAddress, $"/api/v1/Attachment/UploadUserProfilePicture").ToString();
 
         if (CultureInfoManager.InvariantGlobalization is false)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
@@ -41,7 +41,7 @@ public partial class ResponseCacheService
     //#if (module == "Sales" || module == "Admin")
     public async Task PurgeProductCache(int shortId)
     {
-        await PurgeCache("/", $"/product/{shortId}", $"/api/ProductView/Get/{shortId}");
+        await PurgeCache("/", $"/product/{shortId}", $"/api/v1/ProductView/Get/{shortId}");
     }
     //#endif
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Identity/Dtos/UserDto.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Identity/Dtos/UserDto.cs
@@ -44,7 +44,7 @@ public partial class UserDto : IValidatableObject
     {
         return HasProfilePicture is false
             ? null
-            : new Uri(absoluteServerAddress, $"/api/Attachment/GetAttachment/{Id}/{AttachmentKind.UserProfileImageSmall}?v={Version}").ToString();
+            : new Uri(absoluteServerAddress, $"/api/v1/Attachment/GetAttachment/{Id}/{AttachmentKind.UserProfileImageSmall}?v={Version}").ToString();
     }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Identity/IIdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Identity/IIdentityController.cs
@@ -24,7 +24,7 @@ public interface IIdentityController : IAppController
     [HttpPost]
     Task ResetPassword(ResetPasswordRequestDto request, CancellationToken cancellationToken);
 
-    public const string RefreshUri = "api/Identity/Refresh";
+    public const string RefreshUri = "api/v1/Identity/Refresh";
     [HttpPost]
     Task<TokenResponseDto> Refresh(RefreshTokenRequestDto request, CancellationToken cancellationToken) => default!;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Products/ProductDto.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Products/ProductDto.cs
@@ -49,7 +49,7 @@ public partial class ProductDto
     {
         return HasPrimaryImage is false
             ? null
-            : new Uri(absoluteServerAddress, $"/api/Attachment/GetAttachment/{Id}/{AttachmentKind.ProductPrimaryImageMedium}?v={Version}").ToString();
+            : new Uri(absoluteServerAddress, $"/api/v1/Attachment/GetAttachment/{Id}/{AttachmentKind.ProductPrimaryImageMedium}?v={Version}").ToString();
     }
 
     public string FormattedPrice => FormatPrice();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Readme.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Readme.md
@@ -40,7 +40,7 @@ Task<TokenResponseDto> Refresh(RefreshRequestDto body);
 
 **Convention Over Configuration:**
 
-While following the Convention over Configuration principle, methods like `GetCurrentUser` in `IUserController` send requests to `api/User/GetCurrentUser`,
+While following the Convention over Configuration principle, methods like `GetCurrentUser` in `IUserController` send requests to `api/v1/User/GetCurrentUser`,
 you are not bound by this convention. Use any `RoutePrefix` you prefer, as long as your API is accepting/returning json you're all set!
 
 **Important**: IAppControllers support pre-render state internally using `IPrerenderStateService`, so you don't need to handle it manually using `PersistentComponentState` or `[PersistentState]`.


### PR DESCRIPTION
closes #12062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint versions to use versioned routing (v1) across product images, user profiles, and identity services.

* **Documentation**
  * Updated documentation references to reflect current API versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->