### PR TITLE
Add WithOtlpExporter() to infrastructure resources in Boilerplate AppHost (#12336)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
@@ -1,4 +1,4 @@
-﻿//+:cnd:noEmit
+//+:cnd:noEmit
 using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -8,11 +8,13 @@ var builder = DistributedApplication.CreateBuilder(args);
 //#if(redis == true)
 // Redis cache for FusionCache hybrid caching (L2 cache) and SignalR backplane - no persistence needed
 var redisCache = builder.AddRedis("redis-cache")
+    .WithOtlpExporter()
     .WithRedisInsight()
     .WithRedisCommander();
 
 // Redis for Hangfire background jobs, and distributed locking - persistent with AOF for durability
 var redisPersistent = builder.AddRedis("redis-persistent")
+    .WithOtlpExporter()
     .WithRedisInsight()
     .WithRedisCommander()
     .WithDataVolume()
@@ -26,6 +28,7 @@ var redisPersistent = builder.AddRedis("redis-persistent")
 
 //#if (database == "SqlServer")
 var sqlDatabase = builder.AddSqlServer("sqlserver")
+        .WithOtlpExporter()
         .WithDbGate(config => config.WithDataVolume())
         .WithDataVolume()
         .WithImage("mssql/server", "2025-latest")
@@ -33,6 +36,7 @@ var sqlDatabase = builder.AddSqlServer("sqlserver")
 
 //#elif (database == "PostgreSql")
 var postgresDatabase = builder.AddPostgres("postgresserver")
+        .WithOtlpExporter()
         .WithPgAdmin()
         .WithV18DataVolume()
         .WithOptimizedSetup()
@@ -41,6 +45,7 @@ var postgresDatabase = builder.AddPostgres("postgresserver")
 
 //#elif (database == "MySql")
 var mySqlDatabase = builder.AddMySql("mysqlserver")
+        .WithOtlpExporter()
         .WithPhpMyAdmin()
         .WithDataVolume()
         .AddDatabase("mysqldb");
@@ -59,11 +64,13 @@ var azureBlobStorage = builder.AddAzureStorage("storage")
 
 //#elif (filesStorage == "S3")
 var s3Storage = builder.AddMinioContainer("s3")
+    .WithOtlpExporter()
     .WithDataVolume();
 //#endif
 
 // https://aspire.dev/integrations/security/keycloak/
 var keycloak = builder.AddKeycloak("keycloak", 8080)
+    .WithOtlpExporter()
     .WithDataVolume()
     .WithRealmImport("./Infrastructure/Realms");
 


### PR DESCRIPTION
closes #12336

## Summary

Infrastructure resources in `Boilerplate.Server.AppHost/Program.cs` were missing `.WithOtlpExporter()`, so their telemetry (traces, metrics, logs) was not exported to the Aspire dashboard.

This PR adds `.WithOtlpExporter()` to:

- `redis-cache` and `redis-persistent`
- `sqlserver` (SqlServer)
- `postgresserver` (PostgreSQL)
- `mysqlserver` (MySQL)
- `s3` (Minio)
- `keycloak`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure observability with OpenTelemetry OTLP exporting enabled for Redis caching, database services, object storage, and authentication components, providing improved system monitoring and visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->