### PR TITLE
Fix focus events issues in BitOtpInput (#8571)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/OtpInput/BitOtpInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/OtpInput/BitOtpInput.razor.cs
@@ -277,6 +277,10 @@ public partial class BitOtpInput : BitInputBase<string?>
         if (IsEnabled is false) return;
 
         _inputFocusStates[index] = true;
+        // Re-render so the Focused class/style is applied. This must not rely on the implicit
+        // re-render of EventCallback.InvokeAsync because that only happens when the consumer has
+        // attached an OnFocusIn delegate.
+        StateHasChanged();
         await OnFocusIn.InvokeAsync((e, index));
     }
 
@@ -285,6 +289,9 @@ public partial class BitOtpInput : BitInputBase<string?>
         if (IsEnabled is false) return;
 
         _inputFocusStates[index] = false;
+        // Re-render so the Focused class/style is removed regardless of whether an OnFocusOut
+        // delegate is attached.
+        StateHasChanged();
         await OnFocusOut.InvokeAsync((e, index));
     }
 
@@ -317,8 +324,20 @@ public partial class BitOtpInput : BitInputBase<string?>
                 else
                 {
                     _inputValues[index] = diff;
+
+                    // Commit the current value before moving the focus to the next input.
+                    // Auto-advancing the focus raises the focusout/focusin DOM events (and the
+                    // consumer's OnFocusOut/OnFocusIn callbacks) synchronously while this method
+                    // is awaiting FocusAsync. If the value is committed afterwards, those focus
+                    // callbacks observe a stale, incomplete value. So we set it here first.
+                    CurrentValueAsString = string.Join(string.Empty, _inputValues);
+
                     int nextIndex = index + 1;
                     if (nextIndex < Length) await _inputRefs[nextIndex].FocusAsync();
+
+                    await OnInput.InvokeAsync((e, index));
+                    await CallOnFill();
+                    return;
                 }
             }
         }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/OtpInput/BitOtpInputTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/OtpInput/BitOtpInputTests.cs
@@ -125,4 +125,44 @@ public class BitOtpInputTests : BunitTestContext
         Assert.AreEqual(inputTypeAttribute, bitOtpInput.GetAttribute("type"));
         Assert.AreEqual(inputModeAttribute, bitOtpInput.GetAttribute("inputmode"));
     }
+
+    [TestMethod]
+    public void BitOtpInputShouldRespondToFocusEventsWithIndex()
+    {
+        int focusInIndex = -1;
+        int focusOutIndex = -1;
+
+        var com = RenderComponent<BitOtpInput>(parameters =>
+        {
+            parameters.Add(p => p.Length, 3);
+            parameters.Add(p => p.OnFocusIn, args => focusInIndex = args.Index);
+            parameters.Add(p => p.OnFocusOut, args => focusOutIndex = args.Index);
+        });
+
+        var input = com.FindAll(".bit-otp-inp")[1];
+
+        input.FocusIn();
+        Assert.AreEqual(1, focusInIndex);
+
+        com.FindAll(".bit-otp-inp")[1].FocusOut();
+        Assert.AreEqual(1, focusOutIndex);
+    }
+
+    [TestMethod]
+    public void BitOtpInputShouldToggleFocusedClassWithoutFocusCallbacks()
+    {
+        // The Focused class/style must be applied based purely on the input focus state,
+        // independent of whether OnFocusIn/OnFocusOut delegates are attached.
+        var com = RenderComponent<BitOtpInput>(parameters =>
+        {
+            parameters.Add(p => p.Length, 3);
+            parameters.Add(p => p.Classes, new BitOtpInputClassStyles { Focused = "custom-focused" });
+        });
+
+        com.FindAll(".bit-otp-inp")[1].FocusIn();
+        Assert.IsTrue(com.FindAll(".bit-otp-inp")[1].ClassList.Contains("custom-focused"));
+
+        com.FindAll(".bit-otp-inp")[1].FocusOut();
+        Assert.IsFalse(com.FindAll(".bit-otp-inp")[1].ClassList.Contains("custom-focused"));
+    }
 }


### PR DESCRIPTION
closes #8571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTP input focus styling now consistently applies and removes the "Focused" CSS class based on input focus state.
  * OTP values are properly committed before advancing to the next input field.

* **Tests**
  * Added verification tests for OTP input focus behavior and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->