### PR TITLE
Remove redundant Butil assets generation step from pipelines (#12522)

### DIFF
--- a/.github/workflows/bit.full.ci.yml
+++ b/.github/workflows/bit.full.ci.yml
@@ -395,9 +395,6 @@ jobs:
         dotnet build src/Bswup/Bit.Bswup/Bit.Bswup.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
         dotnet pack src/Bswup/Bit.Bswup/Bit.Bswup.csproj --output ./packages --configuration Release
 
-    - name: Generate CSS/JS files Butil
-      run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -t:BeforeBuildTasks --no-restore -f:net10.0 -c Release
-
     - name: Build and pack Butil
       run: |
         dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false

--- a/.github/workflows/nuget.org.yml
+++ b/.github/workflows/nuget.org.yml
@@ -123,8 +123,6 @@ jobs:
     - name: dotnet pack Bswup
       run: dotnet pack src/Bswup/Bit.Bswup/Bit.Bswup.csproj --output . --configuration Release
 
-    - name: Generate CSS/JS files Butil
-      run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -t:BeforeBuildTasks --no-restore -f:net10.0 -c Release
     - name: dotnet build Butil
       run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Butil

--- a/.github/workflows/prerelease.nuget.org.yml
+++ b/.github/workflows/prerelease.nuget.org.yml
@@ -113,9 +113,6 @@ jobs:
     - name: dotnet pack Bswup
       run: dotnet pack src/Bswup/Bit.Bswup/Bit.Bswup.csproj --output . --configuration Release
 
-    - name: Generate CSS/JS files Butil
-      continue-on-error: true
-      run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -t:BeforeBuildTasks --no-restore -f:net10.0 -c Release
     - name: dotnet build Butil
       run: dotnet build src/Butil/Bit.Butil/Bit.Butil.csproj -c Release -p:GeneratePackageOnBuild=false -p:WarningLevel=0 -p:RunCodeAnalysis=false
     - name: dotnet pack Butil


### PR DESCRIPTION
## Summary
Three CI workflows had a redundant `Generate CSS/JS files Butil` step that ran a partial build before the full build, adding unnecessary time to every pipeline run.

## Changes
- Removed redundant `Generate CSS/JS files Butil` step from `.github/workflows/bit.full.ci.yml`
- Removed redundant `Generate CSS/JS files Butil` step from `.github/workflows/nuget.org.yml`
- Removed redundant `Generate CSS/JS files Butil` step from `.github/workflows/prerelease.nuget.org.yml`

## Related Issue
This closes #12522