### PR TITLE
fix dotnet dev-certs --trust fails on .NET SDK 10.0.200+ in CI (#12340)

### DIFF
--- a/.github/workflows/bit.full.ci.yml
+++ b/.github/workflows/bit.full.ci.yml
@@ -72,9 +72,6 @@ jobs:
     - name: Create project from template with PostgreSQL
       run: dotnet new bit-bp --name TestPostgreSQL --database PostgreSQL --module Sales --signalR --aspire --redis
 
-    - name: Trust dotnet cert
-      run: dotnet dev-certs https --trust # Necessary for aspire related resources
-
     - name: Create appsettings.json for Client.Web
       run: |
         echo '{"ServerAddress":"/"}' > TestPostgreSQL/src/Client/TestPostgreSQL.Client.Web/wwwroot/appsettings.json
@@ -85,6 +82,10 @@ jobs:
         dotnet build
         dotnet tool restore
         dotnet ef migrations add Initial --verbose
+
+    - name: Trust dotnet cert
+      continue-on-error: true
+      run: dotnet dev-certs https --trust # Necessary for aspire related resources
 
     - name: Build and run tests
       id: run-test-postgresql

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/ci.yml
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       run: pwsh src/Tests/bin/Debug/net10.0/playwright.ps1 install --with-deps
 
     - name: Trust dotnet cert
+      continue-on-error: true
       run: dotnet dev-certs https --trust # Necessary for aspire related resources
 
     - name: Test


### PR DESCRIPTION
closes #12340 

## Summary

Starting from .NET SDK **10.0.200**, `dotnet dev-certs https --trust` exits with a non-zero exit code in CI (Linux runners), causing the workflow to fail — even though the certificate **is still trusted** successfully.

This is required for Aspire-based automated testing, as Aspire uses the same dev certificate.

## Changes

### `.github/workflows/bit.full.ci.yml`
- **Moved** the "Trust dotnet cert" step to run **after** `dotnet ef migrations add Initial` (right before the tests)
- Added `continue-on-error: true`

### `src/Templates/Boilerplate/Bit.Boilerplate/.github/workflows/ci.yml`
- Added `continue-on-error: true` to the existing "Trust dotnet cert" step

```yaml
- name: Trust dotnet cert
  continue-on-error: true
  run: dotnet dev-certs https --trust # Necessary for aspire related resources
```

## Related

- Issue: #12340
