### PR TITLE
Add digit normalization feature to BitNumberField (#8551)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor
@@ -133,7 +133,7 @@
                    aria-valuemax="@_max"
                    aria-describedby="@AriaDescription"
                    aria-valuenow="@(AriaValueNow ?? CurrentValue)"
-                   aria-valuetext="@(AriaValueText ?? CurrentValueAsString)"
+                   aria-valuetext="@(AriaValueText ?? GetDisplayValueAsString())"
                    aria-disabled="@(IsEnabled is false)" />
 
                    @if (ShowClearButton && (CurrentValue is not null || _tempValue.HasValue()))

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor
@@ -109,7 +109,7 @@
                    @onfocusin="HandleOnFocusIn"
                    @onfocusout="HandleOnFocusOut"
                    @onwheel="HandleOnMouseWheel"
-                   @bind-value:get="@CurrentValueAsString"
+                   @bind-value:get="@GetDisplayValueAsString()"
                    @bind-value:set="@HandleOnStringValueSet"
                    @bind-value:event="@(Immediate ? "oninput" : "onchange")"
                    form=""

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -12,6 +12,8 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     private int _precision;
     private bool _hasFocus;
     private string? _tempValue;
+    private string? _displayValue;
+    private TValue? _displayValueSource;
     private TValue _min = default!;
     private TValue _max = default!;
     private TValue _step = default!;
@@ -404,13 +406,23 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? parsingErrorMessage)
     {
+        // Reset the preserved display text. It is set again below only when the digit
+        // normalization is the sole transformation applied to the user's input.
+        _displayValue = null;
+        _displayValueSource = default;
+
+        var originalValue = value;
+        var digitsNormalized = false;
+
         if (DigitsNormalizer is not null)
         {
             value = DigitsNormalizer(value);
+            digitsNormalized = string.Equals(value, originalValue, StringComparison.Ordinal) is false;
         }
         else if (NormalizeDigits)
         {
             value = NormalizeUnicodeDigits(value);
+            digitsNormalized = string.Equals(value, originalValue, StringComparison.Ordinal) is false;
         }
 
         if (NumberFormat is not null)
@@ -420,9 +432,22 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
         if (BindConverter.TryConvertTo(value, CultureInfo.InvariantCulture, out result))
         {
+            var parsedValue = result;
+
             result = CheckMinAndMax(result);
 
             result = Normalize(result);
+
+            // Keep the user's original text visible in the input when digit normalization was the
+            // only transformation, i.e. the parsed number wasn't altered by min/max clamping or
+            // precision rounding. This avoids visibly converting the typed digits (culture-agnostic,
+            // since it compares the numeric values rather than their formatted strings) while still
+            // updating the bound .NET value to the normalized number.
+            if (digitsNormalized && EqualityComparer<TValue>.Default.Equals(parsedValue, result))
+            {
+                _displayValue = originalValue;
+                _displayValueSource = result;
+            }
 
             parsingErrorMessage = null;
             return true;
@@ -432,6 +457,21 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
             parsingErrorMessage = string.Format(CultureInfo.InvariantCulture, ParsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Returns the string to display in the input. When digit normalization preserved the user's
+    /// original text (see <see cref="TryParseValueFromString"/>), that text is shown as long as it
+    /// still corresponds to the current value; otherwise the regular formatted value is used.
+    /// </summary>
+    private string? GetDisplayValueAsString()
+    {
+        if (_displayValue is not null && EqualityComparer<TValue>.Default.Equals(CurrentValue, _displayValueSource))
+        {
+            return _displayValue;
+        }
+
+        return CurrentValueAsString;
     }
 
     protected override string? FormatValueAsString(TValue? value)
@@ -680,6 +720,11 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
         }
 
         result = CheckMinAndMax(result);
+
+        // The value is being changed via the spin buttons / wheel / arrow keys, so any preserved
+        // user-typed display text is no longer relevant and the formatted value should be shown.
+        _displayValue = null;
+        _displayValueSource = default;
 
         CurrentValue = result;
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -224,6 +224,19 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     [Parameter] public BitSpinButtonMode? Mode { get; set; }
 
     /// <summary>
+    /// Normalizes non-Latin (e.g. Persian "۱۲۳" or Arabic "١٢٣") decimal digits to their Latin (0-9) equivalents before parsing.
+    /// This is culture-agnostic and works for any Unicode decimal digit system.
+    /// </summary>
+    [Parameter] public bool NormalizeDigits { get; set; }
+
+    /// <summary>
+    /// A custom function to normalize the raw input string before it gets parsed into the value.
+    /// When provided, it takes precedence over <see cref="NormalizeDigits"/> and lets the developer plug in their own
+    /// culture-specific or domain-specific transformation (e.g. mapping characters from a particular keyboard layout).
+    /// </summary>
+    [Parameter] public Func<string?, string?>? DigitsNormalizer { get; set; }
+
+    /// <summary>
     /// The format of the number in the number field.
     /// </summary>
     [Parameter] public string? NumberFormat { get; set; }
@@ -391,6 +404,15 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? parsingErrorMessage)
     {
+        if (DigitsNormalizer is not null)
+        {
+            value = DigitsNormalizer(value);
+        }
+        else if (NormalizeDigits)
+        {
+            value = NormalizeUnicodeDigits(value);
+        }
+
         if (NumberFormat is not null)
         {
             value = CleanValue(value);
@@ -719,6 +741,38 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
              : _typeOfValue == typeof(decimal) ? Convert.ToDecimal(result) < Convert.ToDecimal(_min) ? _min : Convert.ToDecimal(result) > Convert.ToDecimal(_max) ? _max : result
              : _typeOfValue == typeof(double) ? Convert.ToDouble(result) < Convert.ToDouble(_min) ? _min : Convert.ToDouble(result) > Convert.ToDouble(_max) ? _max : result
              : _zeroValue;
+    }
+
+    private static string? NormalizeUnicodeDigits(string? value)
+    {
+        if (value.HasNoValue()) return value;
+
+        var chars = value!.ToCharArray();
+        var changed = false;
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var c = chars[i];
+            if (c is >= '0' and <= '9' or '.' or '-') continue;
+
+            // Any Unicode decimal digit (e.g. Persian U+06F0-U+06F9, Arabic-Indic U+0660-U+0669, etc.).
+            var digit = CharUnicodeInfo.GetDecimalDigitValue(c);
+            if (digit >= 0)
+            {
+                chars[i] = (char)('0' + digit);
+                changed = true;
+                continue;
+            }
+
+            // Decimal separator emitted by Persian/Arabic keyboard layouts.
+            if (c is '٫') // U+066B ARABIC DECIMAL SEPARATOR
+            {
+                chars[i] = '.';
+                changed = true;
+            }
+        }
+
+        return changed ? new string(chars) : value;
     }
 
     private static string? CleanValue(string? value)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -15,6 +15,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     private string? _displayValue;
     private TValue? _displayValueSource;
     private bool _keepDisplayValueOnNextChange;
+    private bool _lastNormalizationActive;
     private TValue _min = default!;
     private TValue _max = default!;
     private TValue _step = default!;
@@ -117,6 +118,18 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     /// Initial value of the number field.
     /// </summary>
     [Parameter] public TValue? DefaultValue { get; set; }
+
+    /// <summary>
+    /// A custom function to normalize the raw input string before it gets parsed into the value.
+    /// When provided, it takes precedence over <see cref="NormalizeDigits"/> and lets the developer plug in their own
+    /// culture-specific or domain-specific transformation (e.g. mapping characters from a particular keyboard layout).
+    /// Note that, like <see cref="NormalizeDigits"/>, this function is also applied to the <see cref="Min"/>, <see cref="Max"/>
+    /// and <see cref="Step"/> parameters (and to the precision derived from <see cref="Step"/>), not only to user input, so it
+    /// affects range/step semantics as well. The original typed text is only kept visible in the input when it is digit-equivalent
+    /// to the resulting value (i.e. a pure non-Latin rendering of the same number); transformations that strip units, symbols or
+    /// aliases will display the canonical value instead.
+    /// </summary>
+    [Parameter] public Func<string?, string?>? DigitsNormalizer { get; set; }
 
     /// <summary>
     /// If true, the input is hidden.
@@ -228,17 +241,12 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     /// <summary>
     /// Normalizes non-Latin (e.g. Persian "۱۲۳" or Arabic "١٢٣") decimal digits to their Latin (0-9) equivalents before parsing.
-    /// This is culture-agnostic and works for any Unicode decimal digit system.
-    /// The Arabic decimal separator (U+066B) is mapped to '.', and the Arabic thousands separator (U+066C) is stripped.
+    /// This is culture-agnostic and works for any Unicode decimal digit system, including digits in the supplementary planes
+    /// (surrogate pairs). The Arabic decimal separator (U+066B) is mapped to '.', and the Arabic thousands separator (U+066C) is stripped.
+    /// The same normalization is also applied to the <see cref="Min"/>, <see cref="Max"/> and <see cref="Step"/> parameters so that
+    /// non-Latin constraints (e.g. <c>Min="۱۰"</c>) are parsed consistently with user input.
     /// </summary>
     [Parameter] public bool NormalizeDigits { get; set; }
-
-    /// <summary>
-    /// A custom function to normalize the raw input string before it gets parsed into the value.
-    /// When provided, it takes precedence over <see cref="NormalizeDigits"/> and lets the developer plug in their own
-    /// culture-specific or domain-specific transformation (e.g. mapping characters from a particular keyboard layout).
-    /// </summary>
-    [Parameter] public Func<string?, string?>? DigitsNormalizer { get; set; }
 
     /// <summary>
     /// The format of the number in the number field.
@@ -408,17 +416,32 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     protected override void OnParametersSet()
     {
-        // The Min/Max/Step CallOnSet handlers run during SetParametersAsync and may execute before the
-        // NormalizeDigits/DigitsNormalizer parameters have been assigned (parameter assignment order is
-        // not guaranteed). Re-run them here, after all parameters are set, so non-Latin numeric
-        // parameters are normalized consistently with user input regardless of attribute order.
-        if (NormalizeDigits || DigitsNormalizer is not null)
+        // Whether digit normalization (built-in NormalizeDigits or a custom DigitsNormalizer) is
+        // currently active. The Min/Max/Step string parameters are parsed through this normalization,
+        // so their cached numeric values (and the derived precision) must be recomputed whenever the
+        // normalization is toggled. Re-running only on a state change - rather than on every render -
+        // avoids repeatedly invoking a potentially expensive or side-effectful custom DigitsNormalizer
+        // delegate, while still covering:
+        //   * the first render, where the Min/Max/Step CallOnSet handlers may have executed during
+        //     SetParametersAsync before NormalizeDigits/DigitsNormalizer were assigned (parameter
+        //     assignment order is not guaranteed), and
+        //   * toggling normalization off, where a previously parsed non-Latin Min/Max/Step no longer
+        //     parses and must fall back to the type defaults instead of keeping its stale value.
+        var normalizationActive = NormalizeDigits || DigitsNormalizer is not null;
+        if (normalizationActive != _lastNormalizationActive)
         {
+            _lastNormalizationActive = normalizationActive;
+
             // Only re-run for parameters that were actually provided. Re-running a setter for an
             // unset parameter would reset it to its default (and is unnecessary work).
             if (Min is not null) OnSetMin();
             if (Max is not null) OnSetMax();
             if (Step is not null) OnSetStep();
+
+            // Precision can be derived from Step (CalculatePrecision), so it must be recomputed using
+            // the now-normalized Step; otherwise a non-Latin decimal Step (e.g. "۰٫۰۱") could leave
+            // the precision stale and round fractional values incorrectly.
+            OnSetPrecision();
         }
 
         base.OnParametersSet();
@@ -451,6 +474,18 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
             value = CleanValue(value);
         }
 
+        // The input collapsed to an empty string purely because digit normalization stripped its
+        // contents (e.g. an Arabic thousands separator "٬" typed on its own, or a custom normalizer
+        // removing units/symbols). For nullable types BindConverter would happily turn "" into null,
+        // silently clearing the value. Since the user did type something non-empty, surface a parse
+        // error instead so the value is not silently lost.
+        if (digitsNormalized && value.HasNoValue() && originalValue.HasValue())
+        {
+            result = default;
+            parsingErrorMessage = string.Format(CultureInfo.InvariantCulture, ParsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
+            return false;
+        }
+
         if (BindConverter.TryConvertTo(value, CultureInfo.InvariantCulture, out result))
         {
             var parsedValue = result;
@@ -467,7 +502,15 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
             // When NumberFormat is set the formatted string takes precedence (e.g. on focus-out the
             // field should show "123.00" rather than the raw typed digits), so the original text is
             // only preserved when no further formatting will be applied.
-            if (digitsNormalized && NumberFormat is null && EqualityComparer<TValue>.Default.Equals(parsedValue, result))
+            // Crucially, the original text is only preserved when it is digit-equivalent to the
+            // canonical value (see IsDisplayDigitEquivalent). This prevents an arbitrary custom
+            // DigitsNormalizer (or one that strips units/symbols/aliases) from showing one thing while
+            // a different number is bound - the visible text and the bound value must represent the
+            // same number.
+            if (digitsNormalized
+                && NumberFormat is null
+                && EqualityComparer<TValue>.Default.Equals(parsedValue, result)
+                && IsDisplayDigitEquivalent(originalValue, result))
             {
                 _displayValue = originalValue;
                 _displayValueSource = result;
@@ -502,6 +545,19 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
         }
 
         return CurrentValueAsString;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="originalValue"/> (the raw text the user typed) is merely a
+    /// non-Latin-digit rendering of <paramref name="value"/> (the canonical bound number). It is used
+    /// to decide whether the original text is safe to keep visible: only when mapping its Unicode
+    /// decimal digits to Latin reproduces the canonical formatted value exactly. This guards against a
+    /// custom <see cref="DigitsNormalizer"/> (or any transformation that strips units, symbols, spaces
+    /// or aliases) leaving pre-normalized text visible while a different number is bound.
+    /// </summary>
+    private bool IsDisplayDigitEquivalent(string? originalValue, TValue value)
+    {
+        return string.Equals(NormalizeUnicodeDigits(originalValue), FormatValueAsString(value), StringComparison.Ordinal);
     }
 
     protected override string? FormatValueAsString(TValue? value)
@@ -825,15 +881,39 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
         var sb = new System.Text.StringBuilder(value!.Length);
         var changed = false;
 
-        foreach (var c in value!)
+        for (var i = 0; i < value!.Length; i++)
         {
+            var c = value[i];
+
             if (c is >= '0' and <= '9' or '.' or '-')
             {
                 sb.Append(c);
                 continue;
             }
 
-            // Any Unicode decimal digit (e.g. Persian U+06F0-U+06F9, Arabic-Indic U+0660-U+0669, etc.).
+            // Decimal digits in the Unicode supplementary planes (e.g. U+1D7CE..U+1D7FF Mathematical
+            // digits) are represented by surrogate pairs, so they must be handled before the single
+            // 'char' lookup below which cannot see an astral code point. GetDecimalDigitValue(string,
+            // int) understands the surrogate pair when the index points at the high surrogate.
+            if (char.IsHighSurrogate(c) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+            {
+                var surrogateDigit = CharUnicodeInfo.GetDecimalDigitValue(value, i);
+                if (surrogateDigit >= 0)
+                {
+                    sb.Append((char)('0' + surrogateDigit));
+                    changed = true;
+                }
+                else
+                {
+                    sb.Append(c);
+                    sb.Append(value[i + 1]);
+                }
+
+                i++; // the low surrogate has been consumed as part of this code point.
+                continue;
+            }
+
+            // Any Unicode decimal digit in the BMP (e.g. Persian U+06F0-U+06F9, Arabic-Indic U+0660-U+0669, etc.).
             var digit = CharUnicodeInfo.GetDecimalDigitValue(c);
             if (digit >= 0)
             {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -14,6 +14,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     private string? _tempValue;
     private string? _displayValue;
     private TValue? _displayValueSource;
+    private bool _keepDisplayValueOnNextChange;
     private TValue _min = default!;
     private TValue _max = default!;
     private TValue _step = default!;
@@ -405,12 +406,31 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
         await base.OnInitializedAsync();
     }
 
+    protected override void OnParametersSet()
+    {
+        // The Min/Max/Step CallOnSet handlers run during SetParametersAsync and may execute before the
+        // NormalizeDigits/DigitsNormalizer parameters have been assigned (parameter assignment order is
+        // not guaranteed). Re-run them here, after all parameters are set, so non-Latin numeric
+        // parameters are normalized consistently with user input regardless of attribute order.
+        if (NormalizeDigits || DigitsNormalizer is not null)
+        {
+            // Only re-run for parameters that were actually provided. Re-running a setter for an
+            // unset parameter would reset it to its default (and is unnecessary work).
+            if (Min is not null) OnSetMin();
+            if (Max is not null) OnSetMax();
+            if (Step is not null) OnSetStep();
+        }
+
+        base.OnParametersSet();
+    }
+
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? parsingErrorMessage)
     {
         // Reset the preserved display text. It is set again below only when the digit
         // normalization is the sole transformation applied to the user's input.
         _displayValue = null;
         _displayValueSource = default;
+        _keepDisplayValueOnNextChange = false;
 
         var originalValue = value;
         var digitsNormalized = false;
@@ -451,6 +471,10 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
             {
                 _displayValue = originalValue;
                 _displayValueSource = result;
+                // The value assignment that immediately follows this parse (raised through
+                // OnValueChanged) is the one that produced this preserved text, so it must not clear
+                // it. Any later value change comes from elsewhere (parent/model) and should discard it.
+                _keepDisplayValueOnNextChange = true;
             }
 
             parsingErrorMessage = null;
@@ -470,7 +494,9 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     /// </summary>
     private string? GetDisplayValueAsString()
     {
-        if (_displayValue is not null && EqualityComparer<TValue>.Default.Equals(CurrentValue, _displayValueSource))
+        if (_displayValue is not null
+            && NumberFormat is null
+            && EqualityComparer<TValue>.Default.Equals(CurrentValue, _displayValueSource))
         {
             return _displayValue;
         }
@@ -849,9 +875,30 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
         return matchCollection is null ? value : string.Join("", matchCollection.Select(m => m.Value));
     }
 
+    /// <summary>
+    /// Applies the same digit normalization used for user input (<see cref="DigitsNormalizer"/> or
+    /// <see cref="NormalizeDigits"/>) to the numeric string parameters (<see cref="Min"/>,
+    /// <see cref="Max"/> and <see cref="Step"/>) so that markup like <c>Min="۱۰"</c> or
+    /// <c>Step="۰٫۵"</c> is parsed consistently instead of silently falling back to defaults.
+    /// </summary>
+    private string? NormalizeNumericParameter(string? value)
+    {
+        if (DigitsNormalizer is not null)
+        {
+            return DigitsNormalizer(value);
+        }
+
+        if (NormalizeDigits)
+        {
+            return NormalizeUnicodeDigits(value);
+        }
+
+        return value;
+    }
+
     private void OnSetMin()
     {
-        var min = CleanValue(Min);
+        var min = CleanValue(NormalizeNumericParameter(Min));
         if (BindConverter.TryConvertTo(min, CultureInfo.InvariantCulture, out TValue? result))
         {
             _min = result ?? GetTypeMinValue();
@@ -864,7 +911,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private void OnSetMax()
     {
-        var max = CleanValue(Max);
+        var max = CleanValue(NormalizeNumericParameter(Max));
         if (BindConverter.TryConvertTo(max, CultureInfo.InvariantCulture, out TValue? result))
         {
             _max = result ?? GetTypeMaxValue();
@@ -877,7 +924,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private void OnSetStep()
     {
-        var step = CleanValue(Step);
+        var step = CleanValue(NormalizeNumericParameter(Step));
         if (BindConverter.TryConvertTo(step, CultureInfo.InvariantCulture, out TValue? result))
         {
             _step = result ?? ((TValue)(object)1);
@@ -913,7 +960,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private int CalculatePrecision()
     {
-        var step = Step ?? _step?.ToString() ?? "1";
+        var step = NormalizeNumericParameter(Step) ?? _step?.ToString() ?? "1";
         var regex = new Regex(@"[1-9]([0]+$)|\.([0-9]*)");
         if (regex.IsMatch(step) is false) return 0;
 
@@ -947,6 +994,21 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
 
     private void HandleOnValueChanged(object? sender, EventArgs args)
     {
+        if (_keepDisplayValueOnNextChange)
+        {
+            // This change is the one produced by the user input we intentionally preserved
+            // (see TryParseValueFromString), so keep the display text for this single change only.
+            _keepDisplayValueOnNextChange = false;
+        }
+        else
+        {
+            // The value changed from a source other than the preserved user input (e.g. the parent
+            // resetting or reloading the bound value), so any preserved display text is now stale and
+            // must be discarded to avoid re-showing old user-typed text for a model-driven value.
+            _displayValue = null;
+            _displayValueSource = default;
+        }
+
         NormalizeValue();
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -228,6 +228,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     /// <summary>
     /// Normalizes non-Latin (e.g. Persian "۱۲۳" or Arabic "١٢٣") decimal digits to their Latin (0-9) equivalents before parsing.
     /// This is culture-agnostic and works for any Unicode decimal digit system.
+    /// The Arabic decimal separator (U+066B) is mapped to '.', and the Arabic thousands separator (U+066C) is stripped.
     /// </summary>
     [Parameter] public bool NormalizeDigits { get; set; }
 
@@ -443,7 +444,10 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
             // precision rounding. This avoids visibly converting the typed digits (culture-agnostic,
             // since it compares the numeric values rather than their formatted strings) while still
             // updating the bound .NET value to the normalized number.
-            if (digitsNormalized && EqualityComparer<TValue>.Default.Equals(parsedValue, result))
+            // When NumberFormat is set the formatted string takes precedence (e.g. on focus-out the
+            // field should show "123.00" rather than the raw typed digits), so the original text is
+            // only preserved when no further formatting will be applied.
+            if (digitsNormalized && NumberFormat is null && EqualityComparer<TValue>.Default.Equals(parsedValue, result))
             {
                 _displayValue = originalValue;
                 _displayValueSource = result;
@@ -792,19 +796,22 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     {
         if (value.HasNoValue()) return value;
 
-        var chars = value!.ToCharArray();
+        var sb = new System.Text.StringBuilder(value!.Length);
         var changed = false;
 
-        for (var i = 0; i < chars.Length; i++)
+        foreach (var c in value!)
         {
-            var c = chars[i];
-            if (c is >= '0' and <= '9' or '.' or '-') continue;
+            if (c is >= '0' and <= '9' or '.' or '-')
+            {
+                sb.Append(c);
+                continue;
+            }
 
             // Any Unicode decimal digit (e.g. Persian U+06F0-U+06F9, Arabic-Indic U+0660-U+0669, etc.).
             var digit = CharUnicodeInfo.GetDecimalDigitValue(c);
             if (digit >= 0)
             {
-                chars[i] = (char)('0' + digit);
+                sb.Append((char)('0' + digit));
                 changed = true;
                 continue;
             }
@@ -812,12 +819,24 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
             // Decimal separator emitted by Persian/Arabic keyboard layouts.
             if (c is '٫') // U+066B ARABIC DECIMAL SEPARATOR
             {
-                chars[i] = '.';
+                sb.Append('.');
                 changed = true;
+                continue;
             }
+
+            // Thousands/group separator emitted by Persian/Arabic keyboard layouts. It carries no
+            // numeric meaning, so it's dropped (analogous to how CleanValue strips the Latin grouping
+            // separator) to avoid a silent parse failure on common real-world input like "۱٬۲۳۴".
+            if (c is '٬') // U+066C ARABIC THOUSANDS SEPARATOR
+            {
+                changed = true;
+                continue;
+            }
+
+            sb.Append(c);
         }
 
-        return changed ? new string(chars) : value;
+        return changed ? sb.ToString() : value;
     }
 
     private static string? CleanValue(string? value)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor
@@ -198,7 +198,41 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="Validation" RazorCode="@example13RazorCode" CsharpCode="@example13CsharpCode" Id="example13">
+    <DemoExample Title="NormalizeDigits" RazorCode="@example13RazorCode" CsharpCode="@example13CsharpCode" Id="example13">
+        <div>
+            Enables culture-agnostic normalization of non-Latin decimal digits (e.g. Persian "۱۲۳" or Arabic "١٢٣")
+            and the Arabic decimal separator (٫) to their Latin equivalents before parsing. This makes the field accept
+            numbers typed from the various Persian/Arabic keyboard layouts that emit different Unicode code points.
+        </div>
+        <br />
+        <div>
+            <div class="example-box">
+                <BitNumberField Label="Without NormalizeDigits" @bind-Value="normalizeOffValue" Placeholder="۱۲۳" />
+                <div>Value: @normalizeOffValue</div>
+                <br />
+                <BitNumberField Label="With NormalizeDigits" @bind-Value="normalizeOnValue" NormalizeDigits Placeholder="۱۲۳" />
+                <div>Value: @normalizeOnValue</div>
+                <br />
+                <BitNumberField Label="Fractioned NormalizeDigits" @bind-Value="normalizeDecimalValue" NormalizeDigits Placeholder="۱۲٫۵" />
+                <div>Value: @normalizeDecimalValue</div>
+            </div>
+        </div>
+        <br />
+        <div>
+            For full control, provide a custom <b>DigitsNormalizer</b> function. It receives the raw input string and returns
+            the normalized string before parsing, taking precedence over <b>NormalizeDigits</b>. The example below normalizes
+            non-Latin digits and also strips spaces and thousand separators (both Latin "," and Persian "٬").
+        </div>
+        <br />
+        <div>
+            <div class="example-box">
+                <BitNumberField Label="Custom DigitsNormalizer" @bind-Value="customNormalizerValue" DigitsNormalizer="CustomDigitsNormalizer" Placeholder="۱٬۲۳۴" />
+                <div>Value: @customNormalizerValue</div>
+            </div>
+        </div>
+    </DemoExample>
+
+    <DemoExample Title="Validation" RazorCode="@example14RazorCode" CsharpCode="@example14CsharpCode" Id="example14">
         <div>Demonstrates validation for BitNumberField within a form, including required fields and custom validation messages.</div>
         <br />
         <div class="example-box">
@@ -220,7 +254,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="External Icons" RazorCode="@example14RazorCode" Id="example14">
+    <DemoExample Title="External Icons" RazorCode="@example15RazorCode" Id="example15">
         <div>Use icons from external libraries like FontAwesome, Material Icons, and Bootstrap Icons with the <b>Icon</b>, <b>IncrementIcon</b>, and <b>DecrementIcon</b> parameters.</div>
 
         <br />
@@ -267,7 +301,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="Style & Class" RazorCode="@example15RazorCode" Id="example15">
+    <DemoExample Title="Style & Class" RazorCode="@example16RazorCode" Id="example16">
         <div>Explores styling and class customization for BitNumberField, including component styles, custom classes, and detailed style options.</div>
         <br /><br />
         <div class="example-box">
@@ -298,7 +332,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="RTL" RazorCode="@example16RazorCode" Id="example16">
+    <DemoExample Title="RTL" RazorCode="@example17RazorCode" Id="example17">
         <div>Use BitNumberField in right-to-left (RTL).</div>
         <br />
         <div dir="rtl">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor
@@ -210,10 +210,10 @@
                 <BitNumberField Label="Without NormalizeDigits" @bind-Value="normalizeOffValue" Placeholder="۱۲۳" />
                 <div>Value: @normalizeOffValue</div>
                 <br />
-                <BitNumberField Label="With NormalizeDigits" @bind-Value="normalizeOnValue" NormalizeDigits Placeholder="۱۲۳" />
+                <BitNumberField Label="With NormalizeDigits (۱۲۳)" @bind-Value="normalizeOnValue" NormalizeDigits Placeholder="۱۲۳" />
                 <div>Value: @normalizeOnValue</div>
                 <br />
-                <BitNumberField Label="Fractioned NormalizeDigits" @bind-Value="normalizeDecimalValue" NormalizeDigits Placeholder="۱۲٫۵" />
+                <BitNumberField Label="Fractioned NormalizeDigits (۱۲٫۳)" @bind-Value="normalizeDecimalValue" NormalizeDigits Placeholder="۱۲٫۵" Precision="2" />
                 <div>Value: @normalizeDecimalValue</div>
             </div>
         </div>
@@ -226,7 +226,7 @@
         <br />
         <div>
             <div class="example-box">
-                <BitNumberField Label="Custom DigitsNormalizer" @bind-Value="customNormalizerValue" DigitsNormalizer="CustomDigitsNormalizer" Placeholder="۱٬۲۳۴" />
+                <BitNumberField Label="Custom DigitsNormalizer (۱٬۲۳۴)" @bind-Value="customNormalizerValue" DigitsNormalizer="CustomDigitsNormalizer" Placeholder="۱٬۲۳۴" />
                 <div>Value: @customNormalizerValue</div>
             </div>
         </div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor
@@ -213,7 +213,7 @@
                 <BitNumberField Label="With NormalizeDigits (۱۲۳)" @bind-Value="normalizeOnValue" NormalizeDigits Placeholder="۱۲۳" />
                 <div>Value: @normalizeOnValue</div>
                 <br />
-                <BitNumberField Label="Fractioned NormalizeDigits (۱۲٫۳)" @bind-Value="normalizeDecimalValue" NormalizeDigits Placeholder="۱۲٫۵" Precision="2" />
+                <BitNumberField Label="Fractioned NormalizeDigits (۱۲٫۵)" @bind-Value="normalizeDecimalValue" NormalizeDigits Placeholder="۱۲٫۵" Precision="2" />
                 <div>Value: @normalizeDecimalValue</div>
             </div>
         </div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.cs
@@ -89,6 +89,13 @@ public partial class BitNumberFieldDemo
         },
         new()
         {
+            Name = "DigitsNormalizer",
+            Type = "Func<string?, string?>?",
+            DefaultValue = "null",
+            Description = "A custom function to normalize the raw input string before it gets parsed into the value. When provided, it takes precedence over NormalizeDigits and lets the developer plug in their own culture-specific or domain-specific transformation.",
+        },
+        new()
+        {
             Name = "HideInput",
             Type = "bool",
             DefaultValue = "false",
@@ -217,13 +224,6 @@ public partial class BitNumberFieldDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Normalizes non-Latin (e.g. Persian \"۱۲۳\" or Arabic \"١٢٣\") decimal digits to their Latin (0-9) equivalents before parsing. This is culture-agnostic and works for any Unicode decimal digit system.",
-        },
-        new()
-        {
-            Name = "DigitsNormalizer",
-            Type = "Func<string?, string?>?",
-            DefaultValue = "null",
-            Description = "A custom function to normalize the raw input string before it gets parsed into the value. When provided, it takes precedence over NormalizeDigits and lets the developer plug in their own culture-specific or domain-specific transformation.",
         },
         new()
         {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.cs
@@ -213,6 +213,20 @@ public partial class BitNumberFieldDemo
         },
         new()
         {
+            Name = "NormalizeDigits",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Normalizes non-Latin (e.g. Persian \"۱۲۳\" or Arabic \"١٢٣\") decimal digits to their Latin (0-9) equivalents before parsing. This is culture-agnostic and works for any Unicode decimal digit system.",
+        },
+        new()
+        {
+            Name = "DigitsNormalizer",
+            Type = "Func<string?, string?>?",
+            DefaultValue = "null",
+            Description = "A custom function to normalize the raw input string before it gets parsed into the value. When provided, it takes precedence over NormalizeDigits and lets the developer plug in their own culture-specific or domain-specific transformation.",
+        },
+        new()
+        {
             Name = "NumberFormat",
             Type = "string?",
             DefaultValue = "null",
@@ -590,6 +604,11 @@ public partial class BitNumberFieldDemo
 
     private int? classesValue;
 
+    private int? normalizeOffValue;
+    private int? normalizeOnValue;
+    private double? normalizeDecimalValue;
+    private int? customNormalizerValue;
+
     private int hideInputValue;
 
     private bool invertMouseWheel;
@@ -610,5 +629,23 @@ public partial class BitNumberFieldDemo
     private void HandleInvalidSubmit()
     {
         SuccessMessage = string.Empty;
+    }
+
+    // Custom normalizer: maps any Unicode decimal digit to its Latin equivalent
+    // and strips spaces and thousand separators (Latin ',' and Persian '٬').
+    private string? CustomDigitsNormalizer(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+
+        var sb = new System.Text.StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            if (c is ' ' or ',' or '٬') continue;
+
+            var digit = System.Globalization.CharUnicodeInfo.GetDecimalDigitValue(c);
+            sb.Append(digit >= 0 ? (char)('0' + digit) : c);
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.samples.cs
@@ -284,14 +284,14 @@ private BitNumberFieldValidationModel validationModel = new();";
 <BitNumberField Label=""Without NormalizeDigits"" @bind-Value=""normalizeOffValue"" Placeholder=""۱۲۳"" />
 <div>Value: @normalizeOffValue</div>
 
-<BitNumberField Label=""With NormalizeDigits"" @bind-Value=""normalizeOnValue"" NormalizeDigits Placeholder=""۱۲۳"" />
+<BitNumberField Label=""With NormalizeDigits (۱۲۳)"" @bind-Value=""normalizeOnValue"" NormalizeDigits Placeholder=""۱۲۳"" />
 <div>Value: @normalizeOnValue</div>
 
-<BitNumberField Label=""Fractioned NormalizeDigits"" @bind-Value=""normalizeDecimalValue"" NormalizeDigits Placeholder=""۱۲٫۵"" />
+<BitNumberField Label=""Fractioned NormalizeDigits (۱۲٫۵)"" @bind-Value=""normalizeDecimalValue"" NormalizeDigits Placeholder=""۱۲٫۵"" Precision=""2"" />
 <div>Value: @normalizeDecimalValue</div>
 
 
-<BitNumberField Label=""Custom DigitsNormalizer"" @bind-Value=""customNormalizerValue"" DigitsNormalizer=""CustomDigitsNormalizer"" Placeholder=""۱٬۲۳۴"" />
+<BitNumberField Label=""Custom DigitsNormalizer (۱٬۲۳۴)"" @bind-Value=""customNormalizerValue"" DigitsNormalizer=""CustomDigitsNormalizer"" Placeholder=""۱٬۲۳۴"" />
 <div>Value: @customNormalizerValue</div>";
     private readonly string example13CsharpCode = @"
 private int? normalizeOffValue;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.samples.cs
@@ -127,7 +127,7 @@ private int onIncrementCounter;
 private int onDecrementCounter;
 private int onChangeCounter;";
 
-    private readonly string example13RazorCode = @"
+    private readonly string example14RazorCode = @"
 <EditForm Model=""@validationModel"">
     <DataAnnotationsValidator />
 
@@ -136,7 +136,7 @@ private int onChangeCounter;";
     <br />
     <BitButton ButtonType=""BitButtonType.Submit"">Submit</BitButton>
 </EditForm>";
-    private readonly string example13CsharpCode = @"
+    private readonly string example14CsharpCode = @"
 public class BitNumberFieldValidationModel
 {
     [Required(ErrorMessage = ""Enter an age"")]
@@ -146,7 +146,7 @@ public class BitNumberFieldValidationModel
 
 private BitNumberFieldValidationModel validationModel = new();";
 
-    private readonly string example14RazorCode = @"
+    private readonly string example15RazorCode = @"
 <link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
 
 <div>Component Icon (FontAwesome):</div>
@@ -171,7 +171,7 @@ private BitNumberFieldValidationModel validationModel = new();";
                 IncrementIcon=""@BitIconInfo.Bi(""plus-circle-fill"")""
                 DecrementIcon=""@BitIconInfo.Bi(""dash-circle-fill"")"" />";
 
-    private readonly string example15RazorCode = @"
+    private readonly string example16RazorCode = @"
 <style>
     .custom-class {
         overflow: hidden;
@@ -267,7 +267,7 @@ private BitNumberFieldValidationModel validationModel = new();";
                                  Input = ""custom-input"",
                                  Label = $""custom-label{(classesValue is null ? string.Empty : "" custom-label-top"")}"" })"" />";
 
-    private readonly string example16RazorCode = @"
+    private readonly string example17RazorCode = @"
 <CascadingValue Value=""BitDir.Rtl"">
 
     <BitNumberField Label=""برچسب در بالا"" TValue=""int"" ShowButtons />
@@ -279,4 +279,41 @@ private BitNumberFieldValidationModel validationModel = new();";
     <BitNumberField Label=""الزامی"" TValue=""int"" Required />
 
 </CascadingValue>";
+
+    private readonly string example13RazorCode = @"
+<BitNumberField Label=""Without NormalizeDigits"" @bind-Value=""normalizeOffValue"" Placeholder=""۱۲۳"" />
+<div>Value: @normalizeOffValue</div>
+
+<BitNumberField Label=""With NormalizeDigits"" @bind-Value=""normalizeOnValue"" NormalizeDigits Placeholder=""۱۲۳"" />
+<div>Value: @normalizeOnValue</div>
+
+<BitNumberField Label=""Fractioned NormalizeDigits"" @bind-Value=""normalizeDecimalValue"" NormalizeDigits Placeholder=""۱۲٫۵"" />
+<div>Value: @normalizeDecimalValue</div>
+
+
+<BitNumberField Label=""Custom DigitsNormalizer"" @bind-Value=""customNormalizerValue"" DigitsNormalizer=""CustomDigitsNormalizer"" Placeholder=""۱٬۲۳۴"" />
+<div>Value: @customNormalizerValue</div>";
+    private readonly string example13CsharpCode = @"
+private int? normalizeOffValue;
+private int? normalizeOnValue;
+private double? normalizeDecimalValue;
+private int? customNormalizerValue;
+
+// Custom normalizer: maps any Unicode decimal digit to its Latin equivalent
+// and strips spaces and thousand separators (Latin ',' and Persian '٬').
+private string? CustomDigitsNormalizer(string? value)
+{
+    if (string.IsNullOrEmpty(value)) return value;
+
+    var sb = new StringBuilder(value.Length);
+    foreach (var c in value)
+    {
+        if (c is ' ' or ',' or '٬') continue;
+
+        var digit = CharUnicodeInfo.GetDecimalDigitValue(c);
+        sb.Append(digit >= 0 ? (char)('0' + digit) : c);
+    }
+
+    return sb.ToString();
+}";
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
@@ -740,6 +740,146 @@ public class BitNumberFieldTests : BunitTestContext
         Assert.AreEqual(10, component.Instance.Value);
     }
 
+    [TestMethod]
+    public void BitNumberFieldShouldShowCanonicalValueWhenCustomNormalizerIsNotDigitEquivalent()
+    {
+        // Repro for the value/display divergence: a custom normalizer that maps the typed text to a
+        // different number (here a constant "42") must NOT leave the original "۹۹" visible while
+        // binding 42. The display has to reflect the bound value.
+        static string? normalizer(string? value) => "42";
+
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.DigitsNormalizer, normalizer);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "۹۹" });
+
+        Assert.AreEqual(42, component.Instance.Value);
+        Assert.AreEqual("42", component.Find("input").GetAttribute("value"));
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldShowCanonicalValueWhenNormalizerStripsNonDigitContent()
+    {
+        // A normalizer that strips units/symbols (here non-digit characters) is not a pure
+        // digit-equivalent transformation, so the canonical value must be displayed, not the raw text.
+        static string? normalizer(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var sb = new System.Text.StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                if (char.IsDigit(c)) sb.Append(c);
+            }
+            return sb.ToString();
+        }
+
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.DigitsNormalizer, normalizer);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "12kg" });
+
+        Assert.AreEqual(12, component.Instance.Value);
+        Assert.AreEqual("12", component.Find("input").GetAttribute("value"));
+    }
+
+    [TestMethod]
+    public void BitNumberFieldAriaValueTextShouldMatchPreservedDisplayWhenNormalizeDigitsEnabled()
+    {
+        // When the typed non-Latin digits are preserved in the input, the aria-valuetext must match
+        // the visible text so a screen reader announces what the user sees (not the Latin form).
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "۱۲۳" });
+
+        var refreshed = component.Find("input");
+        Assert.AreEqual("۱۲۳", refreshed.GetAttribute("value"));
+        Assert.AreEqual("۱۲۳", refreshed.GetAttribute("aria-valuetext"));
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldNotClearNullableValueWhenInputNormalizesToEmpty()
+    {
+        // A lone Arabic thousands separator (U+066C) normalizes to an empty string. For a nullable
+        // type this must be treated as an invalid (unparsable) entry rather than silently clearing
+        // the existing value.
+        var boundValue = (int?)5;
+        var component = RenderComponent<BitNumberField<int?>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Value, boundValue);
+            parameters.Add(p => p.ValueChanged, (int? v) => boundValue = v);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "٬" });
+
+        Assert.AreEqual(5, component.Instance.Value);
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldDerivePrecisionFromNormalizedStep()
+    {
+        // Step "۰٫۱" normalizes to 0.1 -> precision of 1 decimal place. If precision were not
+        // recomputed after normalization it would stay 0 and round 1.23 to 1 instead of 1.2.
+        var component = RenderComponent<BitNumberField<double>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Step, "۰٫۱");
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "۱٫۲۳" });
+
+        Assert.AreEqual(1.2, component.Instance.Value);
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldResetNormalizedMinWhenNormalizationDisabled()
+    {
+        // While normalization is enabled, Min "۱۰" parses to 10 and clamps 5 up to 10.
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Min, "۱۰");
+        });
+
+        component.Find("input").Change(new ChangeEventArgs { Value = "5" });
+        Assert.AreEqual(10, component.Instance.Value);
+
+        // Disabling normalization (with the same non-Latin Min) must drop the previously parsed Min,
+        // since "۱۰" no longer parses, falling back to the type minimum (no clamping).
+        component.SetParametersAndRender(parameters => parameters.Add(p => p.NormalizeDigits, false));
+        component.Find("input").Change(new ChangeEventArgs { Value = "5" });
+        Assert.AreEqual(5, component.Instance.Value);
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldNormalizeSupplementaryPlaneDigits()
+    {
+        // Mathematical Bold Digits (U+1D7CE..U+1D7D7) live in the Unicode supplementary plane and are
+        // encoded as surrogate pairs, so they exercise the surrogate-aware normalization path.
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "\U0001D7CF\U0001D7D0\U0001D7D1" }); // bold 1, 2, 3
+
+        Assert.AreEqual(123, component.Instance.Value);
+    }
+
     [TestMethod,
          DataRow(null),
          DataRow("AriaDescription")

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
@@ -622,6 +622,124 @@ public class BitNumberFieldTests : BunitTestContext
         Assert.AreEqual(42, component.Instance.Value);
     }
 
+    [TestMethod]
+    public void BitNumberFieldShouldDiscardPreservedDisplayTextWhenValueChangesFromParent()
+    {
+        // Repro for the stale-display bug: after the user types non-Latin digits (which are preserved
+        // in the input), a parent that resets and then reloads the same numeric value must not cause
+        // the old user-typed text to reappear.
+        var boundValue = 0;
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Value, boundValue);
+            parameters.Add(p => p.ValueChanged, (int v) => boundValue = v);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "۱۲۳" });
+
+        // The typed Persian digits are preserved while the bound value is the normalized Latin number.
+        Assert.AreEqual(123, component.Instance.Value);
+        Assert.AreEqual("۱۲۳", component.Find("input").GetAttribute("value"));
+
+        // The parent resets the bound value to 0.
+        component.SetParametersAndRender(parameters => parameters.Add(p => p.Value, 0));
+        Assert.AreEqual("0", component.Find("input").GetAttribute("value"));
+
+        // The parent then loads 123 again; the stale Persian text must NOT reappear.
+        component.SetParametersAndRender(parameters => parameters.Add(p => p.Value, 123));
+        Assert.AreEqual("123", component.Find("input").GetAttribute("value"));
+    }
+
+    [TestMethod,
+         DataRow("5", 10),    // below the normalized min (۱۰) -> clamped up to 10
+         DataRow("25", 20),   // above the normalized max (۲۰) -> clamped down to 20
+         DataRow("15", 15)    // within range -> unchanged
+    ]
+    public void BitNumberFieldShouldNormalizeNonLatinMinAndMaxWhenNormalizeDigitsEnabled(string userInput, int expectedValue)
+    {
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Min, "۱۰");
+            parameters.Add(p => p.Max, "۲۰");
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(expectedValue, component.Instance.Value);
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldNormalizeNonLatinStepWhenNormalizeDigitsEnabled()
+    {
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Step, "۵");
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "10" });
+        input.KeyDown(new KeyboardEventArgs { Key = "ArrowUp" });
+
+        // The step "۵" is normalized to 5, so incrementing 10 yields 15.
+        Assert.AreEqual(15, component.Instance.Value);
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldNormalizeMinMaxUsingCustomDigitsNormalizer()
+    {
+        // The custom normalizer maps any Unicode decimal digit to Latin and is applied to the
+        // Min/Max parameters too, not just user input.
+        static string? normalizer(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var sb = new System.Text.StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                var digit = System.Globalization.CharUnicodeInfo.GetDecimalDigitValue(c);
+                sb.Append(digit >= 0 ? (char)('0' + digit) : c);
+            }
+            return sb.ToString();
+        }
+
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.DigitsNormalizer, normalizer);
+            parameters.Add(p => p.Min, "۵");
+            parameters.Add(p => p.Max, "۵۰");
+        });
+
+        var input = component.Find("input");
+
+        input.Change(new ChangeEventArgs { Value = "100" });
+        Assert.AreEqual(50, component.Instance.Value);   // clamped to the normalized max (50)
+
+        input.Change(new ChangeEventArgs { Value = "1" });
+        Assert.AreEqual(5, component.Instance.Value);    // clamped to the normalized min (5)
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldNormalizeMinRegardlessOfParameterOrder()
+    {
+        // Min is provided before NormalizeDigits to ensure normalization is still applied even if the
+        // Min CallOnSet handler runs before NormalizeDigits has been assigned.
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.Min, "۱۰");
+            parameters.Add(p => p.NormalizeDigits, true);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "5" });
+
+        Assert.AreEqual(10, component.Instance.Value);
+    }
+
     [TestMethod,
          DataRow(null),
          DataRow("AriaDescription")

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
@@ -495,6 +495,85 @@ public class BitNumberFieldTests : BunitTestContext
     }
 
     [TestMethod,
+         DataRow("۱۲۳", "۱۲۳"),   // Persian / Extended Arabic-Indic digits (U+06F0-U+06F9)
+         DataRow("١٢٣", "١٢٣")    // Arabic-Indic digits (U+0660-U+0669)
+    ]
+    public void BitNumberFieldShouldPreserveOriginalTextInDisplayWhenNormalizeDigitsEnabled(string userInput, string expectedDisplay)
+    {
+        // The bound .NET value is the normalized Latin number while the input keeps showing the
+        // exact characters the user typed, avoiding a jarring visible conversion of the digits.
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(123, component.Instance.Value);
+        Assert.AreEqual(expectedDisplay, component.Find("input").GetAttribute("value"));
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldShowFormattedValueWhenNumberFormatIsSetWithNormalizeDigits()
+    {
+        // When NumberFormat is set the formatted string takes precedence over the preserved
+        // user-typed digits, so the input shows the formatted value rather than the raw input.
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.NumberFormat, "000");
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "۱۲۳" });
+
+        Assert.AreEqual(123, component.Instance.Value);
+        Assert.AreEqual("123", component.Find("input").GetAttribute("value"));
+    }
+
+    [TestMethod]
+    public void BitNumberFieldShouldRevertDisplayToLatinAfterChangeValueWhenNormalizeDigitsEnabled()
+    {
+        // After spinning the value, the preserved user-typed digits are discarded and the regular
+        // (Latin) formatted value is shown again.
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Step, "1");
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = "۱۲۳" });
+
+        // Preconditions: the Persian digits are preserved in the display.
+        Assert.AreEqual("۱۲۳", component.Find("input").GetAttribute("value"));
+
+        // Increment via the up arrow key triggers ChangeValue, which clears the preserved text.
+        input.KeyDown(new KeyboardEventArgs { Key = "ArrowUp" });
+
+        Assert.AreEqual(124, component.Instance.Value);
+        Assert.AreEqual("124", component.Find("input").GetAttribute("value"));
+    }
+
+    [TestMethod,
+         DataRow("۱٬۲۳۴", 1234),   // Persian digits with the Arabic thousands separator (U+066C)
+         DataRow("١٬٢٣٤", 1234)     // Arabic-Indic digits with the Arabic thousands separator
+    ]
+    public void BitNumberFieldShouldStripArabicThousandsSeparatorWhenNormalizeDigitsEnabled(string userInput, int expectedValue)
+    {
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(expectedValue, component.Instance.Value);
+    }
+
+    [TestMethod,
          DataRow("۱٬۲۳۴", 1234),   // Persian digits with a Persian thousands separator and stripping
          DataRow("1 000", 1000)     // Latin digits with a space group separator
     ]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/NumberField/BitNumberFieldTests.cs
@@ -443,6 +443,107 @@ public class BitNumberFieldTests : BunitTestContext
     }
 
     [TestMethod,
+         DataRow("۱۲۳", 123),   // Persian / Extended Arabic-Indic digits (U+06F0-U+06F9)
+         DataRow("١٢٣", 123),   // Arabic-Indic digits (U+0660-U+0669)
+         DataRow("۴۵۶", 456),
+         DataRow("123", 123)    // Latin digits remain unchanged
+    ]
+    public void BitNumberFieldShouldNormalizeNonLatinDigitsWhenEnabled(string userInput, int expectedValue)
+    {
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(expectedValue, component.Instance.Value);
+    }
+
+    [TestMethod,
+         DataRow("۱۲٫۵", 12.5),   // Persian digits with Arabic decimal separator (U+066B)
+         DataRow("٣٫٢٥", 3.25)     // Arabic-Indic digits with Arabic decimal separator
+    ]
+    public void BitNumberFieldShouldNormalizeNonLatinDecimalsWhenEnabled(string userInput, double expectedValue)
+    {
+        var component = RenderComponent<BitNumberField<double>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.Precision, 2);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(expectedValue, component.Instance.Value);
+    }
+
+    [TestMethod, DataRow("۱۲۳")]
+    public void BitNumberFieldShouldNotNormalizeNonLatinDigitsWhenDisabled(string userInput)
+    {
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, false);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        // Parsing fails for non-Latin digits, so the value remains the default.
+        Assert.AreEqual(0, component.Instance.Value);
+    }
+
+    [TestMethod,
+         DataRow("۱٬۲۳۴", 1234),   // Persian digits with a Persian thousands separator and stripping
+         DataRow("1 000", 1000)     // Latin digits with a space group separator
+    ]
+    public void BitNumberFieldShouldUseCustomDigitsNormalizerWhenProvided(string userInput, int expectedValue)
+    {
+        static string? normalizer(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var sb = new System.Text.StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                if (c is ' ' or ',' or '٬') continue;
+                var digit = System.Globalization.CharUnicodeInfo.GetDecimalDigitValue(c);
+                sb.Append(digit >= 0 ? (char)('0' + digit) : c);
+            }
+            return sb.ToString();
+        }
+
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.DigitsNormalizer, normalizer);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(expectedValue, component.Instance.Value);
+    }
+
+    [TestMethod, DataRow("۹۹")]
+    public void BitNumberFieldCustomDigitsNormalizerShouldTakePrecedenceOverNormalizeDigits(string userInput)
+    {
+        // The custom normalizer forces a constant value, proving it overrides the built-in NormalizeDigits.
+        static string? normalizer(string? value) => "42";
+
+        var component = RenderComponent<BitNumberField<int>>(parameters =>
+        {
+            parameters.Add(p => p.NormalizeDigits, true);
+            parameters.Add(p => p.DigitsNormalizer, normalizer);
+        });
+
+        var input = component.Find("input");
+        input.Change(new ChangeEventArgs { Value = userInput });
+
+        Assert.AreEqual(42, component.Instance.Value);
+    }
+
+    [TestMethod,
          DataRow(null),
          DataRow("AriaDescription")
     ]


### PR DESCRIPTION
closes #8551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NumberField component now supports Unicode decimal digit normalization, enabling automatic conversion of Persian, Arabic, and other non-Latin decimal digits to standard format for reliable parsing across different locales.

* **Documentation**
  * Added demo examples and comprehensive test coverage for digit normalization features, including custom normalizer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->