### PR TITLE
Add new Icon parameters to BitDialog (#12242)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
@@ -1,4 +1,4 @@
-﻿@namespace Bit.BlazorUI
+@namespace Bit.BlazorUI
 @inherits BitComponentBase
 
 @if (IsOpen)
@@ -31,15 +31,16 @@
 
                             @if (ShowCloseButton)
                             {
+                                var closeIcon = BitIconInfo.From(CloseIcon, CloseIconName ?? "Cancel");
+
                                 <button @onclick="HandleOnCloseClick"
                                         class="bit-dlg-cls"
                                         type="button"
+                                        title="Close"
                                         aria-label="Close"
-                                        aria-describedby="Close"
-                                        aria-hidden="Close"
-                                        title="Close">
+                                        aria-hidden="true">
                                     <span>
-                                        <i class="bit-icon bit-icon--Cancel" />
+                                        <i class="bit-dlg-cli @closeIcon?.GetCssClasses()" />
                                     </span>
                                 </button>
                             }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
@@ -37,8 +37,7 @@
                                         class="bit-dlg-cls"
                                         type="button"
                                         title="Close"
-                                        aria-label="Close"
-                                        aria-hidden="true">
+                                        aria-label="Close">
                                     <span>
                                         <i class="bit-dlg-cli @closeIcon?.GetCssClasses()" />
                                     </span>

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
@@ -49,6 +49,17 @@ public partial class BitDialog : BitComponentBase
     [Parameter] public BitDialogClassStyles? Classes { get; set; }
 
     /// <summary>
+    /// Gets or sets the icon to display for the close button using custom CSS classes for external icon libraries.
+    /// Takes precedence over <see cref="CloseIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? CloseIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the icon to display for the close button from the built-in Fluent UI icons.
+    /// </summary>
+    [Parameter] public string? CloseIconName { get; set; }
+
+    /// <summary>
     /// The CSS selector of the drag element. by default it's the Dialog container.
     /// </summary>
     [Parameter] public string? DragElementSelector { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor
@@ -212,7 +212,52 @@
         </BitDialog>
     </DemoExample>
 
-    <DemoExample Title="RTL" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+    <DemoExample Title="External Icons" RazorCode="@example9RazorCode" Id="example9">
+        <div>Use icons from external libraries like FontAwesome and Bootstrap Icons for the close button with the <b>CloseIcon</b> parameter.</div>
+
+        <br />
+        <br />
+
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+
+        <div>FontAwesome:</div>
+        <br />
+        <BitButton OnClick="@(() => IsOpenExtIcon1 = true)">Open Dialog (CloseIcon = fa)</BitButton>
+        <BitDialog @bind-IsOpen="IsOpenExtIcon1"
+                   Title="FontAwesome Close Icon"
+                   Message="This dialog uses a FontAwesome icon for the close button."
+                   CloseIcon="@BitIconInfo.Fa("solid xmark")" />
+
+        <br /><br />
+
+        <BitButton OnClick="@(() => IsOpenExtIcon2 = true)">Open Dialog (CloseIcon = Css)</BitButton>
+        <BitDialog @bind-IsOpen="IsOpenExtIcon2"
+                   Title="Custom CSS Close Icon"
+                   Message="This dialog uses custom CSS classes for the close button icon."
+                   CloseIcon="@BitIconInfo.Css("fa-solid fa-circle-xmark")" />
+
+        <br /><br /><br /><br />
+
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+
+        <div>Bootstrap:</div>
+        <br />
+        <BitButton OnClick="@(() => IsOpenExtIcon3 = true)">Open Dialog (CloseIcon = Bi)</BitButton>
+        <BitDialog @bind-IsOpen="IsOpenExtIcon3"
+                   Title="Bootstrap Close Icon"
+                   Message="This dialog uses a Bootstrap icon for the close button."
+                   CloseIcon="@BitIconInfo.Bi("x-lg")" />
+
+        <br /><br />
+
+        <BitButton OnClick="@(() => IsOpenExtIcon4 = true)">Open Dialog (CloseIconName)</BitButton>
+        <BitDialog @bind-IsOpen="IsOpenExtIcon4"
+                   Title="CloseIconName"
+                   Message="This dialog uses CloseIconName to set a built-in Fluent UI icon for the close button."
+                   CloseIconName="@BitIconName.ChromeClose" />
+    </DemoExample>
+
+    <DemoExample Title="RTL" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
         <div dir="rtl">
             <BitButton Dir="BitDir.Rtl" OnClick="@(() => IsOpen10 = true)">باز کردن پنجره پیام</BitButton>
             <BitDialog @bind-IsOpen="IsOpen10"

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor
@@ -1,4 +1,4 @@
-﻿@page "/components/dialog"
+@page "/components/dialog"
 
 <PageOutlet Url="components/dialog"
             Title="Dialog"
@@ -212,7 +212,7 @@
         </BitDialog>
     </DemoExample>
 
-    <DemoExample Title="External Icons" RazorCode="@example9RazorCode" Id="example9">
+    <DemoExample Title="External Icons" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
         <div>Use icons from external libraries like FontAwesome and Bootstrap Icons for the close button with the <b>CloseIcon</b> parameter.</div>
 
         <br />

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
@@ -50,6 +50,24 @@ public partial class BitDialogDemo
         },
         new()
         {
+            Name = "CloseIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Gets or sets the icon to display for the close button using custom CSS classes for external icon libraries. Takes precedence over CloseIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "CloseIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Gets or sets the name of the icon to display for the close button from the built-in Fluent UI icons.",
+            LinkType = LinkType.Link,
+            Href = "https://blazorui.bitplatform.dev/iconography",
+        },
+        new()
+        {
             Name = "DragElementSelector",
             Type = "string?",
             DefaultValue = "null",
@@ -301,7 +319,36 @@ public partial class BitDialogDemo
                     Description = "Custom CSS classes/styles for the cancel button of the BitDialog."
                 }
             ]
-        }
+        },
+        new()
+        {
+            Id = "bit-icon-info",
+            Title = "BitIconInfo",
+            Parameters =
+            [
+               new()
+               {
+                   Name = "Name",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the name of the icon."
+               },
+               new()
+               {
+                   Name = "BaseClass",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the base CSS class for the icon. For built-in Fluent UI icons, this defaults to \"bit-icon\". For external icon libraries like FontAwesome, you might set this to \"fa\" or leave empty."
+               },
+               new()
+               {
+                   Name = "Prefix",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the CSS class prefix used before the icon name. For built-in Fluent UI icons, this defaults to \"bit-icon--\". For external icon libraries, you might set this to \"fa-\" or leave empty."
+               },
+            ]
+        },
     ];
 
     private readonly List<ComponentSubEnum> componentSubEnums =
@@ -352,6 +399,11 @@ public partial class BitDialogDemo
     private bool IsDraggable = false;
     private bool IsOpen8 = false;
     private bool IsOpen9 = false;
+
+    private bool IsOpenExtIcon1 = false;
+    private bool IsOpenExtIcon2 = false;
+    private bool IsOpenExtIcon3 = false;
+    private bool IsOpenExtIcon4 = false;
 
     private bool IsOpen10 = false;
 
@@ -626,6 +678,41 @@ private bool IsOpen9 = false;
 ";
 
     private readonly string example9RazorCode = @"
+<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
+
+<BitButton OnClick=""@(() => IsOpenExtIcon1 = true)"">Open Dialog (CloseIcon = fa)</BitButton>
+<BitDialog @bind-IsOpen=""IsOpenExtIcon1""
+           Title=""FontAwesome Close Icon""
+           Message=""This dialog uses a FontAwesome icon for the close button.""
+           CloseIcon=""@BitIconInfo.Fa(""solid xmark"")"" />
+
+<BitButton OnClick=""@(() => IsOpenExtIcon2 = true)"">Open Dialog (CloseIcon = Css)</BitButton>
+<BitDialog @bind-IsOpen=""IsOpenExtIcon2""
+           Title=""Custom CSS Close Icon""
+           Message=""This dialog uses custom CSS classes for the close button icon.""
+           CloseIcon=""@BitIconInfo.Css(""fa-solid fa-circle-xmark"")"" />
+
+
+<link rel=""stylesheet"" href=""https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"" />
+
+<BitButton OnClick=""@(() => IsOpenExtIcon3 = true)"">Open Dialog (CloseIcon = Bi)</BitButton>
+<BitDialog @bind-IsOpen=""IsOpenExtIcon3""
+           Title=""Bootstrap Close Icon""
+           Message=""This dialog uses a Bootstrap icon for the close button.""
+           CloseIcon=""@BitIconInfo.Bi(""x-lg"")"" />
+
+<BitButton OnClick=""@(() => IsOpenExtIcon4 = true)"">Open Dialog (CloseIconName)</BitButton>
+<BitDialog @bind-IsOpen=""IsOpenExtIcon4""
+           Title=""CloseIconName""
+           Message=""This dialog uses CloseIconName to set a built-in Fluent UI icon for the close button.""
+           CloseIconName=""@BitIconName.ChromeClose"" />";
+    private readonly string example9CsharpCode = @"
+private bool IsOpenExtIcon1 = false;
+private bool IsOpenExtIcon2 = false;
+private bool IsOpenExtIcon3 = false;
+private bool IsOpenExtIcon4 = false;";
+
+    private readonly string example10RazorCode = @"
 <BitButton Dir=""BitDir.Rtl"" OnClick=""@(() => IsOpen10 = true)"">باز کردن پنجره پیام</BitButton>
 <BitDialog @bind-IsOpen=""IsOpen10"" 
            Dir=""BitDir.Rtl""
@@ -633,6 +720,6 @@ private bool IsOpen9 = false;
            OkText=""تایید""
            CancelText=""انصراف""
            Message=""آیا می خواهید این پیام را بدون موضوع ارسال کنید؟"" />";
-    private readonly string example9CsharpCode = @"
+    private readonly string example10CsharpCode = @"
 private bool IsOpen10 = false;";
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
@@ -155,4 +155,144 @@ public class BitDialogTests : BunitTestContext
 
         Assert.AreEqual(expected, roleDiv.GetAttribute("role"));
     }
+
+    [TestMethod]
+    public void BitDialogDefaultCloseIconShouldRenderCancelIcon()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        Assert.IsTrue(icon.ClassList.Contains("bit-icon"));
+        Assert.IsTrue(icon.ClassList.Contains("bit-icon--Cancel"));
+    }
+
+    [TestMethod,
+        DataRow("ChromeClose"),
+        DataRow("Cancel")
+    ]
+    public void BitDialogCloseIconNameTest(string iconName)
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIconName, iconName);
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        Assert.IsTrue(icon.ClassList.Contains("bit-icon"));
+        Assert.IsTrue(icon.ClassList.Contains($"bit-icon--{iconName}"));
+    }
+
+    [TestMethod,
+        DataRow("fa-solid fa-xmark"),
+        DataRow("bi bi-x-lg")
+    ]
+    public void BitDialogCloseIconWithCssClassesTest(string cssClasses)
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIcon, (BitIconInfo)cssClasses!);
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        var classes = cssClasses.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        foreach (var cls in classes)
+        {
+            Assert.IsTrue(icon.ClassList.Contains(cls), $"Icon should contain class '{cls}'");
+        }
+    }
+
+    [TestMethod]
+    public void BitDialogCloseIconInfoCssHelperTest()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIcon, BitIconInfo.Css("fa-solid fa-circle-xmark"));
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        Assert.IsTrue(icon.ClassList.Contains("fa-solid"));
+        Assert.IsTrue(icon.ClassList.Contains("fa-circle-xmark"));
+    }
+
+    [TestMethod]
+    public void BitDialogCloseIconInfoFaHelperTest()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIcon, BitIconInfo.Fa("solid xmark"));
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        Assert.IsTrue(icon.ClassList.Contains("fa-solid"));
+        Assert.IsTrue(icon.ClassList.Contains("fa-xmark"));
+    }
+
+    [TestMethod]
+    public void BitDialogCloseIconInfoBiHelperTest()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIcon, BitIconInfo.Bi("x-lg"));
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        Assert.IsTrue(icon.ClassList.Contains("bi"));
+        Assert.IsTrue(icon.ClassList.Contains("bi-x-lg"));
+    }
+
+    [TestMethod]
+    public void BitDialogCloseIconTakesPrecedenceOverCloseIconNameTest()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIcon, BitIconInfo.Fa("solid xmark"));
+            parameters.Add(p => p.CloseIconName, "Cancel");
+        });
+
+        var icon = component.Find(".bit-dlg-cli");
+
+        // CloseIcon parameter should take precedence
+        Assert.IsTrue(icon.ClassList.Contains("fa-solid"));
+        Assert.IsTrue(icon.ClassList.Contains("fa-xmark"));
+
+        // Should not contain CloseIconName classes
+        Assert.IsFalse(icon.ClassList.Contains("bit-icon"));
+        Assert.IsFalse(icon.ClassList.Contains("bit-icon--Cancel"));
+    }
 }


### PR DESCRIPTION
closes #12242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialog close button icons are now customizable through `CloseIcon` and `CloseIconName` parameters, with support for FontAwesome, Bootstrap Icons, and other custom icon libraries.

* **Tests**
  * Added comprehensive unit tests for dialog close button icon rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->