### PR TITLE
docs(agents): fix agent name, branch convention, and PR title guidance #12352

### DIFF
--- a/.github/agents/contribute-to-bitplatform.agent.md
+++ b/.github/agents/contribute-to-bitplatform.agent.md
@@ -1,5 +1,5 @@
 ---
-name: contribute-to-bitplatform
+name: Contribute to bitplatform
 description: Guides you through the full contribution workflow for bitfoundation/bitplatform — from writing a focused Issue, to branching on your fork, implementing the change, and opening a well-formed Pull Request.
 ---
 
@@ -41,6 +41,11 @@ git push origin develop
 
 A good Issue describes **the problem**, not the solution.
 
+### Issue Title
+The title must state **what is wrong or missing**, not what should be done to fix it.
+
+Use a plain, descriptive sentence — **do not** use conventional-commit prefixes in Issue titles (those are for PR titles only, see Step 5).
+
 ### Choosing a Label
 Pick **one** primary label from the table below.
 If multiple apply, prefer the most specific one.
@@ -62,7 +67,7 @@ If multiple apply, prefer the most specific one.
 | `testing` | Test coverage, test infrastructure |
 | `question` | Asking for clarification or guidance |
 
-After the Issue is created, note the **Issue number** — you will need it in Step 5.
+After the Issue is created, note the **Issue number** — you will need it in Steps 3 and 5.
 
 ---
 
@@ -76,10 +81,10 @@ git checkout -b <branch-name> upstream/develop
 ```
 
 ### Branch Naming Convention
-`<type>/<short-kebab-description>` — for example:
-- `fix/bitbutton-disabled-pointer-events`
-- `feat/add-dark-mode-toggle`
-- `docs/update-contributing-guide`
+`<type>/<issue-number>-<short-kebab-description>` — for example:
+- `fix/1234-bitbutton-disabled-pointer-events`
+- `feat/5678-add-dark-mode-toggle`
+- `docs/9012-update-contributing-guide`
 
 ---
 
@@ -96,7 +101,7 @@ git push origin <branch-name>
 ```
 
 ### PR Title
-Use the **exact same conventional-commit format** as the Issue title, and append the Issue number:
+Use conventional-commit format and include the Issue number with a `#` prefix:
 
 ```
 <prefix>(<scope>): <short description> #<issue-number>


### PR DESCRIPTION
## Summary
Fixes three issues in `contribute-to-bitplatform.agent.md`: the agent display name, branch naming convention, and misleading PR title guidance.

## Changes
- Changed `name` from `contribute-to-bitplatform` to `Contribute to bitplatform` for a human-readable display in VS Code's agent picker
- Updated branch naming convention to include the issue number: `<type>/<issue-number>-<short-kebab-description>` (e.g. `fix/1234-bitbutton-disabled-pointer-events`)
- Fixed PR title guidance to no longer say "same format as Issue title" — Issue titles are plain problem-focused sentences while PR titles use conventional-commit format; the wording now makes this distinction clear
- Updated the "note the Issue number" reminder to reference both Steps 3 and 5

## Related Issue
This closes #12352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated contribution workflow documentation with improved clarity
  * Added dedicated guidance for issue titles with explicit formatting rules
  * Expanded branch naming conventions to include issue number components
  * Clarified pull request title requirements with standard format specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->