### PR TITLE
Add missing test for SuggestItemsProvider in BitSearchBox (#8329)

### DIFF
--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/SearchBox/BitSearchBoxTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/SearchBox/BitSearchBoxTests.cs
@@ -291,14 +291,19 @@ public class BitSearchBoxTests : BunitTestContext
         Context.JSInterop.Mode = JSRuntimeMode.Loose;
 
         string? receivedSearchTerm = null;
+        int receivedTake = 0;
 
         var component = RenderComponent<BitSearchBox>(p =>
         {
             p.Add(x => x.Immediate, true);
+            p.Add(x => x.MinSuggestTriggerChars, 3);
             p.Add(x => x.SuggestItemsProvider, (BitSearchBoxSuggestItemsProviderRequest req) =>
             {
                 receivedSearchTerm = req.SearchTerm;
-                return ValueTask.FromResult<IEnumerable<string>>(new List<string> { "apple", "application" });
+                receivedTake = req.Take;
+                return req.SearchTerm == "app"
+                    ? ValueTask.FromResult<IEnumerable<string>>(new List<string> { "apple", "application" })
+                    : ValueTask.FromResult<IEnumerable<string>>(new List<string> { "banana" });
             });
         });
 
@@ -308,6 +313,17 @@ public class BitSearchBoxTests : BunitTestContext
         var items = component.FindAll(".bit-srb-itm");
 
         Assert.AreEqual("app", receivedSearchTerm);
+        Assert.AreEqual(5, receivedTake);
         Assert.AreEqual(2, items.Count);
+        Assert.AreEqual("apple", items[0].TextContent.Trim());
+        Assert.AreEqual("application", items[1].TextContent.Trim());
+
+        input.Input("ban");
+
+        items = component.FindAll(".bit-srb-itm");
+
+        Assert.AreEqual("ban", receivedSearchTerm);
+        Assert.AreEqual(1, items.Count);
+        Assert.AreEqual("banana", items[0].TextContent.Trim());
     }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/SearchBox/BitSearchBoxTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/SearchBox/BitSearchBoxTests.cs
@@ -284,4 +284,30 @@ public class BitSearchBoxTests : BunitTestContext
 
         await component.Instance.DisposeAsync();
     }
+
+    [TestMethod]
+    public void BitSearchBoxSuggestItemsProviderShouldRenderItems()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        string? receivedSearchTerm = null;
+
+        var component = RenderComponent<BitSearchBox>(p =>
+        {
+            p.Add(x => x.Immediate, true);
+            p.Add(x => x.SuggestItemsProvider, (BitSearchBoxSuggestItemsProviderRequest req) =>
+            {
+                receivedSearchTerm = req.SearchTerm;
+                return ValueTask.FromResult<IEnumerable<string>>(new List<string> { "apple", "application" });
+            });
+        });
+
+        var input = component.Find(".bit-srb-inp");
+        input.Input("app");
+
+        var items = component.FindAll(".bit-srb-itm");
+
+        Assert.AreEqual("app", receivedSearchTerm);
+        Assert.AreEqual(2, items.Count);
+    }
 }


### PR DESCRIPTION
closes #8329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the SearchBox suggestion items provider functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->