### PR TITLE
Add missing CI/CD pipelines for Brouter (#12493)

### DIFF
--- a/.github/workflows/bit.ci.Brouter.yml
+++ b/.github/workflows/bit.ci.Brouter.yml
@@ -1,0 +1,50 @@
+name: bit platform CI - Brouter
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - 'src/Brouter/**'
+
+env:
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+
+jobs:
+  build-Brouter:
+    if: startsWith(github.event.pull_request.title, 'Prerelease') != true && startsWith(github.event.pull_request.title, 'Release') != true && startsWith(github.event.pull_request.title, 'Version') != true
+    name: build Bit.Brouter
+    runs-on: ubuntu-24.04
+
+    steps:
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Setup .NET 10.0
+      uses: actions/setup-dotnet@v5
+      with:
+        global-json-file: src/global.json
+
+    - name: Setup .NET 9.0
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 8.0.x
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24
+
+    - name: dotnet workload restore
+      run:  cd src/Brouter && dotnet workload restore
+
+    - name: InstallNodejsDependencies
+      continue-on-error: true # Error MSB4057, not all csproj files have InstallNodejsDependencies target.
+      run: dotnet build src/Brouter/Bit.Brouter.slnx -t:InstallNodejsDependencies -m:1 -f net10.0
+
+    - name: dotnet build
+      run: dotnet build src/Brouter/Bit.Brouter.slnx

--- a/.github/workflows/bit.full.ci.yml
+++ b/.github/workflows/bit.full.ci.yml
@@ -388,6 +388,11 @@ jobs:
         dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
         dotnet pack src/Butil/Bit.Butil/Bit.Butil.csproj --output ./packages --configuration Release
 
+    - name: Build and pack Brouter
+      run: |
+        dotnet build src/Brouter/Bit.Brouter/Bit.Brouter.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
+        dotnet pack src/Brouter/Bit.Brouter/Bit.Brouter.csproj --output ./packages --configuration Release
+
     - name: Build and pack Besql
       run: |
         dotnet build src/Besql/Bit.Besql/Bit.Besql.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
@@ -474,6 +479,34 @@ jobs:
 
     - name: Build Butil solution in Release mode
       run: dotnet build src/Butil/Bit.Butil.slnx -c Release
+
+
+
+  build-brouter-solution:
+    name: Build Brouter solution
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
+      with:
+        global-json-file: src/global.json
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24
+
+    - name: Install wasm and maui
+      run: cd src && dotnet workload install maui-android wasm-tools
+
+    - name: Install Android Sdk platform tools
+      run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platform-tools"
+
+    - name: Build Brouter solution in Release mode
+      run: dotnet build src/Brouter/Bit.Brouter.slnx -c Release
 
 
 

--- a/.github/workflows/nuget.org.yml
+++ b/.github/workflows/nuget.org.yml
@@ -7,6 +7,7 @@ on:
       - 'main'
     paths:
       - 'src/BlazorUI/**'
+      - 'src/Brouter/**'
       - 'src/Bswup/**'
       - 'src/Butil/**'
       - 'src/CodeAnalyzers/**'
@@ -123,7 +124,12 @@ jobs:
       run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Butil
       run: dotnet pack src/Butil/Bit.Butil/Bit.Butil.csproj --output . --configuration Release
-            
+
+    - name: dotnet build Brouter
+      run: dotnet build src/Brouter/Bit.Brouter/Bit.Brouter.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
+    - name: dotnet pack Brouter
+      run: dotnet pack src/Brouter/Bit.Brouter/Bit.Brouter.csproj --output . --configuration Release
+
     - name: dotnet build Besql
       run: dotnet build src/Besql/Bit.Besql/Bit.Besql.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Besql

--- a/.github/workflows/prerelease.nuget.org.yml
+++ b/.github/workflows/prerelease.nuget.org.yml
@@ -114,7 +114,12 @@ jobs:
       run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Butil
       run: dotnet pack src/Butil/Bit.Butil/Bit.Butil.csproj --output . --configuration Release
-            
+
+    - name: dotnet build Brouter
+      run: dotnet build src/Brouter/Bit.Brouter/Bit.Brouter.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
+    - name: dotnet pack Brouter
+      run: dotnet pack src/Brouter/Bit.Brouter/Bit.Brouter.csproj --output . --configuration Release
+
     - name: dotnet build Besql
       run: dotnet build src/Besql/Bit.Besql/Bit.Besql.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Besql


### PR DESCRIPTION
closes #12493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added GitHub Actions workflows to automatically build and test the new Brouter component
  * Integrated Brouter into NuGet publishing pipelines for continuous package generation and deployment
  * Configured CI processes to validate Brouter builds across standard and prerelease workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->