### PR TITLE
Add Microsoft.EntityFrameworkCore.Design to prevent fallback to 8.x version (#12333)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -130,6 +130,7 @@
         <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Identity.Web" Version="4.9.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.7" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Boilerplate.Server.Api.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Boilerplate.Server.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -66,6 +66,7 @@
         <PackageReference Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="CommunityToolkit.Datasync.Server" />
         <PackageReference Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
         <PackageReference Include="AspNetCore.HealthChecks.Uris" />
         <PackageReference Include="AspNetCore.HealthChecks.Hangfire" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Boilerplate.Server.Web.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Boilerplate.Server.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -16,6 +16,7 @@
         <PackageReference Include="Bit.BlazorES2019" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
         <PackageReference Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
+        <PackageReference Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
         <PackageReference Condition=" '$(sentry)' == 'true' OR '$(sentry)' == '' " Include="Sentry.AspNetCore" />
     </ItemGroup>
 


### PR DESCRIPTION
closes #12333

## Summary

Without an explicit reference to `Microsoft.EntityFrameworkCore.Design`, the EF Core CLI (`dotnet ef`) can fall back to resolving an older `8.x.x` version of the Design package, which causes compatibility issues in an EF Core 10-powered project.

This PR explicitly pins `Microsoft.EntityFrameworkCore.Design` (with `PrivateAssets="all"`) in:

- `Directory.Packages.props` — central version pin at `10.0.7`
- `Boilerplate.Server.Api.csproj` — unconditional reference (always needs EF migrations)
- `Boilerplate.Server.Web.csproj` — conditional reference (same condition as `Microsoft.EntityFrameworkCore.Tools`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added EntityFramework Core Design package to project dependencies across boilerplate template configurations
  * Standardized project file encoding in boilerplate templates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->