### PR TITLE
Correct parameter names of demo examples of BitModal (#12295)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Modal/BitModalDemo.razor
@@ -297,7 +297,7 @@
         </BitModal>
     </DemoExample>
 
-    <DemoExample Title="FullSize" RazorCode="@example7RazorCode" CSharpCode="@example7CsharpCode" Id="example7">
+    <DemoExample Title="FullSize" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
         <div>The FullSize parameter of the BitModal allows the modal to be full-screen.</div><br />
         <BitButton OnClick="() => isOpenFullSize = true">Open Modal</BitButton>
         <BitModal @bind-IsOpen="isOpenFullSize" FullSize="isFullSize">
@@ -324,7 +324,7 @@
         </BitModal>
     </DemoExample>
 
-    <DemoExample Title="Events" RazorCode="@example8RazorCode" CSharpCode="@example8CsharpCode" Id="example8">
+    <DemoExample Title="Events" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
         <div>Discover different events available in the BitModal component.</div><br />
         <BitButton OnClick="() => isEventsOpen = true">Open Modal</BitButton>
         <br /><br />


### PR DESCRIPTION
closes #12295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated parameter naming conventions in demo examples for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->