### PR TITLE
Fix the typo in Template section of BitCalendar demo (#12278)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Calendar/BitCalendarDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Calendar/BitCalendarDemo.razor.samples.cs
@@ -177,7 +177,7 @@ private void HandleInvalidSubmit() { }";
 <BitCalendar>
     <MonthCellTemplate>
         <div style=""width:28px;padding:3px;color:black;background:@(context.Month == 1 ? ""lightcoral"" : ""yellowgreen"")"">
-            @Culture.DateTimeFormat.GetAbbreviatedMonthName(context.Month)
+            @culture.DateTimeFormat.GetAbbreviatedMonthName(context.Month)
         </div>
     </MonthCellTemplate>
 </BitCalendar>


### PR DESCRIPTION
closes #12278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the Calendar component demo where the culture setting was not being correctly applied to month name abbreviations, ensuring localized date formatting displays properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->