### PR TITLE
Replace Microsoft.DotNet.SDK.Preview with Microsoft.DotNet.SDK in winget install command #12356

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor.cs
@@ -25,7 +25,7 @@ public partial class Templates03GettingStartedPage
             command:"$progressPreference = 'silentlyContinue'; Install-PackageProvider -Name NuGet -Force | Out-Null; Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null; Repair-WinGetPackageManager -AllUsers;"),
 
             (text:@"echo 'Install .NET SDK https://dotnet.microsoft.com/en-us/download';",
-            command: $"winget install Microsoft.DotNet.SDK.Preview --accept-source-agreements --accept-package-agreements;"),
+            command: $"winget install Microsoft.DotNet.SDK --accept-source-agreements --accept-package-agreements;"),
             
             (text:@"echo 'Install Microsoft DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows#install';",
             command: $"winget install Microsoft.devtunnel --accept-source-agreements --accept-package-agreements;"),

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates03GettingStartedPage.razor.cs
@@ -25,7 +25,7 @@ public partial class Templates03GettingStartedPage
             command:"$progressPreference = 'silentlyContinue'; Install-PackageProvider -Name NuGet -Force | Out-Null; Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery | Out-Null; Repair-WinGetPackageManager -AllUsers;"),
 
             (text:@"echo 'Install .NET SDK https://dotnet.microsoft.com/en-us/download';",
-            command: $"winget install Microsoft.DotNet.SDK --accept-source-agreements --accept-package-agreements;"),
+            command: $"winget install Microsoft.DotNet.SDK.10 --accept-source-agreements --accept-package-agreements;"),
             
             (text:@"echo 'Install Microsoft DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows#install';",
             command: $"winget install Microsoft.devtunnel --accept-source-agreements --accept-package-agreements;"),


### PR DESCRIPTION
## Summary
The Getting Started page was generating a winget command that installs the preview .NET SDK instead of the stable release.

## Changes
- Replaced `Microsoft.DotNet.SDK.Preview` with `Microsoft.DotNet.SDK` in the winget install command in `Templates03GettingStartedPage.razor.cs`

## Related Issue
This closes #12356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the .NET SDK installation command in the getting started guide to reference the stable SDK package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->