### PR TITLE
Add missing overflow behaviors to BitPivot (#432)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor
@@ -14,10 +14,11 @@
 
             @if (OverflowBehavior is BitPivotOverflowBehavior.Slide)
             {
-                var prevIcon = BitIconInfo.From(PreviousIcon, PreviousIconName ?? "ChevronLeft");
+                var prevIcon = BitIconInfo.From(PreviousIcon, PreviousIconName ?? (_isVertical ? "ChevronUp" : "ChevronLeft"));
                 <button type="button"
                         disabled="@(_slideAtStart || _slideHasOverflow is false)"
                         style="@Styles?.SlideButton"
+                        aria-label="@(PreviousAriaLabel ?? "Previous")"
                         @onclick="() => Slide(false)"
                         class="bit-pvt-sbt bit-pvt-spv @Classes?.SlideButton">
                     <i class="@prevIcon?.GetCssClasses()" />
@@ -34,7 +35,7 @@
                             type="button"
                             style="display:none;@Styles?.OverflowButton"
                             aria-haspopup="true"
-                            aria-label="@OverflowAriaLabel"
+                            aria-label="@(OverflowAriaLabel ?? "More")"
                             aria-expanded="@(_isMenuOpen ? "true" : "false")"
                             @onclick="ToggleMenu"
                             class="bit-pvti bit-pvt-mor @Classes?.OverflowButton">
@@ -47,10 +48,11 @@
 
             @if (OverflowBehavior is BitPivotOverflowBehavior.Slide)
             {
-                var nextIcon = BitIconInfo.From(NextIcon, NextIconName ?? "ChevronRight");
+                var nextIcon = BitIconInfo.From(NextIcon, NextIconName ?? (_isVertical ? "ChevronDown" : "ChevronRight"));
                 <button type="button"
                         disabled="@(_slideAtEnd || _slideHasOverflow is false)"
                         style="@Styles?.SlideButton"
+                        aria-label="@(NextAriaLabel ?? "Next")"
                         @onclick="() => Slide(true)"
                         class="bit-pvt-sbt bit-pvt-snx @Classes?.SlideButton">
                     <i class="@nextIcon?.GetCssClasses()" />

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor
@@ -10,8 +10,96 @@
      dir="@Dir?.ToString().ToLower()">
 
     <CascadingValue Value="this" IsFixed="true">
-        <div style="@Styles?.Header" class="bit-pvt-hct @Classes?.Header" role="tablist">
-            @ChildContent
+        <div style="@Styles?.HeaderContainer" class="bit-pvt-hwr @Classes?.HeaderContainer">
+
+            @if (OverflowBehavior is BitPivotOverflowBehavior.Slide)
+            {
+                var prevIcon = BitIconInfo.From(PreviousIcon, PreviousIconName ?? "ChevronLeft");
+                <button type="button"
+                        disabled="@(_slideAtStart || _slideHasOverflow is false)"
+                        style="@Styles?.SlideButton"
+                        @onclick="() => Slide(false)"
+                        class="bit-pvt-sbt bit-pvt-spv @Classes?.SlideButton">
+                    <i class="@prevIcon?.GetCssClasses()" />
+                </button>
+            }
+
+            <div @ref="_headerRef" style="@Styles?.Header" class="bit-pvt-hct @Classes?.Header" role="tablist">
+                @ChildContent
+
+                @if (OverflowBehavior is BitPivotOverflowBehavior.Menu)
+                {
+                    var moreIcon = BitIconInfo.From(OverflowIcon, OverflowIconName ?? "More");
+                    <button @ref="_moreRef"
+                            type="button"
+                            style="display:none;@Styles?.OverflowButton"
+                            aria-haspopup="true"
+                            aria-label="@OverflowAriaLabel"
+                            aria-expanded="@(_isMenuOpen ? "true" : "false")"
+                            @onclick="ToggleMenu"
+                            class="bit-pvti bit-pvt-mor @Classes?.OverflowButton">
+                        <span>
+                            <i class="@moreIcon?.GetCssClasses()" />
+                        </span>
+                    </button>
+                }
+            </div>
+
+            @if (OverflowBehavior is BitPivotOverflowBehavior.Slide)
+            {
+                var nextIcon = BitIconInfo.From(NextIcon, NextIconName ?? "ChevronRight");
+                <button type="button"
+                        disabled="@(_slideAtEnd || _slideHasOverflow is false)"
+                        style="@Styles?.SlideButton"
+                        @onclick="() => Slide(true)"
+                        class="bit-pvt-sbt bit-pvt-snx @Classes?.SlideButton">
+                    <i class="@nextIcon?.GetCssClasses()" />
+                </button>
+            }
+
+            @if (OverflowBehavior is BitPivotOverflowBehavior.Menu)
+            {
+                <div class="bit-pvt-ovl"
+                     style="display:@(_isMenuOpen ? "block" : "none")"
+                     @onclick="CloseMenu"></div>
+
+                <div style="display:@(_isMenuOpen ? "block" : "none");@Styles?.OverflowCallout"
+                     role="menu"
+                     class="bit-pvt-mnc @Classes?.OverflowCallout">
+                    @foreach (var index in _overflowItemIndexes)
+                    {
+                        var item = (index >= 0 && index < _allItems.Count) ? _allItems[index] : null;
+                        if (item is null) continue;
+
+                        <button type="button"
+                                role="menuitem"
+                                disabled="@(item.IsEnabled is false)"
+                                style="@Styles?.OverflowItem"
+                                @onclick="() => SelectFromMenu(item)"
+                                class="bit-pvt-mni @(item.IsSelected ? "bit-pvt-mni-sel" : null) @Classes?.OverflowItem">
+                            @{
+                                var menuIcon = BitIconInfo.From(item.Icon, item.IconName);
+                            }
+                            @if (menuIcon is not null)
+                            {
+                                <i class="@menuIcon.GetCssClasses()" />
+                            }
+                            @if (item.Header is not null)
+                            {
+                                @item.Header
+                            }
+                            else if (item.HeaderText.HasValue())
+                            {
+                                <span>@item.HeaderText</span>
+                            }
+                            @if (item.ItemCount is not null)
+                            {
+                                <span>(@item.ItemCount)</span>
+                            }
+                        </button>
+                    }
+                </div>
+            }
         </div>
     </CascadingValue>
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor.cs
@@ -6,6 +6,8 @@ namespace Bit.BlazorUI;
 public partial class BitPivot : BitComponentBase
 {
     private bool _jsSetup;
+    private bool _setupRtl;
+    private bool _setupVertical;
     private bool _isMenuOpen;
     private bool _slideAtEnd;
     private bool _slideAtStart = true;
@@ -68,21 +70,9 @@ public partial class BitPivot : BitComponentBase
     [Parameter] public bool MountAll { get; set; }
 
     /// <summary>
-    /// Callback for when a pivot header item is clicked.
+    /// The aria-label of the next button in the Slide overflow behavior (default: Next).
     /// </summary>
-    [Parameter] public EventCallback<BitPivotItem> OnItemClick { get; set; }
-
-    /// <summary>
-    /// Callback for when the selected pivot item changes.
-    /// </summary>
-    [Parameter]
-    public EventCallback<BitPivotItem> OnChange { get; set; }
-
-    /// <summary>
-    /// Overflow behavior when there is not enough room to display all of the links/tabs.
-    /// </summary>
-    [Parameter, ResetClassBuilder]
-    public BitPivotOverflowBehavior? OverflowBehavior { get; set; }
+    [Parameter] public string? NextAriaLabel { get; set; }
 
     /// <summary>
     /// Gets or sets the icon of the next button in the Slide overflow behavior using custom CSS classes for external icon libraries.
@@ -96,9 +86,26 @@ public partial class BitPivot : BitComponentBase
     [Parameter] public string? NextIconName { get; set; }
 
     /// <summary>
-    /// The aria-label of the overflow menu button in the Menu overflow behavior.
+    /// Callback for when the selected pivot item changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<BitPivotItem> OnChange { get; set; }
+
+    /// <summary>
+    /// Callback for when a pivot header item is clicked.
+    /// </summary>
+    [Parameter] public EventCallback<BitPivotItem> OnItemClick { get; set; }
+
+    /// <summary>
+    /// The aria-label of the overflow menu button in the Menu overflow behavior (default: More).
     /// </summary>
     [Parameter] public string? OverflowAriaLabel { get; set; }
+
+    /// <summary>
+    /// Overflow behavior when there is not enough room to display all of the links/tabs.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public BitPivotOverflowBehavior? OverflowBehavior { get; set; }
 
     /// <summary>
     /// Gets or sets the icon of the overflow menu button in the Menu overflow behavior using custom CSS classes for external icon libraries.
@@ -112,6 +119,17 @@ public partial class BitPivot : BitComponentBase
     [Parameter] public string? OverflowIconName { get; set; }
 
     /// <summary>
+    /// Position of the pivot header.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public BitPivotPosition? Position { get; set; }
+
+    /// <summary>
+    /// The aria-label of the previous button in the Slide overflow behavior (default: Previous).
+    /// </summary>
+    [Parameter] public string? PreviousAriaLabel { get; set; }
+
+    /// <summary>
     /// Gets or sets the icon of the previous button in the Slide overflow behavior using custom CSS classes for external icon libraries.
     /// Takes precedence over <see cref="PreviousIconName"/> when both are set.
     /// </summary>
@@ -121,12 +139,6 @@ public partial class BitPivot : BitComponentBase
     /// Gets or sets the name of the icon of the previous button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronLeft).
     /// </summary>
     [Parameter] public string? PreviousIconName { get; set; }
-
-    /// <summary>
-    /// Position of the pivot header.
-    /// </summary>
-    [Parameter, ResetClassBuilder]
-    public BitPivotPosition? Position { get; set; }
 
     /// <summary>
     /// Key of the selected pivot item.
@@ -149,6 +161,8 @@ public partial class BitPivot : BitComponentBase
 
 
     protected override string RootElementClass => "bit-pvt";
+
+    private bool _isVertical => Position is BitPivotPosition.Start or BitPivotPosition.End;
 
     protected override void RegisterCssClasses()
     {
@@ -248,8 +262,10 @@ public partial class BitPivot : BitComponentBase
 
         var behavior = OverflowBehavior ?? BitPivotOverflowBehavior.None;
         var needsJs = behavior is BitPivotOverflowBehavior.Menu or BitPivotOverflowBehavior.Slide;
+        var rtl = Dir is BitDir.Rtl;
+        var vertical = Position is BitPivotPosition.Start or BitPivotPosition.End;
 
-        if (_setupBehavior != behavior)
+        if (_setupBehavior != behavior || (_jsSetup && (_setupRtl != rtl || _setupVertical != vertical)))
         {
             if (_jsSetup)
             {
@@ -276,13 +292,16 @@ public partial class BitPivot : BitComponentBase
                     behavior is BitPivotOverflowBehavior.Menu ? _moreRef : null,
                     behavior is BitPivotOverflowBehavior.Menu,
                     behavior is BitPivotOverflowBehavior.Slide,
-                    Dir is BitDir.Rtl,
+                    rtl,
+                    vertical,
                     _dotnetObj);
 
                 _jsSetup = true;
             }
 
             _setupBehavior = behavior;
+            _setupRtl = rtl;
+            _setupVertical = vertical;
         }
         else if (_jsSetup)
         {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.razor.cs
@@ -5,8 +5,22 @@ namespace Bit.BlazorUI;
 /// </summary>
 public partial class BitPivot : BitComponentBase
 {
+    private bool _jsSetup;
+    private bool _isMenuOpen;
+    private bool _slideAtEnd;
+    private bool _slideAtStart = true;
+    private bool _slideHasOverflow;
+    private ElementReference _moreRef;
+    private ElementReference _headerRef;
     private BitPivotItem? _selectedItem;
+    private int[] _overflowItemIndexes = [];
     private List<BitPivotItem> _allItems = [];
+    private BitPivotOverflowBehavior? _setupBehavior;
+    private DotNetObjectReference<BitPivot>? _dotnetObj;
+
+
+
+    [Inject] private IJSRuntime _js { get; set; } = default!;
 
 
 
@@ -69,6 +83,44 @@ public partial class BitPivot : BitComponentBase
     /// </summary>
     [Parameter, ResetClassBuilder]
     public BitPivotOverflowBehavior? OverflowBehavior { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon of the next button in the Slide overflow behavior using custom CSS classes for external icon libraries.
+    /// Takes precedence over <see cref="NextIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? NextIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the icon of the next button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronRight).
+    /// </summary>
+    [Parameter] public string? NextIconName { get; set; }
+
+    /// <summary>
+    /// The aria-label of the overflow menu button in the Menu overflow behavior.
+    /// </summary>
+    [Parameter] public string? OverflowAriaLabel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon of the overflow menu button in the Menu overflow behavior using custom CSS classes for external icon libraries.
+    /// Takes precedence over <see cref="OverflowIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? OverflowIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the icon of the overflow menu button in the Menu overflow behavior from the built-in Fluent UI icons (default: More).
+    /// </summary>
+    [Parameter] public string? OverflowIconName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon of the previous button in the Slide overflow behavior using custom CSS classes for external icon libraries.
+    /// Takes precedence over <see cref="PreviousIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? PreviousIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the icon of the previous button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronLeft).
+    /// </summary>
+    [Parameter] public string? PreviousIconName { get; set; }
 
     /// <summary>
     /// Position of the pivot header.
@@ -143,6 +195,7 @@ public partial class BitPivot : BitComponentBase
         {
             BitPivotOverflowBehavior.Menu => "bit-pvt-mnu",
             BitPivotOverflowBehavior.Scroll => "bit-pvt-scr",
+            BitPivotOverflowBehavior.Slide => "bit-pvt-sld",
             BitPivotOverflowBehavior.None => "bit-pvt-non",
             _ => "bit-pvt-non"
         });
@@ -183,6 +236,89 @@ public partial class BitPivot : BitComponentBase
         }
 
         await base.OnInitializedAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsDisposed)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            return;
+        }
+
+        var behavior = OverflowBehavior ?? BitPivotOverflowBehavior.None;
+        var needsJs = behavior is BitPivotOverflowBehavior.Menu or BitPivotOverflowBehavior.Slide;
+
+        if (_setupBehavior != behavior)
+        {
+            if (_jsSetup)
+            {
+                await _js.BitPivotDispose(_Id);
+                _jsSetup = false;
+            }
+
+            _dotnetObj?.Dispose();
+            _dotnetObj = null;
+
+            _isMenuOpen = false;
+            _slideAtEnd = false;
+            _slideAtStart = true;
+            _slideHasOverflow = false;
+            _overflowItemIndexes = [];
+
+            if (needsJs)
+            {
+                _dotnetObj = DotNetObjectReference.Create(this);
+
+                await _js.BitPivotSetup(
+                    _Id,
+                    _headerRef,
+                    behavior is BitPivotOverflowBehavior.Menu ? _moreRef : null,
+                    behavior is BitPivotOverflowBehavior.Menu,
+                    behavior is BitPivotOverflowBehavior.Slide,
+                    Dir is BitDir.Rtl,
+                    _dotnetObj);
+
+                _jsSetup = true;
+            }
+
+            _setupBehavior = behavior;
+        }
+        else if (_jsSetup)
+        {
+            await _js.BitPivotRefresh(_Id);
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+
+
+    [JSInvokable("OnSetOverflowItems")]
+    public void OnSetOverflowItems(int[] indexes)
+    {
+        if (IsDisposed) return;
+
+        _overflowItemIndexes = indexes ?? [];
+
+        if (_overflowItemIndexes.Length == 0)
+        {
+            _isMenuOpen = false;
+        }
+
+        StateHasChanged();
+    }
+
+    [JSInvokable("OnSetSlideState")]
+    public void OnSetSlideState(bool hasOverflow, bool atStart, bool atEnd)
+    {
+        if (IsDisposed) return;
+
+        _slideHasOverflow = hasOverflow;
+        _slideAtStart = atStart;
+        _slideAtEnd = atEnd;
+
+        StateHasChanged();
     }
 
 
@@ -283,5 +419,57 @@ public partial class BitPivot : BitComponentBase
     private void OnSetSelectedKey()
     {
         SelectItemByKey(SelectedKey);
+    }
+
+    private void ToggleMenu()
+    {
+        _isMenuOpen = !_isMenuOpen;
+    }
+
+    private void CloseMenu()
+    {
+        _isMenuOpen = false;
+    }
+
+    private async Task SelectFromMenu(BitPivotItem item)
+    {
+        CloseMenu();
+
+        if (IsEnabled is false || item.IsEnabled is false) return;
+
+        SelectItem(item);
+
+        await OnItemClick.InvokeAsync(item);
+
+        if (_jsSetup)
+        {
+            await _js.BitPivotRefresh(_Id);
+        }
+    }
+
+    private async Task Slide(bool forward)
+    {
+        if (IsEnabled is false || _jsSetup is false) return;
+
+        await _js.BitPivotSlide(_Id, forward);
+    }
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (IsDisposed || disposing is false) return;
+
+        if (_dotnetObj is not null)
+        {
+            try
+            {
+                await _js.BitPivotDispose(_Id);
+            }
+            catch (JSDisconnectedException) { } // we can ignore this exception here
+
+            _dotnetObj.Dispose();
+            _dotnetObj = null;
+        }
+
+        await base.DisposeAsync(disposing);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.scss
@@ -33,6 +33,18 @@
     }
 }
 
+.bit-pvt-hwr {
+    display: flex;
+    min-width: 0;
+    position: relative;
+    align-items: center;
+}
+
+.bit-pvt-hwr > .bit-pvt-hct {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
 .bit-pvt-cct {
     margin: 0;
     padding: 0;
@@ -348,3 +360,120 @@
     --bit-pvt-clr-hover: #{$clr-brd-ter-hover};
     --bit-pvt-clr-text: #{$clr-fg-pri};
 }
+
+// #region Slide overflow behavior
+
+.bit-pvt-sld {
+    .bit-pvt-hct {
+        overflow: hidden;
+        scroll-behavior: smooth;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
+    }
+}
+
+.bit-pvt-sbt {
+    border: 0;
+    padding: 0;
+    flex-shrink: 0;
+    cursor: pointer;
+    border-radius: 0;
+    color: $clr-fg-pri;
+    width: spacing(4);
+    align-items: center;
+    height: spacing(5.5);
+    display: inline-flex;
+    box-sizing: border-box;
+    justify-content: center;
+    background-color: transparent;
+
+    @media (hover: hover) {
+        &:hover {
+            color: $clr-fg-pri-hover;
+            background-color: $clr-bg-pri-hover;
+        }
+    }
+
+    &:disabled {
+        cursor: default;
+        color: $clr-fg-dis;
+        pointer-events: none;
+    }
+}
+
+// #endregion
+
+// #region Menu overflow behavior
+
+.bit-pvt-mnu {
+    .bit-pvt-hct {
+        overflow: hidden;
+    }
+}
+
+.bit-pvt-mor {
+    flex-shrink: 0;
+    margin-right: 0;
+}
+
+.bit-pvt-ovl {
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    position: fixed;
+    z-index: $zindex-overlay;
+    background-color: transparent;
+}
+
+.bit-pvt-mnc {
+    top: 100%;
+    display: none;
+    overflow: hidden auto;
+    padding: spacing(0.5) 0;
+    min-width: max-content;
+    box-sizing: border-box;
+    position: absolute;
+    inset-inline-end: 0;
+    z-index: $zindex-callout;
+    box-shadow: $box-shadow-callout;
+    border-radius: 0 0 spacing(0.25) spacing(0.25);
+    background-color: $clr-bg-pri;
+}
+
+.bit-pvt-mni {
+    width: 100%;
+    border: none;
+    display: flex;
+    cursor: pointer;
+    text-align: start;
+    gap: spacing(0.5);
+    color: $clr-fg-pri;
+    white-space: nowrap;
+    align-items: center;
+    background-color: transparent;
+    padding: spacing(1) spacing(2);
+
+    @media (hover: hover) {
+        &:hover {
+            color: $clr-fg-pri-hover;
+            background-color: $clr-bg-pri-hover;
+        }
+    }
+
+    &[disabled] {
+        cursor: default;
+        color: $clr-fg-dis;
+        pointer-events: none;
+    }
+
+    &.bit-pvt-mni-sel {
+        font-weight: 600;
+    }
+}
+
+// #endregion

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivot.scss
@@ -79,6 +79,48 @@
         height: unset;
         flex-flow: column;
     }
+
+    .bit-pvt-hwr {
+        flex-flow: column;
+        align-items: stretch;
+    }
+
+    .bit-pvt-hwr > .bit-pvt-hct {
+        min-height: 0;
+    }
+
+    .bit-pvt-sbt {
+        width: 100%;
+        height: spacing(4);
+    }
+
+    &.bit-pvt-scr .bit-pvt-hct {
+        overflow-x: hidden;
+        overflow-y: auto;
+        padding-bottom: 0;
+        padding-inline-end: spacing(0.5);
+
+        &::-webkit-scrollbar {
+            height: auto;
+            width: spacing(0.625);
+        }
+    }
+}
+
+.bit-pvt-sta .bit-pvt-mnc {
+    top: auto;
+    bottom: 0;
+    inset-inline-end: auto;
+    inset-inline-start: 100%;
+    border-radius: 0 spacing(0.25) spacing(0.25) 0;
+}
+
+.bit-pvt-end .bit-pvt-mnc {
+    top: auto;
+    bottom: 0;
+    inset-inline-start: auto;
+    inset-inline-end: 100%;
+    border-radius: spacing(0.25) 0 0 spacing(0.25);
 }
 
 .bit-pvt-lnk {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivotClassStyles.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivotClassStyles.cs
@@ -13,6 +13,31 @@ public class BitPivotClassStyles
     public string? Header { get; set; }
 
     /// <summary>
+    /// Custom CSS classes/styles for the header container (wrapper) of the BitPivot.
+    /// </summary>
+    public string? HeaderContainer { get; set; }
+
+    /// <summary>
+    /// Custom CSS classes/styles for the slide (next/previous) buttons of the BitPivot in the Slide overflow behavior.
+    /// </summary>
+    public string? SlideButton { get; set; }
+
+    /// <summary>
+    /// Custom CSS classes/styles for the overflow menu button of the BitPivot in the Menu overflow behavior.
+    /// </summary>
+    public string? OverflowButton { get; set; }
+
+    /// <summary>
+    /// Custom CSS classes/styles for the overflow menu (callout) of the BitPivot in the Menu overflow behavior.
+    /// </summary>
+    public string? OverflowCallout { get; set; }
+
+    /// <summary>
+    /// Custom CSS classes/styles for the overflow menu item of the BitPivot in the Menu overflow behavior.
+    /// </summary>
+    public string? OverflowItem { get; set; }
+
+    /// <summary>
     /// Custom CSS classes/styles for the items body of the BitPivot.
     /// </summary>
     public string? Body { get; set; }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivotOverflowBehavior.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Pivot/BitPivotOverflowBehavior.cs
@@ -15,5 +15,10 @@ public enum BitPivotOverflowBehavior
     /// <summary>
     /// Display a scroll bar below of the tabs for moving between them
     /// </summary>
-    Scroll
+    Scroll,
+
+    /// <summary>
+    /// Display next and previous buttons to slide through the tabs that don't fit
+    /// </summary>
+    Slide
 }

--- a/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/PivotJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/PivotJsRuntimeExtensions.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bit.BlazorUI;
+
+internal static class PivotJsRuntimeExtensions
+{
+    internal static ValueTask BitPivotSetup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        this IJSRuntime jsRuntime,
+        string id,
+        ElementReference header,
+        ElementReference? moreButton,
+        bool isMenu,
+        bool isSlide,
+        bool isRtl,
+        DotNetObjectReference<T> dotnetObj) where T : class
+    {
+        return jsRuntime.InvokeVoid("BitBlazorUI.Pivot.setup", id, header, moreButton, isMenu, isSlide, isRtl, dotnetObj);
+    }
+
+    internal static ValueTask BitPivotRefresh(this IJSRuntime jsRuntime, string id)
+    {
+        return jsRuntime.InvokeVoid("BitBlazorUI.Pivot.refresh", id);
+    }
+
+    internal static ValueTask BitPivotSlide(this IJSRuntime jsRuntime, string id, bool forward)
+    {
+        return jsRuntime.InvokeVoid("BitBlazorUI.Pivot.slide", id, forward);
+    }
+
+    internal static ValueTask BitPivotDispose(this IJSRuntime jsRuntime, string id)
+    {
+        return jsRuntime.InvokeVoid("BitBlazorUI.Pivot.dispose", id);
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/PivotJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/PivotJsRuntimeExtensions.cs
@@ -12,9 +12,10 @@ internal static class PivotJsRuntimeExtensions
         bool isMenu,
         bool isSlide,
         bool isRtl,
+        bool isVertical,
         DotNetObjectReference<T> dotnetObj) where T : class
     {
-        return jsRuntime.InvokeVoid("BitBlazorUI.Pivot.setup", id, header, moreButton, isMenu, isSlide, isRtl, dotnetObj);
+        return jsRuntime.InvokeVoid("BitBlazorUI.Pivot.setup", id, header, moreButton, isMenu, isSlide, isRtl, isVertical, dotnetObj);
     }
 
     internal static ValueTask BitPivotRefresh(this IJSRuntime jsRuntime, string id)

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Pivot.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Pivot.ts
@@ -9,12 +9,13 @@ namespace BitBlazorUI {
             isMenu: boolean,
             isSlide: boolean,
             isRtl: boolean,
+            isVertical: boolean,
             dotnetObj: DotNetObject) {
             if (!header) return;
 
             Pivot.dispose(id);
 
-            const instance = new PivotInstance(id, header, moreButton, isMenu, isSlide, isRtl, dotnetObj);
+            const instance = new PivotInstance(id, header, moreButton, isMenu, isSlide, isRtl, isVertical, dotnetObj);
             Pivot._instances[id] = instance;
             instance.start();
         }
@@ -46,6 +47,7 @@ namespace BitBlazorUI {
         private isMenu: boolean;
         private isSlide: boolean;
         private isRtl: boolean;
+        private isVertical: boolean;
         private dotnetObj: DotNetObject;
         private observer: ResizeObserver | null = null;
         private scrollHandler: (() => void) | null = null;
@@ -59,6 +61,7 @@ namespace BitBlazorUI {
             isMenu: boolean,
             isSlide: boolean,
             isRtl: boolean,
+            isVertical: boolean,
             dotnetObj: DotNetObject) {
             this.id = id;
             this.header = header;
@@ -66,6 +69,7 @@ namespace BitBlazorUI {
             this.isMenu = isMenu;
             this.isSlide = isSlide;
             this.isRtl = isRtl;
+            this.isVertical = isVertical;
             this.dotnetObj = dotnetObj;
         }
 
@@ -94,8 +98,13 @@ namespace BitBlazorUI {
             return Array.from(this.header.querySelectorAll<HTMLElement>('.bit-pvti:not(.bit-pvt-mor)'));
         }
 
-        private static outerWidth(el: HTMLElement): number {
+        private outerSize(el: HTMLElement): number {
             const style = window.getComputedStyle(el);
+            if (this.isVertical) {
+                const marginTop = parseFloat(style.marginTop) || 0;
+                const marginBottom = parseFloat(style.marginBottom) || 0;
+                return el.offsetHeight + marginTop + marginBottom;
+            }
             const marginLeft = parseFloat(style.marginLeft) || 0;
             const marginRight = parseFloat(style.marginRight) || 0;
             return el.offsetWidth + marginLeft + marginRight;
@@ -109,21 +118,21 @@ namespace BitBlazorUI {
                 items.forEach(it => (it.style.display = ''));
                 if (this.moreButton) this.moreButton.style.display = 'none';
 
-                const containerWidth = this.header.clientWidth;
+                const containerSize = this.isVertical ? this.header.clientHeight : this.header.clientWidth;
 
                 let total = 0;
-                items.forEach(it => (total += PivotInstance.outerWidth(it)));
+                items.forEach(it => (total += this.outerSize(it)));
 
                 let overflowIndexes: number[] = [];
 
-                if (total > containerWidth + 1) {
+                if (total > containerSize + 1) {
                     if (this.moreButton) this.moreButton.style.display = '';
-                    const moreWidth = this.moreButton ? PivotInstance.outerWidth(this.moreButton) : 0;
-                    const available = containerWidth - moreWidth;
+                    const moreSize = this.moreButton ? this.outerSize(this.moreButton) : 0;
+                    const available = containerSize - moreSize;
 
                     let used = 0;
                     items.forEach((it, i) => {
-                        used += PivotInstance.outerWidth(it);
+                        used += this.outerSize(it);
                         if (used > available) {
                             it.style.display = 'none';
                             overflowIndexes.push(i);
@@ -148,20 +157,29 @@ namespace BitBlazorUI {
 
         private updateSlide() {
             try {
-                const scrollLeft = this.header.scrollLeft;
-                const maxScroll = this.header.scrollWidth - this.header.clientWidth;
-                const hasOverflow = maxScroll > 1;
-
                 let atStart: boolean;
                 let atEnd: boolean;
+                let hasOverflow: boolean;
 
-                if (this.isRtl) {
-                    const abs = Math.abs(scrollLeft);
-                    atStart = abs <= 1;
-                    atEnd = abs >= maxScroll - 1;
+                if (this.isVertical) {
+                    const scrollTop = this.header.scrollTop;
+                    const maxScroll = this.header.scrollHeight - this.header.clientHeight;
+                    hasOverflow = maxScroll > 1;
+                    atStart = scrollTop <= 1;
+                    atEnd = scrollTop >= maxScroll - 1;
                 } else {
-                    atStart = scrollLeft <= 1;
-                    atEnd = scrollLeft >= maxScroll - 1;
+                    const scrollLeft = this.header.scrollLeft;
+                    const maxScroll = this.header.scrollWidth - this.header.clientWidth;
+                    hasOverflow = maxScroll > 1;
+
+                    if (this.isRtl) {
+                        const abs = Math.abs(scrollLeft);
+                        atStart = abs <= 1;
+                        atEnd = abs >= maxScroll - 1;
+                    } else {
+                        atStart = scrollLeft <= 1;
+                        atEnd = scrollLeft >= maxScroll - 1;
+                    }
                 }
 
                 const serialized = `${hasOverflow}|${atStart}|${atEnd}`;
@@ -176,10 +194,15 @@ namespace BitBlazorUI {
 
         public slide(forward: boolean) {
             try {
-                const amount = Math.max(this.header.clientWidth * 0.75, 50);
                 const direction = forward ? 1 : -1;
-                const sign = this.isRtl ? -1 : 1;
-                this.header.scrollBy({ left: direction * sign * amount, behavior: 'smooth' });
+                if (this.isVertical) {
+                    const amount = Math.max(this.header.clientHeight * 0.75, 50);
+                    this.header.scrollBy({ top: direction * amount, behavior: 'smooth' });
+                } else {
+                    const amount = Math.max(this.header.clientWidth * 0.75, 50);
+                    const sign = this.isRtl ? -1 : 1;
+                    this.header.scrollBy({ left: direction * sign * amount, behavior: 'smooth' });
+                }
             } catch (e) {
                 console.error('BitBlazorUI.Pivot.slide:', e);
             }

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Pivot.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Pivot.ts
@@ -1,0 +1,203 @@
+namespace BitBlazorUI {
+    export class Pivot {
+        private static _instances: Record<string, PivotInstance> = {};
+
+        public static setup(
+            id: string,
+            header: HTMLElement,
+            moreButton: HTMLElement | null,
+            isMenu: boolean,
+            isSlide: boolean,
+            isRtl: boolean,
+            dotnetObj: DotNetObject) {
+            if (!header) return;
+
+            Pivot.dispose(id);
+
+            const instance = new PivotInstance(id, header, moreButton, isMenu, isSlide, isRtl, dotnetObj);
+            Pivot._instances[id] = instance;
+            instance.start();
+        }
+
+        public static refresh(id: string) {
+            const instance = Pivot._instances[id];
+            if (!instance) return;
+            instance.update();
+        }
+
+        public static slide(id: string, forward: boolean) {
+            const instance = Pivot._instances[id];
+            if (!instance) return;
+            instance.slide(forward);
+        }
+
+        public static dispose(id: string) {
+            const instance = Pivot._instances[id];
+            if (!instance) return;
+            instance.dispose();
+            delete Pivot._instances[id];
+        }
+    }
+
+    class PivotInstance {
+        private id: string;
+        private header: HTMLElement;
+        private moreButton: HTMLElement | null;
+        private isMenu: boolean;
+        private isSlide: boolean;
+        private isRtl: boolean;
+        private dotnetObj: DotNetObject;
+        private observer: ResizeObserver | null = null;
+        private scrollHandler: (() => void) | null = null;
+        private lastOverflow: string = '';
+        private lastSlideState: string = '';
+
+        constructor(
+            id: string,
+            header: HTMLElement,
+            moreButton: HTMLElement | null,
+            isMenu: boolean,
+            isSlide: boolean,
+            isRtl: boolean,
+            dotnetObj: DotNetObject) {
+            this.id = id;
+            this.header = header;
+            this.moreButton = moreButton;
+            this.isMenu = isMenu;
+            this.isSlide = isSlide;
+            this.isRtl = isRtl;
+            this.dotnetObj = dotnetObj;
+        }
+
+        public start() {
+            try {
+                this.observer = new ResizeObserver(() => this.update());
+                this.observer.observe(this.header);
+
+                if (this.isSlide) {
+                    this.scrollHandler = Utils.throttle(() => this.updateSlide(), 100) as () => void;
+                    this.header.addEventListener('scroll', this.scrollHandler, { passive: true });
+                }
+            } catch (e) {
+                console.error('BitBlazorUI.Pivot.start:', e);
+            }
+
+            this.update();
+        }
+
+        public update() {
+            if (this.isMenu) this.updateMenu();
+            if (this.isSlide) this.updateSlide();
+        }
+
+        private getItems(): HTMLElement[] {
+            return Array.from(this.header.querySelectorAll<HTMLElement>('.bit-pvti:not(.bit-pvt-mor)'));
+        }
+
+        private static outerWidth(el: HTMLElement): number {
+            const style = window.getComputedStyle(el);
+            const marginLeft = parseFloat(style.marginLeft) || 0;
+            const marginRight = parseFloat(style.marginRight) || 0;
+            return el.offsetWidth + marginLeft + marginRight;
+        }
+
+        private updateMenu() {
+            try {
+                const items = this.getItems();
+
+                // reset everything to its natural state before measuring.
+                items.forEach(it => (it.style.display = ''));
+                if (this.moreButton) this.moreButton.style.display = 'none';
+
+                const containerWidth = this.header.clientWidth;
+
+                let total = 0;
+                items.forEach(it => (total += PivotInstance.outerWidth(it)));
+
+                let overflowIndexes: number[] = [];
+
+                if (total > containerWidth + 1) {
+                    if (this.moreButton) this.moreButton.style.display = '';
+                    const moreWidth = this.moreButton ? PivotInstance.outerWidth(this.moreButton) : 0;
+                    const available = containerWidth - moreWidth;
+
+                    let used = 0;
+                    items.forEach((it, i) => {
+                        used += PivotInstance.outerWidth(it);
+                        if (used > available) {
+                            it.style.display = 'none';
+                            overflowIndexes.push(i);
+                        }
+                    });
+
+                    // if nothing actually overflowed (e.g. only the more button didn't fit) hide it.
+                    if (overflowIndexes.length === 0 && this.moreButton) {
+                        this.moreButton.style.display = 'none';
+                    }
+                }
+
+                const serialized = overflowIndexes.join(',');
+                if (serialized === this.lastOverflow) return;
+                this.lastOverflow = serialized;
+
+                this.dotnetObj.invokeMethodAsync('OnSetOverflowItems', overflowIndexes);
+            } catch (e) {
+                console.error('BitBlazorUI.Pivot.updateMenu:', e);
+            }
+        }
+
+        private updateSlide() {
+            try {
+                const scrollLeft = this.header.scrollLeft;
+                const maxScroll = this.header.scrollWidth - this.header.clientWidth;
+                const hasOverflow = maxScroll > 1;
+
+                let atStart: boolean;
+                let atEnd: boolean;
+
+                if (this.isRtl) {
+                    const abs = Math.abs(scrollLeft);
+                    atStart = abs <= 1;
+                    atEnd = abs >= maxScroll - 1;
+                } else {
+                    atStart = scrollLeft <= 1;
+                    atEnd = scrollLeft >= maxScroll - 1;
+                }
+
+                const serialized = `${hasOverflow}|${atStart}|${atEnd}`;
+                if (serialized === this.lastSlideState) return;
+                this.lastSlideState = serialized;
+
+                this.dotnetObj.invokeMethodAsync('OnSetSlideState', hasOverflow, atStart, atEnd);
+            } catch (e) {
+                console.error('BitBlazorUI.Pivot.updateSlide:', e);
+            }
+        }
+
+        public slide(forward: boolean) {
+            try {
+                const amount = Math.max(this.header.clientWidth * 0.75, 50);
+                const direction = forward ? 1 : -1;
+                const sign = this.isRtl ? -1 : 1;
+                this.header.scrollBy({ left: direction * sign * amount, behavior: 'smooth' });
+            } catch (e) {
+                console.error('BitBlazorUI.Pivot.slide:', e);
+            }
+        }
+
+        public dispose() {
+            try {
+                if (this.observer) {
+                    this.observer.disconnect();
+                    this.observer = null;
+                }
+                if (this.scrollHandler) {
+                    this.header.removeEventListener('scroll', this.scrollHandler);
+                    this.scrollHandler = null;
+                }
+            } catch (e) {
+                console.error('BitBlazorUI.Pivot.dispose:', e);
+            }
+        }
+    }
+}

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor
@@ -534,7 +534,104 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="Color" RazorCode="@example11RazorCode" Id="example11">
+    <DemoExample Title="Overflow" RazorCode="@example11RazorCode" Id="example11">
+        <div>The <b>OverflowBehavior</b> parameter controls how the header behaves when there is not enough room to display all the tabs.</div>
+        <br />
+
+        <div><b>Menu</b> (overflown tabs are moved into an overflow menu):</div>
+        <br />
+        <div style="max-width:450px" class="box">
+            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Menu">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div><b>Slide</b> (next and previous buttons slide through the tabs):</div>
+        <br />
+        <div style="max-width:450px" class="box">
+            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Slide">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div><b>Scroll</b> (a scroll bar is shown below the tabs):</div>
+        <br />
+        <div style="max-width:450px" class="box">
+            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Scroll">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div>The overflow behavior also works with a vertical header (<b>Position</b> set to <b>Start</b> or <b>End</b>). A constrained height is required for the header to overflow vertically.</div>
+        <br />
+
+        <div><b>Menu</b> (vertical):</div>
+        <br />
+        <div class="box">
+            <BitPivot Position="@BitPivotPosition.Start" OverflowBehavior="@BitPivotOverflowBehavior.Menu" Style="height:200px">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div><b>Slide</b> (vertical):</div>
+        <br />
+        <div class="box">
+            <BitPivot Position="@BitPivotPosition.Start" OverflowBehavior="@BitPivotOverflowBehavior.Slide" Style="height:200px">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div><b>Scroll</b> (vertical):</div>
+        <br />
+        <div class="box">
+            <BitPivot Position="@BitPivotPosition.Start" OverflowBehavior="@BitPivotOverflowBehavior.Scroll" Style="height:200px">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+    </DemoExample>
+
+    <DemoExample Title="Color" RazorCode="@example12RazorCode" Id="example12">
         <div class="box">
             <BitPivot Color="BitColor.Secondary">
                 <BitPivotItem HeaderText="Primary">
@@ -608,7 +705,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="External Icons" RazorCode="@example12RazorCode" Id="example12">
+    <DemoExample Title="External Icons" RazorCode="@example13RazorCode" Id="example13">
         <div>Use icons from external libraries like FontAwesome, and Bootstrap Icons with the <b>Icon</b> parameter.</div>
         <div>See the <BitLink Href="#bit-icon-info">BitIconInfo</BitLink> section in the parameters table for usage.</div>
 
@@ -678,7 +775,7 @@
         </BitPivot>
     </DemoExample>
 
-    <DemoExample Title="Style & Class" RazorCode="@example13RazorCode" Id="example13">
+    <DemoExample Title="Style & Class" RazorCode="@example14RazorCode" Id="example14">
         <div>
             <div>Component's Style & Class:</div><br />
             <BitPivot Style="border: 1px solid tomato;">
@@ -820,7 +917,7 @@
         </div>
     </DemoExample>
 
-    <DemoExample Title="RTL" RazorCode="@example14RazorCode" Id="example14">
+    <DemoExample Title="RTL" RazorCode="@example15RazorCode" Id="example15">
         <div class="box">
             <BitPivot Dir="BitDir.Rtl" OverflowBehavior="@BitPivotOverflowBehavior.Scroll">
                 <BitPivotItem HeaderText="اسناد" IconName="@BitIconName.Info">
@@ -891,54 +988,6 @@
                     راهکارها و شرایط سخت تایپ به پایان رسد وزمان مورد نیاز شامل حروفچینی دستاوردهای
                     اصلی و جوابگوی سوالات پیوسته اهل دنیای موجود طراحی اساسا مورد استفاده قرار گیرد.
                 </BitPivotItem>
-            </BitPivot>
-        </div>
-    </DemoExample>
-    <DemoExample Title="Overflow" RazorCode="@example15RazorCode" Id="example15">
-        <div>The <b>OverflowBehavior</b> parameter controls how the header behaves when there is not enough room to display all the tabs.</div>
-        <br />
-
-        <div><b>Menu</b> (overflown tabs are moved into an overflow menu):</div>
-        <br />
-        <div style="max-width:450px" class="box">
-            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Menu">
-                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
-            </BitPivot>
-        </div>
-        <br /><br />
-
-        <div><b>Slide</b> (next and previous buttons slide through the tabs):</div>
-        <br />
-        <div style="max-width:450px" class="box">
-            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Slide">
-                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
-            </BitPivot>
-        </div>
-        <br /><br />
-
-        <div><b>Scroll</b> (a scroll bar is shown below the tabs):</div>
-        <br />
-        <div style="max-width:450px" class="box">
-            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Scroll">
-                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
-                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
             </BitPivot>
         </div>
     </DemoExample>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor
@@ -894,4 +894,52 @@
             </BitPivot>
         </div>
     </DemoExample>
+    <DemoExample Title="Overflow" RazorCode="@example15RazorCode" Id="example15">
+        <div>The <b>OverflowBehavior</b> parameter controls how the header behaves when there is not enough room to display all the tabs.</div>
+        <br />
+
+        <div><b>Menu</b> (overflown tabs are moved into an overflow menu):</div>
+        <br />
+        <div style="max-width:450px" class="box">
+            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Menu">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div><b>Slide</b> (next and previous buttons slide through the tabs):</div>
+        <br />
+        <div style="max-width:450px" class="box">
+            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Slide">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+        <br /><br />
+
+        <div><b>Scroll</b> (a scroll bar is shown below the tabs):</div>
+        <br />
+        <div style="max-width:450px" class="box">
+            <BitPivot OverflowBehavior="@BitPivotOverflowBehavior.Scroll">
+                <BitPivotItem HeaderText="File">Content of the File tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Shared with me">Content of the Shared with me tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Recent">Content of the Recent tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Favorites">Content of the Favorites tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Documents">Content of the Documents tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Pictures">Content of the Pictures tab.</BitPivotItem>
+                <BitPivotItem HeaderText="Downloads">Content of the Downloads tab.</BitPivotItem>
+            </BitPivot>
+        </div>
+    </DemoExample>
 </DemoPage>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor.cs
@@ -82,7 +82,7 @@ public partial class BitPivotDemo
             Name = "NextIconName",
             Type = "string?",
             DefaultValue = "null",
-            Description = "Gets or sets the name of the icon of the next button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronRight).",
+            Description = "Gets or sets the name of the icon of the next button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronRight for horizontal pivots and ChevronDown for vertical pivots).",
         },
         new()
         {
@@ -155,7 +155,7 @@ public partial class BitPivotDemo
             Name = "PreviousIconName",
             Type = "string?",
             DefaultValue = "null",
-            Description = "Gets or sets the name of the icon of the previous button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronLeft).",
+            Description = "Gets or sets the name of the icon of the previous button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronLeft for horizontal pivots and ChevronUp for vertical pivots).",
         },
         new()
         {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor.cs
@@ -70,31 +70,6 @@ public partial class BitPivotDemo
         },
         new()
         {
-            Name = "OnItemClick",
-            Type = "EventCallback<BitPivotItem>",
-            Description = "Callback for when the a pivot item is clicked.",
-            LinkType = LinkType.Link,
-            Href = "#pivot-item",
-        },
-        new()
-        {
-            Name = "OnChange",
-            Type = "EventCallback<BitPivotItem>",
-            Description = "Callback for when the selected pivot item changes.",
-            LinkType = LinkType.Link,
-            Href = "#pivot-item",
-        },
-        new()
-        {
-            Name = "OverflowBehavior",
-            Type = "BitPivotOverflowBehavior?",
-            DefaultValue = "null",
-            Description = "Overflow behavior when there is not enough room to display all of the links/tabs.",
-            LinkType = LinkType.Link,
-            Href = "#overflowBehavior-enum",
-        },
-        new()
-        {
             Name = "NextIcon",
             Type = "BitIconInfo?",
             DefaultValue = "null",
@@ -111,10 +86,35 @@ public partial class BitPivotDemo
         },
         new()
         {
+            Name = "OnChange",
+            Type = "EventCallback<BitPivotItem>",
+            Description = "Callback for when the selected pivot item changes.",
+            LinkType = LinkType.Link,
+            Href = "#pivot-item",
+        },
+        new()
+        {
+            Name = "OnItemClick",
+            Type = "EventCallback<BitPivotItem>",
+            Description = "Callback for when the a pivot item is clicked.",
+            LinkType = LinkType.Link,
+            Href = "#pivot-item",
+        },
+        new()
+        {
             Name = "OverflowAriaLabel",
             Type = "string?",
             DefaultValue = "null",
             Description = "The aria-label of the overflow menu button in the Menu overflow behavior.",
+        },
+        new()
+        {
+            Name = "OverflowBehavior",
+            Type = "BitPivotOverflowBehavior?",
+            DefaultValue = "null",
+            Description = "Overflow behavior when there is not enough room to display all of the links/tabs.",
+            LinkType = LinkType.Link,
+            Href = "#overflowBehavior-enum",
         },
         new()
         {
@@ -134,6 +134,15 @@ public partial class BitPivotDemo
         },
         new()
         {
+            Name = "Position",
+            Type = "BitPivotPosition",
+            DefaultValue = "BitPivotPosition.Top",
+            Description = "Position of the pivot header.",
+            LinkType = LinkType.Link,
+            Href = "#pivotPosition-enum",
+        },
+        new()
+        {
             Name = "PreviousIcon",
             Type = "BitIconInfo?",
             DefaultValue = "null",
@@ -147,15 +156,6 @@ public partial class BitPivotDemo
             Type = "string?",
             DefaultValue = "null",
             Description = "Gets or sets the name of the icon of the previous button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronLeft).",
-        },
-        new()
-        {
-            Name = "Position",
-            Type = "BitPivotPosition",
-            DefaultValue = "BitPivotPosition.Top",
-            Description = "Position of the pivot header.",
-            LinkType = LinkType.Link,
-            Href = "#pivotPosition-enum",
         },
         new()
         {
@@ -1203,6 +1203,79 @@ private BitPivotItem selectedPivotItem;";
 </BitPivot>";
 
     private readonly string example11RazorCode = @"
+<div style=""max-width:450px"">
+    <BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Menu"">
+        <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+    </BitPivot>
+</div>
+
+<div style=""max-width:450px"">
+    <BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Slide"">
+        <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+    </BitPivot>
+</div>
+
+<div style=""max-width:450px"">
+    <BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Scroll"">
+        <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+    </BitPivot>
+</div>
+
+<div>
+    <BitPivot Position=""@BitPivotPosition.Start"" OverflowBehavior=""@BitPivotOverflowBehavior.Menu"" Style=""height:200px"">
+        <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+    </BitPivot>
+</div>
+
+<div>
+    <BitPivot Position=""@BitPivotPosition.Start"" OverflowBehavior=""@BitPivotOverflowBehavior.Slide"" Style=""height:200px"">
+        <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+    </BitPivot>
+</div>
+
+<div>
+    <BitPivot Position=""@BitPivotPosition.Start"" OverflowBehavior=""@BitPivotOverflowBehavior.Scroll"" Style=""height:200px"">
+        <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+        <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+    </BitPivot>
+</div>";
+
+    private readonly string example12RazorCode = @"
 <BitPivot Color=""BitColor.Secondary"">
     <BitPivotItem HeaderText=""Primary"">
         <h1>Pivot #1: Primary</h1>
@@ -1271,7 +1344,7 @@ private BitPivotItem selectedPivotItem;";
     </BitPivotItem>
 </BitPivot>";
 
-    private readonly string example12RazorCode = @"
+    private readonly string example13RazorCode = @"
 <link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
 
 <BitPivot>
@@ -1329,7 +1402,7 @@ private BitPivotItem selectedPivotItem;";
     </BitPivotItem>
 </BitPivot>";
 
-    private readonly string example13RazorCode = @"
+    private readonly string example14RazorCode = @"
 <style>
     .custom-class {
         margin: 1rem;
@@ -1489,7 +1562,7 @@ private BitPivotItem selectedPivotItem;";
     </BitPivotItem>
 </BitPivot>";
 
-    private readonly string example14RazorCode = @"
+    private readonly string example15RazorCode = @"
 <BitPivot Dir=""BitDir.Rtl"" OverflowBehavior=""@BitPivotOverflowBehavior.Scroll"">
     <BitPivotItem HeaderText=""اسناد"" IconName=""@BitIconName.Info"">
         لورم ایپسوم متن ساختگی با تولید سادگی نامفهوم از صنعت چاپ و با استفاده از طراحان گرافیک است.
@@ -1556,35 +1629,5 @@ private BitPivotItem selectedPivotItem;";
         اصلی و جوابگوی سوالات پیوسته اهل دنیای موجود طراحی اساسا مورد استفاده قرار گیرد.
     </BitPivotItem>
 </BitPivot>";
-
-    private readonly string example15RazorCode = @"
-<BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Menu"">
-    <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
-</BitPivot>
-
-<BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Slide"">
-    <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
-</BitPivot>
-
-<BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Scroll"">
-    <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
-    <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
-</BitPivot>";
 }
+

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Pivot/BitPivotDemo.razor.cs
@@ -87,11 +87,66 @@ public partial class BitPivotDemo
         new()
         {
             Name = "OverflowBehavior",
-            Type = "BitOverflowBehavior",
-            DefaultValue = "BitOverflowBehavior.None",
+            Type = "BitPivotOverflowBehavior?",
+            DefaultValue = "null",
             Description = "Overflow behavior when there is not enough room to display all of the links/tabs.",
             LinkType = LinkType.Link,
             Href = "#overflowBehavior-enum",
+        },
+        new()
+        {
+            Name = "NextIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Gets or sets the icon of the next button in the Slide overflow behavior using custom CSS classes for external icon libraries. Takes precedence over NextIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "NextIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Gets or sets the name of the icon of the next button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronRight).",
+        },
+        new()
+        {
+            Name = "OverflowAriaLabel",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The aria-label of the overflow menu button in the Menu overflow behavior.",
+        },
+        new()
+        {
+            Name = "OverflowIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Gets or sets the icon of the overflow menu button in the Menu overflow behavior using custom CSS classes for external icon libraries. Takes precedence over OverflowIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "OverflowIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Gets or sets the name of the icon of the overflow menu button in the Menu overflow behavior from the built-in Fluent UI icons (default: More).",
+        },
+        new()
+        {
+            Name = "PreviousIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "Gets or sets the icon of the previous button in the Slide overflow behavior using custom CSS classes for external icon libraries. Takes precedence over PreviousIconName when both are set.",
+            LinkType = LinkType.Link,
+            Href = "#bit-icon-info",
+        },
+        new()
+        {
+            Name = "PreviousIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "Gets or sets the name of the icon of the previous button in the Slide overflow behavior from the built-in Fluent UI icons (default: ChevronLeft).",
         },
         new()
         {
@@ -232,6 +287,41 @@ public partial class BitPivotDemo
                    Type = "string?",
                    DefaultValue = "null",
                    Description = "Custom CSS classes/styles for the header of the BitPivot."
+               },
+               new()
+               {
+                   Name = "HeaderContainer",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the header container (wrapper) of the BitPivot."
+               },
+               new()
+               {
+                   Name = "SlideButton",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the slide (next/previous) buttons of the BitPivot in the Slide overflow behavior."
+               },
+               new()
+               {
+                   Name = "OverflowButton",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the overflow menu button of the BitPivot in the Menu overflow behavior."
+               },
+               new()
+               {
+                   Name = "OverflowCallout",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the overflow menu (callout) of the BitPivot in the Menu overflow behavior."
+               },
+               new()
+               {
+                   Name = "OverflowItem",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the overflow menu item of the BitPivot in the Menu overflow behavior."
                },
                new()
                {
@@ -424,7 +514,7 @@ public partial class BitPivotDemo
         new()
         {
             Id = "overflowBehavior-enum",
-            Name = "BitOverflowBehavior",
+            Name = "BitPivotOverflowBehavior",
             Description = "",
             Items =
             [
@@ -445,6 +535,12 @@ public partial class BitPivotDemo
                     Name= "Scroll",
                     Description="Display a scroll bar below of the tabs for moving between them.",
                     Value="2",
+                },
+                new()
+                {
+                    Name= "Slide",
+                    Description="Display next and previous buttons to slide through the tabs that don't fit.",
+                    Value="3",
                 },
             ]
         },
@@ -1459,5 +1555,36 @@ private BitPivotItem selectedPivotItem;";
         راهکارها و شرایط سخت تایپ به پایان رسد وزمان مورد نیاز شامل حروفچینی دستاوردهای
         اصلی و جوابگوی سوالات پیوسته اهل دنیای موجود طراحی اساسا مورد استفاده قرار گیرد.
     </BitPivotItem>
+</BitPivot>";
+
+    private readonly string example15RazorCode = @"
+<BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Menu"">
+    <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+</BitPivot>
+
+<BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Slide"">
+    <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
+</BitPivot>
+
+<BitPivot OverflowBehavior=""@BitPivotOverflowBehavior.Scroll"">
+    <BitPivotItem HeaderText=""File"">Content of the File tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Shared with me"">Content of the Shared with me tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Recent"">Content of the Recent tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Favorites"">Content of the Favorites tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Documents"">Content of the Documents tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Pictures"">Content of the Pictures tab.</BitPivotItem>
+    <BitPivotItem HeaderText=""Downloads"">Content of the Downloads tab.</BitPivotItem>
 </BitPivot>";
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/Pivot/BitPivotTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/Pivot/BitPivotTests.cs
@@ -6,10 +6,17 @@ namespace Bit.BlazorUI.Tests.Components.Navs.Pivot;
 [TestClass]
 public class BitPivotTests : BunitTestContext
 {
+    [TestInitialize]
+    public void SetupJsInteropMode()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
     [TestMethod,
          DataRow(BitPivotHeaderType.Link, BitSize.Large, BitPivotOverflowBehavior.None),
          DataRow(BitPivotHeaderType.Tab, BitSize.Medium, BitPivotOverflowBehavior.Scroll),
-         DataRow(BitPivotHeaderType.Tab, BitSize.Small, BitPivotOverflowBehavior.Menu)
+         DataRow(BitPivotHeaderType.Tab, BitSize.Small, BitPivotOverflowBehavior.Menu),
+         DataRow(BitPivotHeaderType.Link, BitSize.Small, BitPivotOverflowBehavior.Slide)
      ]
     public void BitPivotShouldRespectParameterRelatedCssClasses(BitPivotHeaderType headerType, BitSize size, BitPivotOverflowBehavior overflowBehavior)
     {
@@ -22,7 +29,7 @@ public class BitPivotTests : BunitTestContext
 
         var sizeClass = $"bit-pvt-{size switch { BitSize.Small => "sm", BitSize.Medium => "md", BitSize.Large => "lg", _ => "md" }}";
         var headerTypeClass = $"bit-pvt-{headerType switch { BitPivotHeaderType.Link => "lnk", BitPivotHeaderType.Tab => "tab", _ => "lnk" }}";
-        var overflowBehaviorClass = $"bit-pvt-{overflowBehavior switch { BitPivotOverflowBehavior.Menu => "mnu", BitPivotOverflowBehavior.Scroll => "scr", BitPivotOverflowBehavior.None => "non", _ => "non" }}";
+        var overflowBehaviorClass = $"bit-pvt-{overflowBehavior switch { BitPivotOverflowBehavior.Menu => "mnu", BitPivotOverflowBehavior.Scroll => "scr", BitPivotOverflowBehavior.Slide => "sld", BitPivotOverflowBehavior.None => "non", _ => "non" }}";
 
         var bitPivot = component.Find(".bit-pvt");
 
@@ -60,12 +67,9 @@ public class BitPivotTests : BunitTestContext
             parameters.AddChildContent<BitPivotItem>(parameters => parameters.Add(p => p.AriaLabel, ariaLabel));
         });
 
-        var bitPivots = com.FindAll(".bit-pvt > div:first-child > div");
+        var items = com.FindAll(".bit-pvt-hct > button");
 
-        foreach (var bitPivot in bitPivots)
-        {
-            Assert.IsTrue(bitPivot?.GetAttribute("aria-label")?.Equals(ariaLabel));
-        }
+        Assert.AreEqual(ariaLabel, items[1].GetAttribute("aria-label"));
     }
 
     [TestMethod,

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/Pivot/BitPivotTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/Pivot/BitPivotTests.cs
@@ -72,6 +72,21 @@ public class BitPivotTests : BunitTestContext
         Assert.AreEqual(ariaLabel, items[1].GetAttribute("aria-label"));
     }
 
+    [TestMethod, DataRow("More options"), DataRow(null)]
+    public void BitPivotOverflowAriaLabelTest(string? overflowAriaLabel)
+    {
+        var com = RenderComponent<BitPivot>(parameters =>
+        {
+            parameters.Add(p => p.OverflowBehavior, BitPivotOverflowBehavior.Menu);
+            parameters.Add(p => p.OverflowAriaLabel, overflowAriaLabel);
+            parameters.AddChildContent<BitPivotItem>();
+        });
+
+        var overflowButton = com.Find(".bit-pvt-mor");
+
+        Assert.AreEqual(overflowAriaLabel ?? "More", overflowButton.GetAttribute("aria-label"));
+    }
+
     [TestMethod,
          DataRow(BitPivotPosition.Top),
          DataRow(BitPivotPosition.Bottom),


### PR DESCRIPTION
closes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pivot overflow support with **Menu**, **Slide**, and **Scroll** modes when tabs don’t fit.
  * Introduced new customization options for next/previous and overflow icons plus **configurable aria-labels**.
  * Added new demo showcasing overflow (including vertical and RTL variants).

* **Bug Fixes**
  * Improved overflow measurements and dynamic updates for more accurate start/end and overflow state.
  * Enhanced accessibility markup and keyboard-friendly overflow/menu behavior.

* **Tests**
  * Extended Pivot tests for slide overflow CSS mapping and new overflow button aria-label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->