### PR TITLE
Set limit for L1 cache in bit Boilerplate (#12108)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
@@ -52,7 +52,11 @@ internal class CacheDelegatingHandler(IMemoryCache memoryCache, HttpMessageHandl
                     ResponseHeaders = response.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()),
                     ContentHeaders = response.Content.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()),
                     LogScopeData = logScopeData.ToDictionary()
-                }, maxAge);
+                }, options: new()
+                {
+                    Size = 1,
+                    AbsoluteExpirationRelativeToNow = maxAge
+                });
             }
 
             return response;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.WebAuthn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.WebAuthn.cs
@@ -42,10 +42,7 @@ public partial class IdentityController
 
         var key = new string([.. options.Challenge.Select(b => (char)b)]);
         await cache.SetAsync(key, options,
-            new FusionCacheEntryOptions
-            {
-                Duration = TimeSpan.FromMinutes(3)
-            },
+            options => options.Duration = TimeSpan.FromMinutes(3),
             cancellationToken);
 
         return options;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/UserController.WebAuthn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/UserController.WebAuthn.cs
@@ -1,4 +1,4 @@
-//+:cnd:noEmit
+﻿//+:cnd:noEmit
 using System.Text;
 using Fido2NetLib;
 using Fido2NetLib.Objects;
@@ -54,10 +54,7 @@ public partial class UserController
 
         var key = GetWebAuthnCacheKey(userId);
         await cache.SetAsync(key, options,
-            new FusionCacheEntryOptions
-            {
-                Duration = TimeSpan.FromMinutes(3)
-            },
+            options => options.Duration = TimeSpan.FromMinutes(3),
             cancellationToken);
 
         return options;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/SignalR/AppChatbot.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/SignalR/AppChatbot.cs
@@ -63,10 +63,7 @@ public partial class AppChatbot
                     .FirstOrDefaultAsync(p => p.PromptKind == PromptKind.Support, cancel);
                 return prompt?.Markdown ?? throw new ResourceNotFoundException();
             },
-            new FusionCacheEntryOptions()
-            {
-                Duration = TimeSpan.FromHours(1)
-            },
+            options => options.Duration = TimeSpan.FromHours(1),
             token: cancellationToken);
 
         // The following variables won't change unless SignalR connection restarts and StartChat gets called again, so setting variables once here is sufficient.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -59,6 +59,7 @@ public static class WebApplicationBuilderExtensions
         //#endif
 
         services.AddFusionCache()
+            .WithDefaultEntryOptions(options => options.Size = 1)
             // Auto-clone cached objects to avoid further issues after scaling out and switching to distributed caching.
             .WithOptions(opt => opt.DefaultEntryOptions.EnableAutoClone = true)
             //#if(redis == true)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs
@@ -38,8 +38,11 @@ public static partial class ISharedServiceCollectionExtensions
         services.ConfigureAuthorizationCore();
 
         services.AddLocalization();
-
-        services.AddMemoryCache();
+        services.AddMemoryCache(options =>
+        {
+            // Total capacity of the cache. Unit is arbitrary; we treat it as 1 unit per average entry.
+            options.SizeLimit = 1_000_000;
+        });
 
         return services;
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs
@@ -40,8 +40,7 @@ public static partial class ISharedServiceCollectionExtensions
         services.AddLocalization();
         services.AddMemoryCache(options =>
         {
-            // Total capacity of the L1 cache. Unit is arbitrary; we treat it as 1 unit per average entry.
-            options.SizeLimit = 100_000;
+            configuration.GetRequiredSection("MemoryCache").Bind(options);
         });
 
         return services;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs
@@ -40,8 +40,8 @@ public static partial class ISharedServiceCollectionExtensions
         services.AddLocalization();
         services.AddMemoryCache(options =>
         {
-            // Total capacity of the cache. Unit is arbitrary; we treat it as 1 unit per average entry.
-            options.SizeLimit = 1_000_000;
+            // Total capacity of the L1 cache. Unit is arbitrary; we treat it as 1 unit per average entry.
+            options.SizeLimit = 100_000;
         });
 
         return services;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/SharedSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/SharedSettings.cs
@@ -1,4 +1,6 @@
-//+:cnd:noEmit
+﻿//+:cnd:noEmit
+using Microsoft.Extensions.Caching.Memory;
+
 namespace Boilerplate.Shared;
 
 public partial class SharedSettings : IValidatableObject
@@ -6,6 +8,8 @@ public partial class SharedSettings : IValidatableObject
     //#if (appInsights == true)
     public ApplicationInsightsOptions? ApplicationInsights { get; set; }
     //#endif
+
+    public MemoryCacheOptions MemoryCache { get; set; } = default!;
 
     public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/appsettings.json
@@ -108,5 +108,9 @@
             }
         }
     },
+    "MemoryCache": {
+        "SizeLimit": 100000,
+        "SizeLimit__Comment": "Total capacity of the L1 cache. Unit is arbitrary; we treat it as 1 unit per average entry."
+    },
     "$schema": "https://json.schemastore.org/appsettings.json"
 }


### PR DESCRIPTION
closes #12108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory cache configuration with explicit size limits and optimized cache entry handling for improved resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->