### PR TITLE
Add mcp section to getting started page of the bit BlazorUI website (#12537)

### DIFF
--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Controllers/BitIconNamesController.cs
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Controllers/BitIconNamesController.cs
@@ -12,9 +12,9 @@ public partial class BitIconNamesController : AppControllerBase
     private static string[]? _allIconNames = null;
 
     [HttpGet]
-    [McpServerTool(Name = nameof(GetAllBitIconNames))]
+    [McpServerTool(Name = nameof(GetAllBitBlazorUIIconNames))]
     [Description("Gets all available BitIconName constant values.")]
-    public string[] GetAllBitIconNames()
+    public string[] GetAllBitBlazorUIIconNames()
     {
         return _allIconNames ??= [.. typeof(BitIconName)
             .GetFields(BindingFlags.Public | BindingFlags.Static)

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Controllers/ComponentDetailsController.cs
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Controllers/ComponentDetailsController.cs
@@ -23,9 +23,9 @@ public partial class ComponentDetailsController : AppControllerBase
                                                         .Where(type => typeof(BitComponentBase).IsAssignableFrom(type) && !type.IsAbstract))];
 
     [HttpGet]
-    [McpServerTool(Name = nameof(GetComponentParameters))]
+    [McpServerTool(Name = nameof(GetBitBlazorUIComponentParameters))]
     [Description("Gets the parameters of a specified component.")]
-    public async Task<ComponentParameterDetailsDto[]> GetComponentParameters(string componentName)
+    public async Task<ComponentParameterDetailsDto[]> GetBitBlazorUIComponentParameters(string componentName)
     {
         if (string.IsNullOrWhiteSpace(componentName))
             return [];
@@ -73,9 +73,9 @@ public partial class ComponentDetailsController : AppControllerBase
     }
 
     [HttpGet]
-    [McpServerTool(Name = nameof(GetComponentExamples))]
+    [McpServerTool(Name = nameof(GetBitBlazorUIComponentExamples))]
     [Description("Gets the examples of a specified component.")]
-    public async Task<string> GetComponentExamples(string componentName)
+    public async Task<string> GetBitBlazorUIComponentExamples(string componentName)
     {
         if (string.IsNullOrWhiteSpace(componentName))
             return "Component name is required.";

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Controllers/ComponentEnumsController.cs
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Controllers/ComponentEnumsController.cs
@@ -17,9 +17,9 @@ public partial class ComponentEnumsController : AppControllerBase
     private static readonly Type[] EnumTypes = [.. ComponentsAssemblies.SelectMany(asm => asm.GetExportedTypes().Where(t => t.IsEnum))];
 
     [HttpGet]
-    [McpServerTool(Name = nameof(GetEnumDetails))]
+    [McpServerTool(Name = nameof(GetBitBlazorUIEnumDetails))]
     [Description("Gets the details of a specified Bit.BlazorUI enum including its values and descriptions.")]
-    public async Task<EnumValueDetailsDto[]?> GetEnumDetails(string enumName)
+    public async Task<EnumValueDetailsDto[]?> GetBitBlazorUIEnumDetails(string enumName)
     {
         if (string.IsNullOrWhiteSpace(enumName))
             return null;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/GettingStartedPage.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/GettingStartedPage.razor
@@ -276,6 +276,80 @@
 
         <br />
 
+        <BitCard>
+            <BitText Typography="BitTypography.H4" Gutter>5. AI/MCP Integration</BitText>
+
+            <br />
+
+            <BitText Gutter>
+                bit BlazorUI now provides full <b>MCP support</b> so AI coding agents (GitHub Copilot, Cursor, Claude, Windsurf, etc.) can discover components, get accurate examples, and follow best practices automatically.
+            </BitText>
+
+            <br />
+
+            <BitText>
+                MCP endpoint:
+            </BitText>
+
+            <BitLink Href="https://blazorui.bitplatform.dev/mcp" Target="_blank">
+                https://blazorui.bitplatform.dev/mcp
+            </BitLink>
+
+            <br /><br />
+
+            <BitText Typography="BitTypography.H6" Gutter>
+                How to configure your AI agent / Copilot instructions
+            </BitText>
+
+            <BitText>
+                Add the following rules to your <b>agents.md</b>, <b>copilot-instructions.md</b>, <b>.cursor/rules</b>, or any equivalent agent configuration file:
+            </BitText>
+
+            <CodeBox Language="markdown">
+### bit BlazorUI
+
+- For all UI-related tasks in this Blazor project, you **MUST** use the bit BlazorUI MCP server.
+- Always start component discovery with the `GetBitBlazorUIComponentsList` tool.
+- For detailed API, parameters, and usage examples, call `GetBitBlazorUIComponentExamples`.
+- Prefer `Bit*` components over plain HTML/CSS or other UI libraries.
+            </CodeBox>
+
+            <br />
+
+            <BitText Gutter>
+                <b>Tip</b>: Many agents (especially Cursor + Claude) will automatically detect and use the MCP server when you add the above instructions.
+
+                <br />
+                <br />
+
+                <b>.vscode/mcp.json</b>
+                <CodeBox Language="json">{
+    "servers": {
+        "bitBlazorUI": {
+            "type": "http",
+            "url": "https://blazorui.bitplatform.dev/mcp"
+        }
+    }
+}</CodeBox>
+
+                <b>mcp.json</b>
+                <CodeBox Language="json">{
+  "mcpServers": {
+    "bitBlazorUI": {
+      "type": "http",
+      "url": "https://blazorui.bitplatform.dev/mcp",
+      "tools": [
+        "*"
+      ]
+    }
+  }
+}</CodeBox>
+            </BitText>
+
+        </BitCard>
+
+        <br />
+
         <FeedbackSection Url="GettingStartedPage.razor" />
     </BitParams>
 </section>


### PR DESCRIPTION
closes #12537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **AI/MCP Integration** section to the Getting Started page with the MCP endpoint, setup guidance, and example configuration snippets for common tools.
  * Updated exposed component and icon lookup endpoints with clearer, more consistent names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->