### PR TITLE
Fix remaining issues of callout positioning (#12529)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
@@ -6,7 +6,6 @@ namespace BitBlazorUI {
 
         public static current = Callouts.DEFAULT_CALLOUT;
         private static _currentParams: BitCalloutParams | null = null;
-        private static _calloutResizeObserver: ResizeObserver | null = null;
         private static _calloutOriginalParents: Map<string, {
             parent: Element | null,
             nextSibling: Node | null,
@@ -72,24 +71,26 @@ namespace BitBlazorUI {
                 scrollContainerId, scrollOffset, headerId, footerId,
                 setCalloutWidth, fixedCalloutWidth, maxWindowWidth);
 
-            // Re-anchor the callout whenever its own size changes (e.g. an autocomplete list
-            // grows/shrinks as the query changes). Because callouts are anchored via `top`, the
-            // bottom edge would otherwise drift away from / overlap the component when the
-            // content height changes; repositioning recomputes `top` from the new height.
-            Callouts.observeCalloutResize(callout);
-
             return result;
         }
 
         // Positions an already-open (and reparented) callout relative to its component.
-        // Positions the callout so it stays correct while the iOS keyboard is shown (or the page
-        // is pinch-zoomed). On iOS, getBoundingClientRect() reports coordinates relative to the
-        // VISIBLE (visual) viewport, but a position:fixed element is laid out against the LAYOUT
-        // viewport, which the keyboard pushes up by visualViewport.offsetTop. So any fixed
-        // coordinate derived from a getBoundingClientRect() value must be translated by
-        // offsetTop/offsetLeft to land where intended. We anchor exclusively via `top`/`left`
-        // (never `bottom`/`right`, whose layout-viewport-size basis is unreliable in this state).
-        // On every other browser offsetTop/offsetLeft are 0, so this reduces to plain positioning.
+        //
+        // The hard part is the on-screen keyboard. getBoundingClientRect() and position:fixed do
+        // NOT share the same coordinate origin once the visible viewport is offset, and the
+        // relationship differs per engine: iOS reports getBoundingClientRect() in visual-viewport
+        // space while fixed is laid out in layout-viewport space (they differ by offsetTop), but
+        // Android Chrome keeps both in the same space (no difference). Rather than special-case
+        // engines, we MEASURE the relationship at runtime with a hidden fixed probe stretched to
+        // the layout viewport: its getBoundingClientRect() gives the layout viewport's edges in
+        // getBoundingClientRect space (`probe.top/left/bottom`). We then compute every target in
+        // getBoundingClientRect space and convert to style values:
+        //   - style.top  = targetTopInRectSpace - probe.top
+        //   - style.bottom = probe.bottom - targetBottomInRectSpace
+        // The visible (visual viewport) band in that same space is [visibleTop, visibleBottom].
+        // `top` anchors the "below" placement; `bottom` anchors the "above"/beside placements so
+        // the browser keeps the callout glued to the component and grows it upward natively when
+        // the content (e.g. an autocomplete list) changes - no reposition required.
         private static position(
             component: HTMLElement,
             callout: HTMLElement,
@@ -106,23 +107,21 @@ namespace BitBlazorUI {
         ) {
             const windowWidth = window.innerWidth;
 
-            // Visible (visual) viewport size, in screen coordinates (the same space that
-            // getBoundingClientRect() reports in). offset* is how far the visible viewport is
-            // pushed within the layout viewport (non-zero mainly when the iOS keyboard is up).
+            // Visible (visual) viewport size and how far it is offset within the layout viewport
+            // (non-zero mainly when the on-screen keyboard is shown).
             const viewport = Utils.getViewport();
             const visualWidth = viewport.width;
             const visualHeight = viewport.height;
-            const layoutHeight = viewport.layoutHeight;
             const offsetTop = viewport.offsetTop;
             const offsetLeft = viewport.offsetLeft;
 
-            // When the visible viewport is offset from the layout viewport (notably while the iOS
-            // keyboard is shown), position:fixed no longer lines up with getBoundingClientRect()'s
-            // coordinates. In that case we anchor via `top` translated by the offset, and rely on
-            // the ResizeObserver to re-anchor when the content height changes. Otherwise (Android,
-            // desktop, iOS without keyboard) we keep the native `bottom` anchoring so the browser
-            // grows the callout upward on content changes with no JS and no reposition jump.
-            const isViewportOffset = offsetTop !== 0 || offsetLeft !== 0;
+            // Measure the layout viewport's edges in getBoundingClientRect space (see method doc).
+            const fixedRect = Callouts.measureFixedViewport();
+            // Visible band, expressed in getBoundingClientRect space.
+            const visibleTop = fixedRect.top + offsetTop;
+            const visibleLeft = fixedRect.left + offsetLeft;
+            const visibleBottom = visibleTop + visualHeight;
+            const visibleRight = visibleLeft + visualWidth;
 
             const scrollContainer = (scrollContainerId
                 ? document.getElementById(scrollContainerId)
@@ -158,12 +157,11 @@ namespace BitBlazorUI {
             const calloutHeight = callout.offsetHeight;
             const { x: calloutLeft } = callout.getBoundingClientRect();
 
-            // All distances are in visible-viewport (screen) space: the visible area spans
-            // [0, visualHeight] vertically and [0, visualWidth] horizontally.
-            const distanceToBottom = visualHeight - (componentY + componentHeight);
-            const distanceToTop = componentY;
-            const distanceToRight = visualWidth - (componentX + componentWidth);
-            const distanceToLeft = componentX;
+            // Distances from the component to each edge of the visible band (getBoundingClientRect space).
+            const distanceToBottom = visibleBottom - (componentY + componentHeight);
+            const distanceToTop = componentY - visibleTop;
+            const distanceToRight = visibleRight - (componentX + componentWidth);
+            const distanceToLeft = componentX - visibleLeft;
 
             const { height: headerHeight } = header.getBoundingClientRect();
             const { height: footerHeight } = footer.getBoundingClientRect();
@@ -192,72 +190,69 @@ namespace BitBlazorUI {
                 callout.style.maxHeight = visualHeight + 'px';
 
                 setTimeout(() => {
-                    scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollContainer.getBoundingClientRect().y - footerHeight - 10) + 'px';
+                    scrollContainer.style.maxHeight = Math.max(0, visibleBottom - scrollContainer.getBoundingClientRect().y - footerHeight - 10) + 'px';
                 });
 
                 return true;
             }
 
+            // Horizontal placement is computed in getBoundingClientRect space then converted to a
+            // style.left value via the measured offset.
             let left = componentX + (isRtl ? (componentWidth - calloutWidth) : 0);
             const right = left + calloutWidth;
-            const correctedLeft = visualWidth - calloutWidth - 3;
+            const correctedLeft = visibleRight - calloutWidth - 3;
             if (maxWindowWidth) {
-                left = (windowWidth >= maxWindowWidth && (right > visualWidth)) ? correctedLeft : left;
+                left = (windowWidth >= maxWindowWidth && (right > visibleRight)) ? correctedLeft : left;
             } else {
-                left = (right > visualWidth) ? correctedLeft : left;
+                left = (right > visibleRight) ? correctedLeft : left;
             }
-            left = (left < 0) ? 0 : left;
-            callout.style.left = (left + offsetLeft) + 'px';
+            left = (left < visibleLeft) ? visibleLeft : left;
+            callout.style.left = (left - fixedRect.left) + 'px';
 
             if (dropDirection == BitDropDirection.TopAndBottom) {
                 if (calloutHeight <= distanceToBottom || distanceToBottom >= distanceToTop) {
-                    callout.style.top = (componentY + componentHeight + 1 + offsetTop) + 'px';
+                    callout.style.top = (componentY + componentHeight + 1 - fixedRect.top) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToBottom - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else {
+                    callout.style.bottom = (fixedRect.bottom - (componentY - 1)) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToTop - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    Callouts.anchorAbove(callout, componentY, layoutHeight, offsetTop, isViewportOffset);
                 }
             } else {
                 if (distanceToBottom >= calloutHeight) {
-                    callout.style.top = (componentY + componentHeight + 1 + offsetTop) + 'px';
+                    callout.style.top = (componentY + componentHeight + 1 - fixedRect.top) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToBottom - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else if (distanceToTop >= calloutHeight) {
+                    callout.style.bottom = (fixedRect.bottom - (componentY - 1)) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToTop - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    Callouts.anchorAbove(callout, componentY, layoutHeight, offsetTop, isViewportOffset);
                 } else if ((isRtl ? distanceToLeft : distanceToRight) >= calloutWidth) {
-                    callout.style.left = ((isRtl ? (componentX - calloutWidth - 1) : (componentX + componentWidth + 1)) + offsetLeft) + 'px';
+                    callout.style.left = ((isRtl ? (componentX - calloutWidth - 1) : (componentX + componentWidth + 1)) - fixedRect.left) + 'px';
+                    callout.style.bottom = (fixedRect.bottom - (visibleBottom - 2)) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    Callouts.anchorToVisibleBottom(callout, visualHeight, layoutHeight, offsetTop, isViewportOffset);
                 } else {
-                    callout.style.left = ((isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1)) + offsetLeft) + 'px';
+                    callout.style.left = ((isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1)) - fixedRect.left) + 'px';
+                    callout.style.bottom = (fixedRect.bottom - (visibleBottom - 2)) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    Callouts.anchorToVisibleBottom(callout, visualHeight, layoutHeight, offsetTop, isViewportOffset);
                 }
             }
 
             return (calloutWidth + calloutLeft) > document.body.offsetWidth;
         }
 
-        // Places the callout just above the component. When the visible viewport is offset from
-        // the layout viewport (iOS keyboard), position:fixed must be anchored via `top` (translated
-        // by the offset) using the callout's current height. Otherwise `bottom` is used, so the
-        // browser keeps the bottom pinned to the component and grows the callout upward as its
-        // content changes - with no JS reposition needed.
-        private static anchorAbove(callout: HTMLElement, componentY: number, layoutHeight: number, offsetTop: number, isViewportOffset: boolean) {
-            if (isViewportOffset) {
-                callout.style.top = (componentY - callout.offsetHeight - 1 + offsetTop) + 'px';
-            } else {
-                callout.style.bottom = (layoutHeight - componentY + 1) + 'px';
-            }
-        }
-
-        // Anchors the callout to the bottom of the visible area (used for the beside-the-component
-        // placements). See anchorAbove for the top-vs-bottom rationale.
-        private static anchorToVisibleBottom(callout: HTMLElement, visualHeight: number, layoutHeight: number, offsetTop: number, isViewportOffset: boolean) {
-            if (isViewportOffset) {
-                callout.style.top = (Math.max(0, visualHeight - callout.offsetHeight - 2) + offsetTop) + 'px';
-            } else {
-                callout.style.bottom = (layoutHeight - visualHeight + 2) + 'px';
+        // Measures the layout viewport's edges in getBoundingClientRect() space by stretching a
+        // hidden position:fixed probe across it. Lets positioning convert between getBoundingClientRect
+        // coordinates and style.top/left/bottom values regardless of how the engine relates fixed
+        // positioning to getBoundingClientRect when the visible viewport is offset (iOS keyboard).
+        private static measureFixedViewport(): { top: number, left: number, bottom: number } {
+            try {
+                const probe = document.createElement('div');
+                probe.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;margin:0;border:0;padding:0;visibility:hidden;pointer-events:none;';
+                document.body.appendChild(probe);
+                const rect = probe.getBoundingClientRect();
+                document.body.removeChild(probe);
+                return { top: rect.top, left: rect.left, bottom: rect.bottom };
+            } catch (e) {
+                console.error('BitBlazorUI.Callouts.measureFixedViewport:', e);
+                return { top: 0, left: 0, bottom: window.innerHeight };
             }
         }
 
@@ -281,34 +276,17 @@ namespace BitBlazorUI {
         public static reset() {
             Callouts.current = Callouts.DEFAULT_CALLOUT;
             Callouts._currentParams = null;
-            Callouts.unobserveCalloutResize();
         }
 
-        // Watches the currently open callout for size changes (content updates) and re-runs
-        // positioning so its anchored edge stays glued to the component. A single observer is
-        // kept for whichever callout is currently open.
-        private static observeCalloutResize(callout: HTMLElement) {
-            Callouts.unobserveCalloutResize();
-            if (typeof ResizeObserver === 'undefined') return;
-
-            // Skip the initial synchronous callback (the callout was just positioned); only react
-            // to subsequent size changes to avoid an unnecessary reposition right after opening.
-            let initial = true;
-            Callouts._calloutResizeObserver = new ResizeObserver(() => {
-                if (initial) { initial = false; return; }
-                // Only the offset (top-anchored) case needs JS to re-anchor on content changes.
-                // Without an offset the native `bottom` anchoring already keeps the callout glued
-                // to the component, so repositioning here would just add a needless reflow/jump.
-                const vp = Utils.getViewport();
-                if (vp.offsetTop === 0 && vp.offsetLeft === 0) return;
-                Callouts.reposition();
-            });
-            Callouts._calloutResizeObserver.observe(callout);
-        }
-
-        private static unobserveCalloutResize() {
-            Callouts._calloutResizeObserver?.disconnect();
-            Callouts._calloutResizeObserver = null;
+        // True when the node lives inside the open callout's anchor component (e.g. the SearchBox
+        // input that owns the suggestion callout). Used so that a scroll/resize while that input is
+        // focused - typically caused by the on-screen keyboard moving the page - re-anchors the
+        // callout to the component's new position instead of dismissing it.
+        public static componentContains(node: Node | null): boolean {
+            if (node == null) return false;
+            const componentId = Callouts._currentParams?.componentId;
+            if (!componentId) return false;
+            return document.getElementById(componentId)?.contains(node) ?? false;
         }
 
         private static moveCalloutToBody(calloutId: string, callout: HTMLElement, overlayId: string) {

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
@@ -112,8 +112,17 @@ namespace BitBlazorUI {
             const viewport = Utils.getViewport();
             const visualWidth = viewport.width;
             const visualHeight = viewport.height;
+            const layoutHeight = viewport.layoutHeight;
             const offsetTop = viewport.offsetTop;
             const offsetLeft = viewport.offsetLeft;
+
+            // When the visible viewport is offset from the layout viewport (notably while the iOS
+            // keyboard is shown), position:fixed no longer lines up with getBoundingClientRect()'s
+            // coordinates. In that case we anchor via `top` translated by the offset, and rely on
+            // the ResizeObserver to re-anchor when the content height changes. Otherwise (Android,
+            // desktop, iOS without keyboard) we keep the native `bottom` anchoring so the browser
+            // grows the callout upward on content changes with no JS and no reposition jump.
+            const isViewportOffset = offsetTop !== 0 || offsetLeft !== 0;
 
             const scrollContainer = (scrollContainerId
                 ? document.getElementById(scrollContainerId)
@@ -206,9 +215,7 @@ namespace BitBlazorUI {
                     scrollContainer.style.maxHeight = Math.max(0, distanceToBottom - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else {
                     scrollContainer.style.maxHeight = Math.max(0, distanceToTop - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    // Anchor the callout's bottom just above the component (top = anchor - height),
-                    // re-reading the height in case the max-height above shrank it.
-                    callout.style.top = (componentY - callout.offsetHeight - 1 + offsetTop) + 'px';
+                    Callouts.anchorAbove(callout, componentY, layoutHeight, offsetTop, isViewportOffset);
                 }
             } else {
                 if (distanceToBottom >= calloutHeight) {
@@ -216,20 +223,42 @@ namespace BitBlazorUI {
                     scrollContainer.style.maxHeight = Math.max(0, distanceToBottom - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else if (distanceToTop >= calloutHeight) {
                     scrollContainer.style.maxHeight = Math.max(0, distanceToTop - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    callout.style.top = (componentY - callout.offsetHeight - 1 + offsetTop) + 'px';
+                    Callouts.anchorAbove(callout, componentY, layoutHeight, offsetTop, isViewportOffset);
                 } else if ((isRtl ? distanceToLeft : distanceToRight) >= calloutWidth) {
                     callout.style.left = ((isRtl ? (componentX - calloutWidth - 1) : (componentX + componentWidth + 1)) + offsetLeft) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    // Beside the component, anchored to the bottom of the visible area.
-                    callout.style.top = (Math.max(0, visualHeight - callout.offsetHeight - 2) + offsetTop) + 'px';
+                    Callouts.anchorToVisibleBottom(callout, visualHeight, layoutHeight, offsetTop, isViewportOffset);
                 } else {
                     callout.style.left = ((isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1)) + offsetLeft) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
-                    callout.style.top = (Math.max(0, visualHeight - callout.offsetHeight - 2) + offsetTop) + 'px';
+                    Callouts.anchorToVisibleBottom(callout, visualHeight, layoutHeight, offsetTop, isViewportOffset);
                 }
             }
 
             return (calloutWidth + calloutLeft) > document.body.offsetWidth;
+        }
+
+        // Places the callout just above the component. When the visible viewport is offset from
+        // the layout viewport (iOS keyboard), position:fixed must be anchored via `top` (translated
+        // by the offset) using the callout's current height. Otherwise `bottom` is used, so the
+        // browser keeps the bottom pinned to the component and grows the callout upward as its
+        // content changes - with no JS reposition needed.
+        private static anchorAbove(callout: HTMLElement, componentY: number, layoutHeight: number, offsetTop: number, isViewportOffset: boolean) {
+            if (isViewportOffset) {
+                callout.style.top = (componentY - callout.offsetHeight - 1 + offsetTop) + 'px';
+            } else {
+                callout.style.bottom = (layoutHeight - componentY + 1) + 'px';
+            }
+        }
+
+        // Anchors the callout to the bottom of the visible area (used for the beside-the-component
+        // placements). See anchorAbove for the top-vs-bottom rationale.
+        private static anchorToVisibleBottom(callout: HTMLElement, visualHeight: number, layoutHeight: number, offsetTop: number, isViewportOffset: boolean) {
+            if (isViewportOffset) {
+                callout.style.top = (Math.max(0, visualHeight - callout.offsetHeight - 2) + offsetTop) + 'px';
+            } else {
+                callout.style.bottom = (layoutHeight - visualHeight + 2) + 'px';
+            }
         }
 
         // Re-runs positioning for the currently open callout. Used when the visual viewport
@@ -267,6 +296,11 @@ namespace BitBlazorUI {
             let initial = true;
             Callouts._calloutResizeObserver = new ResizeObserver(() => {
                 if (initial) { initial = false; return; }
+                // Only the offset (top-anchored) case needs JS to re-anchor on content changes.
+                // Without an offset the native `bottom` anchoring already keeps the callout glued
+                // to the component, so repositioning here would just add a needless reflow/jump.
+                const vp = Utils.getViewport();
+                if (vp.offsetTop === 0 && vp.offsetLeft === 0) return;
                 Callouts.reposition();
             });
             Callouts._calloutResizeObserver.observe(callout);

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
@@ -6,6 +6,7 @@ namespace BitBlazorUI {
 
         public static current = Callouts.DEFAULT_CALLOUT;
         private static _currentParams: BitCalloutParams | null = null;
+        private static _calloutResizeObserver: ResizeObserver | null = null;
         private static _calloutOriginalParents: Map<string, {
             parent: Element | null,
             nextSibling: Node | null,
@@ -67,16 +68,28 @@ namespace BitBlazorUI {
                 setCalloutWidth, fixedCalloutWidth, maxWindowWidth
             };
 
-            return Callouts.position(component, callout, responsiveMode, dropDirection, isRtl,
+            const result = Callouts.position(component, callout, responsiveMode, dropDirection, isRtl,
                 scrollContainerId, scrollOffset, headerId, footerId,
                 setCalloutWidth, fixedCalloutWidth, maxWindowWidth);
+
+            // Re-anchor the callout whenever its own size changes (e.g. an autocomplete list
+            // grows/shrinks as the query changes). Because callouts are anchored via `top`, the
+            // bottom edge would otherwise drift away from / overlap the component when the
+            // content height changes; repositioning recomputes `top` from the new height.
+            Callouts.observeCalloutResize(callout);
+
+            return result;
         }
 
         // Positions an already-open (and reparented) callout relative to its component.
-        // Uses the visual viewport for both axes so the layout stays correct while the iOS
-        // keyboard is shown or the page is pinch-zoomed. getBoundingClientRect() values are
-        // layout-viewport relative, so the visible* values translate the visible region into
-        // the same coordinate space; fixed-position offsets (bottom) use the layout viewport.
+        // Positions the callout so it stays correct while the iOS keyboard is shown (or the page
+        // is pinch-zoomed). On iOS, getBoundingClientRect() reports coordinates relative to the
+        // VISIBLE (visual) viewport, but a position:fixed element is laid out against the LAYOUT
+        // viewport, which the keyboard pushes up by visualViewport.offsetTop. So any fixed
+        // coordinate derived from a getBoundingClientRect() value must be translated by
+        // offsetTop/offsetLeft to land where intended. We anchor exclusively via `top`/`left`
+        // (never `bottom`/`right`, whose layout-viewport-size basis is unreliable in this state).
+        // On every other browser offsetTop/offsetLeft are 0, so this reduces to plain positioning.
         private static position(
             component: HTMLElement,
             callout: HTMLElement,
@@ -93,13 +106,14 @@ namespace BitBlazorUI {
         ) {
             const windowWidth = window.innerWidth;
 
+            // Visible (visual) viewport size, in screen coordinates (the same space that
+            // getBoundingClientRect() reports in). offset* is how far the visible viewport is
+            // pushed within the layout viewport (non-zero mainly when the iOS keyboard is up).
             const viewport = Utils.getViewport();
+            const visualWidth = viewport.width;
             const visualHeight = viewport.height;
-            const layoutHeight = viewport.layoutHeight;
-            const visibleTop = viewport.offsetTop;
-            const visibleBottom = viewport.offsetTop + viewport.height;
-            const visibleLeft = viewport.offsetLeft;
-            const visibleRight = viewport.offsetLeft + viewport.width;
+            const offsetTop = viewport.offsetTop;
+            const offsetLeft = viewport.offsetLeft;
 
             const scrollContainer = (scrollContainerId
                 ? document.getElementById(scrollContainerId)
@@ -135,10 +149,12 @@ namespace BitBlazorUI {
             const calloutHeight = callout.offsetHeight;
             const { x: calloutLeft } = callout.getBoundingClientRect();
 
-            const distanceToBottom = visibleBottom - (componentY + componentHeight);
-            const distanceToTop = componentY - visibleTop;
-            const distanceToRight = visibleRight - (componentX + componentWidth);
-            const distanceToLeft = componentX - visibleLeft;
+            // All distances are in visible-viewport (screen) space: the visible area spans
+            // [0, visualHeight] vertically and [0, visualWidth] horizontally.
+            const distanceToBottom = visualHeight - (componentY + componentHeight);
+            const distanceToTop = componentY;
+            const distanceToRight = visualWidth - (componentX + componentWidth);
+            const distanceToLeft = componentX;
 
             const { height: headerHeight } = header.getBoundingClientRect();
             const { height: footerHeight } = footer.getBoundingClientRect();
@@ -167,7 +183,7 @@ namespace BitBlazorUI {
                 callout.style.maxHeight = visualHeight + 'px';
 
                 setTimeout(() => {
-                    scrollContainer.style.maxHeight = Math.max(0, visibleBottom - scrollContainer.getBoundingClientRect().y - footerHeight - 10) + 'px';
+                    scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollContainer.getBoundingClientRect().y - footerHeight - 10) + 'px';
                 });
 
                 return true;
@@ -175,38 +191,41 @@ namespace BitBlazorUI {
 
             let left = componentX + (isRtl ? (componentWidth - calloutWidth) : 0);
             const right = left + calloutWidth;
-            const correctedLeft = visibleRight - calloutWidth - 3;
+            const correctedLeft = visualWidth - calloutWidth - 3;
             if (maxWindowWidth) {
-                left = (windowWidth >= maxWindowWidth && (right > visibleRight)) ? correctedLeft : left;
+                left = (windowWidth >= maxWindowWidth && (right > visualWidth)) ? correctedLeft : left;
             } else {
-                left = (right > visibleRight) ? correctedLeft : left;
+                left = (right > visualWidth) ? correctedLeft : left;
             }
-            left = (left < visibleLeft) ? visibleLeft : left;
-            callout.style.left = left + 'px';
+            left = (left < 0) ? 0 : left;
+            callout.style.left = (left + offsetLeft) + 'px';
 
             if (dropDirection == BitDropDirection.TopAndBottom) {
                 if (calloutHeight <= distanceToBottom || distanceToBottom >= distanceToTop) {
-                    callout.style.top = componentY + componentHeight + 1 + 'px';
+                    callout.style.top = (componentY + componentHeight + 1 + offsetTop) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToBottom - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else {
-                    callout.style.bottom = (layoutHeight - componentY + 1) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToTop - scrollOffset - headerHeight - footerHeight - 10) + 'px';
+                    // Anchor the callout's bottom just above the component (top = anchor - height),
+                    // re-reading the height in case the max-height above shrank it.
+                    callout.style.top = (componentY - callout.offsetHeight - 1 + offsetTop) + 'px';
                 }
             } else {
                 if (distanceToBottom >= calloutHeight) {
-                    callout.style.top = componentY + componentHeight + 1 + 'px';
+                    callout.style.top = (componentY + componentHeight + 1 + offsetTop) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToBottom - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else if (distanceToTop >= calloutHeight) {
-                    callout.style.bottom = (layoutHeight - componentY + 1) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, distanceToTop - scrollOffset - headerHeight - footerHeight - 10) + 'px';
+                    callout.style.top = (componentY - callout.offsetHeight - 1 + offsetTop) + 'px';
                 } else if ((isRtl ? distanceToLeft : distanceToRight) >= calloutWidth) {
-                    callout.style.bottom = (layoutHeight - visibleBottom + 2) + 'px';
-                    callout.style.left = (isRtl ? (componentX - calloutWidth - 1) : (componentX + componentWidth + 1)) + 'px';
+                    callout.style.left = ((isRtl ? (componentX - calloutWidth - 1) : (componentX + componentWidth + 1)) + offsetLeft) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
+                    // Beside the component, anchored to the bottom of the visible area.
+                    callout.style.top = (Math.max(0, visualHeight - callout.offsetHeight - 2) + offsetTop) + 'px';
                 } else {
-                    callout.style.bottom = (layoutHeight - visibleBottom + 2) + 'px';
-                    callout.style.left = (isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1)) + 'px';
+                    callout.style.left = ((isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1)) + offsetLeft) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
+                    callout.style.top = (Math.max(0, visualHeight - callout.offsetHeight - 2) + offsetTop) + 'px';
                 }
             }
 
@@ -233,6 +252,29 @@ namespace BitBlazorUI {
         public static reset() {
             Callouts.current = Callouts.DEFAULT_CALLOUT;
             Callouts._currentParams = null;
+            Callouts.unobserveCalloutResize();
+        }
+
+        // Watches the currently open callout for size changes (content updates) and re-runs
+        // positioning so its anchored edge stays glued to the component. A single observer is
+        // kept for whichever callout is currently open.
+        private static observeCalloutResize(callout: HTMLElement) {
+            Callouts.unobserveCalloutResize();
+            if (typeof ResizeObserver === 'undefined') return;
+
+            // Skip the initial synchronous callback (the callout was just positioned); only react
+            // to subsequent size changes to avoid an unnecessary reposition right after opening.
+            let initial = true;
+            Callouts._calloutResizeObserver = new ResizeObserver(() => {
+                if (initial) { initial = false; return; }
+                Callouts.reposition();
+            });
+            Callouts._calloutResizeObserver.observe(callout);
+        }
+
+        private static unobserveCalloutResize() {
+            Callouts._calloutResizeObserver?.disconnect();
+            Callouts._calloutResizeObserver = null;
         }
 
         private static moveCalloutToBody(calloutId: string, callout: HTMLElement, overlayId: string) {

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Callouts.ts
@@ -229,7 +229,12 @@ namespace BitBlazorUI {
                     callout.style.bottom = (fixedRect.bottom - (visibleBottom - 2)) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 } else {
-                    callout.style.left = ((isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1)) - fixedRect.left) + 'px';
+                    // Neither horizontal side has enough space; fall back to the opposite side but
+                    // re-clamp so the callout never lands at a negative/off-viewport left offset.
+                    let sideLeft = isRtl ? (componentX + componentWidth + 1) : (componentX - calloutWidth - 1);
+                    if (sideLeft + calloutWidth > visibleRight) sideLeft = visibleRight - calloutWidth - 3;
+                    if (sideLeft < visibleLeft) sideLeft = visibleLeft;
+                    callout.style.left = (sideLeft - fixedRect.left) + 'px';
                     callout.style.bottom = (fixedRect.bottom - (visibleBottom - 2)) + 'px';
                     scrollContainer.style.maxHeight = Math.max(0, visualHeight - scrollOffset - headerHeight - footerHeight - 10) + 'px';
                 }

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/general.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/general.ts
@@ -13,27 +13,38 @@ window.addEventListener('scroll', (e: Event) => {
     const target = e.target as HTMLElement;
     if (target?.id && target.id == currentCallout.scrollContainerId) return;
 
-    // On touch devices (notably iOS) focusing an input shows the virtual keyboard, which
-    // fires a scroll event as the browser brings the field into view. That should not
-    // dismiss an open callout (e.g. a dropdown with a search box), so keep it open while
-    // an editable element is focused, but only when that editable belongs to the active callout.
-    if (BitBlazorUI.Utils.isTouchDevice()
-        && BitBlazorUI.Utils.isEditableElementFocused()
-        && document.activeElement
-        && document.getElementById(BitBlazorUI.Callouts.current.calloutId)?.contains(document.activeElement)) return;
+    // On touch devices (notably iOS) focusing an input shows the virtual keyboard, which fires a
+    // scroll event as the browser brings the field into view. That should not dismiss an open
+    // callout while an editable element tied to that callout is focused.
+    const active = document.activeElement;
+    if (BitBlazorUI.Utils.isTouchDevice() && BitBlazorUI.Utils.isEditableElementFocused() && active) {
+        // The editable lives inside the callout (e.g. a dropdown's search box): the scroll is
+        // internal, so keep the callout open and leave it where it is.
+        if (document.getElementById(currentCallout.calloutId)?.contains(active)) return;
+
+        // The editable is the callout's anchor (e.g. the SearchBox input): the page itself was
+        // scrolled (commonly when the keyboard opens), moving the anchor. Keep the callout open
+        // and re-anchor it to the anchor's new position instead of dismissing it.
+        if (BitBlazorUI.Callouts.componentContains(active)) {
+            BitBlazorUI.Callouts.reposition();
+            return;
+        }
+    }
 
     BitBlazorUI.Callouts.replaceCurrent();
 }, true);
 
 window.addEventListener('resize', () => {
-    // A resize caused by the virtual keyboard (touch devices, notably iOS) should not dismiss
-    // an open callout that owns the focused editable element; reposition it to the new visible
-    // area instead. Any other resize dismisses the callout as before.
+    // A resize caused by the virtual keyboard (touch devices, notably iOS) should not dismiss an
+    // open callout whose focused editable belongs to the callout or is its anchor component;
+    // reposition it instead. Any other resize dismisses the callout as before.
+    const active = document.activeElement;
     if (BitBlazorUI.Utils.isTouchDevice()
         && window.innerWidth < BitBlazorUI.Utils.MAX_MOBILE_WIDTH
         && BitBlazorUI.Utils.isEditableElementFocused()
-        && document.activeElement
-        && document.getElementById(BitBlazorUI.Callouts.current.calloutId)?.contains(document.activeElement)) {
+        && active
+        && (document.getElementById(BitBlazorUI.Callouts.current.calloutId)?.contains(active)
+            || BitBlazorUI.Callouts.componentContains(active))) {
         BitBlazorUI.Callouts.reposition();
         return;
     }
@@ -45,8 +56,20 @@ window.addEventListener('resize', () => {
 // (iOS keyboard show/hide, pinch-zoom). window 'resize' doesn't fire for these on iOS, so
 // listen to visualViewport directly. Reposition is a no-op when no callout is open.
 if (window.visualViewport) {
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
     const onVisualViewportChange = BitBlazorUI.Utils.throttle(() => {
+        // Track the viewport live while it changes (throttled)...
         BitBlazorUI.Callouts.reposition();
+
+        // ...and guarantee one final reposition after it settles. The keyboard animates the page
+        // scroll/visual-viewport over a few hundred ms; a leading-edge throttle can drop the last
+        // frame, leaving the callout anchored to a mid-scroll position of its component. Re-running
+        // once the burst of events stops lands it on the final, settled geometry.
+        if (settleTimer != null) clearTimeout(settleTimer);
+        settleTimer = setTimeout(() => {
+            settleTimer = null;
+            BitBlazorUI.Callouts.reposition();
+        }, 100);
     }, 16);
     window.visualViewport.addEventListener('resize', onVisualViewportChange);
     window.visualViewport.addEventListener('scroll', onVisualViewportChange);


### PR DESCRIPTION
closes #12529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Callouts now stay better anchored when the visible viewport changes, such as when the on-screen keyboard appears or during pinch-zoom.
  * Callouts also reposition automatically if their content size changes.

* **Bug Fixes**
  * Improved callout placement to reduce drifting, overlap, and misalignment.
  * Scrollable callout content now respects the current visible screen area more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->