### PR TITLE
Resolve Azure App Insights error when connection string is missing (#12413)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppInsightsJsSdkService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppInsightsJsSdkService.cs
@@ -7,14 +7,18 @@ namespace Boilerplate.Client.Core.Infrastructure.Services;
 /// <summary>
 /// A Blazor Hybrid / Blazor Server compatible version of <see cref="ApplicationInsights"/>
 /// </summary>
-public partial class AppInsightsJsSdkService : IApplicationInsights
+public class AppInsightsJsSdkService : IApplicationInsights
 {
     private TaskCompletionSource? telemetryInitializerIsAddedTcs;
     private readonly TaskCompletionSource appInsightsJsFilesAreLoaded = new();
 
+    private IJSRuntime jsRuntime = default!;
     private readonly ApplicationInsights applicationInsights = new();
 
-    [AutoInject] private IJSRuntime jsRuntime = default!;
+    public AppInsightsJsSdkService(IJSRuntime jsRuntime)
+    {
+        InitJSRuntime(jsRuntime);
+    }
 
     public CookieMgr GetCookieMgr()
     {
@@ -23,6 +27,7 @@ public partial class AppInsightsJsSdkService : IApplicationInsights
 
     public void InitJSRuntime(IJSRuntime jSRuntime)
     {
+        this.jsRuntime = jSRuntime;
         applicationInsights.InitJSRuntime(jSRuntime);
     }
 


### PR DESCRIPTION
closes #12413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Application Insights service initialization to use explicit dependency injection, ensuring more reliable setup of telemetry collection functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitfoundation/bitplatform/pull/12414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->