### PR TITLE
Add DefaultValue parameter to BitInputBase (#8186)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
@@ -290,6 +290,8 @@ public partial class BitPhoneInput : BitTextInputBase<string?>
             Country = DefaultCountry;
         }
 
+        SetDefaultValue();
+
         base.OnInitialized();
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/BitInputBase.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/BitInputBase.cs
@@ -12,6 +12,7 @@ namespace Bit.BlazorUI;
 public abstract class BitInputBase<TValue> : BitComponentBase
 {
     protected bool ValueHasBeenSet;
+    protected bool DefaultValueHasBeenSet;
 
 
 
@@ -44,6 +45,12 @@ public abstract class BitInputBase<TValue> : BitComponentBase
     [CascadingParameter] private EditContext? CascadedEditContext { get; set; }
 
 
+
+    /// <summary>
+    /// The default value of the input to be used in uncontrolled mode (i.e. when the Value is not bound),
+    /// typically used alongside the <see cref="OnChange"/> callback.
+    /// </summary>
+    [Parameter] public TValue? DefaultValue { get; set; }
 
     /// <summary>
     /// Gets or sets the display name for this field.
@@ -138,6 +145,7 @@ public abstract class BitInputBase<TValue> : BitComponentBase
     public override Task SetParametersAsync(ParameterView parameters)
     {
         ValueHasBeenSet = false;
+        DefaultValueHasBeenSet = false;
 
         var parametersDictionary = (ParametersCache ??= parameters.ToDictionary() as Dictionary<string, object?>);
 
@@ -147,6 +155,12 @@ public abstract class BitInputBase<TValue> : BitComponentBase
             {
                 case nameof(NoValidate):
                     NoValidate = (bool)parameter.Value;
+                    parametersDictionary.Remove(parameter.Key);
+                    break;
+
+                case nameof(DefaultValue):
+                    DefaultValueHasBeenSet = true;
+                    DefaultValue = (TValue?)parameter.Value;
                     parametersDictionary.Remove(parameter.Key);
                     break;
 
@@ -317,9 +331,21 @@ public abstract class BitInputBase<TValue> : BitComponentBase
 
     protected abstract bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? parsingErrorMessage);
 
+    /// <summary>
+    /// Initializes the value of the input from the <see cref="DefaultValue"/> parameter when the
+    /// <see cref="Value"/> is not bound (uncontrolled mode).
+    /// </summary>
+    protected void SetDefaultValue()
+    {
+        if (ValueHasBeenSet || DefaultValueHasBeenSet is false) return;
+
+        Value = DefaultValue;
+    }
+
+
     protected async Task SetCurrentValueAsStringAsync(string? value, bool bypass = false)
     {
-        if (bypass && IsEnabled is false) return;
+        if (IsEnabled is false) return;
 
         _incomingValueBeforeParsing = value;
         _parsingValidationMessages?.Clear();

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Calendar/BitCalendar.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Calendar/BitCalendar.razor.cs
@@ -504,6 +504,8 @@ public partial class BitCalendar : BitInputBase<DateTimeOffset?>
 
     protected override void OnInitialized()
     {
+        SetDefaultValue();
+
         OnValueChanged += HandleOnValueChanged;
 
         OnSetParameters();

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Checkbox/BitCheckbox.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Checkbox/BitCheckbox.razor.cs
@@ -82,12 +82,6 @@ public partial class BitCheckbox : BitInputBase<bool>
     [Parameter] public bool? DefaultIndeterminate { get; set; }
 
     /// <summary>
-    /// Default checkbox state
-    /// Use this if you want an uncontrolled component, meaning the Checkbox instance maintains its own state.
-    /// </summary>
-    [Parameter] public bool? DefaultValue { get; set; }
-
-    /// <summary>
     /// An indeterminate visual state for checkbox. 
     /// Setting indeterminate state takes visual precedence over checked given but does not affect on Value state.
     /// </summary>
@@ -140,10 +134,7 @@ public partial class BitCheckbox : BitInputBase<bool>
 
         OnValueChanged += HandleOnValueChanged;
 
-        if (ValueHasBeenSet is false && DefaultValue is not null)
-        {
-            Value = DefaultValue.Value;
-        }
+        SetDefaultValue();
 
         if (IndeterminateHasBeenSet is false && DefaultIndeterminate is not null)
         {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/ChoiceGroup/BitChoiceGroup.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/ChoiceGroup/BitChoiceGroup.razor.cs
@@ -37,11 +37,6 @@ public partial class BitChoiceGroup<TItem, TValue> : BitInputBase<TValue> where 
     public BitColor? Color { get; set; }
 
     /// <summary>
-    /// Default selected item for ChoiceGroup.
-    /// </summary>
-    [Parameter] public TValue? DefaultValue { get; set; }
-
-    /// <summary>
     /// Renders the items in the ChoiceGroup horizontally.
     /// </summary>
     [Parameter, ResetClassBuilder]

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/CircularTimePicker/BitCircularTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/CircularTimePicker/BitCircularTimePicker.razor.cs
@@ -335,6 +335,8 @@ public partial class BitCircularTimePicker : BitInputBase<TimeSpan?>
         _calloutId = $"{_circularTimePickerId}-callout";
         _overlayId = $"{_circularTimePickerId}-overlay";
 
+        SetDefaultValue();
+
         _hour = CurrentValue?.Hours;
         _minute = CurrentValue?.Minutes;
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DatePicker/BitDatePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DatePicker/BitDatePicker.razor.cs
@@ -722,6 +722,8 @@ public partial class BitDatePicker : BitInputBase<DateTimeOffset?>
         _overlayId = $"{_datePickerId}-overlay";
         _inputId = $"{_datePickerId}-input";
 
+        SetDefaultValue();
+
         OnValueChanged += HandleOnValueChanged;
 
         OnSetParameters();

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DateRangePicker/BitDateRangePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/DateRangePicker/BitDateRangePicker.razor.cs
@@ -814,6 +814,8 @@ public partial class BitDateRangePicker : BitInputBase<BitDateRangePickerValue?>
         _overlayId = $"{_dateRangePickerId}-overlay";
         _inputId = $"{_dateRangePickerId}-input";
 
+        SetDefaultValue();
+
         OnValueChanged += HandleOnValueChanged;
 
         OnSetParameters();

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -154,11 +154,6 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
     [Parameter] public int DebounceTime { get; set; }
 
     /// <summary>
-    /// The default value that will be initially used to set selected item if the Value parameter is not set.
-    /// </summary>
-    [Parameter] public TValue? DefaultValue { get; set; }
-
-    /// <summary>
     /// The default values that will be initially used to set selected items in multi select mode if the Values parameter is not set.
     /// </summary>
     [Parameter] public IEnumerable<TValue?>? DefaultValues { get; set; }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/NumberField/BitNumberField.razor.cs
@@ -115,11 +115,6 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     [Parameter] public string? DecrementTitle { get; set; }
 
     /// <summary>
-    /// Initial value of the number field.
-    /// </summary>
-    [Parameter] public TValue? DefaultValue { get; set; }
-
-    /// <summary>
     /// A custom function to normalize the raw input string before it gets parsed into the value.
     /// When provided, it takes precedence over <see cref="NormalizeDigits"/> and lets the developer plug in their own
     /// culture-specific or domain-specific transformation (e.g. mapping characters from a particular keyboard layout).
@@ -404,10 +399,7 @@ public partial class BitNumberField<[DynamicallyAccessedMembers(DynamicallyAcces
     {
         OnValueChanged += HandleOnValueChanged;
 
-        if (ValueHasBeenSet is false && DefaultValue is not null)
-        {
-            Value = DefaultValue;
-        }
+        SetDefaultValue();
 
         NormalizeValue();
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/OtpInput/BitOtpInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/OtpInput/BitOtpInput.razor.cs
@@ -174,6 +174,8 @@ public partial class BitOtpInput : BitInputBase<string?>
 
         _inputFocusStates = new bool[Length];
 
+        SetDefaultValue();
+
         base.OnInitialized();
     }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Rating/BitRating.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Rating/BitRating.razor.cs
@@ -25,12 +25,6 @@ public partial class BitRating : BitInputBase<double>
     [Parameter] public BitRatingClassStyles? Classes { get; set; }
 
     /// <summary>
-    /// Default value. Must be a number between _min and max. 
-    /// Only provide this if the CurrentValue is an uncontrolled component; otherwise, use the Value property.
-    /// </summary>
-    [Parameter] public double? DefaultValue { get; set; }
-
-    /// <summary>
     /// Optional callback to set the aria-label for rating control in readOnly mode. Also used as a fallback aria-label if ariaLabel prop is not provided.
     /// </summary>
     [Parameter] public Func<double, double, string>? GetAriaLabel { get; set; }
@@ -97,10 +91,7 @@ public partial class BitRating : BitInputBase<double>
 
     protected override async Task OnInitializedAsync()
     {
-        if (ValueHasBeenSet is false && DefaultValue.HasValue)
-        {
-            Value = DefaultValue.Value;
-        }
+        SetDefaultValue();
 
         await base.OnInitializedAsync();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/SearchBox/BitSearchBox.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/SearchBox/BitSearchBox.razor.cs
@@ -71,11 +71,6 @@ public partial class BitSearchBox : BitTextInputBase<string?>
     public BitColor? Color { get; set; }
 
     /// <summary>
-    /// The default value of the text in the search box, in the case of an uncontrolled component.
-    /// </summary>
-    [Parameter] public string? DefaultValue { get; set; }
-
-    /// <summary>
     /// Whether or not to animate the search box icon on focus.
     /// </summary>
     [Parameter, ResetClassBuilder]
@@ -356,10 +351,7 @@ public partial class BitSearchBox : BitTextInputBase<string?>
         _scrollContainerId = $"BitSearchBox-{UniqueId}-scroll-container";
         _inputId = $"BitSearchBox-{UniqueId}-input";
 
-        if (CurrentValue.HasNoValue() && DefaultValue.HasValue())
-        {
-            await SetCurrentValueAsStringAsync(DefaultValue);
-        }
+        SetDefaultValue();
 
         OnValueChanged += HandleOnValueChanged;
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TagsInput/BitTagsInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TagsInput/BitTagsInput.razor.cs
@@ -178,6 +178,8 @@ public partial class BitTagsInput : BitInputBase<ICollection<string>?>
 
         OnValueChanged += HandleOnValueChanged;
 
+        SetDefaultValue();
+
         UpdatePlaceholder();
 
         await base.OnInitializedAsync();

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TextField/BitTextField.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TextField/BitTextField.razor.cs
@@ -81,11 +81,6 @@ public partial class BitTextField : BitTextInputBase<string?>
     [Parameter] public string? ClearButtonIconName { get; set; }
 
     /// <summary>
-    /// Default value of the text field. Only provide this if the text field is an uncontrolled component; otherwise, use the value property.
-    /// </summary>
-    [Parameter] public string? DefaultValue { get; set; }
-
-    /// <summary>
     /// Description displayed below the text field to provide additional details about what text to enter.
     /// </summary>
     [Parameter] public string? Description { get; set; }
@@ -421,10 +416,7 @@ public partial class BitTextField : BitTextInputBase<string?>
         _labelId = $"BitTextField-{UniqueId}-label";
         _descriptionId = $"BitTextField-{UniqueId}-description";
 
-        if (ValueHasBeenSet is false && DefaultValue is not null)
-        {
-            await SetCurrentValueAsStringAsync(DefaultValue, true);
-        }
+        SetDefaultValue();
 
         await base.OnInitializedAsync();
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TimePicker/BitTimePicker.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/TimePicker/BitTimePicker.razor.cs
@@ -412,6 +412,8 @@ public partial class BitTimePicker : BitInputBase<TimeSpan?>
         _calloutId = $"BitTimePicker-{UniqueId}-callout";
         _overlayId = $"BitTimePicker-{UniqueId}-overlay";
 
+        SetDefaultValue();
+
         _hour = CurrentValue?.Hours;
         _minute = CurrentValue?.Minutes;
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Toggle/BitToggle.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Toggle/BitToggle.razor.cs
@@ -23,11 +23,6 @@ public partial class BitToggle : BitInputBase<bool>
     [Parameter] public BitToggleClassStyles? Classes { get; set; }
 
     /// <summary>
-    /// The default value of the toggle when the value parameter has not been assigned.
-    /// </summary>
-    [Parameter] public bool? DefaultValue { get; set; }
-
-    /// <summary>
     /// Renders the toggle in full width of its container while putting space between the label and the knob.
     /// </summary>
     [Parameter, ResetClassBuilder]
@@ -110,10 +105,7 @@ public partial class BitToggle : BitInputBase<bool>
         _buttonId = $"BitToggle-{UniqueId}-button";
         _stateTextId = $"BitToggle-{UniqueId}-state-text";
 
-        if (ValueHasBeenSet is false && DefaultValue is not null)
-        {
-            Value = DefaultValue.Value;
-        }
+        SetDefaultValue();
 
         SetStateText();
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/DemoPage.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/DemoPage.razor.cs
@@ -181,6 +181,13 @@ public partial class DemoPage
     [
         new()
         {
+            Name = "DefaultValue",
+            Type = "TValue?",
+            DefaultValue = "null",
+            Description = "The default value of the input to be used in uncontrolled mode (i.e. when the Value is not bound), typically used alongside the OnChange callback.",
+        },
+        new()
+        {
             Name = "DisplayName",
             Type = "string?",
             DefaultValue = "null",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Checkbox/BitCheckboxDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Checkbox/BitCheckboxDemo.razor.cs
@@ -87,13 +87,6 @@ public partial class BitCheckboxDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "bool?",
-            DefaultValue = "null",
-            Description = "Use this if you want an uncontrolled component, meaning the Checkbox instance maintains its own state.",
-        },
-        new()
-        {
             Name = "Indeterminate",
             Type = "bool",
             DefaultValue = "false",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/ChoiceGroup/BitChoiceGroupDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/ChoiceGroup/BitChoiceGroupDemo.razor.cs
@@ -40,13 +40,6 @@ public partial class BitChoiceGroupDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "string?",
-            DefaultValue = "null",
-            Description = "Default selected Value for ChoiceGroup."
-        },
-        new()
-        {
             Name = "Inline",
             Type = "bool",
             DefaultValue = "false",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor.cs
@@ -139,13 +139,6 @@ public partial class BitDropdownDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "string?",
-            DefaultValue = "null",
-            Description = "The default value that will be initially used to set selected item if the Value parameter is not set.",
-        },
-        new()
-        {
             Name = "DefaultValues",
             Type = "IEnumerable<string?>?",
             DefaultValue = "null",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/NumberField/BitNumberFieldDemo.razor.cs
@@ -82,13 +82,6 @@ public partial class BitNumberFieldDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "TValue?",
-            DefaultValue = "null",
-            Description = "Initial value of the number field.",
-        },
-        new()
-        {
             Name = "DigitsNormalizer",
             Type = "Func<string?, string?>?",
             DefaultValue = "null",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Rating/BitRatingDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Rating/BitRatingDemo.razor.cs
@@ -29,13 +29,6 @@ public partial class BitRatingDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "double?",
-            DefaultValue = "null",
-            Description = "Default rating. Must be a number between min and max. Only provide this if the Rating is an uncontrolled component; otherwise, use the rating property.",
-        },
-        new()
-        {
             Name = "GetAriaLabel",
             Type = "Func<double, double, string>?",
             DefaultValue = "null",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/SearchBox/BitSearchBoxDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/SearchBox/BitSearchBoxDemo.razor.cs
@@ -58,13 +58,6 @@ public partial class BitSearchBoxDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "string?",
-            DefaultValue = "null",
-            Description = "The default value of the text in the search box, in the case of an uncontrolled component.",
-        },
-        new()
-        {
             Name = "DisableAnimation",
             Type = "bool",
             DefaultValue = "false",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TextField/BitTextFieldDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/TextField/BitTextFieldDemo.razor.cs
@@ -71,13 +71,6 @@ public partial class BitTextFieldDemo : IDisposable
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "string?",
-            DefaultValue = "null",
-            Description = "Default value of the text field. Only provide this if the text field is an uncontrolled component; otherwise, use the value property.",
-        },
-        new()
-        {
             Name = "Description",
             Type = "string?",
             DefaultValue = "null",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Toggle/BitToggleDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Toggle/BitToggleDemo.razor.cs
@@ -15,13 +15,6 @@ public partial class BitToggleDemo
         },
         new()
         {
-            Name = "DefaultValue",
-            Type = "bool?",
-            DefaultValue = "null",
-            Description = "The default value of the toggle when the value parameter has not been assigned.",
-        },
-        new()
-        {
             Name = "FullWidth",
             Type = "bool",
             DefaultValue = "false",

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Calendar/BitCalendarTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Calendar/BitCalendarTests.cs
@@ -1065,4 +1065,17 @@ public class BitCalendarTests : BunitTestContext
 
         Assert.IsNotEmpty(component.FindAll(".bit-cal-evi"));
     }
+
+    [TestMethod]
+    public void BitCalendarShouldRespectDefaultValue()
+    {
+        var defaultValue = new DateTimeOffset(2020, 1, 15, 0, 0, 0, DateTimeOffset.Now.Offset);
+
+        var component = RenderComponent<BitCalendar>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, component.Instance.Value);
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Checkbox/BitCheckboxValidationTest.razor
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Checkbox/BitCheckboxValidationTest.razor
@@ -37,9 +37,8 @@
     [Parameter] public string? Name { get; set; }
     [Parameter] public string? Title { get; set; }
     [Parameter] public bool Reversed { get; set; }
-    [Parameter] public bool? DefaultValue { get; set; }
-    [Parameter] public bool? DefaultIndeterminate { get; set; }
-    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public bool DefaultValue { get; set; }
+    [Parameter] public bool? DefaultIndeterminate { get; set; }    [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public BitCheckboxTestModel TestModel { get; set; } = new();
 
     public int ClickCounter { get; set; }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/CircularTimePicker/BitCircularTimePickerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/CircularTimePicker/BitCircularTimePickerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Bunit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -155,5 +156,20 @@ public class BitCircularTimePickerTests : BunitTestContext
         var calloutStyle = callout.GetAttribute("data-test");
 
         Assert.AreEqual("data-value", calloutStyle);
+    }
+
+    [TestMethod]
+    public void BitCircularTimePickerShouldRespectDefaultValue()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var defaultValue = new TimeSpan(10, 30, 0);
+
+        var component = RenderComponent<BitCircularTimePicker>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, component.Instance.Value);
     }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/DatePicker/BitDatePickerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/DatePicker/BitDatePickerTests.cs
@@ -1033,4 +1033,19 @@ public class BitDatePickerTests : BunitTestContext
         Assert.IsNotNull(icon,
             $"Expected class '{expectedClass}' on HideTimePickerIcon but no matching icon element was found.");
     }
+
+    [TestMethod]
+    public void BitDatePickerShouldRespectDefaultValue()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var defaultValue = new DateTimeOffset(2020, 1, 15, 0, 0, 0, DateTimeOffset.Now.Offset);
+
+        var component = RenderComponent<BitDatePicker>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, component.Instance.Value);
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/DateRangePicker/BitDateRangePickerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/DateRangePicker/BitDateRangePickerTests.cs
@@ -1150,4 +1150,25 @@ public class BitDateRangePickerTests : BunitTestContext
 
         await component.Instance.DisposeAsync();
     }
+
+    [TestMethod]
+    public void BitDateRangePickerShouldRespectDefaultValue()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var defaultValue = new BitDateRangePickerValue
+        {
+            StartDate = new DateTimeOffset(2020, 1, 15, 0, 0, 0, DateTimeOffset.Now.Offset),
+            EndDate = new DateTimeOffset(2020, 1, 20, 0, 0, 0, DateTimeOffset.Now.Offset)
+        };
+
+        var component = RenderComponent<BitDateRangePicker>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, component.Instance.Value);
+        Assert.AreEqual(defaultValue.StartDate, component.Instance.Value!.StartDate);
+        Assert.AreEqual(defaultValue.EndDate, component.Instance.Value!.EndDate);
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/OtpInput/BitOtpInputTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/OtpInput/BitOtpInputTests.cs
@@ -165,4 +165,24 @@ public class BitOtpInputTests : BunitTestContext
         com.FindAll(".bit-otp-inp")[1].FocusOut();
         Assert.IsFalse(com.FindAll(".bit-otp-inp")[1].ClassList.Contains("custom-focused"));
     }
+
+    [TestMethod]
+    public void BitOtpInputShouldRespectDefaultValue()
+    {
+        var defaultValue = "1234";
+
+        var com = RenderComponent<BitOtpInput>(parameters =>
+        {
+            parameters.Add(p => p.Length, 4);
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, com.Instance.Value);
+
+        var inputs = com.FindAll(".bit-otp-inp");
+        Assert.AreEqual("1", inputs[0].GetAttribute("value"));
+        Assert.AreEqual("2", inputs[1].GetAttribute("value"));
+        Assert.AreEqual("3", inputs[2].GetAttribute("value"));
+        Assert.AreEqual("4", inputs[3].GetAttribute("value"));
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/SearchBox/BitSearchBoxTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/SearchBox/BitSearchBoxTests.cs
@@ -71,11 +71,26 @@ public class BitSearchBoxTests : BunitTestContext
     }
 
     [TestMethod,
+        DataRow("hello bit"),
+        DataRow("hello world")
+    ]
+    public void BitSearchBoxShouldTakeDefaultValueWhenValueIsNotBound(string defaultValue)
+    {
+        var component = RenderComponent<BitSearchBox>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        var input = component.Find(".bit-srb-inp");
+
+        Assert.AreEqual(defaultValue, input.GetAttribute("value"));
+    }
+
+    [TestMethod,
         DataRow("hello world", "hello bit"),
-        DataRow(null, "hello bit"),
         DataRow("hello world", null)
     ]
-    public void BitSearchBoxShouldTakeDefaultValue(string? value, string defaultValue)
+    public void BitSearchBoxShouldIgnoreDefaultValueWhenValueIsBound(string value, string? defaultValue)
     {
         var component = RenderComponent<BitSearchBox>(parameters =>
         {
@@ -84,9 +99,9 @@ public class BitSearchBoxTests : BunitTestContext
         });
 
         var input = component.Find(".bit-srb-inp");
-        var actualValue = string.IsNullOrEmpty(value) ? defaultValue : value;
 
-        Assert.AreEqual(input.GetAttribute("value"), actualValue);
+        // When Value is bound (controlled mode), DefaultValue is ignored.
+        Assert.AreEqual(value, input.GetAttribute("value"));
     }
 
     [TestMethod,

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TagsInput/BitTagsInputTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TagsInput/BitTagsInputTests.cs
@@ -409,4 +409,18 @@ public class BitTagsInputTests : BunitTestContext
 
         Assert.IsTrue(root.ClassList.Contains("bit-inv"));
     }
+
+    [TestMethod]
+    public void BitTagsInputShouldRespectDefaultValue()
+    {
+        var defaultValue = new List<string> { "apple", "banana", "cherry" };
+
+        var com = RenderComponent<BitTagsInput>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, com.Instance.Value);
+        Assert.AreEqual(defaultValue.Count, com.FindAll(".bit-tgi-tag").Count);
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TagsInput/BitTagsInputTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TagsInput/BitTagsInputTests.cs
@@ -420,7 +420,9 @@ public class BitTagsInputTests : BunitTestContext
             parameters.Add(p => p.DefaultValue, defaultValue);
         });
 
-        Assert.AreEqual(defaultValue, com.Instance.Value);
+        Assert.IsNotNull(com.Instance.Value);
+        Assert.AreEqual(defaultValue.Count, com.Instance.Value.Count);
+        CollectionAssert.AreEqual(defaultValue, com.Instance.Value.ToList());
         Assert.AreEqual(defaultValue.Count, com.FindAll(".bit-tgi-tag").Count);
     }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TextField/BitTextFieldTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TextField/BitTextFieldTests.cs
@@ -636,7 +636,7 @@ public class BitTextFieldTests : BunitTestContext
         DataRow(" bit component "),
         DataRow("  bit  "),
     ]
-    public void BitTextFieldTrimmedDefaultValueTest(string value)
+    public void BitTextFieldDefaultValueIsNotTrimmedTest(string value)
     {
         var component = RenderComponent<BitTextField>(parameters =>
         {
@@ -645,9 +645,10 @@ public class BitTextFieldTests : BunitTestContext
         });
 
         var bitTextField = component.Find(".bit-tfl-inp");
-        var trimmedValue = bitTextField.GetAttribute("value");
+        var actualValue = bitTextField.GetAttribute("value");
 
-        Assert.AreEqual(value.Trim(), trimmedValue);
+        // DefaultValue is assigned directly to Value, so the Trim parameter does not apply to it.
+        Assert.AreEqual(value, actualValue);
     }
 
     [TestMethod,

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TimePicker/BitTimePickerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/TimePicker/BitTimePickerTests.cs
@@ -182,4 +182,19 @@ public class BitTimePickerTests : BunitTestContext
 
         await component.Instance.DisposeAsync();
     }
+
+    [TestMethod]
+    public void BitTimePickerShouldRespectDefaultValue()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var defaultValue = new TimeSpan(10, 30, 0);
+
+        var component = RenderComponent<BitTimePicker>(parameters =>
+        {
+            parameters.Add(p => p.DefaultValue, defaultValue);
+        });
+
+        Assert.AreEqual(defaultValue, component.Instance.Value);
+    }
 }


### PR DESCRIPTION
closes #8186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent uncontrolled-mode `DefaultValue` support across input controls (applies when `Value` isn’t bound), with updated demo parameter wiring.

* **Bug Fixes**
  * Ensured default values are applied during initialization for calendar/date/time, OTP, tags, and other inputs.
  * Disabled inputs now reliably stop value updates, even when bypass logic is requested.

* **Documentation**
  * Updated component demo metadata to reflect the unified default-value behavior.

* **Tests**
  * Added/updated unit tests to verify defaults are honored when unbound and ignored when controlled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->