### PR TITLE
Add Color parameter to BitDropdown (#10693)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor
@@ -51,7 +51,7 @@
          aria-required="@Required"
          aria-disabled="@(IsEnabled is false)"
          aria-expanded=@(IsOpen ? "true" : "false")
-         aria-labelledby="@GetDropdownAriaLabelledby"
+         aria-labelledby="@GetDropdownAriaLabelledby()"
          aria-controls="@(IsOpen? _calloutId : null)">
 
         @if (PrefixTemplate is not null)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -107,6 +107,12 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
     [Parameter] public BitDropdownClassStyles? Classes { get; set; }
 
     /// <summary>
+    /// The general color of the dropdown.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public BitColor? Color { get; set; }
+
+    /// <summary>
     /// The icon of the clear button of the dropdown.
     /// Takes precedence over <see cref="ClearButtonIconName"/> when both are set.
     /// Use this property to render icons from external libraries like FontAwesome, Material Icons, or Bootstrap Icons.
@@ -920,6 +926,28 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
     {
         ClassBuilder.Register(() => Classes?.Root);
 
+        ClassBuilder.Register(() => Color switch
+        {
+            BitColor.Primary => "bit-drp-pri",
+            BitColor.Secondary => "bit-drp-sec",
+            BitColor.Tertiary => "bit-drp-ter",
+            BitColor.Info => "bit-drp-inf",
+            BitColor.Success => "bit-drp-suc",
+            BitColor.Warning => "bit-drp-wrn",
+            BitColor.SevereWarning => "bit-drp-swr",
+            BitColor.Error => "bit-drp-err",
+            BitColor.PrimaryBackground => "bit-drp-pbg",
+            BitColor.SecondaryBackground => "bit-drp-sbg",
+            BitColor.TertiaryBackground => "bit-drp-tbg",
+            BitColor.PrimaryForeground => "bit-drp-pfg",
+            BitColor.SecondaryForeground => "bit-drp-sfg",
+            BitColor.TertiaryForeground => "bit-drp-tfg",
+            BitColor.PrimaryBorder => "bit-drp-pbr",
+            BitColor.SecondaryBorder => "bit-drp-sbr",
+            BitColor.TertiaryBorder => "bit-drp-tbr",
+            _ => "bit-drp-pri"
+        });
+
         ClassBuilder.Register(() => Required ? "bit-drp-req" : string.Empty);
 
         ClassBuilder.Register(() => _selectedItems?.Count > 0 ? "bit-drp-hvl" : string.Empty);
@@ -1645,6 +1673,28 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         {
             classes.Add("bit-drp-rtl");
         }
+
+        classes.Add(Color switch
+        {
+            BitColor.Primary => "bit-drp-pri",
+            BitColor.Secondary => "bit-drp-sec",
+            BitColor.Tertiary => "bit-drp-ter",
+            BitColor.Info => "bit-drp-inf",
+            BitColor.Success => "bit-drp-suc",
+            BitColor.Warning => "bit-drp-wrn",
+            BitColor.SevereWarning => "bit-drp-swr",
+            BitColor.Error => "bit-drp-err",
+            BitColor.PrimaryBackground => "bit-drp-pbg",
+            BitColor.SecondaryBackground => "bit-drp-sbg",
+            BitColor.TertiaryBackground => "bit-drp-tbg",
+            BitColor.PrimaryForeground => "bit-drp-pfg",
+            BitColor.SecondaryForeground => "bit-drp-sfg",
+            BitColor.TertiaryForeground => "bit-drp-tfg",
+            BitColor.PrimaryBorder => "bit-drp-pbr",
+            BitColor.SecondaryBorder => "bit-drp-sbr",
+            BitColor.TertiaryBorder => "bit-drp-tbr",
+            _ => "bit-drp-pri"
+        });
 
         return string.Join(' ', classes).Trim();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -5,7 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace Bit.BlazorUI;
 
 /// <summary>
-/// A dropdown is a list in which the selected item is always visible while other items are visible on demand by clicking a dropdown button. Dropdowns are typically used for forms.
+/// A dropdown is a list in which the selected item is always visible while other items are 
+/// visible on demand by clicking a dropdown button. Dropdowns are typically used for forms.
 /// </summary>
 public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TItem : class, new()
 {
@@ -926,27 +927,7 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
     {
         ClassBuilder.Register(() => Classes?.Root);
 
-        ClassBuilder.Register(() => Color switch
-        {
-            BitColor.Primary => "bit-drp-pri",
-            BitColor.Secondary => "bit-drp-sec",
-            BitColor.Tertiary => "bit-drp-ter",
-            BitColor.Info => "bit-drp-inf",
-            BitColor.Success => "bit-drp-suc",
-            BitColor.Warning => "bit-drp-wrn",
-            BitColor.SevereWarning => "bit-drp-swr",
-            BitColor.Error => "bit-drp-err",
-            BitColor.PrimaryBackground => "bit-drp-pbg",
-            BitColor.SecondaryBackground => "bit-drp-sbg",
-            BitColor.TertiaryBackground => "bit-drp-tbg",
-            BitColor.PrimaryForeground => "bit-drp-pfg",
-            BitColor.SecondaryForeground => "bit-drp-sfg",
-            BitColor.TertiaryForeground => "bit-drp-tfg",
-            BitColor.PrimaryBorder => "bit-drp-pbr",
-            BitColor.SecondaryBorder => "bit-drp-sbr",
-            BitColor.TertiaryBorder => "bit-drp-tbr",
-            _ => "bit-drp-pri"
-        });
+        ClassBuilder.Register(() => GetColorClass());
 
         ClassBuilder.Register(() => Required ? "bit-drp-req" : string.Empty);
 
@@ -1210,13 +1191,25 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         await FocusOnSearchBox();
     }
 
-    private void HandleOnValueChanged(object? sender, EventArgs args) => UpdateSelectedItemsFromValues();
+    private void HandleOnValueChanged(object? sender, EventArgs args)
+    {
+        UpdateSelectedItemsFromValues();
+    }
 
-    private void HandleSearchBoxFocusIn() => _inputSearchHasFocus = true;
+    private void HandleSearchBoxFocusIn()
+    {
+        _inputSearchHasFocus = true;
+    }
 
-    private void HandleSearchBoxFocusOut() => _inputSearchHasFocus = false;
+    private void HandleSearchBoxFocusOut()
+    {
+        _inputSearchHasFocus = false;
+    }
 
-    private Task HandleSearchBoxOnClear() => ClearSearchBox();
+    private Task HandleSearchBoxOnClear()
+    {
+        return ClearSearchBox();
+    }
 
     private async Task HandleFilterChange(ChangeEventArgs e)
     {
@@ -1306,7 +1299,10 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         return className.ToString();
     }
 
-    private string GetDropdownAriaLabelledby => Label.HasValue() ? $"{_labelId} {_dropdownTextContainerId}" : _dropdownTextContainerId;
+    private string GetDropdownAriaLabelledby()
+    {
+        return Label.HasValue() ? $"{_labelId} {_dropdownTextContainerId}" : _dropdownTextContainerId;
+    }
 
     private async Task SearchVirtualized()
     {
@@ -1473,7 +1469,10 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         }
     }
 
-    private Task HandleOnClickUnselectItem(TItem? item) => UnselectItem(item);
+    private Task HandleOnClickUnselectItem(TItem? item)
+    {
+        return UnselectItem(item);
+    }
 
     private async Task HandleOnComboInput(ChangeEventArgs e)
     {
@@ -1674,7 +1673,14 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             classes.Add("bit-drp-rtl");
         }
 
-        classes.Add(Color switch
+        classes.Add(GetColorClass());
+
+        return string.Join(' ', classes).Trim();
+    }
+
+    private string GetColorClass()
+    {
+        return Color switch
         {
             BitColor.Primary => "bit-drp-pri",
             BitColor.Secondary => "bit-drp-sec",
@@ -1694,12 +1700,8 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             BitColor.SecondaryBorder => "bit-drp-sbr",
             BitColor.TertiaryBorder => "bit-drp-tbr",
             _ => "bit-drp-pri"
-        });
-
-        return string.Join(' ', classes).Trim();
+        };
     }
-
-
 
     protected override async ValueTask DisposeAsync(bool disposing)
     {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.scss
@@ -7,6 +7,9 @@
     position: relative;
     flex-direction: column;
     font-family: $tg-font-family;
+    --bit-drp-clr: #{$clr-pri};
+    --bit-drp-clr-hover: #{$clr-pri-hover};
+    --bit-drp-clr-text: #{$clr-pri-text};
 
     &.bit-drp-req {
         .bit-drp-lbl {
@@ -173,7 +176,7 @@
             pointer-events: none;
             inset: spacing(-0.125);
             border-radius: $shp-border-radius;
-            border: spacing(0.25) $shp-border-style $clr-pri;
+            border: spacing(0.25) $shp-border-style var(--bit-drp-clr);
         }
     }
 }
@@ -257,12 +260,12 @@
         background-color: $clr-bg-sec;
 
         .bit-drp-chb {
-            border-color: $clr-pri;
-            background-color: $clr-pri;
+            border-color: var(--bit-drp-clr);
+            background-color: var(--bit-drp-clr);
 
             .bit-drp-chm {
                 opacity: 1;
-                color: $clr-pri-text;
+                color: var(--bit-drp-clr-text);
             }
         }
 
@@ -271,8 +274,8 @@
                 background-color: $clr-bg-pri-hover;
 
                 .bit-drp-chb {
-                    border-color: $clr-pri-hover;
-                    background-color: $clr-pri-hover;
+                    border-color: var(--bit-drp-clr-hover);
+                    background-color: var(--bit-drp-clr-hover);
                 }
             }
         }
@@ -420,7 +423,7 @@
 
             .bit-drp-sic {
                 i {
-                    color: $clr-pri-hover;
+                    color: var(--bit-drp-clr-hover);
                 }
             }
         }
@@ -453,7 +456,7 @@
 
             .bit-drp-sic {
                 i {
-                    color: $clr-pri-hover;
+                    color: var(--bit-drp-clr-hover);
                 }
             }
         }
@@ -464,7 +467,7 @@
             &:hover {
                 .bit-drp-sic {
                     width: spacing(0.5);
-                    color: $clr-pri-hover;
+                    color: var(--bit-drp-clr-hover);
 
                     i {
                         opacity: 0;
@@ -475,7 +478,7 @@
     }
 
     &.bit-drp-shf {
-        border-bottom: spacing(0.25) $shp-border-style $clr-pri;
+        border-bottom: spacing(0.25) $shp-border-style var(--bit-drp-clr);
 
         .bit-drp-sic {
             width: spacing(0.5);
@@ -488,7 +491,7 @@
         @media (hover: hover) {
             &:hover {
                 border-width: 0 0 $shp-border-width;
-                border-bottom: spacing(0.25) $shp-border-style $clr-pri;
+                border-bottom: spacing(0.25) $shp-border-style var(--bit-drp-clr);
             }
         }
     }
@@ -503,7 +506,7 @@
     font-size: spacing(2);
     flex-direction: column;
     justify-content: center;
-    color: $clr-pri;
+    color: var(--bit-drp-clr);
     transition: width 0.167s ease 0s;
 
     i {
@@ -512,7 +515,7 @@
         width: unset;
         height: unset;
         display: inline-block;
-        color: $clr-pri;
+        color: var(--bit-drp-clr);
         transition: opacity 0.167s ease 0s;
     }
 }
@@ -573,7 +576,7 @@
     box-sizing: border-box;
     padding: 0 spacing(0.5);
     font-size: spacing(1.75);
-    color: $clr-pri;
+    color: var(--bit-drp-clr);
     background-color: transparent;
     font-family: $tg-font-family;
     border-radius: 0 spacing(0.125) spacing(0.125) 0;
@@ -649,7 +652,7 @@
 
 .bit-drp-ihd {
     width: 100%;
-    color: $clr-pri;
+    color: var(--bit-drp-clr);
     cursor: default;
     font-weight: 600;
     user-select: none;
@@ -795,4 +798,107 @@
         right: unset;
         transform: translateX(-100%);
     }
+}
+
+
+.bit-drp-pri {
+    --bit-drp-clr: #{$clr-pri};
+    --bit-drp-clr-hover: #{$clr-pri-hover};
+    --bit-drp-clr-text: #{$clr-pri-text};
+}
+
+.bit-drp-sec {
+    --bit-drp-clr: #{$clr-sec};
+    --bit-drp-clr-hover: #{$clr-sec-hover};
+    --bit-drp-clr-text: #{$clr-sec-text};
+}
+
+.bit-drp-ter {
+    --bit-drp-clr: #{$clr-ter};
+    --bit-drp-clr-hover: #{$clr-ter-hover};
+    --bit-drp-clr-text: #{$clr-ter-text};
+}
+
+.bit-drp-inf {
+    --bit-drp-clr: #{$clr-inf};
+    --bit-drp-clr-hover: #{$clr-inf-hover};
+    --bit-drp-clr-text: #{$clr-inf-text};
+}
+
+.bit-drp-suc {
+    --bit-drp-clr: #{$clr-suc};
+    --bit-drp-clr-hover: #{$clr-suc-hover};
+    --bit-drp-clr-text: #{$clr-suc-text};
+}
+
+.bit-drp-wrn {
+    --bit-drp-clr: #{$clr-wrn};
+    --bit-drp-clr-hover: #{$clr-wrn-hover};
+    --bit-drp-clr-text: #{$clr-wrn-text};
+}
+
+.bit-drp-swr {
+    --bit-drp-clr: #{$clr-swr};
+    --bit-drp-clr-hover: #{$clr-swr-hover};
+    --bit-drp-clr-text: #{$clr-swr-text};
+}
+
+.bit-drp-err {
+    --bit-drp-clr: #{$clr-err};
+    --bit-drp-clr-hover: #{$clr-err-hover};
+    --bit-drp-clr-text: #{$clr-err-text};
+}
+
+.bit-drp-pbg {
+    --bit-drp-clr: #{$clr-bg-pri};
+    --bit-drp-clr-hover: #{$clr-bg-pri-hover};
+    --bit-drp-clr-text: #{$clr-fg-pri};
+}
+
+.bit-drp-sbg {
+    --bit-drp-clr: #{$clr-bg-sec};
+    --bit-drp-clr-hover: #{$clr-bg-sec-hover};
+    --bit-drp-clr-text: #{$clr-fg-sec};
+}
+
+.bit-drp-tbg {
+    --bit-drp-clr: #{$clr-bg-ter};
+    --bit-drp-clr-hover: #{$clr-bg-ter-hover};
+    --bit-drp-clr-text: #{$clr-fg-ter};
+}
+
+.bit-drp-pfg {
+    --bit-drp-clr: #{$clr-fg-pri};
+    --bit-drp-clr-hover: #{$clr-fg-pri-hover};
+    --bit-drp-clr-text: #{$clr-bg-pri};
+}
+
+.bit-drp-sfg {
+    --bit-drp-clr: #{$clr-fg-sec};
+    --bit-drp-clr-hover: #{$clr-fg-sec-hover};
+    --bit-drp-clr-text: #{$clr-bg-sec};
+}
+
+.bit-drp-tfg {
+    --bit-drp-clr: #{$clr-fg-ter};
+    --bit-drp-clr-hover: #{$clr-fg-ter-hover};
+    --bit-drp-clr-text: #{$clr-bg-ter};
+}
+
+.bit-drp-pbr {
+    --bit-drp-clr: #{$clr-brd-pri};
+    --bit-drp-clr-hover: #{$clr-brd-pri-hover};
+    --bit-drp-clr-text: #{$clr-fg-pri};
+}
+
+.bit-drp-sbr {
+    --bit-drp-clr: #{$clr-brd-sec};
+    --bit-drp-clr-hover: #{$clr-brd-sec-hover};
+    --bit-drp-clr-text: #{$clr-fg-sec};
+}
+
+.bit-drp-tbr {
+    --bit-drp-clr: #{$clr-brd-ter};
+    --bit-drp-clr-hover: #{$clr-brd-ter-hover};
+    --bit-drp-clr-text: #{$clr-fg-ter};
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
@@ -1199,7 +1199,7 @@ public partial class BitDropdownDemo
                 new()
                 {
                     Name= "Primary",
-                    Description="Info Primary general color.",
+                    Description="Primary general color.",
                     Value="0",
                 },
                 new()

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
@@ -89,6 +89,15 @@ public partial class BitDropdownDemo
         },
         new()
         {
+            Name = "Color",
+            Type = "BitColor?",
+            DefaultValue = "null",
+            Description = "The general color of the dropdown.",
+            LinkType = LinkType.Link,
+            Href = "#color-enum",
+        },
+        new()
+        {
             Name = "ClearButtonIcon",
             Type = "BitIconInfo?",
             DefaultValue = "null",
@@ -1177,6 +1186,117 @@ public partial class BitDropdownDemo
                     Name = "Divider",
                     Description = "Dropdown items are being rendered as a divider, just draw a line.",
                     Value = "2",
+                }
+            ]
+        },
+        new()
+        {
+            Id = "color-enum",
+            Name = "BitColor",
+            Description = "Defines the general colors available in the bit BlazorUI.",
+            Items =
+            [
+                new()
+                {
+                    Name= "Primary",
+                    Description="Info Primary general color.",
+                    Value="0",
+                },
+                new()
+                {
+                    Name= "Secondary",
+                    Description="Secondary general color.",
+                    Value="1",
+                },
+                new()
+                {
+                    Name= "Tertiary",
+                    Description="Tertiary general color.",
+                    Value="2",
+                },
+                new()
+                {
+                    Name= "Info",
+                    Description="Info general color.",
+                    Value="3",
+                },
+                new()
+                {
+                    Name= "Success",
+                    Description="Success general color.",
+                    Value="4",
+                },
+                new()
+                {
+                    Name= "Warning",
+                    Description="Warning general color.",
+                    Value="5",
+                },
+                new()
+                {
+                    Name= "SevereWarning",
+                    Description="SevereWarning general color.",
+                    Value="6",
+                },
+                new()
+                {
+                    Name= "Error",
+                    Description="Error general color.",
+                    Value="7",
+                },
+                new()
+                {
+                    Name= "PrimaryBackground",
+                    Description="Primary background color.",
+                    Value="8",
+                },
+                new()
+                {
+                    Name= "SecondaryBackground",
+                    Description="Secondary background color.",
+                    Value="9",
+                },
+                new()
+                {
+                    Name= "TertiaryBackground",
+                    Description="Tertiary background color.",
+                    Value="10",
+                },
+                new()
+                {
+                    Name= "PrimaryForeground",
+                    Description="Primary foreground color.",
+                    Value="11",
+                },
+                new()
+                {
+                    Name= "SecondaryForeground",
+                    Description="Secondary foreground color.",
+                    Value="12",
+                },
+                new()
+                {
+                    Name= "TertiaryForeground",
+                    Description="Tertiary foreground color.",
+                    Value="13",
+                },
+                new()
+                {
+                    Name= "PrimaryBorder",
+                    Description="Primary border color.",
+                    Value="14",
+                },
+                new()
+                {
+                    Name= "SecondaryBorder",
+                    Description="Secondary border color.",
+                    Value="15",
+                },
+                new()
+                {
+                    Name= "TertiaryBorder",
+                    Description="Tertiary border color.",
+                    Value="16",
                 }
             ]
         },

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor
@@ -556,7 +556,69 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="Style & Class" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
+<DemoExample Title="Color" RazorCode="@example16RazorCode" Id="example16">
+    <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div>
+    <br />
+    <div class="example-content">
+        <BitDropdown Label="Primary"
+                     MultiSelect
+                     Color="BitColor.Primary"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Secondary"
+                     MultiSelect
+                     Color="BitColor.Secondary"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Tertiary"
+                     MultiSelect
+                     Color="BitColor.Tertiary"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Info"
+                     MultiSelect
+                     Color="BitColor.Info"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Success"
+                     MultiSelect
+                     Color="BitColor.Success"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Warning"
+                     MultiSelect
+                     Color="BitColor.Warning"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="SevereWarning"
+                     MultiSelect
+                     Color="BitColor.SevereWarning"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Error"
+                     MultiSelect
+                     Color="BitColor.Error"
+                     Items="GetBasicCustoms()"
+                     NameSelectors="nameSelectors"
+                     Placeholder="Select items" />
+    </div>
+</DemoExample>
+
+<DemoExample Title="Style & Class" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
     <div>Empower customization by overriding default styles and classes, allowing tailored design modifications to suit specific UI requirements.</div>
     <br /><br />
     <div class="example-content">
@@ -598,7 +660,7 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="RTL" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
+<DemoExample Title="RTL" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
     <div>Use BitDropdown in right-to-left (RTL).</div>
     <br />
     <dir dir="rtl" style="padding:0">
@@ -626,7 +688,7 @@
     </dir>
 </DemoExample>
 
-<DemoExample Title="Virtualization" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
+<DemoExample Title="Virtualization" RazorCode="@example19RazorCode" CsharpCode="@example19CsharpCode" Id="example19">
     <div>Demonstrates virtualization in the BitDropdown component for handling large datasets efficiently.</div>
     <br /><br /><br />
     <div class="example-content">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor
@@ -556,7 +556,7 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="Color" RazorCode="@example16RazorCode" Id="example16">
+<DemoExample Title="Color" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
     <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div>
     <br />
     <div class="example-content">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor.samples.cs
@@ -810,7 +810,7 @@ private BitDropdownNameSelectors<Product, string?> nameSelectors = new()
     Value = { Selector = c => c.Value },
 };";
 
-    private readonly string example18RazorCode = @"
+    private readonly string example19RazorCode = @"
 <BitDropdown Label=""Single select""
              Virtualize
              Items=""virtualizeCustoms1""
@@ -852,7 +852,7 @@ private BitDropdownNameSelectors<Product, string?> nameSelectors = new()
              Placeholder=""Select items""
              InitialSelectedItems=""initialSelectedItems""
              NameSelectors=""nameSelectors"" />";
-    private readonly string example18CsharpCode = @"
+    private readonly string example19CsharpCode = @"
 public class Product
 {
     public string? Label { get; set; }
@@ -1333,6 +1333,63 @@ private BitDropdownNameSelectors<Product, string> nameSelectors = new()
 };";
 
     private readonly string example16RazorCode = @"
+<BitDropdown Label=""Primary""
+             MultiSelect
+             Color=""BitColor.Primary""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Secondary""
+             MultiSelect
+             Color=""BitColor.Secondary""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Tertiary""
+             MultiSelect
+             Color=""BitColor.Tertiary""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Info""
+             MultiSelect
+             Color=""BitColor.Info""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Success""
+             MultiSelect
+             Color=""BitColor.Success""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Warning""
+             MultiSelect
+             Color=""BitColor.Warning""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""SevereWarning""
+             MultiSelect
+             Color=""BitColor.SevereWarning""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Error""
+             MultiSelect
+             Color=""BitColor.Error""
+             Items=""GetBasicCustoms()""
+             NameSelectors=""nameSelectors""
+             Placeholder=""Select items"" />";
+
+    private readonly string example17RazorCode = @"
 <style>
     .custom-class {
         margin-inline: 1rem;
@@ -1410,7 +1467,7 @@ private BitDropdownNameSelectors<Product, string> nameSelectors = new()
                                 Container = ""custom-container"",
                                 ItemButton = ""custom-item-button"",
                                 ScrollContainer = ""custom-scroll-container"" })"" />";
-    private readonly string example16CsharpCode = @"
+    private readonly string example17CsharpCode = @"
 public class Product
 {
     public string? Label { get; set; }
@@ -1469,7 +1526,7 @@ private BitDropdownNameSelectors<Product, string?> nameSelectors = new()
     Value = { Selector = c => c.Value },
 };";
 
-    private readonly string example17RazorCode = @"
+    private readonly string example18RazorCode = @"
 <BitDropdown Label=""تک انتخابی""
              Dir=""BitDir.Rtl""
              Items=""GetRtlCustoms()""
@@ -1489,7 +1546,7 @@ private BitDropdownNameSelectors<Product, string?> nameSelectors = new()
              Items=""GetRtlCustoms()""
              NameSelectors=""nameSelectors""
              Placeholder=""لطفا انتخاب کنید"" />";
-    private readonly string example17CsharpCode = @"
+    private readonly string example18CsharpCode = @"
 public class Product
 {
     public string? Label { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownCustomDemo.razor.samples.cs
@@ -1388,6 +1388,46 @@ private BitDropdownNameSelectors<Product, string> nameSelectors = new()
              Items=""GetBasicCustoms()""
              NameSelectors=""nameSelectors""
              Placeholder=""Select items"" />";
+    private readonly string example16CsharpCode = @"
+public class Product
+{
+    public string? Label { get; set; }
+    public string? Key { get; set; }
+    public object? Payload { get; set; }
+    public bool Disabled { get; set; }
+    public bool Visible { get; set; } = true;
+    public BitDropdownItemType Type { get; set; } = BitDropdownItemType.Normal;
+    public string? Text { get; set; }
+    public string? Title { get; set; }
+    public string? Value { get; set; }
+}
+
+private List<Product> GetBasicCustoms() => new()
+{
+    new() { Text = ""Fruits"", Type = BitDropdownItemType.Header },
+    new() { Text = ""Apple"", Value = ""f-app"" },
+    new() { Text = ""Banana"", Value = ""f-ban"" },
+    new() { Text = ""Orange"", Value = ""f-ora"", Disabled = true },
+    new() { Text = ""Grape"", Value = ""f-gra"" },
+    new() { Type = BitDropdownItemType.Divider },
+    new() { Text = ""Vegetables"", Type = BitDropdownItemType.Header },
+    new() { Text = ""Broccoli"", Value = ""v-bro"" },
+    new() { Text = ""Carrot"", Value = ""v-car"" },
+    new() { Text = ""Lettuce"", Value = ""v-let"" }
+};
+
+private BitDropdownNameSelectors<Product, string?> nameSelectors = new()
+{
+    AriaLabel = { Selector = c => c.Label },
+    Id = { Selector = c => c.Key },
+    Data = { Selector = c => c.Payload },
+    IsEnabled = { Selector = c => c.Disabled is false },
+    IsHidden = { Selector = c => c.Visible is false },
+    ItemType = { Selector = c => c.Type },
+    Text = { Selector = c => c.Text },
+    Title = { Selector = c => c.Title },
+    Value = { Selector = c => c.Value },
+};";
 
     private readonly string example17RazorCode = @"
 <style>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor
@@ -544,7 +544,77 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="Style & Class" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
+<DemoExample Title="Color" RazorCode="@example16RazorCode" Id="example16">
+    <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div>
+    <br />
+    <div class="example-content">
+        <BitDropdown Label="Primary"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Primary"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Secondary"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Secondary"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Tertiary"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Tertiary"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Info"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Info"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Success"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Success"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Warning"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Warning"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="SevereWarning"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.SevereWarning"
+                     Placeholder="Select items" />
+        <br /><br />
+        <BitDropdown Label="Error"
+                     MultiSelect
+                     ShowSearchBox
+                     DefaultValue="@("")"
+                     Items="GetBasicItems()"
+                     Color="BitColor.Error"
+                     Placeholder="Select items" />
+    </div>
+</DemoExample>
+
+<DemoExample Title="Style & Class" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
     <div>Empower customization by overriding default styles and classes, allowing tailored design modifications to suit specific UI requirements.</div>
     <br /><br />
     <div class="example-content">
@@ -586,7 +656,7 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="RTL" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
+<DemoExample Title="RTL" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
     <div>Use BitDropdown in right-to-left (RTL).</div>
     <br />
     <dir dir="rtl" style="padding:0">
@@ -614,7 +684,7 @@
     </dir>
 </DemoExample>
 
-<DemoExample Title="Virtualization" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
+<DemoExample Title="Virtualization" RazorCode="@example19RazorCode" CsharpCode="@example19CsharpCode" Id="example19">
     <div>Demonstrates virtualization in the BitDropdown component for handling large datasets efficiently.</div>
     <br /><br /><br />
     <div class="example-content">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor
@@ -544,7 +544,7 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="Color" RazorCode="@example16RazorCode" Id="example16">
+<DemoExample Title="Color" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
     <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div>
     <br />
     <div class="example-content">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor.samples.cs
@@ -530,7 +530,7 @@ private List<BitDropdownItem<string>> GetBasicItems() => new()
     new() { Text = ""Lettuce"", Value = ""v-let"" }
 };";
 
-    private readonly string example18RazorCode = @"
+    private readonly string example19RazorCode = @"
 <BitDropdown Label=""Single select""
              Virtualize
              Items=""virtualizeItems1""
@@ -572,7 +572,7 @@ private List<BitDropdownItem<string>> GetBasicItems() => new()
              Placeholder=""Select items""
              InitialSelectedItems=""initialSelectedItems""
              TItem=""BitDropdownItem<string>"" TValue=""string"" />";
-    private readonly string example18CsharpCode = @"
+    private readonly string example19CsharpCode = @"
 private ICollection<BitDropdownItem<string>>? virtualizeItems1;
 private ICollection<BitDropdownItem<string>>? virtualizeItems2;
 
@@ -902,6 +902,71 @@ private List<BitDropdownItem<string>> GetExternalIconBiItems() => new()
 };";
 
     private readonly string example16RazorCode = @"
+<BitDropdown Label=""Primary""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Primary""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Secondary""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Secondary""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Tertiary""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Tertiary""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Info""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Info""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Success""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Success""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Warning""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Warning""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""SevereWarning""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.SevereWarning""
+             Placeholder=""Select items"" />
+
+<BitDropdown Label=""Error""
+             MultiSelect
+             ShowSearchBox
+             DefaultValue=""@("""")""
+             Items=""GetBasicItems()""
+             Color=""BitColor.Error""
+             Placeholder=""Select items"" />";
+
+    private readonly string example17RazorCode = @"
 <style>
     .custom-class {
         margin-inline: 1rem;
@@ -979,7 +1044,7 @@ private List<BitDropdownItem<string>> GetExternalIconBiItems() => new()
                                 Container = ""custom-container"",
                                 ItemButton = ""custom-item-button"",
                                 ScrollContainer = ""custom-scroll-container"" })"" />";
-    private readonly string example16CsharpCode = @"
+    private readonly string example17CsharpCode = @"
 private List<BitDropdownItem<string>> GetBasicItems() => new()
 {
     new() { ItemType = BitDropdownItemType.Header, Text = ""Fruits"" },
@@ -1008,7 +1073,7 @@ private List<BitDropdownItem<string>> GetStyleClassItems() => new()
     new() { Text = ""Lettuce"", Value = ""v-let"", Class = ""custom-veg"" }
 };";
 
-    private readonly string example17RazorCode = @"
+    private readonly string example18RazorCode = @"
 <BitDropdown Label=""تک انتخابی""
              Items=""GetRtlItems()""
              DefaultValue=""@string.Empty""
@@ -1028,7 +1093,7 @@ private List<BitDropdownItem<string>> GetStyleClassItems() => new()
              Items=""GetRtlItems()""
              DefaultValue=""@string.Empty""
              Placeholder=""لطفا انتخاب کنید"" />";
-    private readonly string example17CsharpCode = @"
+    private readonly string example18CsharpCode = @"
 private List<BitDropdownItem<string>> GetRtlItems() => new()
 {
     new() { ItemType = BitDropdownItemType.Header, Text = ""میوه ها"" },

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownItemDemo.razor.samples.cs
@@ -965,6 +965,20 @@ private List<BitDropdownItem<string>> GetExternalIconBiItems() => new()
              Items=""GetBasicItems()""
              Color=""BitColor.Error""
              Placeholder=""Select items"" />";
+    private readonly string example16CsharpCode = @"
+private List<BitDropdownItem<string>> GetBasicItems() => new()
+{
+    new() { ItemType = BitDropdownItemType.Header, Text = ""Fruits"" },
+    new() { Text = ""Apple"", Value = ""f-app"" },
+    new() { Text = ""Banana"", Value = ""f-ban"" },
+    new() { Text = ""Orange"", Value = ""f-ora"", IsEnabled = false },
+    new() { Text = ""Grape"", Value = ""f-gra"" },
+    new() { ItemType = BitDropdownItemType.Divider },
+    new() { ItemType = BitDropdownItemType.Header, Text = ""Vegetables"" },
+    new() { Text = ""Broccoli"", Value = ""v-bro"" },
+    new() { Text = ""Carrot"", Value = ""v-car"" },
+    new() { Text = ""Lettuce"", Value = ""v-let"" }
+};";
 
     private readonly string example17RazorCode = @"
 <style>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor
@@ -795,7 +795,101 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="Style & Class" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
+<DemoExample Title="Color" RazorCode="@example16RazorCode" Id="example16">
+    <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div>
+    <br />
+    <div class="example-content">
+        <BitDropdown Label="Primary"
+                     MultiSelect
+                     Color="BitColor.Primary"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="Secondary"
+                     MultiSelect
+                     Color="BitColor.Secondary"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="Tertiary"
+                     MultiSelect
+                     Color="BitColor.Tertiary"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="Info"
+                     MultiSelect
+                     Color="BitColor.Info"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="Success"
+                     MultiSelect
+                     Color="BitColor.Success"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="Warning"
+                     MultiSelect
+                     Color="BitColor.Warning"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="SevereWarning"
+                     MultiSelect
+                     Color="BitColor.SevereWarning"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+        <br /><br />
+        <BitDropdown Label="Error"
+                     MultiSelect
+                     Color="BitColor.Error"
+                     Placeholder="Select items"
+                     TItem="BitDropdownOption<string>" TValue="string">
+            @foreach (var item in basicItems)
+            {
+                <BitDropdownOption ItemType="item.ItemType" Text="@item.Text" Value="item.Value" IsEnabled="item.IsEnabled" />
+            }
+        </BitDropdown>
+    </div>
+</DemoExample>
+
+<DemoExample Title="Style & Class" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
     <div>Empower customization by overriding default styles and classes, allowing tailored design modifications to suit specific UI requirements.</div>
     <br /><br />
     <div class="example-content">
@@ -857,7 +951,7 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="RTL" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
+<DemoExample Title="RTL" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
     <div>Use BitDropdown in right-to-left (RTL).</div>
     <br />
     <dir dir="rtl" style="padding:0">
@@ -897,6 +991,6 @@
     </dir>
 </DemoExample>
 
-<DemoExample Title="Virtualization" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
+<DemoExample Title="Virtualization" RazorCode="@example19RazorCode" CsharpCode="@example19CsharpCode" Id="example19">
     <div>Not applicable to option demo!</div>
 </DemoExample>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor
@@ -795,7 +795,7 @@
     </div>
 </DemoExample>
 
-<DemoExample Title="Color" RazorCode="@example16RazorCode" Id="example16">
+<DemoExample Title="Color" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
     <div>Offering a range of specialized color variants with Primary being the default, providing visual cues for specific actions or states within your application.</div>
     <br />
     <div class="example-content">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor.samples.cs
@@ -957,6 +957,95 @@ private readonly List<BitDropdownItem<string>> basicItems =
 ];";
 
     private readonly string example16RazorCode = @"
+<BitDropdown Label=""Primary""
+             MultiSelect
+             Color=""BitColor.Primary""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""Secondary""
+             MultiSelect
+             Color=""BitColor.Secondary""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""Tertiary""
+             MultiSelect
+             Color=""BitColor.Tertiary""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""Info""
+             MultiSelect
+             Color=""BitColor.Info""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""Success""
+             MultiSelect
+             Color=""BitColor.Success""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""Warning""
+             MultiSelect
+             Color=""BitColor.Warning""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""SevereWarning""
+             MultiSelect
+             Color=""BitColor.SevereWarning""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>
+
+<BitDropdown Label=""Error""
+             MultiSelect
+             Color=""BitColor.Error""
+             Placeholder=""Select items""
+             TItem=""BitDropdownOption<string>"" TValue=""string"">
+    @foreach (var item in basicItems)
+    {
+        <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
+    }
+</BitDropdown>";
+
+    private readonly string example17RazorCode = @"
 <style>
     .custom-class {
         margin-inline: 1rem;
@@ -1054,7 +1143,7 @@ private readonly List<BitDropdownItem<string>> basicItems =
         <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
     }
 </BitDropdown>";
-    private readonly string example16CsharpCode = @"
+    private readonly string example17CsharpCode = @"
 private readonly List<BitDropdownItem<string>> basicItems =
 [
     new() { ItemType = BitDropdownItemType.Header, Text = ""Fruits"" },
@@ -1083,7 +1172,7 @@ private readonly List<BitDropdownItem<string>> styleClassItems =
     new() { Text = ""Lettuce"", Value = ""v-let"", Class = ""custom-veg"" }
 ];";
 
-    private readonly string example17RazorCode = @"
+    private readonly string example18RazorCode = @"
 <BitDropdown Label=""تک انتخابی""
              Dir=""BitDir.Rtl""
              Placeholder=""لطفا انتخاب کنید""
@@ -1115,7 +1204,7 @@ private readonly List<BitDropdownItem<string>> styleClassItems =
         <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
     }
 </BitDropdown>";
-    private readonly string example17CsharpCode = @"
+    private readonly string example18CsharpCode = @"
 private readonly List<BitDropdownItem<string>> rtlItems =
 [
     new() { ItemType = BitDropdownItemType.Header, Text = ""میوه ها"" },
@@ -1130,6 +1219,6 @@ private readonly List<BitDropdownItem<string>> rtlItems =
     new() { Text = ""کاهو"", Value = ""v-let"" }
 ];";
 
-    private readonly string example18RazorCode = @"";
-    private readonly string example18CsharpCode = @"";
+    private readonly string example19RazorCode = @"";
+    private readonly string example19CsharpCode = @"";
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/_BitDropdownOptionDemo.razor.samples.cs
@@ -1044,6 +1044,20 @@ private readonly List<BitDropdownItem<string>> basicItems =
         <BitDropdownOption ItemType=""item.ItemType"" Text=""@item.Text"" Value=""item.Value"" IsEnabled=""item.IsEnabled"" />
     }
 </BitDropdown>";
+    private readonly string example16CsharpCode = @"
+private readonly List<BitDropdownItem<string>> basicItems =
+[
+    new() { ItemType = BitDropdownItemType.Header, Text = ""Fruits"" },
+    new() { Text = ""Apple"", Value = ""f-app"" },
+    new() { Text = ""Banana"", Value = ""f-ban"" },
+    new() { Text = ""Orange"", Value = ""f-ora"", IsEnabled = false },
+    new() { Text = ""Grape"", Value = ""f-gra"" },
+    new() { ItemType = BitDropdownItemType.Divider },
+    new() { ItemType = BitDropdownItemType.Header, Text = ""Vegetables"" },
+    new() { Text = ""Broccoli"", Value = ""v-bro"" },
+    new() { Text = ""Carrot"", Value = ""v-car"" },
+    new() { Text = ""Lettuce"", Value = ""v-let"" }
+];";
 
     private readonly string example17RazorCode = @"
 <style>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Dropdown/BitDropdownTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Dropdown/BitDropdownTests.cs
@@ -1208,6 +1208,78 @@ public class BitDropdownTests : BunitTestContext
         }
     }
 
+    [TestMethod]
+    [DataRow(BitColor.Primary, "bit-drp-pri")]
+    [DataRow(BitColor.Secondary, "bit-drp-sec")]
+    [DataRow(BitColor.Tertiary, "bit-drp-ter")]
+    [DataRow(BitColor.Info, "bit-drp-inf")]
+    [DataRow(BitColor.Success, "bit-drp-suc")]
+    [DataRow(BitColor.Warning, "bit-drp-wrn")]
+    [DataRow(BitColor.SevereWarning, "bit-drp-swr")]
+    [DataRow(BitColor.Error, "bit-drp-err")]
+    [DataRow(BitColor.PrimaryBackground, "bit-drp-pbg")]
+    [DataRow(BitColor.SecondaryBackground, "bit-drp-sbg")]
+    [DataRow(BitColor.TertiaryBackground, "bit-drp-tbg")]
+    [DataRow(BitColor.PrimaryForeground, "bit-drp-pfg")]
+    [DataRow(BitColor.SecondaryForeground, "bit-drp-sfg")]
+    [DataRow(BitColor.TertiaryForeground, "bit-drp-tfg")]
+    [DataRow(BitColor.PrimaryBorder, "bit-drp-pbr")]
+    [DataRow(BitColor.SecondaryBorder, "bit-drp-sbr")]
+    [DataRow(BitColor.TertiaryBorder, "bit-drp-tbr")]
+    [DataRow(null, "bit-drp-pri")]
+    public void BitDropdownColorTest(BitColor? color, string expectedClass)
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDropdown<BitDropdownItem<string>, string>>(parameters =>
+        {
+            if (color.HasValue)
+            {
+                parameters.Add(p => p.Color, color.Value);
+            }
+        });
+
+        var bitDrp = component.Find(".bit-drp");
+
+        Assert.IsTrue(bitDrp.ClassList.Contains(expectedClass));
+    }
+
+    [TestMethod]
+    [DataRow(BitColor.Primary, "bit-drp-pri")]
+    [DataRow(BitColor.Secondary, "bit-drp-sec")]
+    [DataRow(BitColor.Tertiary, "bit-drp-ter")]
+    [DataRow(BitColor.Info, "bit-drp-inf")]
+    [DataRow(BitColor.Success, "bit-drp-suc")]
+    [DataRow(BitColor.Warning, "bit-drp-wrn")]
+    [DataRow(BitColor.SevereWarning, "bit-drp-swr")]
+    [DataRow(BitColor.Error, "bit-drp-err")]
+    [DataRow(BitColor.PrimaryBackground, "bit-drp-pbg")]
+    [DataRow(BitColor.SecondaryBackground, "bit-drp-sbg")]
+    [DataRow(BitColor.TertiaryBackground, "bit-drp-tbg")]
+    [DataRow(BitColor.PrimaryForeground, "bit-drp-pfg")]
+    [DataRow(BitColor.SecondaryForeground, "bit-drp-sfg")]
+    [DataRow(BitColor.TertiaryForeground, "bit-drp-tfg")]
+    [DataRow(BitColor.PrimaryBorder, "bit-drp-pbr")]
+    [DataRow(BitColor.SecondaryBorder, "bit-drp-sbr")]
+    [DataRow(BitColor.TertiaryBorder, "bit-drp-tbr")]
+    [DataRow(null, "bit-drp-pri")]
+    public void BitDropdownColorCalloutTest(BitColor? color, string expectedClass)
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDropdown<BitDropdownItem<string>, string>>(parameters =>
+        {
+            if (color.HasValue)
+            {
+                parameters.Add(p => p.Color, color.Value);
+            }
+        });
+
+        var callout = component.Find(".bit-drp-cal");
+
+        Assert.IsTrue(callout.ClassList.Contains(expectedClass));
+    }
+
     private void HandleValueChanged(string value)
     {
         _bitDropdownValue = value;


### PR DESCRIPTION
closes #10693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BitDropdown now supports selectable color themes (Primary, Secondary, Tertiary, Info, Success, Warning, SevereWarning, Error).

* **Style**
  * Dropdown styling migrated to CSS custom properties to enable themed colors across dropdown parts.

* **Documentation**
  * Demo pages and examples updated with a new "Color" demo showcasing color variants; demo examples reindexed accordingly.

* **Tests**
  * Added tests validating dropdown color classes on root and callout elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12323)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->