### PR TITLE
Add missing new Icon parameter to BitPersona (#12230)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Persona/BitPersona.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Persona/BitPersona.razor
@@ -39,7 +39,9 @@
             <div style="@GetImageContainerStyle()" class="@GetImageContainerClass()" @onclick="HandleImageClick">
                 @if (Unknown)
                 {
-                    <i style="@Styles?.UnknownIcon" class="bit-icon bit-icon--Help @Classes?.UnknownIcon" role="presentation" />
+                    var unknownIconInfo = BitIconInfo.From(UnknownIcon, UnknownIconName ?? "Help");
+
+                    <i style="@Styles?.UnknownIcon" class="@unknownIconInfo?.GetCssClasses() @Classes?.UnknownIcon" role="presentation" />
                 }
                 else if (ImageUrl.HasValue() || CoinTemplate is not null)
                 {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Persona/BitPersona.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Notifications/Persona/BitPersona.razor.cs
@@ -214,6 +214,24 @@ public partial class BitPersona : BitComponentBase
     public bool Unknown { get; set; }
 
     /// <summary>
+    /// Icon for the unknown persona coin.
+    /// </summary>
+    /// <remarks>
+    /// When both <see cref="UnknownIcon"/> and <see cref="UnknownIconName"/> are provided, <see cref="UnknownIcon"/> takes precedence.
+    /// Use this property when you need to configure an external or custom icon (for example, when using a custom icon font or SVG).
+    /// </remarks>
+    [Parameter] public BitIconInfo? UnknownIcon { get; set; }
+
+    /// <summary>
+    /// Icon name for the unknown persona coin.
+    /// </summary>
+    /// <remarks>
+    /// This is a convenience property for specifying an icon from the built-in icon set.
+    /// If <see cref="UnknownIcon"/> is specified, this property is ignored and the value of <see cref="UnknownIcon"/> will be used instead.
+    /// </remarks>
+    [Parameter] public string? UnknownIconName { get; set; }
+
+    /// <summary>
     /// Reverses the texts and image location.
     /// </summary>
     [Parameter, ResetClassBuilder]

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Persona/BitPersonaDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Persona/BitPersonaDemo.razor.cs
@@ -230,6 +230,22 @@ public partial class BitPersonaDemo
         },
         new()
         {
+            Name = "UnknownIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Icon for the unknown persona coin using BitIconInfo. Takes precedence over UnknownIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "UnknownIconName",
+            Type = "string?",
+            DefaultValue = "Help",
+            Description = "Icon name for the unknown persona coin.",
+        },
+        new()
+        {
             Name = "Reversed",
             Type = "bool",
             DefaultValue = "false",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Persona/BitPersonaDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Notifications/Persona/BitPersonaDemo.razor.cs
@@ -241,7 +241,7 @@ public partial class BitPersonaDemo
         {
             Name = "UnknownIconName",
             Type = "string?",
-            DefaultValue = "Help",
+            DefaultValue = "null",
             Description = "Icon name for the unknown persona coin.",
         },
         new()


### PR DESCRIPTION
closes #12230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now customize the icon displayed for unknown persona coins in the BitPersona component. Two configuration options allow specification via icon metadata or icon name, with icon metadata taking precedence when both are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->