### PR TITLE
Enable health check endpoint across all environments (#12545)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -787,10 +787,10 @@ public static partial class Program
         configuration.Bind(appSettings);
 
         var healthChecksBuilder = builder.AddDefaultHealthChecks()
-            .AddDbContextCheck<AppDbContext>(tags: ["live"])
-            .AddHangfire(setup => setup.MinimumAvailableServers = 1, tags: ["live"])
-            .AddCheck<UserProfileImagesStorageHealthCheck>("userProfileImages", tags: ["live"])
-            .AddCheck<TwilioHealthCheck>("sms", tags: ["live"]);
+            .AddDbContextCheck<AppDbContext>()
+            .AddHangfire(setup => setup.MinimumAvailableServers = 1)
+            .AddCheck<UserProfileImagesStorageHealthCheck>("userProfileImages")
+            .AddCheck<TwilioHealthCheck>("sms");
 
         //#if (cloudflare == true)
         // Cloudflare Cache Purge API
@@ -800,7 +800,7 @@ public static partial class Program
             healthChecksBuilder.AddUrlGroup(
                 new Uri($"https://api.cloudflare.com/client/v4/zones/{appSettings.Cloudflare.ZoneId}"),
                 name: "cloudflare",
-                tags: ["ready"],
+                tags: [],
                 configureClient: (_, client) =>
                 {
                     client.Timeout = TimeSpan.FromSeconds(10);
@@ -816,7 +816,7 @@ public static partial class Program
             healthChecksBuilder.AddUrlGroup(
                 new Uri($"{keycloakBaseUrl.TrimEnd('/')}/realms/{realm}/.well-known/openid-configuration"),
                 name: "keycloakIdentity",
-                tags: ["ready"],
+                tags: [],
                 configureClient: (_, client) => client.Timeout = TimeSpan.FromSeconds(10));
         }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
@@ -12,30 +12,33 @@ public static class WebApplicationExtensions
 {
     public static WebApplication MapAppHealthChecks(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        var healthChecks = app.MapGroup("");
+
+        healthChecks
+            .CacheOutput("HealthChecks");
+
+        // All health checks must pass for app to be
+        // considered ready to accept traffic after starting
+        healthChecks.MapHealthChecks("/health", new()
+        {
+            Predicate = _ => true
+        });
+
+        // Only health checks tagged with the "live" tag
+        // must pass for app to be considered alive
+        healthChecks.MapHealthChecks("/alive", new()
+        {
+            Predicate = static res => res.Tags.Contains("live")
+        });
+
         if (app.Environment.IsDevelopment())
         {
-            var healthChecks = app.MapGroup("");
-
-            healthChecks
-                .CacheOutput("HealthChecks");
-
-            // All health checks must pass for app to be
-            // considered ready to accept traffic after starting
-            healthChecks.MapHealthChecks("/health");
-
-            // Only health checks tagged with the "live" tag
-            // must pass for app to be considered alive
-            healthChecks.MapHealthChecks("/alive", new()
-            {
-                Predicate = static r => r.Tags.Contains("live")
-            });
-
+            // This endpoint returns more details and must be protected by authentication and authorization in production
             healthChecks.MapHealthChecks("/healthz", new HealthCheckOptions
             {
                 Predicate = _ => true,
-                ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                AllowCachingResponses = true,
+                ResponseWriter = app.Environment.IsDevelopment() ? UIResponseWriter.WriteHealthCheckUIResponse : UIResponseWriter.WriteHealthCheckUIResponseNoExceptionDetails
             });
         }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
@@ -34,10 +34,12 @@ public static class WebApplicationExtensions
         if (app.Environment.IsDevelopment())
         {
             // This endpoint returns more details and must be protected by authentication and authorization in production
+            // Replace outer `IsDevelopment` check with a more robust check for production readiness before exposing this endpoint publicly
             healthChecks.MapHealthChecks("/healthz", new HealthCheckOptions
             {
                 Predicate = _ => true,
                 AllowCachingResponses = true,
+                // The following `IsDevelopment` check must remain in place to avoid exposing sensitive information in production
                 ResponseWriter = app.Environment.IsDevelopment() ? UIResponseWriter.WriteHealthCheckUIResponse : UIResponseWriter.WriteHealthCheckUIResponseNoExceptionDetails
             });
         }


### PR DESCRIPTION
closes #12545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health check endpoints (`/health`, `/alive`, `/healthz`) are now available in all environments, not just development.

* **Bug Fixes**
  * Updated which checks appear under liveness vs readiness based on updated health-check tagging.
  * Standardized health check response caching behavior for consistent performance.
  * The health check UI now adapts to the environment, showing more detailed output only in development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->