### PR TITLE
Add missing new ItemCheckIcon parameter to BitDropdown (#12217)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor
@@ -11,6 +11,7 @@
     var searchBoxIconCss = BitIconInfo.From(SearchBoxIcon, SearchBoxIconName ?? "Search")?.GetCssClasses();
     var searchBoxClearIconCss = BitIconInfo.From(SearchBoxClearIcon, SearchBoxClearIconName ?? "Cancel")?.GetCssClasses();
     var comboBoxAddButtonIconCss = BitIconInfo.From(ComboBoxAddButtonIcon, ComboBoxAddButtonIconName ?? "Add")?.GetCssClasses();
+    var itemCheckIconCss = BitIconInfo.From(ItemCheckIcon, ItemCheckIconName ?? "Accept")?.GetCssClasses();
 }
 
 @if ((Options ?? ChildContent) is not null)
@@ -286,7 +287,7 @@
                                 ItemSize="ItemSize"
                                 OverscanCount="OverscanCount"
                                 Placeholder="VirtualizePlaceholder">
-                        <_BitDropdownItem Item="item" Dropdown="this" />
+                        <_BitDropdownItem Item="item" Dropdown="this" ItemCheckIconCss="@itemCheckIconCss" />
                     </Virtualize>
                 }
                 else
@@ -296,7 +297,7 @@
                                 OverscanCount="OverscanCount"
                                 Placeholder="VirtualizePlaceholder"
                                 ItemsProvider="InternalItemsProvider">
-                        <_BitDropdownItem Item="item" Dropdown="this" />
+                        <_BitDropdownItem Item="item" Dropdown="this" ItemCheckIconCss="@itemCheckIconCss" />
                     </Virtualize>
                 }
             }
@@ -304,7 +305,7 @@
             {
                 @foreach (var item in GetSearchedItems())
                 {
-                    <_BitDropdownItem Item="item" Dropdown="this" />
+                    <_BitDropdownItem Item="item" Dropdown="this" ItemCheckIconCss="@itemCheckIconCss" />
                 }
             }
         </div>

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Linq.Expressions;
 using System.Diagnostics.CodeAnalysis;
 
@@ -570,11 +570,6 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         await AddOrRemoveSelectedItem(item);
 
         StateHasChanged();
-    }
-
-    internal string? GetItemCheckIconCssClasses()
-    {
-        return BitIconInfo.From(ItemCheckIcon, ItemCheckIconName ?? "Accept")?.GetCssClasses();
     }
 
     internal string GetItemWrapperCssClasses(TItem item)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -197,6 +197,20 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
     public bool IsOpen { get; set; }
 
     /// <summary>
+    /// The icon of the check mark in the multi-select items.
+    /// Takes precedence over <see cref="ItemCheckIconName"/> when both are set.
+    /// Use this property to render icons from external libraries like FontAwesome, Material Icons, or Bootstrap Icons.
+    /// For built-in Fluent UI icons, use <see cref="ItemCheckIconName"/> instead.
+    /// </summary>
+    [Parameter] public BitIconInfo? ItemCheckIcon { get; set; }
+
+    /// <summary>
+    /// The icon name of the check mark in the multi-select items from the Fluent UI icon set.
+    /// For external icon libraries, use <see cref="ItemCheckIcon"/> instead.
+    /// </summary>
+    [Parameter] public string? ItemCheckIconName { get; set; }
+
+    /// <summary>
     /// The list of items to display in the callout.
     /// </summary>
     [Parameter] public ICollection<TItem>? Items { get; set; }
@@ -556,6 +570,11 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         await AddOrRemoveSelectedItem(item);
 
         StateHasChanged();
+    }
+
+    internal string? GetItemCheckIconCssClasses()
+    {
+        return BitIconInfo.From(ItemCheckIcon, ItemCheckIconName ?? "Accept")?.GetCssClasses();
     }
 
     internal string GetItemWrapperCssClasses(TItem item)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
@@ -44,7 +44,7 @@
                         <i aria-hidden="true"
                            aria-label="@text"
                            style="@Dropdown.Styles?.ItemCheckIcon"
-                           class="bit-drp-chm @Dropdown.GetItemCheckIconCssClasses() @Dropdown.Classes?.ItemCheckIcon" />
+                           class="@($"bit-drp-chm {ItemCheckIconCss} {Dropdown.Classes?.ItemCheckIcon}".Trim())" />
                     </div>
 
                     @if (Dropdown.ItemTemplate is not null)
@@ -56,7 +56,8 @@
                         var itemIcon = Dropdown.GetIcon(Item);
                         @if (itemIcon is not null)
                         {
-                            <i style="@Dropdown.Styles?.ItemIcon" class="bit-drp-iic @itemIcon.GetCssClasses() @Dropdown.Classes?.ItemIcon" />
+                            <i style="@Dropdown.Styles?.ItemIcon"
+                               class="bit-drp-iic @itemIcon.GetCssClasses() @Dropdown.Classes?.ItemIcon" />
                         }
                         <span style="@Dropdown.Styles?.ItemText"
                               class="bit-drp-itx @Dropdown.Classes?.ItemText">
@@ -68,7 +69,7 @@
         }
         else
         {
-            <button @onclick="()=> Dropdown.HandleOnItemClick(Item)"
+            <button @onclick="() => Dropdown.HandleOnItemClick(Item)"
                     id="@id"
                     type="button"
                     role="option"
@@ -91,7 +92,8 @@
                     var itemIcon = Dropdown.GetIcon(Item);
                     @if (itemIcon is not null)
                     {
-                        <i style="@Dropdown.Styles?.ItemIcon" class="bit-drp-iic @itemIcon.GetCssClasses() @Dropdown.Classes?.ItemIcon" />
+                        <i style="@Dropdown.Styles?.ItemIcon"
+                           class="bit-drp-iic @itemIcon.GetCssClasses() @Dropdown.Classes?.ItemIcon" />
                     }
                     <span style="@Dropdown.Styles?.ItemText"
                           class="@Dropdown.Classes?.ItemText">

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
@@ -44,7 +44,7 @@
                         <i aria-hidden="true"
                            aria-label="@text"
                            style="@Dropdown.Styles?.ItemCheckIcon"
-                           class="bit-drp-chm bit-icon bit-icon--Accept @Dropdown.Classes?.ItemCheckIcon" />
+                           class="bit-drp-chm @Dropdown.GetItemCheckIconCssClasses() @Dropdown.Classes?.ItemCheckIcon" />
                     </div>
 
                     @if (Dropdown.ItemTemplate is not null)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
@@ -44,7 +44,7 @@
                         <i aria-hidden="true"
                            aria-label="@text"
                            style="@Dropdown.Styles?.ItemCheckIcon"
-                           class="@($"bit-drp-chm {ItemCheckIconCss} {Dropdown.Classes?.ItemCheckIcon}".Trim())" />
+                           class="bit-drp-chm @ItemCheckIconCss @Dropdown.Classes?.ItemCheckIcon" />
                     </div>
 
                     @if (Dropdown.ItemTemplate is not null)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor
@@ -42,7 +42,6 @@
                     <div style="@Dropdown.Styles?.ItemCheckBox"
                          class="bit-drp-chb @Dropdown.Classes?.ItemCheckBox">
                         <i aria-hidden="true"
-                           aria-label="@text"
                            style="@Dropdown.Styles?.ItemCheckIcon"
                            class="bit-drp-chm @ItemCheckIconCss @Dropdown.Classes?.ItemCheckIcon" />
                     </div>

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/_BitDropdownItem.razor.cs
@@ -5,4 +5,6 @@ public partial class _BitDropdownItem<TItem, TValue> : ComponentBase where TItem
     [Parameter] public TItem Item { get; set; } = default!;
 
     [Parameter] public BitDropdown<TItem, TValue> Dropdown { get; set; } = default!;
+
+    [Parameter] public string? ItemCheckIconCss { get; set; }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
@@ -203,6 +203,22 @@ public partial class BitDropdownDemo
         },
         new()
         {
+            Name = "ItemCheckIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "The icon of the check mark in the multi-select items. Takes precedence over ItemCheckIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "ItemCheckIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The icon name of the check mark in the multi-select items from the Fluent UI icon set.",
+        },
+        new()
+        {
             Name = "Items",
             Type = "ICollection<TItem>?",
             DefaultValue = "null",


### PR DESCRIPTION
closes #12217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable checkmark icon support to multi-select dropdown components. Users can now provide custom icon definitions or select alternative icon names from the Fluent UI icon set to personalize the visual appearance of selected item indicators. The component defaults to an "Accept" icon when no custom configuration is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->