### PR TITLE
Fix OpenTelemetry exporter issues in Boilerplate (#12521)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -161,6 +161,8 @@ public static class WebApplicationBuilderExtensions
             logging.IncludeScopes = true;
         });
 
+        builder.AddOpenTelemetryExporters();
+
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
@@ -205,13 +207,7 @@ public static class WebApplicationBuilderExtensions
             })
             .ConfigureResource(resource =>
             {
-                var resourceAttributes = new Dictionary<string, object>
-                {
-                    { "service.name", "Boilerplate" }
-                };
-
                 resource
-                    .AddAttributes(resourceAttributes)
                     .AddAzureAppServiceDetector()
                     .AddAzureContainerAppsDetector()
                     .AddAzureVMDetector()
@@ -219,10 +215,9 @@ public static class WebApplicationBuilderExtensions
                     .AddHostDetector()
                     .AddOperatingSystemDetector()
                     .AddProcessDetector()
-                    .AddProcessRuntimeDetector();
+                    .AddProcessRuntimeDetector()
+                    .AddService(builder.Environment.ApplicationName);
             });
-
-        builder.AddOpenTelemetryExporters();
 
         return builder;
     }


### PR DESCRIPTION
## Summary
The OpenTelemetry configuration in the Boilerplate template called `AddOpenTelemetryExporters()` after `AddOpenTelemetry()` and used a hardcoded service name `"Boilerplate"` instead of the actual application name.

## Changes
- Moved `builder.AddOpenTelemetryExporters()` to before `builder.Services.AddOpenTelemetry()` so exporters are registered first
- Replaced `AddAttributes(new Dictionary { "service.name": "Boilerplate" })` with `AddService(builder.Environment.ApplicationName)` so each service reports under its own name

## Related Issue
This closes #12521