### PR TITLE
Add missing parameters to BitDropMenu (#12422)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.razor.cs
@@ -16,9 +16,19 @@ public partial class BitDropMenu : BitComponentBase
 
 
     /// <summary>
+    /// The color kind of the background of the callout of the drop menu.
+    /// </summary>
+    [Parameter] public BitColorKind? Background { get; set; }
+
+    /// <summary>
     /// Alias of the ChildContent.
     /// </summary>
     [Parameter] public RenderFragment? Body { get; set; }
+
+    /// <summary>
+    /// The color kind of the border of the callout of the drop menu.
+    /// </summary>
+    [Parameter] public BitColorKind? Border { get; set; }
 
     /// <summary>
     /// Gets or sets the icon for the chevron down part of the drop menu using custom CSS classes for external icon libraries.
@@ -103,6 +113,11 @@ public partial class BitDropMenu : BitComponentBase
     /// The position of the responsive panel to show on the screen.
     /// </summary>
     [Parameter] public BitPanelPosition? PanelPosition { get; set; }
+
+    /// <summary>
+    /// Removes the box-shadow from the callout of the drop menu.
+    /// </summary>
+    [Parameter] public bool NoShadow { get; set; }
 
     /// <summary>
     /// The id of the element which needs to be scrollable in the content of the callout of the drop menu.
@@ -292,6 +307,29 @@ public partial class BitDropMenu : BitComponentBase
         {
             classes.Add("bit-drm-res");
         }
+
+        if (NoShadow)
+        {
+            classes.Add("bit-drm-nsh");
+        }
+
+        classes.Add(Background switch
+        {
+            BitColorKind.Primary => "bit-drm-pbg",
+            BitColorKind.Secondary => "bit-drm-sbg",
+            BitColorKind.Tertiary => "bit-drm-tbg",
+            BitColorKind.Transparent => "bit-drm-rbg",
+            _ => ""
+        });
+
+        classes.Add(Border switch
+        {
+            BitColorKind.Primary => "bit-drm-brd bit-drm-pbr",
+            BitColorKind.Secondary => "bit-drm-brd bit-drm-sbr",
+            BitColorKind.Tertiary => "bit-drm-brd bit-drm-tbr",
+            BitColorKind.Transparent => "bit-drm-brd bit-drm-rbr",
+            _ => ""
+        });
 
         classes.Add(PanelPosition switch
         {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.scss
@@ -86,49 +86,49 @@
     animation-timing-function: cubic-bezier(0.1, 0.9, 0.2, 1);
     --bit-drm-transform-factor: 1;
 
-    .bit-drm-rtl {
+    &.bit-drm-rtl {
         --bit-drm-transform-factor: -1;
     }
 
-    .bit-drm-nsh {
+    &.bit-drm-nsh {
         box-shadow: none;
     }
 
-    .bit-drm-pbg {
+    &.bit-drm-pbg {
         background-color: $clr-bg-pri;
     }
 
-    .bit-drm-sbg {
+    &.bit-drm-sbg {
         background-color: $clr-bg-sec;
     }
 
-    .bit-drm-tbg {
+    &.bit-drm-tbg {
         background-color: $clr-bg-ter;
     }
 
-    .bit-drm-rbg {
+    &.bit-drm-rbg {
         background-color: transparent;
     }
 
-    .bit-drm-brd {
+    &.bit-drm-brd {
         border-width: $shp-border-width;
         border-style: $shp-border-style;
-    }
 
-    .bit-drm-pbr {
-        border-color: $clr-brd-pri;
-    }
+        &.bit-drm-pbr {
+            border-color: $clr-brd-pri;
+        }
 
-    .bit-drm-sbr {
-        border-color: $clr-brd-sec;
-    }
+        &.bit-drm-sbr {
+            border-color: $clr-brd-sec;
+        }
 
-    .bit-drm-tbr {
-        border-color: $clr-brd-ter;
-    }
+        &.bit-drm-tbr {
+            border-color: $clr-brd-ter;
+        }
 
-    .bit-drm-rbr {
-        border-color: transparent;
+        &.bit-drm-rbr {
+            border-color: transparent;
+        }
     }
 }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/DropMenu/BitDropMenu.scss
@@ -85,10 +85,51 @@
     animation-name: bit-fade-show, bit-slide-down;
     animation-timing-function: cubic-bezier(0.1, 0.9, 0.2, 1);
     --bit-drm-transform-factor: 1;
-}
 
-.bit-drm-cal.bit-drm-rtl {
-    --bit-drm-transform-factor: -1;
+    .bit-drm-rtl {
+        --bit-drm-transform-factor: -1;
+    }
+
+    .bit-drm-nsh {
+        box-shadow: none;
+    }
+
+    .bit-drm-pbg {
+        background-color: $clr-bg-pri;
+    }
+
+    .bit-drm-sbg {
+        background-color: $clr-bg-sec;
+    }
+
+    .bit-drm-tbg {
+        background-color: $clr-bg-ter;
+    }
+
+    .bit-drm-rbg {
+        background-color: transparent;
+    }
+
+    .bit-drm-brd {
+        border-width: $shp-border-width;
+        border-style: $shp-border-style;
+    }
+
+    .bit-drm-pbr {
+        border-color: $clr-brd-pri;
+    }
+
+    .bit-drm-sbr {
+        border-color: $clr-brd-sec;
+    }
+
+    .bit-drm-tbr {
+        border-color: $clr-brd-ter;
+    }
+
+    .bit-drm-rbr {
+        border-color: transparent;
+    }
 }
 
 .bit-drm-res {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor
@@ -8,6 +8,7 @@
           Description="DropMenu component is a versatile dropdown menu used in Blazor applications. It allows you to create a button that, when clicked, opens a callout or dropdown menu. This can be particularly useful for creating navigation menus, action lists, or any other interactive elements that require a dropdown."
           Parameters="componentParameters"
           SubClasses="componentSubClasses"
+          SubEnums="componentSubEnums"
               GitHubUrl="Navs/DropMenu/BitDropMenu.razor"
           GitHubDemoUrl="Navs/DropMenu/BitDropMenuDemo.razor">
     <DemoExample Title="Basic" RazorCode="@example1RazorCode" Id="example1">
@@ -34,9 +35,59 @@
                 <BitToggle>Toggle me</BitToggle>
             </BitStack>
         </BitDropMenu>
+        <br />
+        <BitDropMenu Text="NoShadow" NoShadow>
+            <BitStack Gap="1rem" Style="padding:0.5rem">
+                <BitText Typography="BitTypography.Subtitle1">This is the content</BitText>
+                <BitButton>Click me</BitButton>
+                <BitToggle>Toggle me</BitToggle>
+            </BitStack>
+        </BitDropMenu>
     </DemoExample>
 
-    <DemoExample Title="Icon" RazorCode="@example2RazorCode" Id="example2">
+    <DemoExample Title="Background" RazorCode="@example2RazorCode" Id="example2">
+        <div>Use the <b>Background</b> parameter to set the background color kind of the callout body.</div>
+        <br />
+        <BitChoiceGroup @bind-Value="backgroundColorKind" Horizontal
+                        Label="Background color kind"
+                        TItem="BitChoiceGroupOption<BitColorKind>" TValue="BitColorKind">
+            <BitChoiceGroupOption Text="Primary" Value="BitColorKind.Primary" />
+            <BitChoiceGroupOption Text="Secondary" Value="BitColorKind.Secondary" />
+            <BitChoiceGroupOption Text="Tertiary" Value="BitColorKind.Tertiary" />
+            <BitChoiceGroupOption Text="Transparent" Value="BitColorKind.Transparent" />
+        </BitChoiceGroup>
+        <br />
+        <BitDropMenu Text="Background" Background="backgroundColorKind">
+            <BitStack Gap="1rem" Style="padding:0.5rem">
+                <BitText Typography="BitTypography.Subtitle1">This is the content</BitText>
+                <BitButton>Click me</BitButton>
+                <BitToggle>Toggle me</BitToggle>
+            </BitStack>
+        </BitDropMenu>
+    </DemoExample>
+
+    <DemoExample Title="Border" RazorCode="@example3RazorCode" Id="example3">
+        <div>Use the <b>Border</b> parameter to set the border color kind of the callout body.</div>
+        <br />
+        <BitChoiceGroup @bind-Value="borderColorKind" Horizontal
+                        Label="Border color kind"
+                        TItem="BitChoiceGroupOption<BitColorKind>" TValue="BitColorKind">
+            <BitChoiceGroupOption Text="Primary" Value="BitColorKind.Primary" />
+            <BitChoiceGroupOption Text="Secondary" Value="BitColorKind.Secondary" />
+            <BitChoiceGroupOption Text="Tertiary" Value="BitColorKind.Tertiary" />
+            <BitChoiceGroupOption Text="Transparent" Value="BitColorKind.Transparent" />
+        </BitChoiceGroup>
+        <br />
+        <BitDropMenu Text="Border" Border="borderColorKind">
+            <BitStack Gap="1rem" Style="padding:0.5rem">
+                <BitText Typography="BitTypography.Subtitle1">This is the content</BitText>
+                <BitButton>Click me</BitButton>
+                <BitToggle>Toggle me</BitToggle>
+            </BitStack>
+        </BitDropMenu>
+    </DemoExample>
+
+    <DemoExample Title="Icon" RazorCode="@example4RazorCode" Id="example4">
         <div>Customizing the drop menu icons.</div><br />
         <BitDropMenu Text="IconName" IconName="@BitIconName.Emoji2">
             <BitStack Gap="1rem" Style="padding:0.5rem">
@@ -51,7 +102,7 @@
         </BitDropMenu>
     </DemoExample>
 
-    <DemoExample Title="Responsive" RazorCode="@example3RazorCode" Id="example3">
+    <DemoExample Title="Responsive" RazorCode="@example5RazorCode" Id="example5">
         <div>Rendering the callout in responsive mode on small screens.</div><br />
         
         <BitDropMenu Text="End PanelPosition" Responsive ScrollContainerId="sc-con1" PanelPosition="BitPanelPosition.End">
@@ -77,7 +128,7 @@
         </BitDropMenu>
     </DemoExample>
 
-    <DemoExample Title="Template" RazorCode="@example4RazorCode" Id="example4">
+    <DemoExample Title="Template" RazorCode="@example6RazorCode" Id="example6">
         <div>Here is an example of customizing the drop menu.</div><br />
         <BitDropMenu Text="Add Icon" IconName="@BitIconName.Emoji2">
             <Template>
@@ -95,7 +146,7 @@
         </BitDropMenu>
     </DemoExample>
 
-    <DemoExample Title="Events" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+    <DemoExample Title="Events" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
         <div>Utilizing the drop menu OnClick event:</div><br />
         <BitDropMenu Text="@($"Click me ({clickCounter})")" OnClick="() => clickCounter++">
             <BitStack Gap="1rem" Style="padding:0.5rem">
@@ -104,7 +155,7 @@
         </BitDropMenu>
     </DemoExample>
 
-    <DemoExample Title="External Icons" RazorCode="@example6RazorCode" Id="example6">
+    <DemoExample Title="External Icons" RazorCode="@example8RazorCode" Id="example8">
         <div>Use icons from external libraries like FontAwesome, Material Icons, and Bootstrap Icons with the <b>Icon</b> and <b>ChevronDownIcon</b> parameters.</div>
         <br />
         <div>
@@ -157,7 +208,7 @@
         </BitDropMenu>
     </DemoExample>
 
-    <DemoExample Title="Style & Class" RazorCode="@example7RazorCode" Id="example7">
+    <DemoExample Title="Style & Class" RazorCode="@example9RazorCode" Id="example9">
         <div>Further customization by overriding default styles and classes, allowing tailored design modifications to suit specific UI requirements.</div>
         <br /><br />
         <div>Component's Style & Class:</div><br />
@@ -197,7 +248,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="RTL" RazorCode="@example8RazorCode" Id="example8">
+    <DemoExample Title="RTL" RazorCode="@example10RazorCode" Id="example10">
         <div>Use BitDropMenu in right-to-left (RTL).</div>
         <br />
         <div class="example-content" dir="rtl">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor.cs
@@ -6,10 +6,28 @@ public partial class BitDropMenuDemo
     [
         new()
         {
+            Name = "Background",
+            Type = "BitColorKind?",
+            DefaultValue = "null",
+            Description = "The color kind of the background of the callout of the drop menu.",
+            LinkType = LinkType.Link,
+            Href = "#color-kind-enum"
+        },
+        new()
+        {
             Name = "Body",
             Type = "RenderFragment?",
             DefaultValue = "null",
             Description = "Alias of the ChildContent."
+        },
+        new()
+        {
+            Name = "Border",
+            Type = "BitColorKind?",
+            DefaultValue = "null",
+            Description = "The color kind of the border of the callout of the drop menu.",
+            LinkType = LinkType.Link,
+            Href = "#color-kind-enum"
         },
         new()
         {
@@ -83,6 +101,13 @@ public partial class BitDropMenuDemo
             Type = "EventCallback",
             DefaultValue = "",
             Description = "The callback is called when the drop menu is dismissed."
+        },
+        new()
+        {
+            Name = "NoShadow",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Removes the box-shadow from the callout of the drop menu."
         },
         new()
         {
@@ -227,5 +252,44 @@ public partial class BitDropMenuDemo
         }
     ];
 
+    private readonly List<ComponentSubEnum> componentSubEnums =
+    [
+        new()
+        {
+            Id = "color-kind-enum",
+            Name = "BitColorKind",
+            Description = "Defines the color kinds available in the bit BlazorUI.",
+            Items =
+            [
+                new()
+                {
+                    Name = "Primary",
+                    Description = "The primary color kind.",
+                    Value = "0",
+                },
+                new()
+                {
+                    Name = "Secondary",
+                    Description = "The secondary color kind.",
+                    Value = "1",
+                },
+                new()
+                {
+                    Name = "Tertiary",
+                    Description = "The tertiary color kind.",
+                    Value = "2",
+                },
+                new()
+                {
+                    Name = "Transparent",
+                    Description = "The transparent color kind.",
+                    Value = "3",
+                },
+            ]
+        }
+    ];
+
     private int clickCounter;
+    private BitColorKind backgroundColorKind = BitColorKind.Primary;
+    private BitColorKind borderColorKind = BitColorKind.Primary;
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/DropMenu/BitDropMenuDemo.razor.samples.cs
@@ -25,9 +25,59 @@ public partial class BitDropMenuDemo
         <BitButton>Click me</BitButton>
         <BitToggle>Toggle me</BitToggle>
     </BitStack>
+</BitDropMenu>
+
+<BitDropMenu Text=""NoShadow"" NoShadow>
+    <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
+        <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
+        <BitButton>Click me</BitButton>
+        <BitToggle>Toggle me</BitToggle>
+    </BitStack>
 </BitDropMenu>";
 
     private readonly string example2RazorCode = @"
+<BitChoiceGroup @bind-Value=""backgroundColorKind"" Horizontal
+                Label=""Background color kind""
+                TItem=""BitChoiceGroupOption<BitColorKind>"" TValue=""BitColorKind"">
+    <BitChoiceGroupOption Text=""Primary"" Value=""BitColorKind.Primary"" />
+    <BitChoiceGroupOption Text=""Secondary"" Value=""BitColorKind.Secondary"" />
+    <BitChoiceGroupOption Text=""Tertiary"" Value=""BitColorKind.Tertiary"" />
+    <BitChoiceGroupOption Text=""Transparent"" Value=""BitColorKind.Transparent"" />
+</BitChoiceGroup>
+
+<BitDropMenu Text=""Background"" Background=""backgroundColorKind"">
+    <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
+        <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
+        <BitButton>Click me</BitButton>
+        <BitToggle>Toggle me</BitToggle>
+    </BitStack>
+</BitDropMenu>
+@code {
+    private BitColorKind backgroundColorKind = BitColorKind.Primary;
+}";
+
+    private readonly string example3RazorCode = @"
+<BitChoiceGroup @bind-Value=""borderColorKind"" Horizontal
+                Label=""Border color kind""
+                TItem=""BitChoiceGroupOption<BitColorKind>"" TValue=""BitColorKind"">
+    <BitChoiceGroupOption Text=""Primary"" Value=""BitColorKind.Primary"" />
+    <BitChoiceGroupOption Text=""Secondary"" Value=""BitColorKind.Secondary"" />
+    <BitChoiceGroupOption Text=""Tertiary"" Value=""BitColorKind.Tertiary"" />
+    <BitChoiceGroupOption Text=""Transparent"" Value=""BitColorKind.Transparent"" />
+</BitChoiceGroup>
+
+<BitDropMenu Text=""Border"" Border=""borderColorKind"">
+    <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
+        <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
+        <BitButton>Click me</BitButton>
+        <BitToggle>Toggle me</BitToggle>
+    </BitStack>
+</BitDropMenu>
+@code {
+    private BitColorKind borderColorKind = BitColorKind.Primary;
+}";
+
+    private readonly string example4RazorCode = @"
 <BitDropMenu Text=""IconName"" IconName=""@BitIconName.Emoji2"">
     <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
         <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
@@ -40,7 +90,7 @@ public partial class BitDropMenuDemo
     </BitStack>
 </BitDropMenu>";
 
-    private readonly string example3RazorCode = @"
+    private readonly string example5RazorCode = @"
 <BitDropMenu Text=""End PanelPosition"" Responsive ScrollContainerId=""sc-con1"" PanelPosition=""BitPanelPosition.End"">
     <div style=""max-width:200px;overflow:auto"" id=""sc-con1"">
         <BitStack FitWidth Gap=""1rem"" Style=""padding:0.5rem"">
@@ -63,7 +113,7 @@ public partial class BitDropMenuDemo
     </div>
 </BitDropMenu>";
 
-    private readonly string example4RazorCode = @"
+    private readonly string example6RazorCode = @"
 <BitDropMenu Text=""Add Icon"" IconName=""@BitIconName.Emoji2"">
     <Template>
         <div style=""display:flex;gap:10px;"">
@@ -79,16 +129,16 @@ public partial class BitDropMenuDemo
     </Body>
 </BitDropMenu>";
 
-    private readonly string example5RazorCode = @"
+    private readonly string example7RazorCode = @"
 <BitDropMenu Text=""@($""Click me ({clickCounter})"")"" OnClick=""() => clickCounter++"">
     <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
         <BitText Typography=""BitTypography.Subtitle1"">This is the content</BitText>
     </BitStack>
 </BitDropMenu>";
-    private readonly string example5CsharpCode = @"
+    private readonly string example7CsharpCode = @"
 private int clickCounter;";
 
-    private readonly string example6RazorCode = @"
+    private readonly string example8RazorCode = @"
 <link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
 
 <BitDropMenu Text=""House"" Icon=""@(""fa-solid fa-house"")"">
@@ -124,7 +174,7 @@ private int clickCounter;";
     </BitStack>
 </BitDropMenu>";
 
-    private readonly string example7RazorCode = @"
+    private readonly string example9RazorCode = @"
 <style>
     .custom-class {
         border-radius: 1rem;
@@ -190,7 +240,7 @@ private int clickCounter;";
     </BitStack>
 </BitDropMenu>";
 
-    private readonly string example8RazorCode = @"
+    private readonly string example10RazorCode = @"
 <BitDropMenu Text=""منو"" Dir=""BitDir.Rtl"">
     <BitStack Gap=""1rem"" Style=""padding:0.5rem"">
         <BitText Typography=""BitTypography.Subtitle1"">این یک محتوای تستی می باشد.</BitText>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/DropMenu/BitDropMenuTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/DropMenu/BitDropMenuTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -88,4 +88,117 @@ public class BitDropMenuTests : BunitTestContext
         Assert.IsTrue(markup.Contains("bit-drm"));
         Assert.IsTrue(markup.Contains("Body"));
     }
+
+    [TestMethod]
+    public void BitDropMenuShouldNotAddNoShadowClassByDefault()
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsFalse(callout.ClassList.Contains("bit-drm-nsh"));
+    }
+
+    [TestMethod]
+    public void BitDropMenuShouldAddNoShadowClassWhenNoShadowIsSet()
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+            parameters.Add(p => p.NoShadow, true);
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsTrue(callout.ClassList.Contains("bit-drm-nsh"));
+    }
+
+    [TestMethod]
+    [DataRow(BitColorKind.Primary, "bit-drm-pbg")]
+    [DataRow(BitColorKind.Secondary, "bit-drm-sbg")]
+    [DataRow(BitColorKind.Tertiary, "bit-drm-tbg")]
+    [DataRow(BitColorKind.Transparent, "bit-drm-rbg")]
+    public void BitDropMenuShouldAddBackgroundClass(BitColorKind background, string expectedClass)
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+            parameters.Add(p => p.Background, background);
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsTrue(callout.ClassList.Contains(expectedClass));
+    }
+
+    [TestMethod]
+    public void BitDropMenuShouldNotAddBackgroundClassByDefault()
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsFalse(callout.ClassList.Contains("bit-drm-pbg"));
+        Assert.IsFalse(callout.ClassList.Contains("bit-drm-sbg"));
+        Assert.IsFalse(callout.ClassList.Contains("bit-drm-tbg"));
+        Assert.IsFalse(callout.ClassList.Contains("bit-drm-rbg"));
+    }
+
+    [TestMethod]
+    [DataRow(BitColorKind.Primary, "bit-drm-pbr")]
+    [DataRow(BitColorKind.Secondary, "bit-drm-sbr")]
+    [DataRow(BitColorKind.Tertiary, "bit-drm-tbr")]
+    [DataRow(BitColorKind.Transparent, "bit-drm-rbr")]
+    public void BitDropMenuShouldAddBorderClass(BitColorKind border, string expectedColorClass)
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+            parameters.Add(p => p.Border, border);
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsTrue(callout.ClassList.Contains("bit-drm-brd"));
+        Assert.IsTrue(callout.ClassList.Contains(expectedColorClass));
+    }
+
+    [TestMethod]
+    public void BitDropMenuShouldNotAddBorderClassByDefault()
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsFalse(callout.ClassList.Contains("bit-drm-brd"));
+    }
+
+    [TestMethod]
+    public void BitDropMenuShouldCombineNoShadowBackgroundAndBorderClasses()
+    {
+        var component = RenderComponent<BitDropMenu>(parameters =>
+        {
+            parameters.Add(p => p.Text, "Menu");
+            parameters.Add(p => p.NoShadow, true);
+            parameters.Add(p => p.Background, BitColorKind.Secondary);
+            parameters.Add(p => p.Border, BitColorKind.Tertiary);
+        });
+
+        var callout = component.Find(".bit-drm-cal");
+
+        Assert.IsTrue(callout.ClassList.Contains("bit-drm-nsh"));
+        Assert.IsTrue(callout.ClassList.Contains("bit-drm-sbg"));
+        Assert.IsTrue(callout.ClassList.Contains("bit-drm-brd"));
+        Assert.IsTrue(callout.ClassList.Contains("bit-drm-tbr"));
+    }
 }
+


### PR DESCRIPTION
closes #12422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* DropMenu component now offers customizable callout styling with configurable background color and border color.
* Added `NoShadow` parameter to optionally remove the callout shadow effect for cleaner appearance.
* Enhanced documentation includes expanded examples demonstrating all styling options, responsive behavior, icon variations, and RTL support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->