### PR TITLE
Fix parsing input value issues in BitPhoneInput (#12549)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
@@ -592,14 +592,26 @@ public partial class BitPhoneInput : BitTextInputBase<string?>
         // country unchanged and the whole input as the local number.
         var (country, number) = ParseFullNumber(e.Value?.ToString());
 
-        await AssignNumber(number);
-
         // Only switch the country when parsing actually resolved a different one. AssignCountry
         // returns false for a one-way controlled Country (set without CountryChanged); in that
         // case the selection can't change, so OnCountryChange must not fire (see HandleOnCountrySelect).
-        if (country is not null && country.Iso2 != Country?.Iso2 && await AssignCountry(country))
+        if (country is not null && country.Iso2 != Country?.Iso2)
         {
-            await OnCountryChange.InvokeAsync(country);
+            // 'number' is the local part stripped of the parsed country's dialing code, so it is
+            // only valid once that country is actually adopted. Defer the number assignment until
+            // the country switch succeeds; otherwise a one-way controlled Country would keep the
+            // old country while Number held a local part parsed for a different one, leaving the
+            // country and the local part out of sync (and recomposing into a wrong full value).
+            if (await AssignCountry(country))
+            {
+                await AssignNumber(number);
+
+                await OnCountryChange.InvokeAsync(country);
+            }
+        }
+        else
+        {
+            await AssignNumber(number);
         }
 
         await UpdateValueFromParts();

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/PhoneInput/BitPhoneInput.razor.cs
@@ -586,7 +586,21 @@ public partial class BitPhoneInput : BitTextInputBase<string?>
     {
         if (IsEnabled is false || ReadOnly) return;
 
-        await AssignNumber(e.Value?.ToString());
+        // Parse what the user typed so a full number entered with an international prefix
+        // ('+' or its "00" equivalent) selects the matching country and keeps only the local
+        // digits in the number input. Without such a prefix ParseFullNumber returns the current
+        // country unchanged and the whole input as the local number.
+        var (country, number) = ParseFullNumber(e.Value?.ToString());
+
+        await AssignNumber(number);
+
+        // Only switch the country when parsing actually resolved a different one. AssignCountry
+        // returns false for a one-way controlled Country (set without CountryChanged); in that
+        // case the selection can't change, so OnCountryChange must not fire (see HandleOnCountrySelect).
+        if (country is not null && country.Iso2 != Country?.Iso2 && await AssignCountry(country))
+        {
+            await OnCountryChange.InvokeAsync(country);
+        }
 
         await UpdateValueFromParts();
     }


### PR DESCRIPTION
closes #12549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone number input now recognizes full international numbers when the value starts with `+` or `00`, and separates the local number from the detected country.
* **Bug Fixes**
  * Country detection is now applied only when it actually differs from the current selection, preventing unnecessary country updates.
  * The stored phone number now reflects the local digits rather than keeping the entire raw international string in the number field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->