### PR TITLE
Correct mismatched example code in Culture sample of BitCalendar demo (#12274)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Calendar/BitCalendarDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Calendar/BitCalendarDemo.razor.samples.cs
@@ -21,8 +21,8 @@ private DateTimeOffset? startingValue = new DateTimeOffset(2020, 12, 4, 20, 45, 
 <BitCalendar ShowTimePicker=""true"" MinuteStep=""15"" />";
 
     private readonly string example4RazorCode = @"
-<BitCalendar GoToToday=""برو به امروز"" Culture=""CultureInfoHelper.GetFaIrCultureWithFarsiNames()"" />
-<BitCalendar GoToToday=""Boro be emrouz"" Culture=""CultureInfoHelper.GetFaIrCultureWithFingilishNames()"" />";
+<BitCalendar GoToTodayTitle=""برو به امروز"" Culture=""CultureInfoHelper.GetFaIrCultureWithFarsiNames()"" />
+<BitCalendar GoToTodayTitle=""Boro be emrouz"" Culture=""CultureInfoHelper.GetFaIrCultureWithFingilishNames()"" />";
 
     private readonly string example5RazorCode = @"
 <BitCalendar @bind-Value=""@timeZoneDate1"" ShowTimePicker />


### PR DESCRIPTION
closes #12274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Calendar component demo samples to reflect the correct parameter usage for the "go to today" feature across culture-specific examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->