### PR TITLE
Add new Icon parameters to BitBreadcrumb (#12102)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor
@@ -1,4 +1,4 @@
-﻿@namespace Bit.BlazorUI
+@namespace Bit.BlazorUI
 @inherits BitComponentBase
 @typeparam TItem
 
@@ -35,7 +35,8 @@
                         }
                         else
                         {
-                            <i style="@Styles?.OverflowButtonIcon" class="bit-icon bit-icon--@(OverflowIconName ?? "More") @Classes?.OverflowButtonIcon" />
+                            var overflowIcon = BitIconInfo.From(OverflowIcon, OverflowIconName ?? "More");
+                            <i style="@Styles?.OverflowButtonIcon" class="@overflowIcon?.GetCssClasses() @Classes?.OverflowButtonIcon" />
                         }
                     </button>
                 }
@@ -58,10 +59,10 @@
                             }
                             else
                             {
-                                var iconName = GetIconName(item);
-                                @if (iconName.HasValue())
+                                var icon = GetIcon(item);
+                                @if (icon is not null)
                                 {
-                                    <i style="@Styles?.ItemIcon" class="bit-icon bit-icon--@iconName @Classes?.ItemIcon" />
+                                    <i style="@Styles?.ItemIcon" class="@icon.GetCssClasses() @Classes?.ItemIcon" />
                                 }
                                 <span style="@Styles?.ItemText" class="@Classes?.ItemText">@GetItemText(item)</span>
                             }
@@ -84,10 +85,10 @@
                             }
                             else
                             {
-                                var iconName = GetIconName(item);
-                                @if (iconName.HasValue())
+                                var icon = GetIcon(item);
+                                @if (icon is not null)
                                 {
-                                    <i style="@Styles?.ItemIcon" class="bit-icon bit-icon--@iconName @Classes?.ItemIcon" />
+                                    <i style="@Styles?.ItemIcon" class="@icon.GetCssClasses() @Classes?.ItemIcon" />
                                 }
                                 <span style="@Styles?.ItemText" class="@Classes?.ItemText">@GetItemText(item)</span>
                             }
@@ -108,10 +109,10 @@
                             }
                             else
                             {
-                                var iconName = GetIconName(item);
-                                @if (iconName.HasValue())
+                                var icon = GetIcon(item);
+                                @if (icon is not null)
                                 {
-                                    <i style="@Styles?.ItemIcon" class="bit-icon bit-icon--@iconName @Classes?.ItemIcon" />
+                                    <i style="@Styles?.ItemIcon" class="@icon.GetCssClasses() @Classes?.ItemIcon" />
                                 }
                                 <span style="@Styles?.ItemText" class="@Classes?.ItemText">@GetItemText(item)</span>
                             }
@@ -129,8 +130,9 @@
                     }
                     else
                     {
+                        var dividerIcon = BitIconInfo.From(DividerIcon, DividerIconName ?? "ChevronRight bit-brc-trd");
                         <i style="@Styles?.DividerIcon"
-                           class="bit-brc-div bit-icon bit-icon--@(DividerIconName ?? "ChevronRight bit-brc-trd") @Classes?.DividerIcon" />
+                           class="bit-brc-div @dividerIcon?.GetCssClasses() @Classes?.DividerIcon" />
                     }
                 </li>
             }
@@ -163,10 +165,10 @@
                             }
                             else
                             {
-                                var iconName = GetIconName(item);
-                                @if (iconName.HasValue())
+                                var icon = GetIcon(item);
+                                @if (icon is not null)
                                 {
-                                    <i style="@Styles?.OverflowItemIcon" class="bit-icon bit-icon--@iconName @Classes?.OverflowItemIcon" />
+                                    <i style="@Styles?.OverflowItemIcon" class="@icon.GetCssClasses() @Classes?.OverflowItemIcon" />
                                 }
                                 <span style="@Styles?.OverflowItemText" class="@Classes?.OverflowItemText">@GetItemText(item)</span>
                             }
@@ -189,10 +191,10 @@
                             }
                             else
                             {
-                                var iconName = GetIconName(item);
-                                @if (iconName.HasValue())
+                                var icon = GetIcon(item);
+                                @if (icon is not null)
                                 {
-                                    <i style="@Styles?.OverflowItemIcon" class="bit-icon bit-icon--@iconName @Classes?.OverflowItemIcon" />
+                                    <i style="@Styles?.OverflowItemIcon" class="@icon.GetCssClasses() @Classes?.OverflowItemIcon" />
                                 }
                                 <span style="@Styles?.OverflowItemText" class="@Classes?.OverflowItemText">@GetItemText(item)</span>
                             }
@@ -213,10 +215,10 @@
                               }
                               else
                               {
-                                  var iconName = GetIconName(item);
-                                  @if (iconName.HasValue())
+                                  var icon = GetIcon(item);
+                                  @if (icon is not null)
                                   {
-                                      <i style="@Styles?.OverflowItemIcon" class="bit-icon bit-icon--@iconName @Classes?.OverflowItemIcon" />
+                                      <i style="@Styles?.OverflowItemIcon" class="@icon.GetCssClasses() @Classes?.OverflowItemIcon" />
                                   }
                                   <span style="@Styles?.OverflowItemText" class="@Classes?.OverflowItemText">@GetItemText(item)</span>
                               }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumb.razor.cs
@@ -1,4 +1,4 @@
-﻿namespace Bit.BlazorUI;
+namespace Bit.BlazorUI;
 
 /// <summary>
 /// Breadcrumbs should be used as a navigational aid in your app or site. They indicate the current page’s location within a hierarchy and help the user understand where they are in relation to the rest of that hierarchy.
@@ -33,6 +33,11 @@ public partial class BitBreadcrumb<TItem> : BitComponentBase where TItem : class
     /// Custom CSS classes for different parts of the breadcrumb.
     /// </summary>
     [Parameter] public BitBreadcrumbClassStyles? Classes { get; set; }
+
+    /// <summary>
+    /// Render a custom divider icon in place of the default chevron >
+    /// </summary>
+    [Parameter] public BitIconInfo? DividerIcon { get; set; }
 
     /// <summary>
     /// Render a custom divider in place of the default chevron >
@@ -84,6 +89,11 @@ public partial class BitBreadcrumb<TItem> : BitComponentBase where TItem : class
     /// Optional index where overflow items will be collapsed.
     /// </summary>
     [Parameter] public uint OverflowIndex { get; set; }
+
+    /// <summary>
+    /// Render a custom overflow icon in place of the default icon.
+    /// </summary>
+    [Parameter] public BitIconInfo? OverflowIcon { get; set; }
 
     /// <summary>
     /// Render a custom overflow icon in place of the default icon.
@@ -453,26 +463,41 @@ public partial class BitBreadcrumb<TItem> : BitComponentBase where TItem : class
         return item.GetValueFromProperty<string?>(NameSelectors.Text.Name);
     }
 
-    private string? GetIconName(TItem item)
+    private BitIconInfo? GetIcon(TItem item)
     {
         if (item is BitBreadcrumbItem breadcrumbItem)
         {
-            return breadcrumbItem.IconName;
+            return BitIconInfo.From(breadcrumbItem.Icon, breadcrumbItem.IconName);
         }
 
         if (item is BitBreadcrumbOption bitBreadcrumbOption)
         {
-            return bitBreadcrumbOption.IconName;
+            return BitIconInfo.From(bitBreadcrumbOption.Icon, bitBreadcrumbOption.IconName);
         }
 
         if (NameSelectors is null) return null;
 
-        if (NameSelectors.IconName.Selector is not null)
+        BitIconInfo? icon = null;
+        if (NameSelectors.Icon.Selector is not null)
         {
-            return NameSelectors.IconName.Selector!(item);
+            icon = NameSelectors.Icon.Selector!(item);
+        }
+        else
+        {
+            icon = item.GetValueFromProperty<BitIconInfo?>(NameSelectors.Icon.Name);
         }
 
-        return item.GetValueFromProperty<string?>(NameSelectors.IconName.Name);
+        string? iconName = null;
+        if (NameSelectors.IconName.Selector is not null)
+        {
+            iconName = NameSelectors.IconName.Selector!(item);
+        }
+        else
+        {
+            iconName = item.GetValueFromProperty<string?>(NameSelectors.IconName.Name);
+        }
+
+        return BitIconInfo.From(icon, iconName);
     }
 
     private bool GetReversedIcon(TItem item)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumbItem.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumbItem.cs
@@ -14,6 +14,11 @@ public class BitBreadcrumbItem
     public string? Href { get; set; }
 
     /// <summary>
+    /// Icon to render next to the item text.
+    /// </summary>
+    public BitIconInfo? Icon { get; set; }
+
+    /// <summary>
     /// Name of an icon to render next to the item text.
     /// </summary>
     public string? IconName { get; set; }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumbNameSelectors.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumbNameSelectors.cs
@@ -13,6 +13,11 @@ public class BitBreadcrumbNameSelectors<TItem> where TItem : class
     public BitNameSelectorPair<TItem, string?> Href { get; set; } = new(nameof(BitBreadcrumbItem.Href));
 
     /// <summary>
+    /// The Icon field name and selector of the custom input class.
+    /// </summary>
+    public BitNameSelectorPair<TItem, BitIconInfo?> Icon { get; set; } = new(nameof(BitBreadcrumbItem.Icon));
+
+    /// <summary>
     /// The IconName field name and selector of the custom input class.
     /// </summary>
     public BitNameSelectorPair<TItem, string?> IconName { get; set; } = new(nameof(BitBreadcrumbItem.IconName));

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumbOption.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Breadcrumb/BitBreadcrumbOption.cs
@@ -22,6 +22,11 @@ public partial class BitBreadcrumbOption : ComponentBase, IDisposable
     [Parameter] public string? Href { get; set; }
 
     /// <summary>
+    /// Icon to render next to the item text.
+    /// </summary>
+    [Parameter] public BitIconInfo? Icon { get; set; }
+
+    /// <summary>
     /// Name of an icon to render next to the item text.
     /// </summary>
     [Parameter] public string? IconName { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/BitBreadcrumbDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/BitBreadcrumbDemo.razor.cs
@@ -1,4 +1,4 @@
-﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
+namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
 
 public partial class BitBreadcrumbDemo
 {
@@ -19,6 +19,15 @@ public partial class BitBreadcrumbDemo
             Description = "Custom CSS classes for different parts of the breadcrumb.",
             LinkType = LinkType.Link,
             Href = "#class-styles",
+        },
+        new()
+        {
+            Name = "DividerIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Render a custom divider icon in place of the default chevron.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
         },
         new()
         {
@@ -92,6 +101,15 @@ public partial class BitBreadcrumbDemo
             Type = "uint",
             DefaultValue = "0",
             Description = "Optional index where overflow items will be collapsed."
+        },
+        new()
+        {
+            Name = "OverflowIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Render a custom overflow icon in place of the default icon.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
         },
         new()
         {
@@ -169,6 +187,14 @@ public partial class BitBreadcrumbDemo
                    Name = "Style",
                    Type = "string?",
                    Description = "Style attribute for breadcrumb item.",
+               },
+               new()
+               {
+                   Name = "Icon",
+                   Type = "BitIconInfo?",
+                   Description = "Icon to render next to the item text.",
+                   LinkType = LinkType.Link,
+                   Href = "#bit-icon-info",
                },
                new()
                {
@@ -250,6 +276,14 @@ public partial class BitBreadcrumbDemo
                    Name = "Style",
                    Type = "string?",
                    Description = "Style attribute for breadcrumb option.",
+               },
+               new()
+               {
+                   Name = "Icon",
+                   Type = "BitIconInfo?",
+                   Description = "Icon to render next to the item text.",
+                   LinkType = LinkType.Link,
+                   Href = "#bit-icon-info",
                },
                new()
                {
@@ -490,6 +524,15 @@ public partial class BitBreadcrumbDemo
                },
                new()
                {
+                   Name = "Icon",
+                   Type = "BitNameSelectorPair<TItem, BitIconInfo?>",
+                   DefaultValue = "new(nameof(BitBreadcrumbItem.Icon))",
+                   Description = "The Icon field name and selector of the custom input class.",
+                   LinkType = LinkType.Link,
+                   Href = "#name-selector-pair"
+               },
+               new()
+               {
                    Name = "IconName",
                    Type = "BitNameSelectorPair<TItem, string?>",
                    DefaultValue = "new(nameof(BitBreadcrumbItem.IconName))",
@@ -568,6 +611,36 @@ public partial class BitBreadcrumbDemo
                    Type = "Func<TItem, TProp?>?",
                    Description = "Custom class property selector."
                }
+            ]
+        },
+        new()
+        {
+            Id = "bit-icon-info",
+            Title = "BitIconInfo",
+            Description = "Represents icon information for rendering icons. Supports built-in Fluent UI icons and external icon libraries (FontAwesome, Bootstrap Icons, etc.). Use BitIconInfo.Css(\"fa-solid fa-star\"), BitIconInfo.Fa(\"solid star\"), or BitIconInfo.Bi(\"star-fill\") for external icons.",
+            Parameters =
+            [
+                new()
+                {
+                    Name = "Name",
+                    Type = "string?",
+                    DefaultValue = "null",
+                    Description = "Gets or sets the name of the icon. For external icons, this can be the full CSS class name if BaseClass and Prefix are empty."
+                },
+                new()
+                {
+                    Name = "BaseClass",
+                    Type = "string?",
+                    DefaultValue = "null",
+                    Description = "Gets or sets the base CSS class for the icon. For built-in Fluent UI icons, this defaults to \"bit-icon\". For external icon libraries like FontAwesome, you might set this to \"fa\" or leave empty."
+                },
+                new()
+                {
+                    Name = "Prefix",
+                    Type = "string?",
+                    DefaultValue = "null",
+                    Description = "Gets or sets the CSS class prefix used before the icon name. For built-in Fluent UI icons, this defaults to \"bit-icon--\". For external icon libraries, you might set this to \"fa-\" or leave empty."
+                },
             ]
         },
     ];

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/PageInfo.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/PageInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
+namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
 
 public class PageInfo
 {
@@ -11,6 +11,8 @@ public class PageInfo
     public string? HtmlStyle { get; set; }
 
     public string? Icon { get; set; }
+
+    public BitIconInfo? IconInfo { get; set; }
 
     public bool IsCurrent { get; set; }
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbCustomDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbCustomDemo.razor
@@ -1,4 +1,4 @@
-﻿<DemoExample Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
+<DemoExample Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
     <div class="example-box">
         <div>
             <div>Basic</div>
@@ -171,6 +171,45 @@
                 <BitNumberField @bind-Value="MaxDisplayedItems" Label="Max displayed items" ShowButtons="true" />
                 <BitNumberField @bind-Value="OverflowIndex" Label="Overflow index" ShowButtons="true" />
             </div>
+        </div>
+    </div>
+</DemoExample>
+
+<DemoExample Title="External Icons" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+    <div>External icon libraries like FontAwesome can be used with the Icon parameter.</div>
+    <br /><br />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+    <div class="example-box">
+        <div>
+            <div>Implicit string conversion (auto-detects external icons)</div>
+            <BitBreadcrumb Items="CustomBreadcrumbItemsWithExternalIcon1"
+                           NameSelectors="nameSelectors"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })" />
+        </div>
+        <br />
+        <div>
+            <div>BitIconInfo.Css (uses CSS classes directly)</div>
+            <BitBreadcrumb Items="CustomBreadcrumbItemsWithExternalIcon2"
+                           NameSelectors="nameSelectors"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })" />
+        </div>
+        <br />
+        <div>
+            <div>BitIconInfo.Fa (FontAwesome helper)</div>
+            <BitBreadcrumb Items="CustomBreadcrumbItemsWithExternalIcon3"
+                           NameSelectors="nameSelectors"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })" />
+        </div>
+        <br />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+        <div>
+            <div>BitIconInfo.Bi (Bootstrap Icons helper)</div>
+            <BitBreadcrumb Items="CustomBreadcrumbItemsWithExternalIcon4"
+                           NameSelectors="nameSelectors"
+                           MaxDisplayedItems="3" OverflowIndex="2" />
         </div>
     </div>
 </DemoExample>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbCustomDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbCustomDemo.razor.cs
@@ -1,4 +1,4 @@
-﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
+namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
 
 public partial class _BitBreadcrumbCustomDemo
 {
@@ -74,6 +74,38 @@ public partial class _BitBreadcrumbCustomDemo
         new() { Name = "پوشه ششم" },
     ];
 
+    private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon1 =
+    [
+        new() { Name = "Home", IconInfo = "fa-solid fa-house" },
+        new() { Name = "Products", IconInfo = "fa-solid fa-box" },
+        new() { Name = "Electronics", IconInfo = "fa-solid fa-microchip" },
+        new() { Name = "Laptops", IconInfo = "fa-solid fa-laptop", IsCurrent = true }
+    ];
+
+    private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon2 =
+    [
+        new() { Name = "Home", IconInfo = BitIconInfo.Css("fa-solid fa-house") },
+        new() { Name = "Products", IconInfo = BitIconInfo.Css("fa-solid fa-box") },
+        new() { Name = "Electronics", IconInfo = BitIconInfo.Css("fa-solid fa-microchip") },
+        new() { Name = "Laptops", IconInfo = BitIconInfo.Css("fa-solid fa-laptop"), IsCurrent = true }
+    ];
+
+    private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon3 =
+    [
+        new() { Name = "Home", IconInfo = BitIconInfo.Fa("solid house") },
+        new() { Name = "Products", IconInfo = BitIconInfo.Fa("solid box") },
+        new() { Name = "Electronics", IconInfo = BitIconInfo.Fa("solid microchip") },
+        new() { Name = "Laptops", IconInfo = BitIconInfo.Fa("solid laptop"), IsCurrent = true }
+    ];
+
+    private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon4 =
+    [
+        new() { Name = "Home", IconInfo = BitIconInfo.Bi("house-fill") },
+        new() { Name = "Products", IconInfo = BitIconInfo.Bi("box-seam-fill") },
+        new() { Name = "Electronics", IconInfo = BitIconInfo.Bi("cpu-fill") },
+        new() { Name = "Laptops", IconInfo = BitIconInfo.Bi("laptop-fill"), IsCurrent = true }
+    ];
+
     private BitBreadcrumbNameSelectors<PageInfo> nameSelectors = new()
     {
         Text = { Selector = c => c.Name },
@@ -83,7 +115,8 @@ public partial class _BitBreadcrumbCustomDemo
         Style = { Selector = c => c.HtmlStyle },
         IconName = { Selector = c => c.Icon },
         Template = { Name = nameof(PageInfo.Fragment) },
-        OverflowTemplate = { Name = nameof(PageInfo.OverflowFragment) }
+        OverflowTemplate = { Name = nameof(PageInfo.OverflowFragment) },
+        Icon = { Selector = c => c.IconInfo },
     };
 
     private void HandleOnCustomClick(PageInfo model)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbCustomDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbCustomDemo.razor.samples.cs
@@ -385,6 +385,79 @@ private void RemoveCustomItem()
     }
 }";
 
+    private readonly string example9RazorCode = @"
+<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
+
+<BitBreadcrumb Items=""CustomBreadcrumbItemsWithExternalIcon1""
+               NameSelectors=""externalIconNameSelectors""
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"" />
+
+<BitBreadcrumb Items=""CustomBreadcrumbItemsWithExternalIcon2""
+               NameSelectors=""externalIconNameSelectors""
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"" />
+
+<BitBreadcrumb Items=""CustomBreadcrumbItemsWithExternalIcon3""
+               NameSelectors=""externalIconNameSelectors""
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"" />
+
+<link rel=""stylesheet"" href=""https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"" />
+
+<BitBreadcrumb Items=""CustomBreadcrumbItemsWithExternalIcon4""
+               NameSelectors=""externalIconNameSelectors""
+               MaxDisplayedItems=""3"" OverflowIndex=""2"" />";
+    private readonly string example9CsharpCode = @"
+public class PageInfo
+{
+    public string? Name { get; set; }
+    public string? Address { get; set; }
+    public BitIconInfo? IconInfo { get; set; }
+    public bool IsCurrent { get; set; }
+    public bool IsEnabled { get; set; } = true;
+}
+
+private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon1 =
+[
+    new() { Name = ""Home"", IconInfo = ""fa-solid fa-house"" },
+    new() { Name = ""Products"", IconInfo = ""fa-solid fa-box"" },
+    new() { Name = ""Electronics"", IconInfo = ""fa-solid fa-microchip"" },
+    new() { Name = ""Laptops"", IconInfo = ""fa-solid fa-laptop"", IsCurrent = true }
+];
+
+private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon2 =
+[
+    new() { Name = ""Home"", IconInfo = BitIconInfo.Css(""fa-solid fa-house"") },
+    new() { Name = ""Products"", IconInfo = BitIconInfo.Css(""fa-solid fa-box"") },
+    new() { Name = ""Electronics"", IconInfo = BitIconInfo.Css(""fa-solid fa-microchip"") },
+    new() { Name = ""Laptops"", IconInfo = BitIconInfo.Css(""fa-solid fa-laptop""), IsCurrent = true }
+];
+
+private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon3 =
+[
+    new() { Name = ""Home"", IconInfo = BitIconInfo.Fa(""solid house"") },
+    new() { Name = ""Products"", IconInfo = BitIconInfo.Fa(""solid box"") },
+    new() { Name = ""Electronics"", IconInfo = BitIconInfo.Fa(""solid microchip"") },
+    new() { Name = ""Laptops"", IconInfo = BitIconInfo.Fa(""solid laptop""), IsCurrent = true }
+];
+
+private readonly List<PageInfo> CustomBreadcrumbItemsWithExternalIcon4 =
+[
+    new() { Name = ""Home"", IconInfo = BitIconInfo.Bi(""house-fill"") },
+    new() { Name = ""Products"", IconInfo = BitIconInfo.Bi(""box-seam-fill"") },
+    new() { Name = ""Electronics"", IconInfo = BitIconInfo.Bi(""cpu-fill"") },
+    new() { Name = ""Laptops"", IconInfo = BitIconInfo.Bi(""laptop-fill""), IsCurrent = true }
+];
+
+private BitBreadcrumbNameSelectors<PageInfo> externalIconNameSelectors = new()
+{
+    Text = { Selector = c => c.Name },
+    Href = { Selector = c => c.Address },
+    IsSelected = { Selector = c => c.IsCurrent },
+    Icon = { Selector = c => c.IconInfo },
+};";
+
     private readonly string example7RazorCode = @"
 <style>
     .custom-class {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbItemDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbItemDemo.razor
@@ -1,4 +1,4 @@
-﻿<DemoExample Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
+<DemoExample Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
     <div class="example-box">
         <div>
             <div>Basic</div>
@@ -145,6 +145,52 @@
                 <BitNumberField @bind-Value="MaxDisplayedItems" Label="Max displayed items" ShowButtons="true" />
                 <BitNumberField @bind-Value="OverflowIndex" Label="Overflow index" ShowButtons="true" />
             </div>
+        </div>
+    </div>
+</DemoExample>
+
+<DemoExample Title="External Icons" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+    <div>External icon libraries like FontAwesome can be used with the Icon parameter.</div>
+
+    <br />
+    <br />
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+
+    <div class="example-box">
+        <div>
+            <div>Implicit string conversion (auto-detects external icons)</div>
+            <BitBreadcrumb Items="BreadcrumbItemsWithExternalIcon1"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })" />
+        </div>
+
+        <br />
+
+        <div>
+            <div>BitIconInfo.Css (uses CSS classes directly)</div>
+            <BitBreadcrumb Items="BreadcrumbItemsWithExternalIcon2"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })" />
+        </div>
+
+        <br />
+
+        <div>
+            <div>BitIconInfo.Fa (FontAwesome helper)</div>
+            <BitBreadcrumb Items="BreadcrumbItemsWithExternalIcon3"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })" />
+        </div>
+
+        <br />
+
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+
+        <div>
+            <div>BitIconInfo.Bi (Bootstrap Icons helper)</div>
+            <BitBreadcrumb Items="BreadcrumbItemsWithExternalIcon4"
+                           MaxDisplayedItems="3" OverflowIndex="2" />
         </div>
     </div>
 </DemoExample>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbItemDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbItemDemo.razor.cs
@@ -1,4 +1,4 @@
-﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
+namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Navs.Breadcrumb;
 
 public partial class _BitBreadcrumbItemDemo
 {
@@ -63,6 +63,38 @@ public partial class _BitBreadcrumbItemDemo
         new() { Text = "Item 2" },
         new() { Text = "Item 3" },
         new() { Text = "Item 4", IsSelected = true }
+    ];
+
+    private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon1 =
+    [
+        new() { Text = "Home", Icon = "fa-solid fa-house" },
+        new() { Text = "Products", Icon = "fa-solid fa-box" },
+        new() { Text = "Electronics", Icon = "fa-solid fa-microchip" },
+        new() { Text = "Laptops", Icon = "fa-solid fa-laptop", IsSelected = true }
+    ];
+
+    private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon2 =
+    [
+        new() { Text = "Home", Icon = BitIconInfo.Css("fa-solid fa-house") },
+        new() { Text = "Products", Icon = BitIconInfo.Css("fa-solid fa-box") },
+        new() { Text = "Electronics", Icon = BitIconInfo.Css("fa-solid fa-microchip") },
+        new() { Text = "Laptops", Icon = BitIconInfo.Css("fa-solid fa-laptop"), IsSelected = true }
+    ];
+
+    private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon3 =
+    [
+        new() { Text = "Home", Icon = BitIconInfo.Fa("solid house") },
+        new() { Text = "Products", Icon = BitIconInfo.Fa("solid box") },
+        new() { Text = "Electronics", Icon = BitIconInfo.Fa("solid microchip") },
+        new() { Text = "Laptops", Icon = BitIconInfo.Fa("solid laptop"), IsSelected = true }
+    ];
+
+    private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon4 =
+    [
+        new() { Text = "Home", Icon = BitIconInfo.Bi("house-fill") },
+        new() { Text = "Products", Icon = BitIconInfo.Bi("box-seam-fill") },
+        new() { Text = "Electronics", Icon = BitIconInfo.Bi("cpu-fill") },
+        new() { Text = "Laptops", Icon = BitIconInfo.Bi("laptop-fill"), IsSelected = true }
     ];
 
     private readonly List<BitBreadcrumbItem> RtlBreadcrumbItems =

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbItemDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbItemDemo.razor.samples.cs
@@ -207,6 +207,58 @@ private void RemoveCustomItem()
     }
 }";
 
+    private readonly string example9RazorCode = @"
+<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
+
+<BitBreadcrumb Items=""BreadcrumbItemsWithExternalIcon1""
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"" />
+
+<BitBreadcrumb Items=""BreadcrumbItemsWithExternalIcon2""
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"" />
+
+<BitBreadcrumb Items=""BreadcrumbItemsWithExternalIcon3""
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"" />
+
+<link rel=""stylesheet"" href=""https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"" />
+
+<BitBreadcrumb Items=""BreadcrumbItemsWithExternalIcon4""
+               MaxDisplayedItems=""3"" OverflowIndex=""2"" />";
+    private readonly string example9CsharpCode = @"
+private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon1 =
+[
+    new() { Text = ""Home"", Icon = ""fa-solid fa-house"" },
+    new() { Text = ""Products"", Icon = ""fa-solid fa-box"" },
+    new() { Text = ""Electronics"", Icon = ""fa-solid fa-microchip"" },
+    new() { Text = ""Laptops"", Icon = ""fa-solid fa-laptop"", IsSelected = true }
+];
+
+private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon2 =
+[
+    new() { Text = ""Home"", Icon = BitIconInfo.Css(""fa-solid fa-house"") },
+    new() { Text = ""Products"", Icon = BitIconInfo.Css(""fa-solid fa-box"") },
+    new() { Text = ""Electronics"", Icon = BitIconInfo.Css(""fa-solid fa-microchip"") },
+    new() { Text = ""Laptops"", Icon = BitIconInfo.Css(""fa-solid fa-laptop""), IsSelected = true }
+];
+
+private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon3 =
+[
+    new() { Text = ""Home"", Icon = BitIconInfo.Fa(""solid house"") },
+    new() { Text = ""Products"", Icon = BitIconInfo.Fa(""solid box"") },
+    new() { Text = ""Electronics"", Icon = BitIconInfo.Fa(""solid microchip"") },
+    new() { Text = ""Laptops"", Icon = BitIconInfo.Fa(""solid laptop""), IsSelected = true }
+];
+
+private readonly List<BitBreadcrumbItem> BreadcrumbItemsWithExternalIcon4 =
+[
+    new() { Text = ""Home"", Icon = BitIconInfo.Bi(""house-fill"") },
+    new() { Text = ""Products"", Icon = BitIconInfo.Bi(""box-seam-fill"") },
+    new() { Text = ""Electronics"", Icon = BitIconInfo.Bi(""cpu-fill"") },
+    new() { Text = ""Laptops"", Icon = BitIconInfo.Bi(""laptop-fill""), IsSelected = true }
+];";
+
     private readonly string example7RazorCode = @"
 <style>
     .custom-class {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbOptionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbOptionDemo.razor
@@ -1,4 +1,4 @@
-﻿<DemoExample Title="Basic" RazorCode="@example1RazorCode" Id="example1">
+<DemoExample Title="Basic" RazorCode="@example1RazorCode" Id="example1">
     <div class="example-box">
         <div>
             <div>Basic</div>
@@ -229,6 +229,60 @@
                 <BitNumberField @bind-Value="MaxDisplayedItems" Label="Max displayed options" ShowButtons />
                 <BitNumberField @bind-Value="OverflowIndex" Label="Overflow index" ShowButtons />
             </div>
+        </div>
+    </div>
+</DemoExample>
+
+<DemoExample Title="External Icons" RazorCode="@example9RazorCode" Id="example9">
+    <div>External icon libraries like FontAwesome can be used with the Icon parameter.</div>
+    <br /><br />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+    <div class="example-box">
+        <div>
+            <div>Implicit string conversion (auto-detects external icons)</div>
+            <BitBreadcrumb TItem="BitBreadcrumbOption"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })">
+                <BitBreadcrumbOption Text="Home" Icon="@("fa-solid fa-house")" />
+                <BitBreadcrumbOption Text="Products" Icon="@("fa-solid fa-box")" />
+                <BitBreadcrumbOption Text="Electronics" Icon="@("fa-solid fa-microchip")" />
+                <BitBreadcrumbOption Text="Laptops" Icon="@("fa-solid fa-laptop")" IsSelected />
+            </BitBreadcrumb>
+        </div>
+        <br />
+        <div>
+            <div>BitIconInfo.Css (uses CSS classes directly)</div>
+            <BitBreadcrumb TItem="BitBreadcrumbOption"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })">
+                <BitBreadcrumbOption Text="Home" Icon="@BitIconInfo.Css("fa-solid fa-house")" />
+                <BitBreadcrumbOption Text="Products" Icon="@BitIconInfo.Css("fa-solid fa-box")" />
+                <BitBreadcrumbOption Text="Electronics" Icon="@BitIconInfo.Css("fa-solid fa-microchip")" />
+                <BitBreadcrumbOption Text="Laptops" Icon="@BitIconInfo.Css("fa-solid fa-laptop")" IsSelected />
+            </BitBreadcrumb>
+        </div>
+        <br />
+        <div>
+            <div>BitIconInfo.Fa (FontAwesome helper)</div>
+            <BitBreadcrumb TItem="BitBreadcrumbOption"
+                           MaxDisplayedItems="3" OverflowIndex="2"
+                           Styles="@(new() { ItemIcon = "line-height:unset" })">
+                <BitBreadcrumbOption Text="Home" Icon="@BitIconInfo.Fa("solid house")" />
+                <BitBreadcrumbOption Text="Products" Icon="@BitIconInfo.Fa("solid box")" />
+                <BitBreadcrumbOption Text="Electronics" Icon="@BitIconInfo.Fa("solid microchip")" />
+                <BitBreadcrumbOption Text="Laptops" Icon="@BitIconInfo.Fa("solid laptop")" IsSelected />
+            </BitBreadcrumb>
+        </div>
+        <br />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+        <div>
+            <div>BitIconInfo.Bi (Bootstrap Icons helper)</div>
+            <BitBreadcrumb TItem="BitBreadcrumbOption" MaxDisplayedItems="3" OverflowIndex="2">
+                <BitBreadcrumbOption Text="Home" Icon="@BitIconInfo.Bi("house-fill")" />
+                <BitBreadcrumbOption Text="Products" Icon="@BitIconInfo.Bi("box-seam-fill")" />
+                <BitBreadcrumbOption Text="Electronics" Icon="@BitIconInfo.Bi("cpu-fill")" />
+                <BitBreadcrumbOption Text="Laptops" Icon="@BitIconInfo.Bi("laptop-fill")" IsSelected />
+            </BitBreadcrumb>
         </div>
     </div>
 </DemoExample>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbOptionDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/_BitBreadcrumbOptionDemo.razor.samples.cs
@@ -170,6 +170,45 @@ private uint OverflowIndex = 2;
 private uint MaxDisplayedItems = 3;
 private int CustomizedSelectedOptionNumber = 4;";
 
+    private readonly string example9RazorCode = @"
+<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
+
+<BitBreadcrumb TItem=""BitBreadcrumbOption"" 
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"">
+    <BitBreadcrumbOption Text=""Home"" Icon=""@(""fa-solid fa-house"")"" />
+    <BitBreadcrumbOption Text=""Products"" Icon=""@(""fa-solid fa-box"")"" />
+    <BitBreadcrumbOption Text=""Electronics"" Icon=""@(""fa-solid fa-microchip"")"" />
+    <BitBreadcrumbOption Text=""Laptops"" Icon=""@(""fa-solid fa-laptop"")"" IsSelected />
+</BitBreadcrumb>
+
+<BitBreadcrumb TItem=""BitBreadcrumbOption"" 
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"">
+    <BitBreadcrumbOption Text=""Home"" Icon=""@BitIconInfo.Css(""fa-solid fa-house"")"" />
+    <BitBreadcrumbOption Text=""Products"" Icon=""@BitIconInfo.Css(""fa-solid fa-box"")"" />
+    <BitBreadcrumbOption Text=""Electronics"" Icon=""@BitIconInfo.Css(""fa-solid fa-microchip"")"" />
+    <BitBreadcrumbOption Text=""Laptops"" Icon=""@BitIconInfo.Css(""fa-solid fa-laptop"")"" IsSelected />
+</BitBreadcrumb>
+
+<BitBreadcrumb TItem=""BitBreadcrumbOption"" 
+               MaxDisplayedItems=""3"" OverflowIndex=""2""
+               Styles=""@(new() { ItemIcon = ""line-height:unset"" })"">
+    <BitBreadcrumbOption Text=""Home"" Icon=""@BitIconInfo.Fa(""solid house"")"" />
+    <BitBreadcrumbOption Text=""Products"" Icon=""@BitIconInfo.Fa(""solid box"")"" />
+    <BitBreadcrumbOption Text=""Electronics"" Icon=""@BitIconInfo.Fa(""solid microchip"")"" />
+    <BitBreadcrumbOption Text=""Laptops"" Icon=""@BitIconInfo.Fa(""solid laptop"")"" IsSelected />
+</BitBreadcrumb>
+
+<link rel=""stylesheet"" href=""https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"" />
+
+<BitBreadcrumb TItem=""BitBreadcrumbOption"" MaxDisplayedItems=""3"" OverflowIndex=""2"">
+    <BitBreadcrumbOption Text=""Home"" Icon=""@BitIconInfo.Bi(""house-fill"")"" />
+    <BitBreadcrumbOption Text=""Products"" Icon=""@BitIconInfo.Bi(""box-seam-fill"")"" />
+    <BitBreadcrumbOption Text=""Electronics"" Icon=""@BitIconInfo.Bi(""cpu-fill"")"" />
+    <BitBreadcrumbOption Text=""Laptops"" Icon=""@BitIconInfo.Bi(""laptop-fill"")"" IsSelected />
+</BitBreadcrumb>";
+
     private readonly string example7RazorCode = @"
 <style>
     .custom-class {


### PR DESCRIPTION
closes #12102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable icon support to breadcrumb components, including `DividerIcon` and `OverflowIcon` parameters for divider and overflow customization
  * Breadcrumb items and options now support custom icons via the `Icon` property
  * Added support for external icon libraries (FontAwesome, Bootstrap Icons, and CSS-based icons)

* **Documentation**
  * Added demonstrations and samples showing how to integrate external icon libraries with breadcrumb components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->