### PR TITLE
Improve automated test run speed for Aspire-enabled Boilerplate projects (#12332)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/TestsAssemblyInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/TestsAssemblyInitializer.cs
@@ -1,4 +1,4 @@
-﻿//+:cnd:noEmit
+//+:cnd:noEmit
 using Microsoft.EntityFrameworkCore;
 //#if (aspire == true)
 using Aspire.Hosting;
@@ -46,19 +46,39 @@ public partial class TestsAssemblyInitializer
     /// </summary>
     private static async Task RunAspireHost(TestContext testContext)
     {
-        var aspireBuilder = await DistributedApplicationTestingBuilder
+        var aspireAppBuilder = await DistributedApplicationTestingBuilder
             .CreateAsync<Program>(testContext.CancellationToken);
 
-        foreach (var res in aspireBuilder.Resources.OfType<ProjectResource>().ToList())
-            aspireBuilder.Resources.Remove(res);
-        foreach (var res in aspireBuilder.Resources.OfType<DevTunnelResource>().ToList()) // remove unnecessary resources.
-            aspireBuilder.Resources.Remove(res);
+        foreach (var res in aspireAppBuilder.Resources.Where(r => r is ProjectResource or IResourceWithParent<ProjectResource>).ToList())
+            aspireAppBuilder.Resources.Remove(res);
 
-        aspireApp = await aspireBuilder.BuildAsync(testContext.CancellationToken);
+        // The following resources are not that much useful in tests and just add to the startup time, so we remove them from the application.
+        foreach (var res in aspireAppBuilder.Resources.Where(r => r is DevTunnelResource or DevTunnelPortResource
+            //#if (database == 'SqlServer')
+            or DbGateContainerResource
+            //#elif (database == 'PostgreSql')
+            or Aspire.Hosting.Postgres.PgAdminContainerResource
+            //#elif (database == 'MySql')
+            or Aspire.Hosting.MySql.PhpMyAdminContainerResource
+            //#elif (database == 'Sqlite')
+            or SqliteWebResource
+            //#endif
+            //#if (redis == true)
+            or Aspire.Hosting.Redis.RedisInsightResource
+            or Aspire.Hosting.Redis.RedisCommanderResource
+            //#endif
+            or Aspire.Hosting.Maui.MauiAndroidDeviceResource
+            or Aspire.Hosting.Maui.MauiAndroidEmulatorResource
+            || r.GetType().Name is "OtlpLoopbackResource").ToList())
+        {
+            aspireAppBuilder.Resources.Remove(res);
+        }
+
+        aspireApp = await aspireAppBuilder.BuildAsync(testContext.CancellationToken);
 
         await aspireApp.StartAsync(testContext.CancellationToken);
 
-        foreach (var connectionString in aspireBuilder.Resources.OfType<IResourceWithConnectionString>())
+        foreach (var connectionString in aspireAppBuilder.Resources.OfType<IResourceWithConnectionString>())
         {
             Environment.SetEnvironmentVariable($"ConnectionStrings__{connectionString.Name}", await aspireApp.GetConnectionStringAsync(connectionString.Name, testContext.CancellationToken));
             await aspireApp.ResourceNotifications.WaitForResourceAsync(connectionString.Name, [.. KnownResourceStates.TerminalStates, KnownResourceStates.Running], testContext.CancellationToken);


### PR DESCRIPTION
closes #12332

## Summary

When running `dotnet test` on an Aspire-enabled Boilerplate project, the AppHost starts all resources defined — including admin UIs, dev tunnels, telemetry listeners, and MAUI device emulators. These add significant startup time without providing any value during automated tests.

This PR updates `TestsAssemblyInitializer.cs` to remove the following unnecessary resources before building and starting the Aspire app:

- `DevTunnelResource` / `DevTunnelPortResource`
- Database admin UIs: `DbGateContainerResource` (SqlServer), `PgAdminContainerResource` (PostgreSQL), `PhpMyAdminContainerResource` (MySQL), `SqliteWebResource` (Sqlite)
- Redis UI tools: `RedisInsightResource`, `RedisCommanderResource`
- MAUI device resources: `MauiAndroidDeviceResource`, `MauiAndroidEmulatorResource`
- OTLP loopback resource

Only essential infrastructure (databases, Redis, etc.) runs during tests, reducing startup time considerably.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test infrastructure by streamlining Aspire test host setup to remove unnecessary resources during testing, improving test reliability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->