### PR TITLE
Add missing FullWidth parameter to BitPhoneInput in identity and account pages of Boilerplate (#12519)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ConfirmPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ConfirmPage.razor
@@ -99,7 +99,7 @@
 
                                     <BitStack FillContent>
                                         <BitPhoneInput @bind-Value="phoneModel.PhoneNumber"
-                                                      AutoFocus TabIndex="1"
+                                                       AutoFocus TabIndex="1" FullWidth
                                                       DefaultCountry="@BitCountries.Current"
                                                       Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                                       IsEnabled="string.IsNullOrEmpty(PhoneNumberQueryString)"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ForgotPasswordPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ForgotPasswordPage.razor
@@ -31,7 +31,7 @@
 
                             <BitPivotItem HeaderText="@Localizer[nameof(AppStrings.PhoneNumber)]" Key="@PhoneKey">
                                 <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                              AutoFocus
+                                              AutoFocus FullWidth
                                               DefaultCountry="@BitCountries.Current"
                                               Immediate DebounceTime="500"
                                               Label="@Localizer[nameof(AppStrings.PhoneNumber)]"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ResetPasswordPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/ResetPasswordPage.razor
@@ -39,7 +39,7 @@
 
                                         <BitPivotItem HeaderText="@Localizer[nameof(AppStrings.Phone)]" Key="@PhoneKey">
                                             <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                                          AutoFocus TabIndex="1"
+                                                          AutoFocus TabIndex="1" FullWidth
                                                           DefaultCountry="@BitCountries.Current"
                                                           Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                                           IsEnabled="string.IsNullOrEmpty(PhoneNumberQueryString)"
@@ -61,7 +61,7 @@
                                 else if (showPhone)
                                 {
                                     <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                                  AutoFocus TabIndex="1"
+                                                  AutoFocus TabIndex="1" FullWidth
                                                   DefaultCountry="@BitCountries.Current"
                                                   Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                                   IsEnabled="string.IsNullOrEmpty(PhoneNumberQueryString)"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPanel.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPanel.razor
@@ -48,7 +48,7 @@
                                         else
                                         {
                                             <BitPhoneInput @bind-Value="model.PhoneNumber"
-                                                          AutoFocus TabIndex="1"
+                                                          AutoFocus TabIndex="1" FullWidth
                                                           DefaultCountry="@BitCountries.Current"
                                                           Immediate DebounceTime="500"
                                                           Label="@Localizer[nameof(AppStrings.PhoneNumber)]"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUp/SignUpPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignUp/SignUpPage.razor
@@ -45,7 +45,7 @@
 
                             <BitPivotItem HeaderText="@Localizer[nameof(AppStrings.Phone)]">
                                 <BitPhoneInput @bind-Value="signUpModel.PhoneNumber"
-                                              AutoFocus TabIndex="1"
+                                               AutoFocus TabIndex="1" FullWidth
                                               DefaultCountry="@BitCountries.Current"
                                               Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                               Placeholder="@Localizer[nameof(AppStrings.PhoneNumberPlaceholder)]" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePhoneNumberTab.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePhoneNumberTab.razor
@@ -14,7 +14,7 @@
                     }
 
                     <BitPhoneInput @bind-Value="sendModel.PhoneNumber"
-                                   DefaultCountry="@BitCountries.Current"
+                                   DefaultCountry="@BitCountries.Current" FullWidth
                                    Label="@Localizer[nameof(AppStrings.NewPhoneNumber)]"
                                    Placeholder="@Localizer[nameof(AppStrings.NewPhoneNumberPlaceholder)]" />
                     <ValidationMessage For="@(() => sendModel.PhoneNumber)" />
@@ -49,7 +49,7 @@
                 <BitStack FillContent>
                     <BitPhoneInput @bind-Value="changeModel.PhoneNumber"
                                    IsEnabled="isPhoneNumberUnavailable"
-                                   DefaultCountry="@BitCountries.Current"
+                                   DefaultCountry="@BitCountries.Current" FullWidth
                                    Label="@Localizer[nameof(AppStrings.PhoneNumber)]"
                                    Placeholder="@Localizer[nameof(AppStrings.PhoneNumberPlaceholder)]" />
                     <ValidationMessage For="@(() => changeModel.PhoneNumber)" />


### PR DESCRIPTION
## Summary
`BitPhoneInput` components in Boilerplate identity and account pages were missing the `FullWidth` attribute, causing phone inputs to not fill their container width unlike other form fields.

## Changes
- Added `FullWidth` to `BitPhoneInput` in `ConfirmPage.razor`
- Added `FullWidth` to `BitPhoneInput` in `ForgotPasswordPage.razor`
- Added `FullWidth` to `BitPhoneInput` in `ResetPasswordPage.razor`
- Added `FullWidth` to `BitPhoneInput` in `SignInPanel.razor`
- Added `FullWidth` to `BitPhoneInput` in `SignUpPage.razor`
- Added `FullWidth` to `BitPhoneInput` in `ChangePhoneNumberTab.razor`

## Related Issue
This closes #12519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated phone input fields across identity and account management pages to display at full width for improved visual consistency and better utilization of available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->