### PR TITLE
Add new Icon parameter to BitProPanel (#12246)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/ProPanel/BitProPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/ProPanel/BitProPanel.razor
@@ -42,10 +42,11 @@
 
             @if (ShowCloseButton)
             {
+                var closeIcon = BitIconInfo.From(CloseIcon, CloseIconName ?? "Cancel");
                 <button @onclick="ClosePanel"
                         style="@Styles?.CloseButton"
                         class="bit-ppl-cls @Classes?.CloseButton">
-                    <i style="@Styles?.CloseIcon" class="bit-icon bit-icon--Cancel @Classes?.CloseIcon" />
+                    <i style="@Styles?.CloseIcon" class="bit-ppl-cli @closeIcon?.GetCssClasses() @Classes?.CloseIcon" />
                 </button>
             }
         </div>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/ProPanel/BitProPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/ProPanel/BitProPanel.razor
@@ -1,4 +1,4 @@
-﻿@namespace Bit.BlazorUI
+@namespace Bit.BlazorUI
 @inherits BitComponentBase
 
 <BitPanel AriaLabel="@AriaLabel"
@@ -43,10 +43,15 @@
             @if (ShowCloseButton)
             {
                 var closeIcon = BitIconInfo.From(CloseIcon, CloseIconName ?? "Cancel");
+
                 <button @onclick="ClosePanel"
+                        type="button"
+                        title="Close"
+                        aria-label="Close"
                         style="@Styles?.CloseButton"
                         class="bit-ppl-cls @Classes?.CloseButton">
-                    <i style="@Styles?.CloseIcon" class="bit-ppl-cli @closeIcon?.GetCssClasses() @Classes?.CloseIcon" />
+                    <i style="@Styles?.CloseIcon"
+                       class="@closeIcon?.GetCssClasses() @Classes?.CloseIcon" />
                 </button>
             }
         </div>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/ProPanel/BitProPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/ProPanel/BitProPanel.razor.cs
@@ -35,6 +35,26 @@ public partial class BitProPanel : BitComponentBase
     [Parameter] public BitProPanelClassStyles? Classes { get; set; }
 
     /// <summary>
+    /// Gets or sets the icon to display in the close button using custom CSS classes for external icon libraries.
+    /// Takes precedence over <see cref="CloseIconName"/> when both are set.
+    /// </summary>
+    /// <remarks>
+    /// Use this property to render icons from external libraries like FontAwesome, Material Icons, or Bootstrap Icons.
+    /// For built-in Fluent UI icons, use <see cref="CloseIconName"/> instead.
+    /// </remarks>
+    [Parameter] public BitIconInfo? CloseIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the icon to display in the close button from the built-in Fluent UI icons.
+    /// </summary>
+    /// <remarks>
+    /// The icon name should be from the Fluent UI icon set (e.g., <c>BitIconName.Cancel</c>).
+    /// <br />
+    /// For external icon libraries, use <see cref="CloseIcon"/> instead.
+    /// </remarks>
+    [Parameter] public string? CloseIconName { get; set; }
+
+    /// <summary>
     /// The template used to render the footer section of the panel.
     /// </summary>
     [Parameter] public RenderFragment? Footer { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor
@@ -322,7 +322,25 @@
                 </BitProPanel>
             </DemoExample>
 
-            <DemoExample Title="RTL" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+            <DemoExample Title="External Icon" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+                <div>Use icons from external libraries like FontAwesome to customize the close button icon with the <b>CloseIcon</b> parameter.</div>
+                <br /><br />
+                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+                <BitButton OnClick="() => isExternalIconProPanelOpen = true">Open ProPanel</BitButton>
+                <BitProPanel @bind-IsOpen="isExternalIconProPanelOpen"
+                             ShowCloseButton
+                             HeaderText="External Close Icon"
+                             CloseIcon="@BitIconInfo.Fa("solid xmark")">
+                    <div style="max-width:300px">
+                        Once upon a time, stories wove connections between people, a symphony of voices crafting shared dreams. 
+                        Each word carried meaning, each pause brought understanding. Placeholder text reminds us of that moment 
+                        when possibilities are limitless, waiting for content to emerge. The spaces here are open for growth, 
+                        for ideas that change minds and spark emotions. This is where the journey begins—your words will lead the way.
+                    </div>
+                </BitProPanel>
+            </DemoExample>
+
+            <DemoExample Title="RTL" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
                 <div>Use BitProPanel in right-to-left (RTL).</div>
                 <br /><br />
                 <div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor.cs
@@ -683,10 +683,10 @@ private BitTextField onDismissTextFieldRef = default!;";
     </div>
 </BitProPanel>";
     private readonly string example6CsharpCode = @"
-private bool isStyledPanelOpen;
-private bool isClassedPanelOpen;
-private bool isPanelStylesOpen;
-private bool isPanelClassesOpen;";
+private bool isStyledProPanelOpen;
+private bool isClassedProPanelOpen;
+private bool isProPanelStylesOpen;
+private bool isProPanelClassesOpen;";
 
     private readonly string example7RazorCode = @"
 <link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor.cs
@@ -43,6 +43,24 @@ public partial class BitProPanelDemo
         },
         new()
         {
+            Name = "CloseIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Gets or sets the icon to display in the close button using custom CSS classes for external icon libraries. Takes precedence over CloseIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "CloseIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Gets or sets the name of the icon to display in the close button from the built-in Fluent UI icons.",
+            LinkType = LinkType.Link,
+            Href = "https://blazorui.bitplatform.dev/iconography",
+        },
+        new()
+        {
             Name = "Footer",
             Type = "RenderFragment?",
             DefaultValue = "null",
@@ -240,6 +258,35 @@ public partial class BitProPanelDemo
                    Description = "Custom CSS classes/styles for the footer container of the BitProPanel."
                }
             ]
+        },
+        new()
+        {
+            Id = "bit-icon-info",
+            Title = "BitIconInfo",
+            Parameters =
+            [
+               new()
+               {
+                   Name = "Name",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the name of the icon."
+               },
+               new()
+               {
+                   Name = "BaseClass",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the base CSS class for the icon. For built-in Fluent UI icons, this defaults to \"bit-icon\". For external icon libraries like FontAwesome, you might set this to \"fa\" or leave empty."
+               },
+               new()
+               {
+                   Name = "Prefix",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the CSS class prefix used before the icon name. For built-in Fluent UI icons, this defaults to \"bit-icon--\". For external icon libraries, you might set this to \"fa-\" or leave empty."
+               },
+            ]
         }
     ];
 
@@ -290,6 +337,8 @@ public partial class BitProPanelDemo
     private bool isClassedProPanelOpen;
     private bool isProPanelStylesOpen;
     private bool isProPanelClassesOpen;
+
+    private bool isExternalIconProPanelOpen;
 
     private bool isRtlProPanelOpenStart;
     private bool isRtlProPanelOpenEnd;
@@ -640,6 +689,24 @@ private bool isPanelStylesOpen;
 private bool isPanelClassesOpen;";
 
     private readonly string example7RazorCode = @"
+<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
+
+<BitButton OnClick=""() => isExternalIconProPanelOpen = true"">Open ProPanel</BitButton>
+<BitProPanel @bind-IsOpen=""isExternalIconProPanelOpen""
+             ShowCloseButton
+             HeaderText=""External Close Icon""
+             CloseIcon=""@BitIconInfo.Fa(""solid xmark"")"">  
+    <div style=""max-width:300px"">
+        Once upon a time, stories wove connections between people, a symphony of voices crafting shared dreams. 
+        Each word carried meaning, each pause brought understanding. Placeholder text reminds us of that moment 
+        when possibilities are limitless, waiting for content to emerge. The spaces here are open for growth, 
+        for ideas that change minds and spark emotions. This is where the journey begins—your words will lead the way.
+    </div>
+</BitProPanel>";
+    private readonly string example7CsharpCode = @"
+private bool isExternalIconProPanelOpen;";
+
+    private readonly string example8RazorCode = @"
 <BitButton OnClick=""() => isRtlPanelOpenStart = true"">آغاز</BitButton>
 <BitButton OnClick=""() => isRtlPanelOpenEnd = true"">پایان</BitButton>
 
@@ -665,7 +732,7 @@ private bool isPanelClassesOpen;";
         در این صورت می توان امید داشت که تمام و دشواری موجود در ارائه راهکارها و شرایط سخت تایپ به پایان رسد وزمان مورد نیاز شامل حروفچینی دستاوردهای اصلی و جوابگوی سوالات پیوسته اهل دنیای موجود طراحی اساسا مورد استفاده قرار گیرد.
     </div>
 </BitProPanel>";
-    private readonly string example7CsharpCode = @"
+    private readonly string example8CsharpCode = @"
 private bool isRtlProPanelOpenStart;
 private bool isRtlProPanelOpenEnd;";
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/ProPanel/BitProPanelDemo.razor.cs
@@ -707,8 +707,8 @@ private bool isPanelClassesOpen;";
 private bool isExternalIconProPanelOpen;";
 
     private readonly string example8RazorCode = @"
-<BitButton OnClick=""() => isRtlPanelOpenStart = true"">آغاز</BitButton>
-<BitButton OnClick=""() => isRtlPanelOpenEnd = true"">پایان</BitButton>
+<BitButton OnClick=""() => isRtlProPanelOpenStart = true"">آغاز</BitButton>
+<BitButton OnClick=""() => isRtlProPanelOpenEnd = true"">پایان</BitButton>
 
 <BitProPanel @bind-IsOpen=""isRtlProPanelOpenStart""
              Dir=""BitDir.Rtl""


### PR DESCRIPTION
closes #12246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable close button icons: The ProPanel component now supports configurable close button icons through new `CloseIcon` and `CloseIconName` parameters
  * External icon library support: Seamlessly integrate with external icon libraries like FontAwesome for enhanced visual customization
  * Flexible configuration: When both parameters are provided, explicit icon configuration takes precedence for maximum control
  * Enhanced documentation: Updated demo examples showcase practical implementation patterns with external icon library integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->