### PR TITLE
fix(pipeline,templates,Butil): non-dependency fixes #12518 #12519 #12520 #12521 #12522

### DIFF
--- a/.github/workflows/bit.full.ci.yml
+++ b/.github/workflows/bit.full.ci.yml
@@ -395,9 +395,6 @@ jobs:
         dotnet build src/Bswup/Bit.Bswup/Bit.Bswup.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
         dotnet pack src/Bswup/Bit.Bswup/Bit.Bswup.csproj --output ./packages --configuration Release
 
-    - name: Generate CSS/JS files Butil
-      run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -t:BeforeBuildTasks --no-restore -f:net10.0 -c Release
-
     - name: Build and pack Butil
       run: |
         dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false

--- a/.github/workflows/nuget.org.yml
+++ b/.github/workflows/nuget.org.yml
@@ -123,8 +123,6 @@ jobs:
     - name: dotnet pack Bswup
       run: dotnet pack src/Bswup/Bit.Bswup/Bit.Bswup.csproj --output . --configuration Release
 
-    - name: Generate CSS/JS files Butil
-      run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -t:BeforeBuildTasks --no-restore -f:net10.0 -c Release
     - name: dotnet build Butil
       run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Butil

--- a/.github/workflows/prerelease.nuget.org.yml
+++ b/.github/workflows/prerelease.nuget.org.yml
@@ -113,9 +113,6 @@ jobs:
     - name: dotnet pack Bswup
       run: dotnet pack src/Bswup/Bit.Bswup/Bit.Bswup.csproj --output . --configuration Release
 
-    - name: Generate CSS/JS files Butil
-      continue-on-error: true
-      run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -t:BeforeBuildTasks --no-restore -f:net10.0 -c Release
     - name: dotnet build Butil
       run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Butil

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.grafana/dashboard.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.grafana/dashboard.json
@@ -3,8 +3,8 @@
     "kind": "Dashboard",
     "metadata": {
         "name": "boilerplate-app-overview",
-        "generation": 117,
-        "creationTimestamp": "2026-06-12T11:54:48Z",
+        "generation": 7,
+        "creationTimestamp": "2026-06-15T15:50:30Z",
         "labels": {},
         "annotations": {}
     },
@@ -77,7 +77,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -250,7 +250,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -424,7 +424,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -554,7 +554,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -685,7 +685,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -815,7 +815,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -949,10 +949,11 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "table",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "cellHeight": "sm",
+                                "enablePagination": true,
                                 "showHeader": true,
                                 "sortBy": [
                                     {
@@ -981,6 +982,7 @@
                                         "cellOptions": {
                                             "type": "auto"
                                         },
+                                        "filterable": true,
                                         "footer": {
                                             "reducers": []
                                         },
@@ -1041,10 +1043,11 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "table",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "cellHeight": "sm",
+                                "enablePagination": true,
                                 "showHeader": true,
                                 "sortBy": [
                                     {
@@ -1073,6 +1076,7 @@
                                         "cellOptions": {
                                             "type": "auto"
                                         },
+                                        "filterable": true,
                                         "footer": {
                                             "reducers": []
                                         },
@@ -1173,10 +1177,11 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "table",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "cellHeight": "sm",
+                                "enablePagination": true,
                                 "showHeader": true,
                                 "sortBy": [
                                     {
@@ -1205,6 +1210,7 @@
                                         "cellOptions": {
                                             "type": "auto"
                                         },
+                                        "filterable": true,
                                         "footer": {
                                             "reducers": []
                                         },
@@ -1265,7 +1271,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -1440,11 +1446,11 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "table",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "cellHeight": "sm",
-                                "enablePagination": false,
+                                "enablePagination": true,
                                 "showHeader": true
                             },
                             "fieldConfig": {
@@ -1467,6 +1473,7 @@
                                         "cellOptions": {
                                             "type": "auto"
                                         },
+                                        "filterable": true,
                                         "footer": {
                                             "reducers": []
                                         },
@@ -1525,7 +1532,7 @@
                     "vizConfig": {
                         "kind": "VizConfig",
                         "group": "timeseries",
-                        "version": "13.1.0-27335746580",
+                        "version": "13.1.0-27822252871",
                         "spec": {
                             "options": {
                                 "annotations": {
@@ -1981,7 +1988,7 @@
                         "spec": {
                             "azureLogAnalytics": {
                                 "mode": "raw",
-                                "query": "AppExceptions\r\n| distinct iff(isempty(AppRoleName), \"Client\", AppRoleName)",
+                                "query": "AppExceptions\r\n| where $__timeFilter(TimeGenerated)\r\n| distinct iff(isempty(AppRoleName), \"Client\", AppRoleName)",
                                 "resources": [
                                     "${workspace}"
                                 ]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ConfirmPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ConfirmPage.razor
@@ -99,7 +99,7 @@
 
                                     <BitStack FillContent>
                                         <BitPhoneInput @bind-Value="phoneModel.PhoneNumber"
-                                                      AutoFocus TabIndex="1"
+                                                       AutoFocus TabIndex="1" FullWidth
                                                       DefaultCountry="@BitCountries.Current"
                                                       Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                                       IsEnabled="string.IsNullOrEmpty(PhoneNumberQueryString)"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ForgotPasswordPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ForgotPasswordPage.razor
@@ -31,7 +31,7 @@
 
                             <BitPivotItem HeaderText="@Localizer[nameof(AppStrings.PhoneNumber)]" Key="@PhoneKey">
                                 <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                              AutoFocus
+                                              AutoFocus FullWidth
                                               DefaultCountry="@BitCountries.Current"
                                               Immediate DebounceTime="500"
                                               Label="@Localizer[nameof(AppStrings.PhoneNumber)]"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ResetPasswordPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ResetPasswordPage.razor
@@ -39,7 +39,7 @@
 
                                         <BitPivotItem HeaderText="@Localizer[nameof(AppStrings.Phone)]" Key="@PhoneKey">
                                             <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                                          AutoFocus TabIndex="1"
+                                                          AutoFocus TabIndex="1" FullWidth
                                                           DefaultCountry="@BitCountries.Current"
                                                           Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                                           IsEnabled="string.IsNullOrEmpty(PhoneNumberQueryString)"
@@ -61,7 +61,7 @@
                                 else if (showPhone)
                                 {
                                     <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                                  AutoFocus TabIndex="1"
+                                                  AutoFocus TabIndex="1" FullWidth
                                                   DefaultCountry="@BitCountries.Current"
                                                   Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                                   IsEnabled="string.IsNullOrEmpty(PhoneNumberQueryString)"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPanel.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPanel.razor
@@ -48,7 +48,7 @@
                                         else
                                         {
                                             <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                                          AutoFocus TabIndex="1"
+                                                          AutoFocus TabIndex="1" FullWidth
                                                           DefaultCountry="@BitCountries.Current"
                                                           Immediate DebounceTime="500"
                                                           Label="@Localizer[nameof(AppStrings.PhoneNumber)]"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUp/SignUpPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUp/SignUpPage.razor
@@ -45,7 +45,7 @@
 
                             <BitPivotItem HeaderText="@Localizer[nameof(AppStrings.Phone)]">
                                 <BitPhoneInput @bind-Value="signUpModel.PhoneNumber"
-                                              AutoFocus TabIndex="1"
+                                               AutoFocus TabIndex="1" FullWidth
                                               DefaultCountry="@BitCountries.Current"
                                               Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                               Placeholder="@Localizer[nameof(AppStrings.PhoneNumberPlaceholder)]" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePhoneNumberTab.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePhoneNumberTab.razor
@@ -14,7 +14,7 @@
                     }
 
                     <BitPhoneInput @bind-Value="sendModel.PhoneNumber"
-                                   DefaultCountry="@BitCountries.Current"
+                                   DefaultCountry="@BitCountries.Current" FullWidth
                                    Label="@Localizer[nameof(AppStrings.NewPhoneNumber)]"
                                    Placeholder="@Localizer[nameof(AppStrings.NewPhoneNumberPlaceholder)]" />
                     <ValidationMessage For="@(() => sendModel.PhoneNumber)" />
@@ -49,7 +49,7 @@
                 <BitStack FillContent>
                     <BitPhoneInput @bind-Value="changeModel.PhoneNumber"
                                    IsEnabled="isPhoneNumberUnavailable"
-                                   DefaultCountry="@BitCountries.Current"
+                                   DefaultCountry="@BitCountries.Current" FullWidth
                                    Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                    Placeholder="@Localizer[nameof(AppStrings.PhoneNumberPlaceholder)]" />
                     <ValidationMessage For="@(() => changeModel.PhoneNumber)" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -161,6 +161,8 @@ public static class WebApplicationBuilderExtensions
             logging.IncludeScopes = true;
         });
 
+        builder.AddOpenTelemetryExporters();
+
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
@@ -205,13 +207,7 @@ public static class WebApplicationBuilderExtensions
             })
             .ConfigureResource(resource =>
             {
-                var resourceAttributes = new Dictionary<string, object>
-                {
-                    { "service.name", "Boilerplate" }
-                };
-
                 resource
-                    .AddAttributes(resourceAttributes)
                     .AddAzureAppServiceDetector()
                     .AddAzureContainerAppsDetector()
                     .AddAzureVMDetector()
@@ -219,10 +215,9 @@ public static class WebApplicationBuilderExtensions
                     .AddHostDetector()
                     .AddOperatingSystemDetector()
                     .AddProcessDetector()
-                    .AddProcessRuntimeDetector();
+                    .AddProcessRuntimeDetector()
+                    .AddService(builder.Environment.ApplicationName);
             });
-
-        builder.AddOpenTelemetryExporters();
 
         return builder;
     }

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil16NavigatorPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil16NavigatorPage.razor
@@ -276,7 +276,7 @@
                     </BitPivotItem>
                     <BitPivotItem HeaderText="Result">
                         <br />
-                        <BitButton OnClick="@(() => navigator.SendBeacon())">SendBeacon</BitButton>
+                        <BitButton OnClick="@(() => navigator.SendBeacon(NavigationManager.BaseUri))">SendBeacon</BitButton>
                         <br />
                     </BitPivotItem>
                 </BitPivot>


### PR DESCRIPTION
## Summary

This PR bundles five small non-dependency fixes that were included in the dependency-update PR #12517 but deserve their own tracked issues and PR.

## Changes

- **CI/CD**: Remove redundant `Generate CSS/JS files Butil` pre-build step from all three CI workflows — the subsequent full build already covers it.
- **Grafana dashboard**: Enable pagination and column filtering on all table panels; add `$__timeFilter(TimeGenerated)` to the AppExceptions query so it respects the selected time range.
- **Boilerplate identity pages**: Add `FullWidth` attribute to all `BitPhoneInput` components across identity and account pages so phone inputs fill their container like other form fields.
- **OpenTelemetry**: Move `AddOpenTelemetryExporters()` before `AddOpenTelemetry()` to ensure exporters are registered first; replace hardcoded `"service.name": "Boilerplate"` with `AddService(builder.Environment.ApplicationName)`.
- **Butil demo**: Fix `SendBeacon()` sample call to pass `NavigationManager.BaseUri` as the required URL argument.

## Related Issues

- Closes #12518
- Closes #12519
- Closes #12520
- Closes #12521
- Closes #12522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phone number input fields now use full-width layout on sign-in, sign-up, password reset, and account settings pages.
  * Grafana dashboard tables now support pagination and column filtering for improved data management.

* **Documentation**
  * Updated SendBeacon API sample code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->