### PR TITLE
Add missing URL argument to SendBeacon sample in Platform website (#12518)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil16NavigatorPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil16NavigatorPage.razor
@@ -276,7 +276,7 @@
                     </BitPivotItem>
                     <BitPivotItem HeaderText="Result">
                         <br />
-                        <BitButton OnClick="@(() => navigator.SendBeacon())">SendBeacon</BitButton>
+                        <BitButton OnClick="@(() => navigator.SendBeacon(NavigationManager.BaseUri))">SendBeacon</BitButton>
                         <br />
                     </BitPivotItem>
                 </BitPivot>


### PR DESCRIPTION
## Summary
The `SendBeacon()` call in the Butil Navigator demo page was missing the required URL argument, making the sample non-functional.

## Changes
- Pass `NavigationManager.BaseUri` as the URL argument to `navigator.SendBeacon()` in `Butil16NavigatorPage.razor`.

## Related Issue
This closes #12518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SendBeacon sample to demonstrate proper API usage with required parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->