### PR TITLE
Update devcontainer.json to use dotnet SDK 10.0.300 (#12348)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     },
     "ghcr.io/devcontainers/features/node:1": { "version": "24" }
   },
-  "image": "mcr.microsoft.com/dotnet/sdk:10.0.203",
+  "image": "mcr.microsoft.com/dotnet/sdk:10.0.300",
   "postStartCommand": "dotnet workload install wasm-tools && dotnet dev-certs https --trust",
   "waitFor": "onCreateCommand",
   "customizations": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.devcontainer/devcontainer.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Boilerplate",
-    "image": "mcr.microsoft.com/dotnet/sdk:10.0.203",
+    "image": "mcr.microsoft.com/dotnet/sdk:10.0.300",
     "hostRequirements": {
         "cpus": 8
     },

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor
@@ -99,7 +99,7 @@
                             {
                                 <br />
                                 <BitAccordion Title="Ubuntu instructions">
-                                <CodeBox>wget https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-x64.tar.gz -O $HOME/dotnet.tar.gz
+                                <CodeBox>wget https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.300/dotnet-sdk-10.0.300-linux-x64.tar.gz -O $HOME/dotnet.tar.gz
 mkdir -p $HOME/.dotnet
 tar zxf $HOME/dotnet.tar.gz -C "$HOME/.dotnet"
 echo 'PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc


### PR DESCRIPTION
Closes #12348

## Changes

Updated both devcontainer configurations to use the latest .NET 10 SDK image `10.0.300` (was `10.0.203`):

- `.devcontainer/devcontainer.json`
- `src/Templates/Boilerplate/Bit.Boilerplate/.devcontainer/devcontainer.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .NET SDK version in development container configurations to the latest patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->