### PR TITLE
Add missing implementations of Immediate in BitPhoneInput (#12488)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
@@ -8,6 +8,8 @@ namespace Bit.BlazorUI;
 /// </summary>
 public partial class BitPhoneInput : BitInputBase<string?>
 {
+    private readonly BitInputRateLimiter<ChangeEventArgs> _rateLimiter = new();
+
     private bool _isOpen;
     private bool _hasFocus;
     private int _activeIndex = -1;
@@ -63,6 +65,11 @@ public partial class BitPhoneInput : BitInputBase<string?>
     /// </summary>
     [Parameter, TwoWayBound]
     public BitCountry? Country { get; set; }
+
+    /// <summary>
+    /// The debounce time in milliseconds for the number input (applied when Immediate is enabled).
+    /// </summary>
+    [Parameter] public int DebounceTime { get; set; }
 
     /// <summary>
     /// The default selected country to be initially used when the Country parameter is not set.
@@ -140,6 +147,11 @@ public partial class BitPhoneInput : BitInputBase<string?>
     /// Custom CSS styles for different parts of the BitPhoneInput.
     /// </summary>
     [Parameter] public BitPhoneInputClassStyles? Styles { get; set; }
+
+    /// <summary>
+    /// The throttle time in milliseconds for the number input (applied when Immediate is enabled).
+    /// </summary>
+    [Parameter] public int ThrottleTime { get; set; }
 
 
 
@@ -478,7 +490,8 @@ public partial class BitPhoneInput : BitInputBase<string?>
 
         if (Immediate is false) return;
 
-        await SetCurrentValueAsStringAsync(e.Value?.ToString());
+        await _rateLimiter.Run(e, DebounceTime, ThrottleTime, async args =>
+            await InvokeAsync(async () => await HandleOnNumberChange(args)));
     }
 
     private void HandleOnInputFocusIn()

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
@@ -12,12 +12,10 @@ public partial class BitPhoneInput : BitInputBase<string?>
 
     private bool _isOpen;
     private bool _hasFocus;
+    private string? _searchText;
     private int _activeIndex = -1;
     private int _lastScrolledIndex = -1;
-    private string? _searchText;
-    private List<BitCountry> _viewItems = [];
-    private List<BitCountry> _allItems = [];
-    private ICollection<BitCountry>? _lastCountries;
+
     private string _labelId = string.Empty;
     private string _inputId = string.Empty;
     private string _searchId = string.Empty;
@@ -26,9 +24,13 @@ public partial class BitPhoneInput : BitInputBase<string?>
     private string _dropdownId = string.Empty;
     private string _fieldGroupId = string.Empty;
     private string _scrollContainerId = string.Empty;
-    private DotNetObjectReference<BitPhoneInput>? _dotnetObj;
+    
+    private List<BitCountry> _allItems = [];
+    private List<BitCountry> _viewItems = [];
     private ElementReference _searchInputRef;
     private ElementReference _dropdownButtonRef;
+    private ICollection<BitCountry>? _lastCountries;
+    private DotNetObjectReference<BitPhoneInput>? _dotnetObj;
 
     // Keys whose default browser behavior must be suppressed. These are applied through a
     // deterministic JS keydown listener (see BitExtrasSetPreventKeys) so the suppression
@@ -68,6 +70,7 @@ public partial class BitPhoneInput : BitInputBase<string?>
 
     /// <summary>
     /// The debounce time in milliseconds for the number input (applied when Immediate is enabled).
+    /// When both DebounceTime and ThrottleTime are greater than zero, debounce takes precedence and throttle is ignored.
     /// </summary>
     [Parameter] public int DebounceTime { get; set; }
 
@@ -150,6 +153,7 @@ public partial class BitPhoneInput : BitInputBase<string?>
 
     /// <summary>
     /// The throttle time in milliseconds for the number input (applied when Immediate is enabled).
+    /// Throttle is ignored when both DebounceTime and ThrottleTime are set, as debounce takes precedence.
     /// </summary>
     [Parameter] public int ThrottleTime { get; set; }
 
@@ -519,6 +523,8 @@ public partial class BitPhoneInput : BitInputBase<string?>
         await base.DisposeAsync(disposing);
 
         _dotnetObj?.Dispose();
+
+        _rateLimiter.Reset();
 
         try
         {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/PhoneInput/BitPhoneInputDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/PhoneInput/BitPhoneInputDemo.razor
@@ -72,7 +72,39 @@
             <BitPhoneInput FullWidth DefaultCountry="BitCountries.Italy" Placeholder="Enter your number" />
         </DemoExample>
 
-        <DemoExample Title="Disabled & ReadOnly" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+        <DemoExample Title="Immediate" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+            <div>
+                By default the value updates on the change event (when the input loses focus). Enable the
+                <b>Immediate</b> parameter to update the value on every keystroke (the 'oninput' event). To
+                rate-limit how often the value updates while typing, combine it with <b>DebounceTime</b> (waits
+                until typing pauses) or <b>ThrottleTime</b> (updates at most once per interval).
+            </div>
+            <br />
+            <div>Immediate:</div>
+            <BitPhoneInput Immediate
+                           DefaultCountry="BitCountries.UnitedStates"
+                           Placeholder="Enter your number"
+                           @bind-Value="immediateNumber" />
+            <div>Value: [@immediateNumber]</div>
+            <br />
+            <div>Immediate + DebounceTime (500ms):</div>
+            <BitPhoneInput Immediate
+                           DebounceTime="500"
+                           DefaultCountry="BitCountries.UnitedStates"
+                           Placeholder="Enter your number"
+                           @bind-Value="debouncedNumber" />
+            <div>Value: [@debouncedNumber]</div>
+            <br />
+            <div>Immediate + ThrottleTime (500ms):</div>
+            <BitPhoneInput Immediate
+                           ThrottleTime="500"
+                           DefaultCountry="BitCountries.UnitedStates"
+                           Placeholder="Enter your number"
+                           @bind-Value="throttledNumber" />
+            <div>Value: [@throttledNumber]</div>
+        </DemoExample>
+
+        <DemoExample Title="Disabled & ReadOnly" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
             <div>Disabled:</div>
             <br />
             <BitPhoneInput IsEnabled="false" DefaultCountry="BitCountries.Spain" Value="1234567" />
@@ -82,7 +114,7 @@
             <BitPhoneInput ReadOnly DefaultCountry="BitCountries.Spain" Value="1234567" />
         </DemoExample>
 
-        <DemoExample Title="Events" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+        <DemoExample Title="Events" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
             <div>Use the OnCountryChange callback to react to the selected country changes.</div>
             <br />
             <BitPhoneInput DefaultCountry="BitCountries.UnitedStates"
@@ -92,7 +124,7 @@
             <div>Selected country: @changedCountry?.Name</div>
         </DemoExample>
 
-        <DemoExample Title="Style & Class" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+        <DemoExample Title="Style & Class" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
             <div>Customize the appearance of the BitPhoneInput using Style, Class, Styles, and Classes.</div>
             <br />
             <BitPhoneInput DefaultCountry="BitCountries.Netherlands"
@@ -103,7 +135,7 @@
                            Classes="@(new() { Input = "custom-input" })" />
         </DemoExample>
 
-        <DemoExample Title="RTL" RazorCode="@example10RazorCode" Id="example10">
+        <DemoExample Title="RTL" RazorCode="@example11RazorCode" Id="example11">
             <div>Use BitPhoneInput in right-to-left (RTL).</div>
             <br />
             <div dir="rtl">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/PhoneInput/BitPhoneInputDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/PhoneInput/BitPhoneInputDemo.razor.cs
@@ -51,6 +51,13 @@ public partial class BitPhoneInputDemo
         },
         new()
         {
+            Name = "DebounceTime",
+            Type = "int",
+            DefaultValue = "0",
+            Description = "The debounce time in milliseconds for the number input (applied when Immediate is enabled).",
+        },
+        new()
+        {
             Name = "DropDirection",
             Type = "BitDropDirection",
             DefaultValue = "BitDropDirection.TopAndBottom",
@@ -149,6 +156,13 @@ public partial class BitPhoneInputDemo
             LinkType = LinkType.Link,
             Href = "#class-styles",
         },
+        new()
+        {
+            Name = "ThrottleTime",
+            Type = "int",
+            DefaultValue = "0",
+            Description = "The throttle time in milliseconds for the number input (applied when Immediate is enabled).",
+        },
     ];
 
     private readonly List<ComponentSubClass> componentSubClasses =
@@ -214,6 +228,9 @@ public partial class BitPhoneInputDemo
     private string? bindingNumber;
     private BitCountry? bindingCountry;
     private BitCountry? changedCountry;
+    private string? immediateNumber;
+    private string? debouncedNumber;
+    private string? throttledNumber;
     private readonly List<BitCountry> customCountries =
     [
         BitCountries.UnitedStates,
@@ -267,30 +284,55 @@ private readonly List<BitCountry> customCountries =
 <BitPhoneInput FullWidth DefaultCountry=""BitCountries.Italy"" Placeholder=""Enter your number"" />";
 
     private readonly string example7RazorCode = @"
+<BitPhoneInput Immediate
+               DefaultCountry=""BitCountries.UnitedStates""
+               Placeholder=""Enter your number""
+               @bind-Value=""immediateNumber"" />
+<div>Value: [@immediateNumber]</div>
+
+<BitPhoneInput Immediate
+               DebounceTime=""500""
+               DefaultCountry=""BitCountries.UnitedStates""
+               Placeholder=""Enter your number""
+               @bind-Value=""debouncedNumber"" />
+<div>Value: [@debouncedNumber]</div>
+
+<BitPhoneInput Immediate
+               ThrottleTime=""500""
+               DefaultCountry=""BitCountries.UnitedStates""
+               Placeholder=""Enter your number""
+               @bind-Value=""throttledNumber"" />
+<div>Value: [@throttledNumber]</div>";
+    private readonly string example7CsharpCode = @"
+private string? immediateNumber;
+private string? debouncedNumber;
+private string? throttledNumber;";
+
+    private readonly string example8RazorCode = @"
 <BitPhoneInput IsEnabled=""false"" DefaultCountry=""BitCountries.Spain"" Value=""1234567"" />
 
 <BitPhoneInput ReadOnly DefaultCountry=""BitCountries.Spain"" Value=""1234567"" />";
-    private readonly string example7CsharpCode = @"";
+    private readonly string example8CsharpCode = @"";
 
-    private readonly string example8RazorCode = @"
+    private readonly string example9RazorCode = @"
 <BitPhoneInput DefaultCountry=""BitCountries.UnitedStates""
                OnCountryChange=""c => changedCountry = c""
                Placeholder=""Enter your number"" />
 
 <div>Selected country: @changedCountry?.Name</div>";
-    private readonly string example8CsharpCode = @"
+    private readonly string example9CsharpCode = @"
 private BitCountry? changedCountry;";
 
-    private readonly string example9RazorCode = @"
+    private readonly string example10RazorCode = @"
 <BitPhoneInput DefaultCountry=""BitCountries.Netherlands""
                Placeholder=""Enter your number""
                Style=""width: 300px;""
                Class=""custom-class""
                Styles=""@(new() { FieldGroup = ""border-color: blueviolet;"" })""
                Classes=""@(new() { Input = ""custom-input"" })"" />";
-    private readonly string example9CsharpCode = @"";
+    private readonly string example10CsharpCode = @"";
 
-    private readonly string example10RazorCode = @"
+    private readonly string example11RazorCode = @"
 <div dir=""rtl"">
     <BitPhoneInput Dir=""BitDir.Rtl"" DefaultCountry=""BitCountries.Iran"" Placeholder=""شماره خود را وارد کنید"" />
 </div>";


### PR DESCRIPTION
closes #12488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* PhoneInput now supports input rate limiting in immediate mode via new `DebounceTime` and `ThrottleTime` parameters (debounce takes precedence when both are set).
* PhoneInput demo updated with a new “Immediate” example showcasing immediate updates plus debounced and throttled variants; other examples were renumbered for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->