### PR TITLE
Remove redundant z-index from FulllWidth style of BitButton (#12167)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Buttons/Button/BitButton.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Buttons/Button/BitButton.scss
@@ -100,7 +100,6 @@
 
 .bit-btn-flw {
     width: 100%;
-    z-index: $zindex-base;
 }
 
 .bit-btn-fab {


### PR DESCRIPTION
closes #12167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button styling by removing unnecessary stacking context configuration from full-width button layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->