### PR TITLE
Fix docs info of DefaultIsShown parameter of BitTooltip (#12307)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Tooltip/BitTooltipDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Tooltip/BitTooltipDemo.razor.cs
@@ -30,8 +30,8 @@ public partial class BitTooltipDemo
         new()
         {
             Name = "DefaultIsShown",
-            Type = "bool",
-            DefaultValue = "false",
+            Type = "bool?",
+            DefaultValue = "null",
             Description = "Default value of the IsShown."
         },
         new()


### PR DESCRIPTION
closes #12307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Tooltip component initialization behavior by modifying the default parameter handling to support null states, enabling more robust control over component display states and improving initialization consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->