### PR TITLE
Add Undo/Redo feature to BitMarkdownEditor (#10278)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
@@ -26,7 +26,8 @@ namespace BitBlazorUI {
             const editor = MarkdownEditor._editors[id];
             if (!editor) return;
 
-            return editor.value = value;
+            editor.value = value;
+            editor.resetHistory();
         }
 
         public static run(id: string, cmd: string) {
@@ -66,6 +67,7 @@ namespace BitBlazorUI {
         private _history: string[] = [];
         private _historyIndex: number = -1;
         private _historyDebounce: ReturnType<typeof setTimeout> | null = null;
+        private readonly _maxHistorySize: number = 100;
 
         private textArea: HTMLTextAreaElement;
         private dotnetObj: DotNetObject | undefined | null;
@@ -105,6 +107,9 @@ namespace BitBlazorUI {
             if (this._history.length > 0 && this._history[this._historyIndex] === current) return;
             this._history = this._history.slice(0, this._historyIndex + 1);
             this._history.push(current);
+            if (this._history.length > this._maxHistorySize) {
+                this._history = this._history.slice(this._history.length - this._maxHistorySize);
+            }
             this._historyIndex = this._history.length - 1;
         }
 
@@ -112,28 +117,22 @@ namespace BitBlazorUI {
             this.pushHistory();
             if (this._historyIndex > 0) {
                 this._historyIndex--;
+                if (this._historyDebounce !== null) {
+                    clearTimeout(this._historyDebounce);
+                    this._historyDebounce = null;
+                }
                 this.value = this._history[this._historyIndex]!;
-                setTimeout(() => {
-                    this.change({} as Event);
-                    if (this._historyDebounce !== null) {
-                        clearTimeout(this._historyDebounce);
-                        this._historyDebounce = null;
-                    }
-                }, 0);
             }
         }
 
         private redo() {
             if (this._historyIndex < this._history.length - 1) {
                 this._historyIndex++;
+                if (this._historyDebounce !== null) {
+                    clearTimeout(this._historyDebounce);
+                    this._historyDebounce = null;
+                }
                 this.value = this._history[this._historyIndex]!;
-                setTimeout(() => {
-                    this.change({} as Event);
-                    if (this._historyDebounce !== null) {
-                        clearTimeout(this._historyDebounce);
-                        this._historyDebounce = null;
-                    }
-                }, 0);
             }
         }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
@@ -10,6 +10,8 @@ namespace BitBlazorUI {
                 editor.value = defaultValue;
             }
 
+            editor.resetHistory();
+
             MarkdownEditor._editors[id] = editor;
         }
 
@@ -51,8 +53,8 @@ namespace BitBlazorUI {
     }
 
     class Editor {
-        _opens: string[] = [];
-        _pairs: { [key: string]: string } = {
+        private _opens: string[] = [];
+        private _pairs: { [key: string]: string } = {
             '(': ')',
             '{': '}',
             '[': ']',
@@ -60,6 +62,10 @@ namespace BitBlazorUI {
             '"': '"',
             "'": "'",
         };
+
+        private _history: string[] = [];
+        private _historyIndex: number = -1;
+        private _historyDebounce: ReturnType<typeof setTimeout> | null = null;
 
         private textArea: HTMLTextAreaElement;
         private dotnetObj: DotNetObject | undefined | null;
@@ -85,8 +91,65 @@ namespace BitBlazorUI {
             this.textArea.addEventListener('keydown', this.keydownHandler);
         }
 
+        resetHistory() {
+            if (this._historyDebounce !== null) {
+                clearTimeout(this._historyDebounce);
+                this._historyDebounce = null;
+            }
+            this._history = [this.textArea.value];
+            this._historyIndex = 0;
+        }
+
+        private pushHistory() {
+            const current = this.textArea.value;
+            if (this._history.length > 0 && this._history[this._historyIndex] === current) return;
+            this._history = this._history.slice(0, this._historyIndex + 1);
+            this._history.push(current);
+            this._historyIndex = this._history.length - 1;
+        }
+
+        private undo() {
+            this.pushHistory();
+            if (this._historyIndex > 0) {
+                this._historyIndex--;
+                this.textArea.value = this._history[this._historyIndex]!;
+                setTimeout(() => {
+                    this.change({} as Event);
+                    if (this._historyDebounce !== null) {
+                        clearTimeout(this._historyDebounce);
+                        this._historyDebounce = null;
+                    }
+                }, 0);
+            }
+        }
+
+        private redo() {
+            if (this._historyIndex < this._history.length - 1) {
+                this._historyIndex++;
+                this.textArea.value = this._history[this._historyIndex]!;
+                setTimeout(() => {
+                    this.change({} as Event);
+                    if (this._historyDebounce !== null) {
+                        clearTimeout(this._historyDebounce);
+                        this._historyDebounce = null;
+                    }
+                }, 0);
+            }
+        }
+
+        private scheduleHistorySave() {
+            if (this._historyDebounce !== null) {
+                clearTimeout(this._historyDebounce);
+            }
+            this._historyDebounce = setTimeout(() => {
+                this.pushHistory();
+                this._historyDebounce = null;
+            }, 200);
+        }
+
 
         addContent(value: string, type: ContentType = 'block') {
+            this.pushHistory();
             this.add({ type, value });
         }
 
@@ -145,11 +208,11 @@ namespace BitBlazorUI {
 
         insert(content: Content, start: number, end: number) {
             if (content.type === 'inline') {
-                this.value = `${this.value.slice(0, end)}${content.value}${this.value.slice(end)}`;
+                this.textArea.value = `${this.textArea.value.slice(0, end)}${content.value}${this.textArea.value.slice(end)}`;
             } else if (content.type === 'wrap') {
-                this.value = insert(this.value, content.value, start);
-                this.value = insert(
-                    this.value,
+                this.textArea.value = insert(this.textArea.value, content.value, start);
+                this.textArea.value = insert(
+                    this.textArea.value,
                     this._pairs[content.value] ? this._pairs[content.value] : content.value,
                     end + content.value.length,
                 );
@@ -164,7 +227,7 @@ namespace BitBlazorUI {
                 } else {
                     total[num] = content.value + total[num];
                 }
-                this.value = total.join('\n');
+                this.textArea.value = total.join('\n');
             } else if (content.type === 'init') { }
         }
 
@@ -233,7 +296,7 @@ namespace BitBlazorUI {
                 total[i] = l.slice(String(number).length);
                 total[i] = String(newNumber) + total[i];
             }
-            this.value = total.join('\n');
+            this.textArea.value = total.join('\n');
         }
 
         dispose() {
@@ -242,6 +305,11 @@ namespace BitBlazorUI {
             this.textArea.removeEventListener('input', this.changeHandler);
             this.textArea.removeEventListener('dblclick', this.dblClickHandler);
             this.textArea.removeEventListener('keydown', this.keydownHandler);
+
+            if (this._historyDebounce !== null) {
+                clearTimeout(this._historyDebounce);
+                this._historyDebounce = null;
+            }
 
             this.dotnetObj = undefined;
         }
@@ -258,6 +326,7 @@ namespace BitBlazorUI {
             } else if (e.key === 'Tab') {
                 if (this.block % 2 !== 0) {
                     e.preventDefault();
+                    this.pushHistory();
                     this.add({ type: 'inline', value: '\t' });
                 }
             } else if (e.key === 'Enter') {
@@ -266,6 +335,16 @@ namespace BitBlazorUI {
                 const nextIsPaired = Object.values(this._pairs).includes(next);
                 const isSelected = this.start !== this.end;
                 if (e.ctrlKey || e.metaKey) {
+                    if (e.key === 'z' && !e.shiftKey) {
+                        e.preventDefault();
+                        this.undo();
+                        return;
+                    }
+                    if (e.key === 'y' || (e.shiftKey && e.key === 'Z')) {
+                        e.preventDefault();
+                        this.redo();
+                        return;
+                    }
                     if (this.start === this.end) {
                         if (e.key === 'c' || e.key === 'x') {
                             e.preventDefault();
@@ -275,8 +354,9 @@ namespace BitBlazorUI {
 
                             if (e.key === 'x') {
                                 const pos = this.start - col;
+                                this.pushHistory();
                                 total.splice(num, 1);
-                                this.value = total.join('\n');
+                                this.textArea.value = total.join('\n');
                                 setTimeout(() => this.set(pos, pos), 0);
                             }
                         }
@@ -294,6 +374,7 @@ namespace BitBlazorUI {
                     this._opens.pop();
                 } else if (e.key in this._pairs) {
                     e.preventDefault();
+                    this.pushHistory();
                     this.add({ type: 'wrap', value: e.key });
                     this._opens.push(e.key);
                 }
@@ -308,10 +389,11 @@ namespace BitBlazorUI {
                 next === this._pairs[prev]
             ) {
                 e.preventDefault();
+                this.pushHistory();
                 const start = this.start - 1;
                 const end = this.end - 1;
-                this.value = remove(this.value, start);
-                this.value = remove(this.value, end);
+                this.textArea.value = remove(this.textArea.value, start);
+                this.textArea.value = remove(this.textArea.value, end);
                 setTimeout(() => {
                     this.set(start, end);
                 }, 0);
@@ -319,10 +401,11 @@ namespace BitBlazorUI {
             }
             if (prev === '\n' && this.start === this.end) {
                 e.preventDefault();
+                this.pushHistory();
                 const pos = this.start - 1;
                 const { num } = this.getLine();
                 this.correct(num, true);
-                this.value = remove(this.value, pos);
+                this.textArea.value = remove(this.textArea.value, pos);
                 setTimeout(async () => {
                     this.set(pos, pos);
                 }, 0);
@@ -340,6 +423,7 @@ namespace BitBlazorUI {
 
             if (rep && (orig && orig.length < col)) {
                 e.preventDefault();
+                this.pushHistory();
                 const start = this.start;
                 const end = this.end;
 
@@ -347,12 +431,13 @@ namespace BitBlazorUI {
                 this.add({ type: 'inline', value: `\n${rep}` }, start, end);
             } else if (rep && (orig && orig.length === col)) {
                 e.preventDefault();
+                this.pushHistory();
 
                 const origEnd = this.end;
                 const pos = origEnd - orig.length;
 
                 for (let i = 0; i < orig.length; i++) {
-                    this.value = remove(this.value, origEnd - (i + 1));
+                    this.textArea.value = remove(this.textArea.value, origEnd - (i + 1));
                 }
 
                 setTimeout(async () => {
@@ -380,6 +465,7 @@ namespace BitBlazorUI {
 
         change(e: Event) {
             this.dotnetObj?.invokeMethodAsync('OnChange', this.value);
+            this.scheduleHistorySave();
         }
 
         command(cmd: string) {
@@ -418,6 +504,7 @@ namespace BitBlazorUI {
             }
 
             if (content) {
+                this.pushHistory();
                 this.add(content);
             }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
@@ -26,6 +26,8 @@ namespace BitBlazorUI {
             const editor = MarkdownEditor._editors[id];
             if (!editor) return;
 
+            if (editor.value === value) return;
+
             editor.value = value;
             editor.resetHistory();
         }
@@ -137,11 +139,18 @@ namespace BitBlazorUI {
         }
 
         private scheduleHistorySave() {
+            // Truncate the redo branch immediately so stale future states are unreachable at once
+            this._history = this._history.slice(0, this._historyIndex + 1);
+
             if (this._historyDebounce !== null) {
                 clearTimeout(this._historyDebounce);
             }
             this._historyDebounce = setTimeout(() => {
-                this.pushHistory();
+                const current = this.value;
+                if (this._history[this._historyIndex] !== current) {
+                    this._history.push(current);
+                    this._historyIndex = this._history.length - 1;
+                }
                 this._historyDebounce = null;
             }, 200);
         }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
@@ -70,6 +70,7 @@ namespace BitBlazorUI {
         private _historyIndex: number = -1;
         private _historyDebounce: ReturnType<typeof setTimeout> | null = null;
         private readonly _maxHistorySize: number = 100;
+        private _isUndoRedo: boolean = false;
 
         private textArea: HTMLTextAreaElement;
         private dotnetObj: DotNetObject | undefined | null;
@@ -123,6 +124,7 @@ namespace BitBlazorUI {
                     clearTimeout(this._historyDebounce);
                     this._historyDebounce = null;
                 }
+                this._isUndoRedo = true;
                 this.value = this._history[this._historyIndex]!;
             }
         }
@@ -134,11 +136,17 @@ namespace BitBlazorUI {
                     clearTimeout(this._historyDebounce);
                     this._historyDebounce = null;
                 }
+                this._isUndoRedo = true;
                 this.value = this._history[this._historyIndex]!;
             }
         }
 
         private scheduleHistorySave() {
+            if (this._isUndoRedo) {
+                this._isUndoRedo = false;
+                return;
+            }
+
             // Truncate the redo branch immediately so stale future states are unreachable at once
             this._history = this._history.slice(0, this._historyIndex + 1);
 
@@ -149,6 +157,9 @@ namespace BitBlazorUI {
                 const current = this.value;
                 if (this._history[this._historyIndex] !== current) {
                     this._history.push(current);
+                    if (this._history.length > this._maxHistorySize) {
+                        this._history = this._history.slice(this._history.length - this._maxHistorySize);
+                    }
                     this._historyIndex = this._history.length - 1;
                 }
                 this._historyDebounce = null;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownEditor/BitMarkdownEditor.ts
@@ -96,12 +96,12 @@ namespace BitBlazorUI {
                 clearTimeout(this._historyDebounce);
                 this._historyDebounce = null;
             }
-            this._history = [this.textArea.value];
+            this._history = [this.value];
             this._historyIndex = 0;
         }
 
         private pushHistory() {
-            const current = this.textArea.value;
+            const current = this.value;
             if (this._history.length > 0 && this._history[this._historyIndex] === current) return;
             this._history = this._history.slice(0, this._historyIndex + 1);
             this._history.push(current);
@@ -112,7 +112,7 @@ namespace BitBlazorUI {
             this.pushHistory();
             if (this._historyIndex > 0) {
                 this._historyIndex--;
-                this.textArea.value = this._history[this._historyIndex]!;
+                this.value = this._history[this._historyIndex]!;
                 setTimeout(() => {
                     this.change({} as Event);
                     if (this._historyDebounce !== null) {
@@ -126,7 +126,7 @@ namespace BitBlazorUI {
         private redo() {
             if (this._historyIndex < this._history.length - 1) {
                 this._historyIndex++;
-                this.textArea.value = this._history[this._historyIndex]!;
+                this.value = this._history[this._historyIndex]!;
                 setTimeout(() => {
                     this.change({} as Event);
                     if (this._historyDebounce !== null) {
@@ -208,11 +208,11 @@ namespace BitBlazorUI {
 
         insert(content: Content, start: number, end: number) {
             if (content.type === 'inline') {
-                this.textArea.value = `${this.textArea.value.slice(0, end)}${content.value}${this.textArea.value.slice(end)}`;
+                this.value = `${this.value.slice(0, end)}${content.value}${this.value.slice(end)}`;
             } else if (content.type === 'wrap') {
-                this.textArea.value = insert(this.textArea.value, content.value, start);
-                this.textArea.value = insert(
-                    this.textArea.value,
+                this.value = insert(this.value, content.value, start);
+                this.value = insert(
+                    this.value,
                     this._pairs[content.value] ? this._pairs[content.value] : content.value,
                     end + content.value.length,
                 );
@@ -227,7 +227,7 @@ namespace BitBlazorUI {
                 } else {
                     total[num] = content.value + total[num];
                 }
-                this.textArea.value = total.join('\n');
+                this.value = total.join('\n');
             } else if (content.type === 'init') { }
         }
 
@@ -296,7 +296,7 @@ namespace BitBlazorUI {
                 total[i] = l.slice(String(number).length);
                 total[i] = String(newNumber) + total[i];
             }
-            this.textArea.value = total.join('\n');
+            this.value = total.join('\n');
         }
 
         dispose() {
@@ -356,7 +356,7 @@ namespace BitBlazorUI {
                                 const pos = this.start - col;
                                 this.pushHistory();
                                 total.splice(num, 1);
-                                this.textArea.value = total.join('\n');
+                                this.value = total.join('\n');
                                 setTimeout(() => this.set(pos, pos), 0);
                             }
                         }
@@ -392,8 +392,8 @@ namespace BitBlazorUI {
                 this.pushHistory();
                 const start = this.start - 1;
                 const end = this.end - 1;
-                this.textArea.value = remove(this.textArea.value, start);
-                this.textArea.value = remove(this.textArea.value, end);
+                this.value = remove(this.value, start);
+                this.value = remove(this.value, end);
                 setTimeout(() => {
                     this.set(start, end);
                 }, 0);
@@ -405,7 +405,7 @@ namespace BitBlazorUI {
                 const pos = this.start - 1;
                 const { num } = this.getLine();
                 this.correct(num, true);
-                this.textArea.value = remove(this.textArea.value, pos);
+                this.value = remove(this.value, pos);
                 setTimeout(async () => {
                     this.set(pos, pos);
                 }, 0);
@@ -437,7 +437,7 @@ namespace BitBlazorUI {
                 const pos = origEnd - orig.length;
 
                 for (let i = 0; i < orig.length; i++) {
-                    this.textArea.value = remove(this.textArea.value, origEnd - (i + 1));
+                    this.value = remove(this.value, origEnd - (i + 1));
                 }
 
                 setTimeout(async () => {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownEditor/BitMarkdownEditorDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownEditor/BitMarkdownEditorDemo.razor
@@ -86,7 +86,18 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Advanced" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+        <DemoExample Title="Undo/Redo" RazorCode="@example5RazorCode" Id="example5">
+            <div>
+                The BitMarkdownEditor has built-in undo/redo support that tracks all your changes automatically.
+                Use <strong>Ctrl+Z</strong> to undo the last change and <strong>Ctrl+Y</strong> (or <strong>Ctrl+Shift+Z</strong>) to redo it.
+            </div>
+            <br />
+            <div style="height:300px">
+                <BitMarkdownEditor DefaultValue="# Undo/Redo Demo" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Advanced" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
             <div>
                 In this example you can see all advanced features of the BitMarkdownEditor in shaping an editor very similar 
                 to the github one.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownEditor/BitMarkdownEditorDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownEditor/BitMarkdownEditorDemo.razor.cs
@@ -145,7 +145,7 @@ public partial class BitMarkdownEditorDemo
     ];
 
 
-    private string? introValue = "# BitMarkdownEditor in action\n\n- Ctrl+H  =>  Heading\n- Ctrl+B  =>  Bold\n- Ctrl+I  =>  Italic\n- Ctrl+L  =>  Link\n- Ctrl+P  =>  Picture/Image\n- Ctrl+Q  =>  Quote\n- auto handling ordered/unordered lists\n- auto handling Ctrl+X and Ctrl+C\n\n### Missing features:\n1. Undo/Redo\n2. Multi-level unordered lists\n3. Tab to go deeper list level\n\nStart typing here...";
+    private string? introValue = "# BitMarkdownEditor in action\n\n- Ctrl+H  =>  Heading\n- Ctrl+B  =>  Bold\n- Ctrl+I  =>  Italic\n- Ctrl+L  =>  Link\n- Ctrl+P  =>  Picture/Image\n- Ctrl+Q  =>  Quote\n- auto handling ordered/unordered lists\n- auto handling Ctrl+X and Ctrl+C\n- Ctrl+Z  =>  Undo\n- Ctrl+Y / Ctrl+Shift+Z  =>  Redo\n\n### Missing features:\n1. Multi-level unordered lists\n2. Tab to go deeper list level\n\nStart typing here...";
 
     private BitMarkdownEditor editorRef = default!;
     private string? value;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownEditor/BitMarkdownEditorDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownEditor/BitMarkdownEditorDemo.razor.cs
@@ -204,6 +204,11 @@ private string? onChangeValue;";
 private string? bindingValue;";
 
     private readonly string example5RazorCode = @"
+<div style=""height:300px"">
+    <BitMarkdownEditor DefaultValue=""# Undo/Redo Demo"" />
+</div>";
+
+    private readonly string example6RazorCode = @"
 <div style=""display:flex;gap:1rem;margin-bottom:1rem"">
     <BitToggleButton Color=""BitColor.Tertiary"" Variant=""BitVariant.Outline"" OnText=""Write"" OffText=""Preview"" @bind-IsChecked=""showPreview"" />
             
@@ -237,7 +242,7 @@ private string? bindingValue;";
     <BitMarkdownViewer Markdown=""@advancedValue"" 
                        Style=""@($""display:{(showPreview ? ""block"" : ""none"")}"")"" />
 </div>";
-    private readonly string example5CsharpCode = @"
+    private readonly string example6CsharpCode = @"
 private bool showPreview;
 private string? advancedValue;
 private BitMarkdownEditor advancedRef = default!;";


### PR DESCRIPTION
closes #10278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Undo/Redo functionality added to MarkdownEditor with keyboard shortcuts (Ctrl+Z for undo, Ctrl+Y/Shift+Z for redo).

* **Documentation**
  * Updated demo page with new example demonstrating undo/redo capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->