### PR TITLE
Fix persistent containers recreated on every run due to WithOtlpExporter() #12358

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
@@ -14,7 +14,7 @@ var redisCache = builder.AddRedis("redis-cache")
 
 // Redis for Hangfire background jobs, and distributed locking - persistent with AOF for durability
 var redisPersistent = builder.AddRedis("redis-persistent")
-    .WithOtlpExporter()
+    // WithOtlpExporter() is intentionally omitted for containers with WithDataVolume() due to https://github.com/microsoft/aspire/issues/17191
     .WithRedisInsight()
     .WithRedisCommander()
     .WithDataVolume()
@@ -28,7 +28,7 @@ var redisPersistent = builder.AddRedis("redis-persistent")
 
 //#if (database == "SqlServer")
 var sqlDatabase = builder.AddSqlServer("sqlserver")
-        .WithOtlpExporter()
+        // WithOtlpExporter() is intentionally omitted for containers with WithDataVolume() due to https://github.com/microsoft/aspire/issues/17191
         .WithDbGate(config => config.WithDataVolume())
         .WithDataVolume()
         .WithImage("mssql/server", "2025-latest")
@@ -36,7 +36,7 @@ var sqlDatabase = builder.AddSqlServer("sqlserver")
 
 //#elif (database == "PostgreSql")
 var postgresDatabase = builder.AddPostgres("postgresserver")
-        .WithOtlpExporter()
+        // WithOtlpExporter() is intentionally omitted for containers with WithDataVolume() due to https://github.com/microsoft/aspire/issues/17191
         .WithPgAdmin()
         .WithV18DataVolume()
         .WithOptimizedSetup()
@@ -45,7 +45,7 @@ var postgresDatabase = builder.AddPostgres("postgresserver")
 
 //#elif (database == "MySql")
 var mySqlDatabase = builder.AddMySql("mysqlserver")
-        .WithOtlpExporter()
+        // WithOtlpExporter() is intentionally omitted for containers with WithDataVolume() due to https://github.com/microsoft/aspire/issues/17191
         .WithPhpMyAdmin()
         .WithDataVolume()
         .AddDatabase("mysqldb");
@@ -64,13 +64,13 @@ var azureBlobStorage = builder.AddAzureStorage("storage")
 
 //#elif (filesStorage == "S3")
 var s3Storage = builder.AddMinioContainer("s3")
-    .WithOtlpExporter()
+    // WithOtlpExporter() is intentionally omitted for containers with WithDataVolume() due to https://github.com/microsoft/aspire/issues/17191
     .WithDataVolume();
 //#endif
 
 // https://aspire.dev/integrations/security/keycloak/
 var keycloak = builder.AddKeycloak("keycloak", 8080)
-    .WithOtlpExporter()
+    // WithOtlpExporter() is intentionally omitted for containers with WithDataVolume() due to https://github.com/microsoft/aspire/issues/17191
     .WithDataVolume()
     .WithRealmImport("./Infrastructure/Realms");
 


### PR DESCRIPTION
## Summary
Remove `WithOtlpExporter()` from all persistent Aspire containers (those with `WithDataVolume()`) to prevent them from being recreated on every run.

## Changes
- Removed `WithOtlpExporter()` from `redis-persistent`, `sqlserver`, `postgresserver`, `mysqlserver`, `s3` (Minio), and `keycloak` in `Boilerplate.Server.AppHost/Program.cs`
- Added a comment on each removal referencing the upstream Aspire bug
- `redis-cache` retains `WithOtlpExporter()` as it is intentionally ephemeral (no data volume)

## Related Issue
This closes #12358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined container configuration settings for persistent data storage and observability in the application host infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->