### PR TITLE
Migrate Copilot prompts to agents format (#12139)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/bitify.agent.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/bitify.agent.md
@@ -1,3 +1,9 @@
+---
+name: bitify
+description: Modernizes Blazor pages by replacing raw HTML elements and custom CSS with Bit.BlazorUI components and theme-aware styling. Analyzes existing markup and creates a targeted replacement plan.
+tools: ["read", "edit", "search"]
+---
+
 # Bitify: Replace raw html/css with Bit.BlazorUI components
 
 You are an expert at modernizing Blazor pages by replacing standard HTML elements and custom CSS with Bit.BlazorUI components and theme-aware styling.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/code-reviewer.agent.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/code-reviewer.agent.md
@@ -1,0 +1,47 @@
+---
+name: code-reviewer
+description: Reviews code changes against the project's coding conventions and best practices. Focuses on Bit.BlazorUI usage, theming, lifecycle methods, Mapperly conventions, structured logging, modern C#, error handling, security, and nullable awareness. Does not modify code.
+tools: ["read", "search"]
+---
+
+# Project Code Reviewer
+
+You are a code reviewer specialized in this project's conventions. Review changes and surface only genuine issues, bugs, security concerns, convention violations, and logic errors. Never comment on formatting or style that `.editorconfig` handles.
+
+## Review Checklist
+
+### Blazor Components
+- [ ] Uses Bit.BlazorUI components (not raw HTML elements)
+- [ ] Event handlers wrapped with `WrapHandled`
+- [ ] Enhanced lifecycle methods (`OnInitAsync`, `OnParamsSetAsync`, `OnAfterFirstRenderAsync`)
+- [ ] Code-behind in `.razor.cs` (no `@code` blocks)
+- [ ] Styles in `.razor.scss` (no inline styles)
+- [ ] `[AutoInject]` for DI in components
+
+### Theming
+- [ ] Uses `BitColor` enum for component color parameters, `BitCss.Class` for CSS classes, and `BitCss.Var` for inline style CSS variables in C#/Razor (no hardcoded colors)
+- [ ] Uses `$bit-color-*` SCSS variables (no hex/rgb colors)
+- [ ] Uses `::deep` for Bit component style overrides
+
+### API Controllers
+- [ ] Inherits `AppControllerBase`
+- [ ] Implements `IAppController` interface
+- [ ] Uses `[EnableQuery]` with OData
+- [ ] Uses Mapperly with partial static mapper classes and extension methods
+- [ ] Uses Mapperly `Project()` for OData query projection
+- [ ] Proper error handling (`ResourceNotFoundException`, `BadRequestException`)
+- [ ] `long Version` for concurrency control
+
+### DTOs
+- [ ] Has `[DtoResourceType(typeof(AppStrings))]`
+- [ ] Validation uses `nameof(AppStrings.X)` for error messages
+- [ ] Includes `Id` and `Version` properties
+- [ ] Registered in `AppJsonContext.cs`
+
+### General
+- [ ] Nullable reference types properly handled
+- [ ] `async/await` for I/O operations
+- [ ] Structured logging used (no plain `Console.Write` or string-concatenated log messages)
+- [ ] Modern C# features used (latest language features, implicit/global usings, no deprecated patterns)
+- [ ] No secrets or credentials in code
+- [ ] Localized strings use `Localizer[nameof(AppStrings.X)]`

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/resx.agent.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/resx.agent.md
@@ -1,3 +1,9 @@
+---
+name: resx
+description: Moves hardcoded user-facing strings from code to .resx resource files for localization. Identifies strings, adds entries to AppStrings.resx, generates C# code, and updates code to use IStringLocalizer.
+tools: ["read", "edit", "search", "terminal"]
+---
+
 # Move Hardcoded Strings to Resource Files
 
 You are an expert at localizing .NET applications using resource files (.resx) and `IStringLocalizer<AppStrings>`.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/scaffold.agent.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/agents/scaffold.agent.md
@@ -1,3 +1,9 @@
+---
+name: scaffold
+description: Scaffolds complete CRUD entity implementations including entity model, EF configuration, DTO, Mapperly mapper, API controller, IAppController interface, resource strings, and Blazor pages.
+tools: ["read", "edit", "search", "terminal"]
+---
+
 # Scaffold Complete Entity with Full CRUD
 
 You are an expert at scaffolding complete entity implementations for the project.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/lsp.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/lsp.json
@@ -1,0 +1,35 @@
+{
+    "lspServers": {
+        "csharp": {
+            "command": "dotnet",
+            "args": [
+                "Microsoft.CodeAnalysis.LanguageServer",
+                "--stdio"
+            ],
+            "fileExtensions": {
+                ".cs": "csharp",
+                ".razor": "razor"
+            }
+        },
+        "typescript": {
+            "command": "typescript-language-server",
+            "args": [
+                "--stdio"
+            ],
+            "fileExtensions": {
+                ".ts": "typescript",
+                ".tsx": "typescriptreact"
+            }
+        },
+        "css": {
+            "command": "vscode-css-language-server",
+            "args": [
+                "--stdio"
+            ],
+            "fileExtensions": {
+                ".css": "css",
+                ".scss": "scss"
+            }
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.vscode/settings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.vscode/settings.json
@@ -4,13 +4,16 @@
     "dotnet.unitTests.runSettingsPath": "src/Tests/.runsettings",
     "chat.tools.autoApprove": true,
     "github.copilot.chat.codesearch.enabled": true,
+    "github.copilot.chat.scopeSelection": true,
+    "github.copilot.chat.agent.thinkingTool": true,
     "csharp.preview.improvedLaunchExperience": true,
     "explorer.fileNesting.enabled": true,
     "explorer.fileNesting.patterns": {
         "*.resx": "$(capture).*.resx",
         "*.razor": "$(capture).*.razor, $(capture).razor.cs, $(capture).razor.scss",
         "*.scss": "$(capture).*.scss, $(capture).css, $(capture).css.map",
-        "*.json": "$(capture).*.json, $(capture).*.json"
+        "*.json": "$(capture).*.json, $(capture).*.json",
+        "AGENTS.md": "CLAUDE.md, GEMINI.md, COPILOT.md"
     },
     "workbench.editorAssociations": {   
         "*.md": "vscode.markdown.preview.editor"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md
@@ -1,4 +1,4 @@
-# GitHub Copilot Instructions
+# AGENTS.md
 
 ## 1. Core Principles
 
@@ -77,7 +77,7 @@ Before writing code, investigate thoroughly.
 *   If the user provides a **URL**, you **MUST** use the `fetch` or `get_web_pages` tools to retrieve its content.
 *   If the user provides a **git commit id/hash**, you **MUST** run the `git --no-pager show <commit-id>` command to retrieve its details.
 *   If the user talked about current changes in the codebase, you **MUST** run the `git --no-pager diff` and `git --no-pager diff --staged` commands to see the differences.
-*   **IMPORTANT:** If you want to add new entity, entity type configuration, DTO, mapper, controller, or IAppController, you **MUST** read `.github\prompts\scaffold.prompt.md` to understand the structure, naming conventions, file locations, and implementation patterns.
+*   **IMPORTANT:** If you want to add new entity, entity type configuration, DTO, mapper, controller, or IAppController, you **MUST** read `.github/agents/scaffold.agent.md` to understand the structure, naming conventions, file locations, and implementation patterns.
 *   For UI-related tasks, you **MUST** first ask `DeepWiki`: *"What features does BitPlatform offer to help me complete this task? [USER'S ORIGINAL REQUEST]"*
 *   For anything related to `Bit.BlazorUI`, `bit Bswup`, `bit Butil`, `bit Besql`, or the bit project template, you **MUST** use the `DeepWiki_ask_question` tool with repository `bitfoundation/bitplatform` to find relevant information.
 *   For mapper/mapping entity/dto related tasks, you **MUST** use the `DeepWiki_ask_question` tool with repository `riok/mapperly` to find correct implementation and usage patterns focusing on its static classes and extension methods approach.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.sln
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".SolutionItems", ".Solution
         .editorconfig = .editorconfig
         .gitignore = .gitignore
         .vsconfig = .vsconfig
+		AGENTS.md = AGENTS.md
         Bit.ResxTranslator.json = Bit.ResxTranslator.json
         settings.VisualStudio.json = settings.VisualStudio.json
         Clean.bat = Clean.bat
@@ -47,15 +48,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 #endif
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{3E577755-186F-4E63-8153-B8DE890015C9}"
-    ProjectSection(SolutionItems) = preProject
-        .github\copilot-instructions.md = .github\copilot-instructions.md
-    EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "prompts", "prompts", "{4A5D6E7F-8B9C-1A2B-3C4D-5E6F7A8B9C0D}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "agents", "agents", "{4A5D6E7F-8B9C-1A2B-3C4D-5E6F7A8B9C0D}"
     ProjectSection(SolutionItems) = preProject
-        .github\prompts\resx.prompt.md = .github\prompts\resx.prompt.md
-        .github\prompts\bitify.prompt.md = .github\prompts\bitify.prompt.md
-        .github\prompts\scaffold.prompt.md = .github\prompts\scaffold.prompt.md
+        .github\agents\resx.agent.md = .github\agents\resx.agent.md
+		.github\agents\code-reviewer.agent.md = .github\agents\code-reviewer.agent.md
+        .github\agents\bitify.agent.md = .github\agents\bitify.agent.md
+        .github\agents\scaffold.agent.md = .github\agents\scaffold.agent.md
     EndProjectSection
 EndProject
 #if (pipeline == "GitHub")

--- a/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.slnx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.slnx
@@ -8,6 +8,7 @@
     <File Path=".editorconfig" />
     <File Path=".gitignore" />
     <File Path=".vsconfig" />
+	<File Path="AGENTS.md" />
     <File Path="Clean.bat" />
     <File Path="global.json" />
     <File Path="vs-spell.dic" />
@@ -25,13 +26,12 @@
     <File Path=".azure-devops/workflows/ci.yml" />
   </Folder>
 <!--#endif-->
-  <Folder Name="/.SolutionItems/.github/">
-    <File Path=".github/copilot-instructions.md" />
-  </Folder>
-  <Folder Name="/.SolutionItems/.github/prompts/">
-    <File Path=".github/prompts/resx.prompt.md" />
-    <File Path=".github/prompts/bitify.prompt.md" />
-    <File Path=".github/prompts/scaffold.prompt.md" />
+  <Folder Name="/.SolutionItems/.github/" />
+  <Folder Name="/.SolutionItems/.github/agents/">
+    <File Path=".github/agents/resx.agent.md" />
+	<File Path=".github/agents/code-reviewer.agent.md" />
+    <File Path=".github/agents/bitify.agent.md" />
+    <File Path=".github/agents/scaffold.agent.md" />
   </Folder>
   <Folder Name="/.SolutionItems/.docs/">
     <File Path=".docs/00- Wiki.md" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/settings.VisualStudio.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/settings.VisualStudio.json
@@ -14,6 +14,7 @@
   "copilot.general.completions.enableNextEditSuggestions": true,
   "copilot.general.editor.enableAdaptivePaste": true,
   "copilot.general.chat.enablePlanning": true,
+  "copilot.general.chat.enableCopilotCodingAgent": true,
   "languages.razor.tabs.character": "space",
   "languages.xml.tabs.character": "space",
   "languages.t-sql90.tabs.character": "space",


### PR DESCRIPTION
## Description

Closes #12139

Migrates the Boilerplate template from the older GitHub Copilot **prompts** format to the newer **agents** format with full YAML frontmatter support, and adds LSP configuration for Copilot CLI.

## Changes

- **Rename prompts → agents**: `.github/prompts/*.prompt.md` → `.github/agents/*.agent.md` with YAML frontmatter (name, description, tools)
- **New code-reviewer agent**: Comprehensive review checklist for Blazor components, theming, API controllers, DTOs, and general conventions
- **Move copilot-instructions → AGENTS.md**: Relocated to project root for broader AI tool compatibility
- **Add LSP config**: `.github/lsp.json` with C#, TypeScript, and CSS language server definitions
- **Update IDE settings**: New Copilot features in VS Code (`scopeSelection`, `thinkingTool`, file nesting) and Visual Studio (`enableCopilotCodingAgent`)
- **Update solution files**: `Boilerplate.sln` and `Boilerplate.slnx` reflect all renames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AI-powered agents for code review, scaffolding, and Blazor component modernization.
  * Added Language Server Protocol configuration for enhanced IDE support across C#, TypeScript, and CSS.

* **Documentation**
  * Updated agent documentation and guidance references.

* **Chores**
  * Enhanced VSCode and Visual Studio settings for improved AI assistant integration.
  * Reorganized development tooling configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->