### PR TITLE
Add missing Butil docs to Platform website (#12561)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil04CryptoPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil04CryptoPage.razor
@@ -34,7 +34,7 @@
             <br />
             <b>Encrypt</b>: <br />
             The Encrypt method of the Crypto interface that encrypts data
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -59,7 +59,7 @@
 
             <b>Decrypt</b>: <br />
             The Decrypt method of the Crypto interface that decrypts data
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil05WebAuthnPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil05WebAuthnPage.razor
@@ -45,7 +45,7 @@
             <br />
             <b>CreateCredential</b>: <br />
             Creates a new credential using the provided options.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -72,7 +72,7 @@
 
             <b>GetCredential</b>: <br />
             Gets a credential using the provided options.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil06ClipboardPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil06ClipboardPage.razor
@@ -34,7 +34,7 @@
             <b>ReadText</b>: <br />
             Requests text from the system clipboard, returning a Promise that is fulfilled with
             a string containing the clipboard's text once it's available
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -56,7 +56,7 @@
             <b>WriteText</b>: <br />
             Requests text from the system clipboard, returning a Promise that is fulfilled with
             a string containing the clipboard's text once it's available
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -77,7 +77,7 @@
             <b>Read</b>: <br />
             Requests arbitrary data (such as images) from the clipboard, returning a Promise that
             resolves with an array of ClipboardItem objects containing the clipboard's contents
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/read" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/read" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -105,7 +105,7 @@
             <b>Write</b>: <br />
             Writes arbitrary data to the system clipboard, returning a Promise
             that resolves when the operation completes
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil08ConsolePage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil08ConsolePage.razor
@@ -35,7 +35,7 @@
             <br />
             <b>Assert</b>: <br />
             Log a message and stack trace to console if the first argument is false
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/assert_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/assert_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -59,7 +59,7 @@
 
             <b>Count</b>: <br />
             Log the number of times this line has been called with the given label
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/count_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/count_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -83,7 +83,7 @@
 
             <b>CountReset</b>: <br />
             Resets the value of the counter with the given label
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/countreset_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/countreset_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -107,7 +107,7 @@
 
             <b>Debug</b>: <br />
             Outputs a message to the console with the log level debug
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/debug_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/debug_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -131,7 +131,7 @@
 
             <b>Dir</b>: <br />
             Displays an interactive listing of the properties of a specified JavaScript object
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/dir_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/dir_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -155,7 +155,7 @@
 
             <b>Dirxml</b>: <br />
             Displays an XML/HTML Element representation of the specified object if possible or the JavaScript Object view if it is not possible
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/dirxml_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/dirxml_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -179,7 +179,7 @@
 
             <b>Error</b>: <br />
             Outputs an error message. You may use string substitution and additional arguments with this method
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/error_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/error_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -203,7 +203,7 @@
 
             <b>Group</b>: <br />
             Creates a new inline group, indenting all following output by another level. To move back out a level, call console.groupEnd()
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/group_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/group_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -225,7 +225,7 @@
 
             <b>GroupCollapsed</b>: <br />
             Creates a new inline group, indenting all following output by another level. However, unlike console.group() this starts with the inline group collapsed requiring the use of a disclosure button to expand it. To move back out a level, call console.groupEnd()
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/groupcollapsed_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/groupcollapsed_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -247,7 +247,7 @@
 
             <b>GroupEnd</b>: <br />
             Exits the current inline group
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/groupend_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/groupend_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -269,7 +269,7 @@
 
             <b>Info</b>: <br />
             Informative logging of information. You may use string substitution and additional arguments with this method
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/info_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/info_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -293,7 +293,7 @@
 
             <b>Log</b>: <br />
             For general output of logging information. You may use string substitution and additional arguments with this method
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/log_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/log_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -317,7 +317,7 @@
 
             <b>Warn</b>: <br />
             Outputs a warning message
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/warn_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/warn_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -341,7 +341,7 @@
 
             <b>Table</b>: <br />
             Displays tabular data as a table
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/table_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/table_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -365,7 +365,7 @@
 
             <b>Profile</b>: <br />
             Starts the browser's built-in profiler (for example, the Firefox performance tool). You can specify an optional name for the profile
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/profile_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/profile_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -389,7 +389,7 @@
 
             <b>ProfileEnd</b>: <br />
             Stops the profiler. You can see the resulting profile in the browser's performance tool (for example, the Firefox performance tool)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/profileend_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/profileend_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -413,7 +413,7 @@
 
             <b>Time</b>: <br />
             Starts a timer with a name specified as an input parameter. Up to 10,000 simultaneous timers can run on a given page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/time_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/time_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -437,7 +437,7 @@
 
             <b>TimeLog</b>: <br />
             Logs the value of the specified timer to the console
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/timelog_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/timelog_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -461,7 +461,7 @@
 
             <b>TimeEnd</b>: <br />
             Stops the specified timer and logs the elapsed time in milliseconds since it started
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/timeend_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/timeend_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -485,7 +485,7 @@
 
             <b>TimeStamp</b>: <br />
             Adds a marker to the browser performance tool's timeline
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/timestamp_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/timestamp_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -509,7 +509,7 @@
 
             <b>Trace</b>: <br />
             Outputs a stack trace
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/trace_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/trace_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -533,7 +533,7 @@
 
             <b>Clear</b>: <br />
             Clear the console
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/clear_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/console/clear_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil09NotificationPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil09NotificationPage.razor
@@ -55,7 +55,7 @@
 
             <b>GetPermission</b>: <br />
             Gets the current permission of the Notification API.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/permission_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/permission_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -77,7 +77,7 @@
 
             <b>RequestPermission</b>: <br />
             Requests permission from the user for the current origin to display notifications.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -99,7 +99,7 @@
 
             <b>Show</b>: <br />
             Requests a native notification to show to the user.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br/>
             <b>Note</b>: The Notification api has some limitation on Android and for it to work properly a
             Service Worker needs to be registered first.

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil10StoragePage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil10StoragePage.razor
@@ -36,7 +36,7 @@
             <br />
             <b>GetLength</b>: <br />
             Returns an integer representing the number of data items stored in the Storage object
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/length" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/length" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -61,7 +61,7 @@
 
             <b>GetKey</b>: <br />
             When passed a number n, this method will return the name of the nth key in the storage
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/key" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/key" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -88,7 +88,7 @@
 
             <b>GetItem</b>: <br />
             When passed a key name, will return that key's value
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -118,7 +118,7 @@
 
             <b>SetItem</b>: <br />
             When passed a key name and value, will add that key to the storage, or update that key's value if it already exists
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -143,7 +143,7 @@
 
             <b>RemoveItem</b>: <br />
             When passed a key name, will remove that key from the storage
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/removeItem" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/removeItem" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -168,7 +168,7 @@
 
             <b>Clear</b>: <br />
             When invoked, will empty all keys out of the storage
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/clear" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage/clear" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil11CookiePage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil11CookiePage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>Set</b>, <b>Get</b>: <br />
             Gets/Sets a cookie by providing the cookie name
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil12HistoryPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil12HistoryPage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>GetLength</b>: <br />
             Returns an Integer representing the number of elements in the session history, including the currently loaded page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/length" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/length" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -56,7 +56,7 @@
 
             <b>SetScrollRestoration</b>, <b>GetScrollRestoration</b>: <br />
             Gets/Sets default scroll restoration behavior on history navigation. This property can be either auto or manual
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/scrollRestoration" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/scrollRestoration" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -77,13 +77,13 @@
             <br /><br />
 
             <b>GetState</b>: Returns an any value representing the state at the top of the history stack
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/state" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/state" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
 
             <b>GoBack</b>: <br />
             This asynchronous method goes to the previous page in session history, the same action as when the user clicks the browser's Back button.
             Calling this method to go back beyond the first page in the session history has no effect and doesn't raise an exception
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/back" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/back" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -104,7 +104,7 @@
             <b>GoForward</b>: <br />
             This asynchronous method goes to the next page in session history, the same action as when the user clicks the browser's Forward button.
             Calling this method to go forward beyond the most recent page in the session history has no effect and doesn't raise an exception
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/forward" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/forward" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -125,7 +125,7 @@
             <b>Go</b>: <br />
             Asynchronously loads a page from the session history, identified by its relative location to the current page, for example -1 for the previous page or 1 for the next page.
             Calling this method without parameters or a value of 0 reloads the current page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/go" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/go" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -147,7 +147,7 @@
 
             <b>PushState</b>: <br />
             Pushes the given data onto the session history stack with the specified title (and, if provided, URL)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/pushState" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/pushState" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -169,7 +169,7 @@
 
             <b>ReplaceState</b>: <br />
             Updates the most recent entry on the history stack to have the specified data, title, and, if provided, URL
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -191,7 +191,7 @@
 
             <b>AddPopState</b>, <b>RemovePopState</b>: <br />
             The popstate event of the Window interface is fired when the active history entry changes while the user navigates the session history
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil13ElementPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil13ElementPage.razor
@@ -36,7 +36,7 @@
             <br />
             <b>GetAttribute</b>: <br />
             Retrieves the value of the named attribute from the current node and returns it as a string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -66,7 +66,7 @@
 
             <b>GetAttributeNames</b>: <br />
             Returns an array of attribute names from the current element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -94,7 +94,7 @@
 
             <b>GetBoundingClientRect</b>: <br />
             Returns the size of an element and its position relative to the viewport
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -122,7 +122,7 @@
 
             <b>HasAttribute</b>: <br />
             Returns a boolean value indicating if the element has the specified attribute or not
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttribute" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttribute" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -152,7 +152,7 @@
 
             <b>HasAttributes</b>: <br />
             Returns a boolean value indicating if the element has one or more HTML attributes present
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttributes" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttributes" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -180,22 +180,22 @@
 
             <b>SetPointerCapture</b>: <br />
             Designates a specific element as the capture target of future pointer events
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>HasPointerCapture</b>: <br />
             Indicates whether the element on which it is invoked has pointer capture for the pointer identified by the given pointer ID
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>ReleasePointerCapture</b>: <br />
             Releases (stops) pointer capture that was previously set for a specific pointer event
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>RequestPointerLock</b>: <br />
             Allows to asynchronously ask for the pointer to be locked on the given element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -222,7 +222,7 @@
 
             <b>RequestFullScreen</b>: <br />
             Asynchronously asks the browser to make the element fullscreen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -247,7 +247,7 @@
 
             <b>Matches</b>: <br />
             Returns a boolean value indicating whether or not the element would be selected by the specified selector string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/matches" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/matches" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -278,7 +278,7 @@
 
             <b>Scroll</b>: <br />
             Scrolls to a particular set of coordinates inside a given element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -319,7 +319,7 @@
 
             <b>ScrollBy</b>: <br />
             Scrolls an element by the given amount
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollBy" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -360,7 +360,7 @@
 
             <b>ScrollIntoView</b>: <br />
             Scrolls the page until the element gets into the view
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -411,7 +411,7 @@
 
             <b>RemoveAttribute</b>: <br />
             Removes the named attribute from the current node
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -438,7 +438,7 @@
 
             <b>SetAttribute</b>: <br />
             Sets the value of a named attribute of the current node
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -467,7 +467,7 @@
 
             <b>ToggleAttribute</b>: <br />
             Toggles a boolean attribute, removing it if it is present and adding it if it is not present, on the specified element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -496,7 +496,7 @@
 
             <b>SetAccessKey</b>, <b>GetAccessKey</b>: <br />
             Gets/Sets a string representing the access key assigned to the element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -528,7 +528,7 @@
 
             <b>SetClassName</b>, <b>GetClassName</b>: <br />
             Gets/Sets a string representing the class of the element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/className" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/className" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -560,7 +560,7 @@
 
             <b>GetClientHeight</b>: <br />
             Returns a number representing the inner height of the element in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -588,7 +588,7 @@
 
             <b>GetClientLeft</b>: <br />
             Returns a number representing the width of the left border of the element in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -616,7 +616,7 @@
 
             <b>GetClientTop</b>: <br />
             Returns a number representing the width of the top border of the element in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -644,7 +644,7 @@
 
             <b>GetClientWidth</b>: <br />
             Returns a number representing the inner width of the element in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -672,7 +672,7 @@
 
             <b>SetId</b>, <b>GetId</b>: <br />
             Gets/Sets a string representing the id of the element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/id" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/id" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -704,7 +704,7 @@
 
             <b>SetInnerHTML</b>, <b>GetInnerHTML</b>: <br />
             Gets/Sets a string representing the markup of the element's content
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -736,7 +736,7 @@
 
             <b>SetOuterHtml</b>, <b>GetOuterHtml</b>: <br />
             Gets/Sets a string representing the markup of the element including its content. When used as a setter, replaces the element with nodes parsed from the given string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -764,7 +764,7 @@
 
             <b>GetScrollHeight</b>: <br />
             Returns a number representing the scroll view height of an element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -796,7 +796,7 @@
 
             <b>GetScrollLeft</b>: <br />
             A number representing the left scroll offset of the element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -828,7 +828,7 @@
 
             <b>GetScrollTop</b>: <br />
             A number representing number of pixels the top of the element is scrolled vertically
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -860,7 +860,7 @@
 
             <b>GetScrollWidth</b>: <br />
             Returns a number representing the scroll view width of the element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -892,7 +892,7 @@
 
             <b>GetTagName</b>: <br />
             Returns a string with the name of the tag for the given element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -920,7 +920,7 @@
 
             <b>IsContentEditable</b>: <br />
             Returns a boolean value indicating whether or not the content of the element can be edited
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -948,7 +948,7 @@
 
             <b>SetContentEditable</b>, <b>GetContentEditable</b>: <br />
             Gets/Sets the contentEditable property, which specifies whether or not the element is editable
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contentEditable" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contentEditable" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -987,7 +987,7 @@
 
             <b>SetDir</b>, <b>GetDir</b>: <br />
             Gets/Sets the text writing directionality of the content of the current element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dir" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dir" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1026,7 +1026,7 @@
 
             <b>SetEnterKeyHint</b>, <b>GetEnterKeyHint</b>: <br />
             Gets/Sets the enterKeyHint property, which is an enumerated property defining what action label (or icon) to present for the enter key on virtual keyboards
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/enterKeyHint" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/enterKeyHint" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1068,12 +1068,12 @@
 
             <b>SetHidden</b>, <b>GetHidden</b>: <br />
             Gets/Sets the hidden property, which reflects the value of the element's hidden attribute
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/hidden" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/hidden" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>SetInert</b>, <b>GetInert</b>: <br />
             Gets/Sets the inert property, which reflects the value of the element's inert attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1109,7 +1109,7 @@
 
             <b>SetInnerText</b>, <b>GetInnerText</b>: <br />
             Gets/Sets the innerText property, which represents the rendered text content of a node and its descendants
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1141,7 +1141,7 @@
 
             <b>SetInputMode</b>, <b>GetInputMode</b>: <br />
             Gets/Sets the inputMode property, which reflects the value of the element's inputmode attribute
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inputMode" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inputMode" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1184,7 +1184,7 @@
 
             <b>SetTabIndex</b>, <b>GetTabIndex</b>: <br />
             Gets/Sets a number representing the position of the element in the tabbing order
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1216,7 +1216,7 @@
 
             <b>GetOffsetHeight</b>: <br />
             Returns the height of an element, including vertical padding and borders in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1244,7 +1244,7 @@
 
             <b>GetOffsetLeft</b>: <br />
             Returns the number of pixels that the upper left corner of the current element is offset to the left within the offsetParent node
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1272,7 +1272,7 @@
 
             <b>GetOffsetTop</b>: <br />
             Returns the distance from the outer border of the current element (including its margin) to the top padding edge of the offsetParent, the closest positioned ancestor element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1300,7 +1300,7 @@
 
             <b>GetOffsetWidth</b>: <br />
             The layout width of an element in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1328,7 +1328,7 @@
 
             <b>Blur</b>: <br />
             Removes keyboard focus from the currently focused element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -1352,7 +1352,7 @@
 
             <b>Remove</b>: <br />
             Removes the element from the children list of its parent
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/remove" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/remove" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil14WindowPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil14WindowPage.razor
@@ -37,17 +37,17 @@
             contained document, and associated resources are about to be unloaded. The main use case for this event is to
             trigger a browser-generated confirmation dialog that asks users to confirm if they really want to leave the page
             when they try to close or reload it, or navigate somewhere else. This is intended to help prevent loss of unsaved data
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>AddEventListener</b>, <b>RemoveEventListener</b>: <br />
             Sets up a function that will be called whenever the specified event is delivered to the window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetInnerHeight</b>: <br />
             Gets the height of the content area of the browser window in px including, if rendered, the horizontal scrollbar
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -70,7 +70,7 @@
 
             <b>GetInnerWidth</b>: <br />
             Gets the width of the content area of the browser window in px including, if rendered, the vertical scrollbar
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -93,22 +93,22 @@
 
             <b>IsSecureContext</b>: <br />
             Returns a boolean indicating whether the current context is secure (true) or not (false)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/isSecureContext" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/isSecureContext" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetLocationBar</b>: <br />
             Returns the locationbar object. For privacy and interoperability reasons, the value of the visible property is now false if this Window is a popup, and true otherwise
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/locationbar" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/locationbar" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>SetName</b>, <b>GetName</b>: <br />
             Gets/Sets the name of the window's browsing context
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/name" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/name" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetOrigin</b>: <br />
             Returns the global object's origin, serialized as a string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/origin" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/origin" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -131,7 +131,7 @@
 
             <b>GetOuterHeight</b>: <br />
             Gets the height of the outside of the browser window in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -154,7 +154,7 @@
 
             <b>GetOuterWidth</b>: <br />
             Gets the width of the outside of the browser window in px
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/outerWidth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/outerWidth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -177,27 +177,27 @@
 
             <b>GetScreenX</b>: <br />
             Returns the horizontal distance in px from the left border of the user's browser viewport to the left side of the screen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/screenX" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/screenX" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetScreenY</b>: <br />
             Returns the vertical distance in px from the top border of the user's browser viewport to the top side of the screen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/screenY" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/screenY" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetScrollX</b>: <br />
             Returns the number of pixels that the document has already been scrolled horizontally
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetScrollY</b>: <br />
             Returns the number of pixels that the document has already been scrolled vertically
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Btoa</b>: <br />
             Creates a base-64 encoded ASCII string from a string of binary data
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/btoa" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/btoa" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -222,7 +222,7 @@
 
             <b>Atob</b>: <br />
             Decodes a string of data which has been encoded using base-64 encoding
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/atob" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/atob" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -247,7 +247,7 @@
 
             <b>Alert</b>: <br />
             Displays an alert dialog
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/alert" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/alert" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -267,17 +267,17 @@
 
             <b>Blur</b>: <br />
             Sets focus away from the window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/blur" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/blur" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Close</b>: <br />
             Closes the current window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/close" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/close" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Confirm</b>: <br />
             Displays a dialog with a message that the user needs to respond to
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -297,52 +297,52 @@
 
             <b>Find</b>: <br />
             Searches for a given string in a window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/find" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/find" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Focus</b>: <br />
             Sets focus on the current window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/focus" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/focus" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetSelection</b>: <br />
             Returns the selection text representing the selected item(s)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>MatchMedia</b>: <br />
             Returns a MediaQueryList object representing the specified media query string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Open</b>: <br />
             Opens a new window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/open" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/open" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Print</b>: <br />
             Opens the Print Dialog to print the current document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/print" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/print" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Prompt</b>: <br />
             Returns the text entered by the user in a prompt dialog
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Scroll</b>: <br />
             Scrolls the window to a particular place in the document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>ScrollBy</b>: <br />
             Scrolls the document in the window by the given amount
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollBy" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>Stop</b>: <br />
             This method stops window loading
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/stop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/stop" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil15DocumentPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil15DocumentPage.razor
@@ -34,32 +34,32 @@
             <br />
             <b>AddEventListener</b>, <b>RemoveEventListener</b>: <br />
             Sets up a function that will be called whenever the specified event is delivered to the document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetCharacterSet</b>: <br />
             Returns the character set being used by the document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/characterSet" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/characterSet" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetCompatMode</b>: <br />
             Indicates whether the document is rendered in quirks or strict mode
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/compatMode" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/compatMode" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetContentType</b>: <br />
             Returns the Content-Type from the MIME Header of the current document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/contentType" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/contentType" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetDocumentURI</b>: <br />
             Returns the document location as a string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/documentURI" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/documentURI" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>SetDesignMode</b>, <b>GetDesignMode</b>: <br />
             Gets/Sets ability to edit the whole document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/designMode" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/designMode" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -81,32 +81,32 @@
 
             <b>SetDir</b>, <b>GetDir</b>: <br />
             Gets/Sets directionality (Rtl/Ltr) of the document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/dir" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/dir" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>SetTitle</b>, <b>GetTitle</b>: <br />
             Gets/Sets the title of the current document
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/title" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/title" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetReferrer</b>: <br />
             Returns the URI of the page that linked to this page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>GetUrl</b>: <br />
             Returns the document location as a string
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/URL" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/URL" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>ExitFullscreen</b>: <br />
             Stops document's fullscreen element from being displayed fullscreen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>ExitPointerLock</b>: <br />
             Release the pointer lock
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/exitPointerLock" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/exitPointerLock" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil16NavigatorPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil16NavigatorPage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>GetDeviceMemory</b>: <br />
             Returns the amount of device memory in gigabytes. This value is an approximation given by rounding to the nearest power of 2 and dividing that number by 1024
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -56,7 +56,7 @@
 
             <b>GetHardwareConcurrency</b>: <br />
             Returns the number of logical processor cores available
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -79,7 +79,7 @@
 
             <b>GetLanguage</b>: <br />
             Returns a string representing the preferred language of the user, usually the language of the browser UI. The null value is returned when this is unknown
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -102,7 +102,7 @@
 
             <b>GetLanguages</b>: <br />
             Returns an array of strings representing the languages known to the user, by order of preference
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -125,7 +125,7 @@
 
             <b>GetMaxTouchPoints</b>: <br />
             Returns the maximum number of simultaneous touch contact points are supported by the current device
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -148,7 +148,7 @@
 
             <b>IsOnLine</b>: <br />
             Returns a boolean value indicating whether the browser is working online
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -171,7 +171,7 @@
 
             <b>IsPdfViewerEnabled</b>: <br />
             Returns true if the browser can display PDF files inline when navigating to them, and false otherwise
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/pdfViewerEnabled" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/pdfViewerEnabled" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -194,7 +194,7 @@
 
             <b>GetUserAgent</b>: <br />
             Returns the user agent string for the current browser
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -217,12 +217,12 @@
 
             <b>IsWebDriver</b>: <br />
             Indicates whether the user agent is controlled by automation
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>CanShare</b>: <br />
             Returns true if a call to navigator.Share() would succeed
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -245,7 +245,7 @@
 
             <b>ClearAppBadge</b>: <br />
             Clears a badge on the current app's icon and returns a Promise that resolves with undefined
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clearAppBadge" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clearAppBadge" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -265,7 +265,7 @@
 
             <b>SendBeacon</b>: <br />
             Used to asynchronously transfer a small amount of data using HTTP from the User Agent to a web server
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -285,7 +285,7 @@
 
             <b>SetAppBadge</b>: <br />
             Sets a badge on the icon associated with this app and returns a Promise that resolves with undefined
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/setAppBadge" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/setAppBadge" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -305,7 +305,7 @@
 
             <b>Share</b>: <br />
             Invokes the native sharing mechanism of the current platform
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -331,7 +331,7 @@
 
             <b>Vibrate</b>: <br />
             Causes vibration on devices with support for it. Does nothing if vibration support isn't available
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil17LocationPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil17LocationPage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>SetHref</b>, <b>GetHref</b>: <br />
             Gets/Sets the href of the location and then the associated document navigates to the new page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/href" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/href" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -60,7 +60,7 @@
 
             <b>SetProtocol</b>, <b>GetProtocol</b>: <br />
             Gets/Sets a string containing the protocol scheme of the URL, including the final ':'
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -87,7 +87,7 @@
 
             <b>SetHost</b>, <b>GetHost</b>: <br />
             Gets/Sets a string containing the host, that is the hostname, a ':', and the port of the URL
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/host" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/host" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -114,7 +114,7 @@
 
             <b>SetHostname</b>, <b>GetHostname</b>: <br />
             Gets/Sets the hostname of the location and then the associated document navigates to the new page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hostname" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hostname" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -141,7 +141,7 @@
 
             <b>SetPort</b>, <b>GetPort</b>: <br />
             Gets/Sets the port of the location and then the associated document navigates to the new page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/port" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/port" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -168,7 +168,7 @@
 
             <b>SetPathname</b>, <b>GetPathname</b>: <br />
             Gets/Sets a string containing an initial '/' followed by the path of the URL, not including the query string or fragment
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -195,7 +195,7 @@
 
             <b>SetSearch</b>, <b>GetSearch</b>: <br />
             Gets/Sets a string containing a '#' followed by the fragment identifier of the URL
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -222,7 +222,7 @@
 
             <b>SetHash</b>, <b>GetHash</b>: <br />
             Gets/Sets the hash of the location and then the associated document navigates to the new page
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hash" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/hash" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -249,7 +249,7 @@
 
             <b>GetOrigin</b>: <br />
             Returns a string containing the canonical form of the origin of the specific location
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/origin" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/origin" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -272,7 +272,7 @@
 
             <b>Assign</b>: <br />
             Loads the resource at the URL provided in parameter
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/assign" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/assign" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -294,7 +294,7 @@
 
             <b>Reload</b>: <br />
             Reloads the current URL, like the Refresh button
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/reload" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/reload" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -314,7 +314,7 @@
 
             <b>Replace</b>: <br />
             Replaces the current resource with the one at the provided URL (redirects to the provided URL)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/replace" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Location/replace" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil18ScreenPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil18ScreenPage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>GetAvailableHeight</b>: <br />
             Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -56,7 +56,7 @@
 
             <b>GetAvailableWidth</b>: <br />
             Returns the amount of horizontal space in pixels available to the window
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availWidth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/availWidth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -79,7 +79,7 @@
 
             <b>GetColorDepth</b>: <br />
             Returns the color depth of the screen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/colorDepth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/colorDepth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -102,7 +102,7 @@
 
             <b>GetHeight</b>: <br />
             Returns the height of the screen in pixels
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/height" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/height" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -125,7 +125,7 @@
 
             <b>IsExtended</b>: <br />
             Returns true if the user's device has multiple screens, and false if not
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/isExtended" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/isExtended" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -148,7 +148,7 @@
 
             <b>GetPixelDepth</b>: <br />
             Gets the bit depth of the screen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/pixelDepth" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/pixelDepth" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -171,7 +171,7 @@
 
             <b>GetWidth</b>: <br />
             Returns the width of the screen
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/width" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/width" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -194,7 +194,7 @@
 
             <b>AddChange</b>, <b>RemoveChange</b>: <br />
             Fired on a specific screen when it changes in some way - width or height, available width or height, color depth, or orientation
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/change_event" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen/change_event" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil19VisualViewportPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil19VisualViewportPage.razor
@@ -34,7 +34,7 @@
             <b>GetOffsetLeft</b>: <br />
             Returns the offset of the left edge of the visual viewport from the left edge of
             the layout viewport in CSS pixels, or 0 if current document is not fully active.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/offsetLeft" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/offsetLeft" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -58,7 +58,7 @@
             <b>GetOffsetTop</b>: <br />
             Returns the offset of the top edge of the visual viewport from the top edge of
             the layout viewport in CSS pixels, or 0 if current document is not fully active.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/offsetTop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/offsetTop" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -82,7 +82,7 @@
             <b>GetPageLeft</b>: <br />
             Returns the x coordinate of the left edge of the visual viewport relative to the
             initial containing block origin, in CSS pixels, or 0 if current document is not fully active.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/pageLeft" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/pageLeft" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -106,7 +106,7 @@
             <b>GetPageTop</b>: <br />
             Returns the y coordinate of the top edge of the visual viewport relative to the
             initial containing block origin, in CSS pixels, or 0 if current document is not fully active.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/pageTop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/pageTop" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -129,7 +129,7 @@
 
             <b>GetWidth</b>: <br />
             Returns the width of the visual viewport, in CSS pixels, or 0 if current document is not fully active.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/width" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/width" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -152,7 +152,7 @@
 
             <b>GetHeight</b>: <br />
             Returns the height of the visual viewport, in CSS pixels, or 0 if current document is not fully active.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/height" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/height" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -176,7 +176,7 @@
             <b>GetScale</b>: <br />
             Returns the pinch-zoom scaling factor applied to the visual viewport, or 0 if current
             document is not fully active, or 1 if there is no output device.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/scale" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/scale" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -199,12 +199,12 @@
 
             <b>AddResize</b>, <b>RemoveResize</b>: <br />
             Fired when the visual viewport is resized.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/resize_event" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/resize_event" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>AddScroll</b>, <b>RemoveScroll</b>: <br />
             Fired when the visual viewport is scrolled.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/scroll_event" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/scroll_event" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil20ScreenOrientationPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil20ScreenOrientationPage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>GetOrientationType</b>: <br />
             Returns the document's current orientation type.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/type" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/type" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -56,7 +56,7 @@
 
             <b>GetAngle</b>: <br />
             Returns the document's current orientation angle.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/angle" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/angle" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -80,18 +80,18 @@
             <b>Lock</b>: <br />
             Locks the orientation of the containing document to the specified orientation.
             Typically orientation locking is only enabled on mobile devices, and when the browser context is full screen.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
             
             <b>Unlock</b>: <br />
             Unlocks the orientation of the containing document from its default orientation.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br /><br />
 
             <b>AddChange</b>, <b>RemoveChange</b>: <br />
             The change event of the ScreenOrientation interface fires when the orientation of the
             screen has changed, for example when a user rotates their mobile phone.
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/change_event" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/change_event" target="_blank" rel="noopener noreferrer">MDN</a>).
         </div>
     </section>
 </div>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil21UserAgentPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil21UserAgentPage.razor
@@ -65,4 +65,4 @@
     </section>
 </div>
 
-<NavigationButtons Prev="ScreenOrientation" PrevUrl="/butil/screenOrientation" />
+<NavigationButtons Prev="ScreenOrientation" PrevUrl="/butil/screenOrientation" Next="Device" NextUrl="/butil/device" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor
@@ -1,0 +1,180 @@
+@page "/butil/device"
+@inherits AppComponentBase
+@inject Bit.Butil.Battery battery
+@inject Bit.Butil.NetworkInformation networkInformation
+@inject Bit.Butil.WakeLock wakeLock
+@inject Bit.Butil.IdleDetector idleDetector
+
+<PageOutlet Url="butil/device"
+            Title="Device - Butil"
+            Description="Device sensors (Battery, Network, WakeLock, IdleDetector) of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Device</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the device sensor classes of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            The device sensor features are spread across a few classes. Inject the ones you need and use them like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.Battery battery
+@@inject Bit.Butil.NetworkInformation networkInformation
+@@inject Bit.Butil.WakeLock wakeLock
+@@inject Bit.Butil.IdleDetector idleDetector
+
+@@code {
+    var status = await battery.GetStatus();
+    var net = await networkInformation.GetStatus();
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Battery</BitText>
+        <div class="section-card-txt">
+            The <b>Battery</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API" target="_blank">Battery Status API</a>.
+            <br /><br />
+
+            <b>IsSupported</b>: <br />
+            Returns whether the Battery Status API is available in the current browser.
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@batterySupportedExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="BatterySupported">IsSupported</BitButton>
+                        <br /><br />
+                        <div>Is supported: @batterySupported</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>GetStatus</b>: <br />
+            Returns a snapshot of the battery charging state and level
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@batteryStatusExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="BatteryStatus">GetStatus</BitButton>
+                        <br /><br />
+                        <div>Battery: @batteryStatus</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>NetworkInformation</BitText>
+        <div class="section-card-txt">
+            The <b>NetworkInformation</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank">Network Information API</a>
+            plus the always-available <b>navigator.onLine</b> flag.
+            <br /><br />
+
+            <b>GetStatus</b>: <br />
+            Returns the online flag, effective connection type, downlink and round-trip-time estimates.
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@networkStatusExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="NetworkStatus">GetStatus</BitButton>
+                        <br /><br />
+                        <div>Network: @networkStatus</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>WakeLock</BitText>
+        <div class="section-card-txt">
+            The <b>WakeLock</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API" target="_blank">Screen Wake Lock API</a>,
+            which prevents the screen from dimming while the app is active.
+            <br /><br />
+
+            <b>Request / Release</b>: <br />
+            Acquires or releases a screen wake lock. <b>RequestPersistent</b> keeps the lock re-acquired automatically when the page becomes visible again.
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@wakeLockExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="AcquireWakeLock">Request</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="ReleaseWakeLock">Release</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="AcquirePersistentWakeLock">RequestPersistent</BitButton>
+                        <br /><br />
+                        <div>@wakeLockResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>IdleDetector</BitText>
+        <div class="section-card-txt">
+            The <b>IdleDetector</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector" target="_blank">Idle Detection API</a>
+            (Chromium-based browsers, requires permission).
+            <br /><br />
+
+            <b>RequestPermission / Start</b>: <br />
+            Requests the idle-detection permission and starts watching the user/screen idle state until it is stopped.
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@idleDetectorExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitNumberField @bind-Value="idleThreshold" Label="Threshold (seconds, min 60)" Style="max-width: 18.75rem;" />
+                        <br />
+                        <BitButton OnClick="RequestIdlePermission">RequestPermission</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StartIdleWatch">Start</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopIdleWatch">Stop</BitButton>
+                        <br /><br />
+                        <div>Permission: @idlePermission</div>
+                        <div>State: @idleState</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="UserAgent" PrevUrl="/butil/userAgent" Next="Geolocation" NextUrl="/butil/geolocation" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor
@@ -38,7 +38,7 @@
         <BitText Typography="BitTypography.H5" Gutter>Battery</BitText>
         <div class="section-card-txt">
             The <b>Battery</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API" target="_blank">Battery Status API</a>.
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API" target="_blank" rel="noopener noreferrer">Battery Status API</a>.
             <br /><br />
 
             <b>IsSupported</b>: <br />
@@ -62,7 +62,7 @@
 
             <b>GetStatus</b>: <br />
             Returns a snapshot of the battery charging state and level
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -85,7 +85,7 @@
         <BitText Typography="BitTypography.H5" Gutter>NetworkInformation</BitText>
         <div class="section-card-txt">
             The <b>NetworkInformation</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank">Network Information API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank" rel="noopener noreferrer">Network Information API</a>
             plus the always-available <b>navigator.onLine</b> flag.
             <br /><br />
 
@@ -113,7 +113,7 @@
         <BitText Typography="BitTypography.H5" Gutter>WakeLock</BitText>
         <div class="section-card-txt">
             The <b>WakeLock</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API" target="_blank">Screen Wake Lock API</a>,
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API" target="_blank" rel="noopener noreferrer">Screen Wake Lock API</a>,
             which prevents the screen from dimming while the app is active.
             <br /><br />
 
@@ -145,7 +145,7 @@
         <BitText Typography="BitTypography.H5" Gutter>IdleDetector</BitText>
         <div class="section-card-txt">
             The <b>IdleDetector</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector" target="_blank">Idle Detection API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector" target="_blank" rel="noopener noreferrer">Idle Detection API</a>
             (Chromium-based browsers, requires permission).
             <br /><br />
 
@@ -159,7 +159,7 @@
                     </BitPivotItem>
                     <BitPivotItem HeaderText="Result">
                         <br />
-                        <BitNumberField @bind-Value="idleThreshold" Label="Threshold (seconds, min 60)" Style="max-width: 18.75rem;" />
+                        <BitNumberField @bind-Value="idleThreshold" Min="60" Label="Threshold (seconds, min 60)" Style="max-width: 18.75rem;" />
                         <br />
                         <BitButton OnClick="RequestIdlePermission">RequestPermission</BitButton>
                         &nbsp;

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor.cs
@@ -1,0 +1,221 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil22DevicePage
+{
+    private string? batterySupported;
+    private string? batteryStatus;
+    private string? networkStatus;
+    private string? wakeLockResult;
+    private string? idlePermission;
+    private string? idleState;
+
+    private int idleThreshold = 60;
+    private ButilSubscription? idleSub;
+    private IAsyncDisposable? persistentWakeLock;
+
+
+    private async Task BatterySupported()
+    {
+        batterySupported = (await battery.IsSupported()).ToString();
+    }
+
+    private async Task BatteryStatus()
+    {
+        var status = await battery.GetStatus();
+        batteryStatus = $"level={status.Level:P0}, charging={status.Charging}";
+    }
+
+    private async Task NetworkStatus()
+    {
+        var status = await networkInformation.GetStatus();
+        networkStatus = $"online={status.Online}, type={status.EffectiveType ?? status.Type ?? "n/a"}, downlink={status.Downlink}, rtt={status.Rtt}";
+    }
+
+    private async Task AcquireWakeLock()
+    {
+        if (await wakeLock.IsSupported() is false)
+        {
+            wakeLockResult = "Wake lock is not supported.";
+            return;
+        }
+
+        var ok = await wakeLock.Request();
+        wakeLockResult = ok ? "Wake lock acquired." : "Wake lock request failed.";
+    }
+
+    private async Task ReleaseWakeLock()
+    {
+        await wakeLock.Release();
+        wakeLockResult = "Wake lock released.";
+    }
+
+    private async Task AcquirePersistentWakeLock()
+    {
+        if (await wakeLock.IsSupported() is false)
+        {
+            wakeLockResult = "Wake lock is not supported.";
+            return;
+        }
+
+        if (persistentWakeLock is not null)
+            await persistentWakeLock.DisposeAsync();
+
+        persistentWakeLock = await wakeLock.RequestPersistent();
+        wakeLockResult = "Persistent wake lock started (auto re-acquire on visibility).";
+    }
+
+    private async Task RequestIdlePermission()
+    {
+        if (await idleDetector.IsSupported() is false)
+        {
+            idlePermission = "IdleDetector is not supported.";
+            return;
+        }
+
+        idlePermission = (await idleDetector.RequestPermission()).ToString();
+    }
+
+    private async Task StartIdleWatch()
+    {
+        await StopIdleWatch();
+
+        if (await idleDetector.IsSupported() is false)
+        {
+            idleState = "IdleDetector is not supported.";
+            return;
+        }
+
+        idleSub = await idleDetector.Start(idleThreshold, state =>
+        {
+            idleState = $"user={state.UserState}, screen={state.ScreenState}";
+            InvokeAsync(StateHasChanged);
+        });
+
+        idleState = "Idle watch started.";
+    }
+
+    private async Task StopIdleWatch()
+    {
+        if (idleSub is null) return;
+        await idleSub.DisposeAsync();
+        idleSub = null;
+        idleState = "Idle watch stopped.";
+    }
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (idleSub is not null)
+            await idleSub.DisposeAsync();
+        if (persistentWakeLock is not null)
+            await persistentWakeLock.DisposeAsync();
+        await wakeLock.DisposeAsync();
+
+        await base.DisposeAsync(disposing);
+    }
+
+
+    private readonly string batterySupportedExampleCode =
+@"@inject Bit.Butil.Battery battery
+
+<BitButton OnClick=""BatterySupported"">IsSupported</BitButton>
+
+<div>Is supported: @batterySupported</div>
+
+@code {
+    private string? batterySupported;
+
+    private async Task BatterySupported()
+    {
+        batterySupported = (await battery.IsSupported()).ToString();
+    }
+}";
+
+    private readonly string batteryStatusExampleCode =
+@"@inject Bit.Butil.Battery battery
+
+<BitButton OnClick=""BatteryStatus"">GetStatus</BitButton>
+
+<div>Battery: @batteryStatus</div>
+
+@code {
+    private string? batteryStatus;
+
+    private async Task BatteryStatus()
+    {
+        var status = await battery.GetStatus();
+        batteryStatus = $""level={status.Level:P0}, charging={status.Charging}"";
+    }
+}";
+
+    private readonly string networkStatusExampleCode =
+@"@inject Bit.Butil.NetworkInformation networkInformation
+
+<BitButton OnClick=""NetworkStatus"">GetStatus</BitButton>
+
+<div>Network: @networkStatus</div>
+
+@code {
+    private string? networkStatus;
+
+    private async Task NetworkStatus()
+    {
+        var status = await networkInformation.GetStatus();
+        networkStatus = $""online={status.Online}, type={status.EffectiveType}, downlink={status.Downlink}, rtt={status.Rtt}"";
+    }
+}";
+
+    private readonly string wakeLockExampleCode =
+@"@inject Bit.Butil.WakeLock wakeLock
+
+<BitButton OnClick=""AcquireWakeLock"">Request</BitButton>
+<BitButton OnClick=""ReleaseWakeLock"">Release</BitButton>
+<BitButton OnClick=""AcquirePersistentWakeLock"">RequestPersistent</BitButton>
+
+@code {
+    private IAsyncDisposable? persistentWakeLock;
+
+    private async Task AcquireWakeLock()
+    {
+        if (await wakeLock.IsSupported() is false) return;
+        await wakeLock.Request();
+    }
+
+    private async Task ReleaseWakeLock()
+    {
+        await wakeLock.Release();
+    }
+
+    private async Task AcquirePersistentWakeLock()
+    {
+        persistentWakeLock = await wakeLock.RequestPersistent();
+    }
+}";
+
+    private readonly string idleDetectorExampleCode =
+@"@inject Bit.Butil.IdleDetector idleDetector
+
+<BitButton OnClick=""RequestIdlePermission"">RequestPermission</BitButton>
+<BitButton OnClick=""StartIdleWatch"">Start</BitButton>
+
+@code {
+    private ButilSubscription? idleSub;
+
+    private async Task RequestIdlePermission()
+    {
+        if (await idleDetector.IsSupported() is false) return;
+        var permission = await idleDetector.RequestPermission();
+    }
+
+    private async Task StartIdleWatch()
+    {
+        idleSub = await idleDetector.Start(60, state =>
+        {
+            var current = $""user={state.UserState}, screen={state.ScreenState}"";
+            InvokeAsync(StateHasChanged);
+        });
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor.cs
@@ -163,7 +163,7 @@ public partial class Butil22DevicePage
     private async Task NetworkStatus()
     {
         var status = await networkInformation.GetStatus();
-        networkStatus = $""online={status.Online}, type={status.EffectiveType}, downlink={status.Downlink}, rtt={status.Rtt}"";
+        networkStatus = $""online={status.Online}, type={status.EffectiveType ?? status.Type ?? ""n/a""}, downlink={status.Downlink}, rtt={status.Rtt}"";
     }
 }";
 

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil22DevicePage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor
@@ -1,0 +1,103 @@
+@page "/butil/geolocation"
+@inherits AppComponentBase
+@inject Bit.Butil.Geolocation geolocation
+
+<PageOutlet Url="butil/geolocation"
+            Title="Geolocation - Butil"
+            Description="Geolocation class of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Geolocation</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the Geolocation class of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            To read the device's position you need to inject the Bit.Butil.Geolocation class and use it like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.Geolocation geolocation
+
+@@code {
+    var position = await geolocation.GetCurrentPosition();
+    await using var sub = await geolocation.SubscribeWatch(p => { /* ... */ });
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Methods</BitText>
+        <div class="section-card-txt">
+            The <b>Geolocation</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API" target="_blank">Geolocation API</a>
+            (<b>navigator.geolocation</b>).
+            <br /><br />
+
+            <b>IsSupported</b>: <br />
+            Returns whether the Geolocation API (<b>navigator.geolocation</b>) is available in the current browser
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@isSupportedExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="IsSupported">IsSupported</BitButton>
+                        <br /><br />
+                        <div>Is supported: @isSupported</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>GetCurrentPosition</b>: <br />
+            Returns the device's current position once. The browser prompts for permission on first use
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@getCurrentPositionExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="GetCurrentPosition">GetCurrentPosition</BitButton>
+                        <br /><br />
+                        <div>Current position: @currentPosition</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>SubscribeWatch</b>: <br />
+            Subscribes to continuous position updates and returns a <b>ButilSubscription</b> handle. Dispose the handle to stop watching
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@subscribeWatchExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StartWatch">Start watch</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopWatch">Stop watch</BitButton>
+                        <br /><br />
+                        <div>Watch: @watchResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="Device" PrevUrl="/butil/device" Next="MediaDevices" NextUrl="/butil/mediaDevices" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor
@@ -32,13 +32,13 @@
         <BitText Typography="BitTypography.H5" Gutter>Methods</BitText>
         <div class="section-card-txt">
             The <b>Geolocation</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API" target="_blank">Geolocation API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API" target="_blank" rel="noopener noreferrer">Geolocation API</a>
             (<b>navigator.geolocation</b>).
             <br /><br />
 
             <b>IsSupported</b>: <br />
             Returns whether the Geolocation API (<b>navigator.geolocation</b>) is available in the current browser
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -58,7 +58,7 @@
 
             <b>GetCurrentPosition</b>: <br />
             Returns the device's current position once. The browser prompts for permission on first use
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -78,7 +78,7 @@
 
             <b>SubscribeWatch</b>: <br />
             Subscribes to continuous position updates and returns a <b>ButilSubscription</b> handle. Dispose the handle to stop watching
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor.cs
@@ -1,0 +1,143 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil23GeolocationPage
+{
+    private string? isSupported;
+    private string? currentPosition;
+    private string? watchResult;
+
+    private ButilSubscription? watchSub;
+
+
+    private async Task IsSupported()
+    {
+        isSupported = (await geolocation.IsSupported()).ToString();
+    }
+
+    private async Task GetCurrentPosition()
+    {
+        try
+        {
+            var position = await geolocation.GetCurrentPosition();
+            var coords = position.Coords;
+            currentPosition = $"lat={coords.Latitude:F6}, lng={coords.Longitude:F6}, accuracy={coords.Accuracy:F1}m";
+        }
+        catch (GeolocationException ex)
+        {
+            currentPosition = $"{ex.Code} → {ex.Message}";
+        }
+    }
+
+    private async Task StartWatch()
+    {
+        await StopWatch();
+
+        watchSub = await geolocation.SubscribeWatch(
+            onPosition: position =>
+            {
+                var coords = position.Coords;
+                watchResult = $"lat={coords.Latitude:F6}, lng={coords.Longitude:F6}, accuracy={coords.Accuracy:F1}m";
+                InvokeAsync(StateHasChanged);
+            },
+            onError: ex =>
+            {
+                watchResult = $"{ex.Code} → {ex.Message}";
+                InvokeAsync(StateHasChanged);
+            });
+
+        watchResult = "Watch started.";
+    }
+
+    private async Task StopWatch()
+    {
+        if (watchSub is null) return;
+        await watchSub.DisposeAsync();
+        watchSub = null;
+        watchResult = "Watch stopped.";
+    }
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (watchSub is not null)
+            await watchSub.DisposeAsync();
+
+        await base.DisposeAsync(disposing);
+    }
+
+
+    private readonly string isSupportedExampleCode =
+@"@inject Bit.Butil.Geolocation geolocation
+
+<BitButton OnClick=""IsSupported"">IsSupported</BitButton>
+
+<div>Is supported: @isSupported</div>
+
+@code {
+    private string? isSupported;
+
+    private async Task IsSupported()
+    {
+        isSupported = (await geolocation.IsSupported()).ToString();
+    }
+}";
+
+    private readonly string getCurrentPositionExampleCode =
+@"@inject Bit.Butil.Geolocation geolocation
+
+<BitButton OnClick=""GetCurrentPosition"">GetCurrentPosition</BitButton>
+
+<div>Current position: @currentPosition</div>
+
+@code {
+    private string? currentPosition;
+
+    private async Task GetCurrentPosition()
+    {
+        try
+        {
+            var position = await geolocation.GetCurrentPosition();
+            var coords = position.Coords;
+            currentPosition = $""lat={coords.Latitude:F6}, lng={coords.Longitude:F6}, accuracy={coords.Accuracy:F1}m"";
+        }
+        catch (GeolocationException ex)
+        {
+            currentPosition = $""{ex.Code} → {ex.Message}"";
+        }
+    }
+}";
+
+    private readonly string subscribeWatchExampleCode =
+@"@inject Bit.Butil.Geolocation geolocation
+
+<BitButton OnClick=""StartWatch"">Start watch</BitButton>
+<BitButton OnClick=""StopWatch"">Stop watch</BitButton>
+
+<div>Watch: @watchResult</div>
+
+@code {
+    private ButilSubscription? watchSub;
+
+    private async Task StartWatch()
+    {
+        await StopWatch();
+
+        watchSub = await geolocation.SubscribeWatch(
+            onPosition: position =>
+            {
+                var coords = position.Coords;
+                watchResult = $""lat={coords.Latitude:F6}, lng={coords.Longitude:F6}"";
+                InvokeAsync(StateHasChanged);
+            });
+    }
+
+    private async Task StopWatch()
+    {
+        if (watchSub is null) return;
+        await watchSub.DisposeAsync();
+        watchSub = null;
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil23GeolocationPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor
@@ -1,0 +1,115 @@
+@page "/butil/mediaDevices"
+@inherits AppComponentBase
+@inject Bit.Butil.MediaDevices mediaDevices
+
+<PageOutlet Url="butil/mediaDevices"
+            Title="MediaDevices - Butil"
+            Description="MediaDevices class of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>MediaDevices</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the MediaDevices class of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            Inject the <b>MediaDevices</b> class, enumerate the available cameras and microphones,
+            request a live stream, and attach it to a <b>video</b> element:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.MediaDevices mediaDevices
+
+@@code {
+    var devices = await mediaDevices.EnumerateDevices();
+    var stream  = await mediaDevices.GetUserMedia(audio: true, video: true);
+    await stream.AttachTo(videoElement);
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Methods</BitText>
+        <div class="section-card-txt">
+            The <b>MediaDevices</b> class wraps
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices" target="_blank">navigator.mediaDevices</a>.
+            <br /><br />
+
+            <b>IsSupported</b>: <br />
+            Returns whether <b>navigator.mediaDevices</b> is available in the current browser
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@isSupportedExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="IsSupported">IsSupported</BitButton>
+                        <br /><br />
+                        <div>Is supported: @isSupported</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>EnumerateDevices</b>: <br />
+            Lists all input/output media devices. Labels may be empty until the user has granted
+            permission to a matching input
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@enumerateDevicesExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="EnumerateDevices">EnumerateDevices</BitButton>
+                        <br /><br />
+                        <div>Devices: @devices</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>GetUserMedia / AttachTo / SetEnabled</b>: <br />
+            Requests camera and/or microphone access and returns a <b>MediaStreamHandle</b> (or null when
+            the user denies the prompt). Attach the stream to a <b>video</b> element with <b>AttachTo</b>,
+            pause or resume its tracks with <b>SetEnabled</b>, and stop the stream by disposing the handle
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@getUserMediaExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitCheckbox @bind-Value="requestAudio" Label="Audio" />
+                        <BitCheckbox @bind-Value="requestVideo" Label="Video" />
+                        <br />
+                        <BitButton OnClick="StartStream">Start stream</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="ToggleEnabled">Toggle enabled</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopStream">Stop stream</BitButton>
+                        <br /><br />
+                        <video @ref="preview" autoplay playsinline muted
+                               style="max-width:100%;border-radius:0.5rem;background:#111;min-height:7.5rem"></video>
+                        <br /><br />
+                        <div>@streamResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="Geolocation" PrevUrl="/butil/geolocation" Next="Permissions" NextUrl="/butil/permissions" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor
@@ -34,12 +34,12 @@
         <BitText Typography="BitTypography.H5" Gutter>Methods</BitText>
         <div class="section-card-txt">
             The <b>MediaDevices</b> class wraps
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices" target="_blank">navigator.mediaDevices</a>.
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices" target="_blank" rel="noopener noreferrer">navigator.mediaDevices</a>.
             <br /><br />
 
             <b>IsSupported</b>: <br />
             Returns whether <b>navigator.mediaDevices</b> is available in the current browser
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -60,7 +60,7 @@
             <b>EnumerateDevices</b>: <br />
             Lists all input/output media devices. Labels may be empty until the user has granted
             permission to a matching input
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -82,7 +82,7 @@
             Requests camera and/or microphone access and returns a <b>MediaStreamHandle</b> (or null when
             the user denies the prompt). Attach the stream to a <b>video</b> element with <b>AttachTo</b>,
             pause or resume its tracks with <b>SetEnabled</b>, and stop the stream by disposing the handle
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor.cs
@@ -14,6 +14,7 @@ public partial class Butil24MediaDevicesPage
 
     private ElementReference preview;
     private MediaStreamHandle? stream;
+    private bool startingStream;
 
 
     private async Task IsSupported()
@@ -41,24 +42,36 @@ public partial class Butil24MediaDevicesPage
 
     private async Task StartStream()
     {
-        await StopStream();
+        // Guard against overlapping clicks racing across the GetUserMedia await and
+        // leaking/overwriting the active stream - only one invocation may run at a time.
+        if (startingStream) return;
+        startingStream = true;
 
-        if (!requestAudio && !requestVideo)
+        try
         {
-            streamResult = "Enable at least audio or video.";
-            return;
-        }
+            await StopStream();
 
-        stream = await mediaDevices.GetUserMedia(requestAudio, requestVideo);
-        if (stream is null)
+            if (!requestAudio && !requestVideo)
+            {
+                streamResult = "Enable at least audio or video.";
+                return;
+            }
+
+            stream = await mediaDevices.GetUserMedia(requestAudio, requestVideo);
+            if (stream is null)
+            {
+                streamResult = "GetUserMedia returned null - permission denied or no device available.";
+                return;
+            }
+
+            await stream.AttachTo(preview);
+            enabled = true;
+            streamResult = $"Stream started → {stream.Id}";
+        }
+        finally
         {
-            streamResult = "GetUserMedia returned null - permission denied or no device available.";
-            return;
+            startingStream = false;
         }
-
-        await stream.AttachTo(preview);
-        enabled = true;
-        streamResult = $"Stream started → {stream.Id}";
     }
 
     private async Task ToggleEnabled()

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor.cs
@@ -1,0 +1,170 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil24MediaDevicesPage
+{
+    private string? isSupported;
+    private string? devices;
+    private string? streamResult;
+
+    private bool requestAudio = true;
+    private bool requestVideo = true;
+    private bool enabled = true;
+
+    private ElementReference preview;
+    private MediaStreamHandle? stream;
+
+
+    private async Task IsSupported()
+    {
+        isSupported = (await mediaDevices.IsSupported()).ToString();
+    }
+
+    private async Task EnumerateDevices()
+    {
+        var result = await mediaDevices.EnumerateDevices();
+        if (result.Length == 0)
+        {
+            devices = "No media devices reported.";
+            return;
+        }
+
+        devices = string.Join(", ", result.Select(d =>
+        {
+            var label = string.IsNullOrEmpty(d.Label)
+                ? d.DeviceId[..Math.Min(8, d.DeviceId.Length)] + "…"
+                : d.Label;
+            return $"{d.Kind}: {label}";
+        }));
+    }
+
+    private async Task StartStream()
+    {
+        await StopStream();
+
+        if (!requestAudio && !requestVideo)
+        {
+            streamResult = "Enable at least audio or video.";
+            return;
+        }
+
+        stream = await mediaDevices.GetUserMedia(requestAudio, requestVideo);
+        if (stream is null)
+        {
+            streamResult = "GetUserMedia returned null - permission denied or no device available.";
+            return;
+        }
+
+        await stream.AttachTo(preview);
+        enabled = true;
+        streamResult = $"Stream started → {stream.Id}";
+    }
+
+    private async Task ToggleEnabled()
+    {
+        if (stream is null)
+        {
+            streamResult = "Start a stream first.";
+            return;
+        }
+
+        enabled = !enabled;
+        await stream.SetEnabled(enabled);
+        streamResult = $"Tracks enabled → {enabled}";
+    }
+
+    private async Task StopStream()
+    {
+        if (stream is null) return;
+        await stream.DisposeAsync();
+        stream = null;
+        streamResult = "Stream stopped.";
+    }
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (stream is not null)
+            await stream.DisposeAsync();
+
+        await base.DisposeAsync(disposing);
+    }
+
+
+    private readonly string isSupportedExampleCode =
+@"@inject Bit.Butil.MediaDevices mediaDevices
+
+<BitButton OnClick=""IsSupported"">IsSupported</BitButton>
+
+<div>Is supported: @isSupported</div>
+
+@code {
+    private string? isSupported;
+
+    private async Task IsSupported()
+    {
+        isSupported = (await mediaDevices.IsSupported()).ToString();
+    }
+}";
+
+    private readonly string enumerateDevicesExampleCode =
+@"@inject Bit.Butil.MediaDevices mediaDevices
+
+<BitButton OnClick=""EnumerateDevices"">EnumerateDevices</BitButton>
+
+<div>Devices: @devices</div>
+
+@code {
+    private string? devices;
+
+    private async Task EnumerateDevices()
+    {
+        var result = await mediaDevices.EnumerateDevices();
+        devices = string.Join("", "", result.Select(d => $""{d.Kind}: {d.Label}""));
+    }
+}";
+
+    private readonly string getUserMediaExampleCode =
+@"@inject Bit.Butil.MediaDevices mediaDevices
+
+<BitCheckbox @bind-Value=""requestAudio"" Label=""Audio"" />
+<BitCheckbox @bind-Value=""requestVideo"" Label=""Video"" />
+
+<BitButton OnClick=""StartStream"">Start stream</BitButton>
+<BitButton OnClick=""ToggleEnabled"">Toggle enabled</BitButton>
+<BitButton OnClick=""StopStream"">Stop stream</BitButton>
+
+<video @ref=""preview"" autoplay playsinline muted></video>
+
+@code {
+    private bool requestAudio = true;
+    private bool requestVideo = true;
+    private bool enabled = true;
+    private ElementReference preview;
+    private MediaStreamHandle? stream;
+
+    private async Task StartStream()
+    {
+        await StopStream();
+        stream = await mediaDevices.GetUserMedia(requestAudio, requestVideo);
+        if (stream is null) return;
+        await stream.AttachTo(preview);
+        enabled = true;
+    }
+
+    private async Task ToggleEnabled()
+    {
+        if (stream is null) return;
+        enabled = !enabled;
+        await stream.SetEnabled(enabled);
+    }
+
+    private async Task StopStream()
+    {
+        if (stream is null) return;
+        await stream.DisposeAsync();
+        stream = null;
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil24MediaDevicesPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor
@@ -1,0 +1,92 @@
+@page "/butil/permissions"
+@inherits AppComponentBase
+@inject Bit.Butil.Permissions permissions
+
+<PageOutlet Url="butil/permissions"
+            Title="Permissions - Butil"
+            Description="Permissions class of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Permissions</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the Permissions class of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            To query the browser's permission state you need to inject the Bit.Butil.Permissions class and use it like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.Permissions permissions
+
+@@code {
+    var state = await permissions.Query("geolocation");
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Methods</BitText>
+        <div class="section-card-txt">
+            <br />
+            <b>IsSupported</b>: <br />
+            Returns whether the Permissions API (navigator.permissions) is available in the current browser
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Permissions" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>
+                            @isSupportedExampleCode
+                        </CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="@CheckSupported">IsSupported</BitButton>
+                        <br />
+                        <br />
+                        <div>Is supported: @isSupported</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Query</b>: <br />
+            Returns the current state (granted, denied, prompt or unknown) for a given permission descriptor name, without triggering a prompt
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>
+                            @queryExampleCode
+                        </CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <select @bind="selectedPermission">
+                            @foreach (var name in permissionNames)
+                            {
+                                <option value="@name">@name</option>
+                            }
+                        </select>
+                        <br />
+                        <br />
+                        <BitButton OnClick="@QuerySelected">Query selected</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="@QueryAll">Query all common</BitButton>
+                        <br />
+                        <br />
+                        <div>@queryResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="MediaDevices" PrevUrl="/butil/mediaDevices" Next="Fetch" NextUrl="/butil/fetch" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor
@@ -33,7 +33,7 @@
             <br />
             <b>IsSupported</b>: <br />
             Returns whether the Permissions API (navigator.permissions) is available in the current browser
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Permissions" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Permissions" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -56,7 +56,7 @@
 
             <b>Query</b>: <br />
             Returns the current state (granted, denied, prompt or unknown) for a given permission descriptor name, without triggering a prompt
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor.cs
@@ -1,0 +1,110 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil25PermissionsPage
+{
+    private string? isSupported;
+
+    private string selectedPermission = "geolocation";
+
+    private string? queryResult;
+
+    private static readonly string[] permissionNames =
+    [
+        "geolocation",
+        "notifications",
+        "camera",
+        "microphone",
+        "clipboard-read",
+        "clipboard-write",
+        "push",
+        "midi",
+        "background-sync",
+        "persistent-storage",
+    ];
+
+
+    private async Task CheckSupported()
+    {
+        isSupported = (await permissions.IsSupported()).ToString();
+    }
+
+    private async Task QuerySelected()
+    {
+        var state = await permissions.Query(selectedPermission);
+        queryResult = $"{selectedPermission} → {state}";
+    }
+
+    private async Task QueryAll()
+    {
+        var result = "";
+        foreach (var name in permissionNames)
+        {
+            var state = await permissions.Query(name);
+            result += $"{name} → {state}\n";
+        }
+        queryResult = result;
+    }
+
+
+    private string isSupportedExampleCode =
+@"@inject Bit.Butil.Permissions permissions
+
+<BitButton OnClick=""@CheckSupported"">IsSupported</BitButton>
+
+<div>Is supported: @isSupported</div>
+
+@code {
+    private string? isSupported;
+
+    private async Task CheckSupported()
+    {
+        isSupported = (await permissions.IsSupported()).ToString();
+    }
+}";
+
+    private string queryExampleCode =
+@"@inject Bit.Butil.Permissions permissions
+
+<select @bind=""selectedPermission"">
+    @foreach (var name in permissionNames)
+    {
+        <option value=""@name"">@name</option>
+    }
+</select>
+
+<BitButton OnClick=""@QuerySelected"">Query selected</BitButton>
+<BitButton OnClick=""@QueryAll"">Query all common</BitButton>
+
+<div>@queryResult</div>
+
+@code {
+    private string selectedPermission = ""geolocation"";
+    private string? queryResult;
+
+    private static readonly string[] permissionNames =
+    [
+        ""geolocation"", ""notifications"", ""camera"", ""microphone"",
+        ""clipboard-read"", ""clipboard-write"", ""push"", ""midi"",
+        ""background-sync"", ""persistent-storage"",
+    ];
+
+    private async Task QuerySelected()
+    {
+        var state = await permissions.Query(selectedPermission);
+        queryResult = $""{selectedPermission} → {state}"";
+    }
+
+    private async Task QueryAll()
+    {
+        var result = """";
+        foreach (var name in permissionNames)
+        {
+            var state = await permissions.Query(name);
+            result += $""{name} → {state}\n"";
+        }
+        queryResult = result;
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil25PermissionsPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor
@@ -18,7 +18,7 @@
         <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
         <div class="section-card-txt">
             The <b>Fetch</b> class wraps the browser's
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API" target="_blank">Fetch API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API" target="_blank" rel="noopener noreferrer">Fetch API</a>
             with progress reporting and an abortable handle. Prefer <b>HttpClient</b> for normal API calls;
             reach for this when you need progress for big downloads or fetch-only semantics. Inject it and use it like this:
 <CodeBox HideCopyButton>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor
@@ -1,0 +1,85 @@
+@page "/butil/fetch"
+@inherits AppComponentBase
+@inject Bit.Butil.Fetch fetch
+
+<PageOutlet Url="butil/fetch"
+            Title="Fetch - Butil"
+            Description="Fetch class of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Fetch</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the Fetch class of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            The <b>Fetch</b> class wraps the browser's
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API" target="_blank">Fetch API</a>
+            with progress reporting and an abortable handle. Prefer <b>HttpClient</b> for normal API calls;
+            reach for this when you need progress for big downloads or fetch-only semantics. Inject it and use it like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.Fetch fetch
+
+@@code {
+    var response = await fetch.Send(new FetchRequest { Url = "https://..." },
+        onProgress: p => { /* bytes received */ });
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Methods</BitText>
+        <div class="section-card-txt">
+            <b>Send</b>: <br />
+            Sends the request and returns the full <b>FetchResponse</b> (status, headers and body bytes).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@sendGetExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitTextField @bind-Value="url" Label="URL" Style="max-width: 25rem;" />
+                        <br />
+                        <BitButton OnClick="SendGet">Send GET</BitButton>
+                        <br /><br />
+                        <div>@sendGetStatus</div>
+                        @if (sendGetBody is not null)
+                        {
+                            <pre style="margin-top:1rem;white-space:pre-wrap;word-break:break-all">@sendGetBody</pre>
+                        }
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Send with progress and cancellation</b>: <br />
+            Pass an <b>onProgress</b> callback to watch bytes arrive, and a <b>CancellationToken</b> to abort mid-flight.
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@sendProgressExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="SendWithProgress">Download with progress</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="AbortRequest">Abort</BitButton>
+                        <br /><br />
+                        <div>@progressText</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="Permissions" PrevUrl="/butil/permissions" Next="Files" NextUrl="/butil/files" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.cs
@@ -1,0 +1,166 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil26FetchPage
+{
+    private string url = "https://jsonplaceholder.typicode.com/todos/1";
+    private string? sendGetStatus;
+    private string? sendGetBody;
+    private string? progressText;
+
+    private CancellationTokenSource? cts;
+
+
+    private async Task SendGet()
+    {
+        sendGetStatus = null;
+        sendGetBody = null;
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            sendGetStatus = "Enter a URL first.";
+            return;
+        }
+
+        try
+        {
+            var response = await fetch.Send(new FetchRequest { Url = url.Trim() });
+
+            if (response.Error is not null)
+            {
+                sendGetStatus = $"Error: {response.Error}";
+                return;
+            }
+
+            sendGetStatus = $"Status {response.Status} {response.StatusText} - {response.Body.Length} bytes from {response.Url}";
+            sendGetBody = PreviewBody(response.Body);
+        }
+        catch (Exception ex)
+        {
+            sendGetStatus = $"Error: {ex.Message}";
+        }
+    }
+
+    private async Task SendWithProgress()
+    {
+        progressText = null;
+        cts?.Dispose();
+        cts = new CancellationTokenSource();
+
+        try
+        {
+            var response = await fetch.Send(
+                new FetchRequest { Url = "https://jsonplaceholder.typicode.com/photos" },
+                onProgress: p =>
+                {
+                    progressText = p.Total.HasValue
+                        ? $"Received {p.Loaded} / {p.Total} bytes"
+                        : $"Received {p.Loaded} bytes";
+                    InvokeAsync(StateHasChanged);
+                },
+                cancellationToken: cts.Token);
+
+            progressText = response.Aborted ? "Aborted" : $"Complete - {response.Body.Length} bytes";
+        }
+        catch (OperationCanceledException)
+        {
+            progressText = "Cancelled";
+        }
+        catch (Exception ex)
+        {
+            progressText = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            cts.Dispose();
+            cts = null;
+        }
+    }
+
+    private void AbortRequest() => cts?.Cancel();
+
+    private static string PreviewBody(byte[] body)
+    {
+        if (body.Length == 0) return "(empty body)";
+        var text = System.Text.Encoding.UTF8.GetString(body);
+        return text.Length > 500 ? text[..500] + "..." : text;
+    }
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (cts is not null)
+        {
+            cts.Dispose();
+            cts = null;
+        }
+
+        await base.DisposeAsync(disposing);
+    }
+
+
+    private readonly string sendGetExampleCode =
+@"@inject Bit.Butil.Fetch fetch
+
+<BitTextField @bind-Value=""url"" Label=""URL"" />
+
+<BitButton OnClick=""SendGet"">Send GET</BitButton>
+
+<div>@sendGetStatus</div>
+<pre>@sendGetBody</pre>
+
+@code {
+    private string url = ""https://jsonplaceholder.typicode.com/todos/1"";
+    private string? sendGetStatus;
+    private string? sendGetBody;
+
+    private async Task SendGet()
+    {
+        var response = await fetch.Send(new FetchRequest { Url = url.Trim() });
+
+        if (response.Error is not null)
+        {
+            sendGetStatus = $""Error: {response.Error}"";
+            return;
+        }
+
+        sendGetStatus = $""Status {response.Status} {response.StatusText} - {response.Body.Length} bytes from {response.Url}"";
+        sendGetBody = System.Text.Encoding.UTF8.GetString(response.Body);
+    }
+}";
+
+    private readonly string sendProgressExampleCode =
+@"@inject Bit.Butil.Fetch fetch
+
+<BitButton OnClick=""SendWithProgress"">Download with progress</BitButton>
+<BitButton OnClick=""AbortRequest"">Abort</BitButton>
+
+<div>@progressText</div>
+
+@code {
+    private string? progressText;
+    private CancellationTokenSource? cts;
+
+    private async Task SendWithProgress()
+    {
+        cts?.Dispose();
+        cts = new CancellationTokenSource();
+
+        var response = await fetch.Send(
+            new FetchRequest { Url = ""https://jsonplaceholder.typicode.com/photos"" },
+            onProgress: p =>
+            {
+                progressText = p.Total.HasValue
+                    ? $""Received {p.Loaded} / {p.Total} bytes""
+                    : $""Received {p.Loaded} bytes"";
+                InvokeAsync(StateHasChanged);
+            },
+            cancellationToken: cts.Token);
+
+        progressText = response.Aborted ? ""Aborted"" : ""Complete"";
+    }
+
+    private void AbortRequest() => cts?.Cancel();
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.cs
@@ -42,11 +42,21 @@ public partial class Butil26FetchPage
         }
     }
 
+    private bool sending;
+
     private async Task SendWithProgress()
     {
+        // Prevent overlapping downloads from racing on the shared cts field.
+        if (sending) return;
+        sending = true;
+
         progressText = null;
+
+        // Cancel and dispose any previous source before replacing it; keep a local
+        // reference so this call only ever disposes/clears its own token source.
+        cts?.Cancel();
         cts?.Dispose();
-        cts = new CancellationTokenSource();
+        var localCts = cts = new CancellationTokenSource();
 
         try
         {
@@ -59,7 +69,7 @@ public partial class Butil26FetchPage
                         : $"Received {p.Loaded} bytes";
                     InvokeAsync(StateHasChanged);
                 },
-                cancellationToken: cts.Token);
+                cancellationToken: localCts.Token);
 
             progressText = response.Aborted ? "Aborted" : $"Complete - {response.Body.Length} bytes";
         }
@@ -69,8 +79,9 @@ public partial class Butil26FetchPage
         }
         finally
         {
-            cts.Dispose();
-            cts = null;
+            if (ReferenceEquals(cts, localCts)) cts = null;
+            localCts.Dispose();
+            sending = false;
         }
     }
 

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.cs
@@ -63,10 +63,6 @@ public partial class Butil26FetchPage
 
             progressText = response.Aborted ? "Aborted" : $"Complete - {response.Body.Length} bytes";
         }
-        catch (OperationCanceledException)
-        {
-            progressText = "Cancelled";
-        }
         catch (Exception ex)
         {
             progressText = $"Error: {ex.Message}";
@@ -92,6 +88,9 @@ public partial class Butil26FetchPage
     {
         if (cts is not null)
         {
+            // Cancel first so any in-flight SendWithProgress request aborts the JS fetch
+            // (via BitButil.fetch.abort) instead of being left running after teardown.
+            cts.Cancel();
             cts.Dispose();
             cts = null;
         }

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil26FetchPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor
@@ -1,0 +1,216 @@
+@page "/butil/files"
+@inherits AppComponentBase
+@inject Bit.Butil.FileReader fileReader
+@inject Bit.Butil.ObjectUrls objectUrls
+
+<PageOutlet Url="butil/files"
+            Title="Files - Butil"
+            Description="FileReader and ObjectUrls classes of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Files</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the file related classes of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            The file features live in two classes. Inject the ones you need and use them like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.FileReader fileReader
+@@inject Bit.Butil.ObjectUrls objectUrls
+
+@@code {
+    var text = await fileReader.ReadAsText(fileInput);
+    var url = await objectUrls.Create(bytes, "image/png");
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>FileReader</BitText>
+        <div class="section-card-txt">
+            The <b>FileReader</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader" target="_blank">FileReader API</a>
+            to read files selected in an <c>&lt;input type="file"&gt;</c> element as metadata, text, bytes or data URLs.
+            <br /><br />
+
+            <b>GetFileInfos</b>: <br />
+            Returns metadata (Name, Size and Type) for every file selected in the given input element
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/File" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@getFileInfosExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <input type="file" @ref="fileInput" multiple />
+                        <br /><br />
+                        <BitButton OnClick="GetFileInfos">GetFileInfos</BitButton>
+                        <br /><br />
+                        <div>@fileInfos</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>ReadAsText</b>: <br />
+            Reads the first selected file as UTF-8 text
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@readAsTextExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <input type="file" @ref="fileInput" multiple />
+                        <br /><br />
+                        <BitButton OnClick="ReadAsText">ReadAsText</BitButton>
+                        <br /><br />
+                        <div>@fileText</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>ReadAsBytes</b>: <br />
+            Reads the first selected file as raw bytes
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@readAsBytesExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <input type="file" @ref="fileInput" multiple />
+                        <br /><br />
+                        <BitButton OnClick="ReadAsBytes">ReadAsBytes</BitButton>
+                        <br /><br />
+                        <div>@fileBytes</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>ReadAsDataUrl</b>: <br />
+            Reads the first selected file as a base-64 data URL, convenient for image previews
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@readAsDataUrlExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <input type="file" @ref="fileInput" multiple />
+                        <br /><br />
+                        <BitButton OnClick="ReadAsDataUrl">ReadAsDataUrl</BitButton>
+                        <br /><br />
+                        <div>@fileDataUrl</div>
+                        @if (imagePreviewUrl is not null)
+                        {
+                            <br />
+                            <img src="@imagePreviewUrl" alt="Preview" style="max-width: 15rem; border-radius: 0.5rem;" />
+                        }
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Clear</b>: <br />
+            Clears the input's selection (resets its <c>files</c> list)
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@clearExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <input type="file" @ref="fileInput" multiple />
+                        <br /><br />
+                        <BitButton OnClick="Clear">Clear</BitButton>
+                        <br /><br />
+                        <div>@clearResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>ObjectUrls</BitText>
+        <div class="section-card-txt">
+            The <b>ObjectUrls</b> class wraps
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static" target="_blank">URL.createObjectURL</a>
+            and
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static" target="_blank">URL.revokeObjectURL</a>
+            for arbitrary byte payloads.
+            <br /><br />
+
+            <b>Create</b>: <br />
+            Creates a blob object URL from raw bytes plus an optional MIME type
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@createExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitTextField @bind-Value="blobText" Label="Text to blob" Style="max-width: 25rem;" />
+                        <br />
+                        <BitButton OnClick="CreateObjectUrl">Create</BitButton>
+                        <br /><br />
+                        @if (objectUrl is not null)
+                        {
+                            <div>
+                                <a href="@objectUrl" target="_blank" rel="noopener">Open blob URL</a>
+                            </div>
+                        }
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Revoke</b>: <br />
+            Revokes a previously created object URL to release its memory
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@revokeExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="RevokeObjectUrl">Revoke</BitButton>
+                        <br /><br />
+                        <div>@revokeResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="Fetch" PrevUrl="/butil/fetch" Next="Speech" NextUrl="/butil/speech" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor
@@ -34,13 +34,13 @@
         <BitText Typography="BitTypography.H5" Gutter>FileReader</BitText>
         <div class="section-card-txt">
             The <b>FileReader</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader" target="_blank">FileReader API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader" target="_blank" rel="noopener noreferrer">FileReader API</a>
             to read files selected in an <c>&lt;input type="file"&gt;</c> element as metadata, text, bytes or data URLs.
             <br /><br />
 
             <b>GetFileInfos</b>: <br />
             Returns metadata (Name, Size and Type) for every file selected in the given input element
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/File" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/File" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -62,7 +62,7 @@
 
             <b>ReadAsText</b>: <br />
             Reads the first selected file as UTF-8 text
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -84,7 +84,7 @@
 
             <b>ReadAsBytes</b>: <br />
             Reads the first selected file as raw bytes
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -106,7 +106,7 @@
 
             <b>ReadAsDataUrl</b>: <br />
             Reads the first selected file as a base-64 data URL, convenient for image previews
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -133,7 +133,7 @@
 
             <b>Clear</b>: <br />
             Clears the input's selection (resets its <c>files</c> list)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -158,15 +158,15 @@
         <BitText Typography="BitTypography.H5" Gutter>ObjectUrls</BitText>
         <div class="section-card-txt">
             The <b>ObjectUrls</b> class wraps
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static" target="_blank">URL.createObjectURL</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static" target="_blank" rel="noopener noreferrer">URL.createObjectURL</a>
             and
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static" target="_blank">URL.revokeObjectURL</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static" target="_blank" rel="noopener noreferrer">URL.revokeObjectURL</a>
             for arbitrary byte payloads.
             <br /><br />
 
             <b>Create</b>: <br />
             Creates a blob object URL from raw bytes plus an optional MIME type
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -193,7 +193,7 @@
 
             <b>Revoke</b>: <br />
             Revokes a previously created object URL to release its memory
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor.cs
@@ -100,6 +100,15 @@ public partial class Butil27FilesPage
     }
 
 
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        // Ensure any blob URL created via CreateObjectUrl is revoked when the user leaves the page.
+        await RevokeObjectUrlInternal();
+
+        await base.DisposeAsync(disposing);
+    }
+
+
     private readonly string getFileInfosExampleCode =
 @"@inject Bit.Butil.FileReader fileReader
 
@@ -188,6 +197,13 @@ public partial class Butil27FilesPage
     private async Task ReadAsDataUrl()
     {
         var dataUrl = await fileReader.ReadAsDataUrl(fileInput);
+        if (string.IsNullOrEmpty(dataUrl))
+        {
+            fileDataUrl = ""No file selected."";
+            imagePreviewUrl = null;
+            return;
+        }
+
         imagePreviewUrl = dataUrl.StartsWith(""data:image/"", StringComparison.OrdinalIgnoreCase)
             ? dataUrl
             : null;

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor.cs
@@ -1,0 +1,252 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil27FilesPage
+{
+    private ElementReference fileInput;
+
+    private string? fileInfos;
+    private string? fileText;
+    private string? fileBytes;
+    private string? fileDataUrl;
+    private string? clearResult;
+    private string? imagePreviewUrl;
+
+    private string? blobText = "Hello from Bit.Butil ObjectUrls!";
+    private string? objectUrl;
+    private string? revokeResult;
+
+
+    private async Task GetFileInfos()
+    {
+        var infos = await fileReader.GetFileInfos(fileInput);
+        if (infos.Length == 0)
+        {
+            fileInfos = "No file selected.";
+            return;
+        }
+
+        fileInfos = string.Join(" | ", infos.Select(i => $"{i.Name} ({i.Size} bytes, {i.Type})"));
+    }
+
+    private async Task ReadAsText()
+    {
+        var text = await fileReader.ReadAsText(fileInput);
+        if (string.IsNullOrEmpty(text))
+        {
+            fileText = "No file or empty content.";
+            return;
+        }
+
+        fileText = text.Length > 300 ? text[..300] + "…" : text;
+    }
+
+    private async Task ReadAsBytes()
+    {
+        var bytes = await fileReader.ReadAsBytes(fileInput);
+        if (bytes is null)
+        {
+            fileBytes = "No file selected.";
+            return;
+        }
+
+        fileBytes = $"{bytes.Length} bytes";
+    }
+
+    private async Task ReadAsDataUrl()
+    {
+        var dataUrl = await fileReader.ReadAsDataUrl(fileInput);
+        if (string.IsNullOrEmpty(dataUrl))
+        {
+            fileDataUrl = "No file selected.";
+            imagePreviewUrl = null;
+            return;
+        }
+
+        imagePreviewUrl = dataUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)
+            ? dataUrl
+            : null;
+
+        fileDataUrl = dataUrl.Length > 120 ? dataUrl[..120] + "…" : dataUrl;
+    }
+
+    private async Task Clear()
+    {
+        await fileReader.Clear(fileInput);
+        imagePreviewUrl = null;
+        clearResult = "Input cleared.";
+    }
+
+    private async Task CreateObjectUrl()
+    {
+        await RevokeObjectUrlInternal();
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(blobText ?? string.Empty);
+        objectUrl = await objectUrls.Create(bytes, "text/plain");
+    }
+
+    private async Task RevokeObjectUrl()
+    {
+        await RevokeObjectUrlInternal();
+        revokeResult = "Object URL revoked.";
+    }
+
+    private async Task RevokeObjectUrlInternal()
+    {
+        if (objectUrl is null) return;
+        await objectUrls.Revoke(objectUrl);
+        objectUrl = null;
+    }
+
+
+    private readonly string getFileInfosExampleCode =
+@"@inject Bit.Butil.FileReader fileReader
+
+<input type=""file"" @ref=""fileInput"" multiple />
+
+<BitButton OnClick=""GetFileInfos"">GetFileInfos</BitButton>
+
+<div>@fileInfos</div>
+
+@code {
+    private ElementReference fileInput;
+    private string? fileInfos;
+
+    private async Task GetFileInfos()
+    {
+        var infos = await fileReader.GetFileInfos(fileInput);
+        if (infos.Length == 0)
+        {
+            fileInfos = ""No file selected."";
+            return;
+        }
+
+        fileInfos = string.Join("" | "", infos.Select(i => $""{i.Name} ({i.Size} bytes, {i.Type})""));
+    }
+}";
+
+    private readonly string readAsTextExampleCode =
+@"@inject Bit.Butil.FileReader fileReader
+
+<input type=""file"" @ref=""fileInput"" multiple />
+
+<BitButton OnClick=""ReadAsText"">ReadAsText</BitButton>
+
+<div>@fileText</div>
+
+@code {
+    private ElementReference fileInput;
+    private string? fileText;
+
+    private async Task ReadAsText()
+    {
+        var text = await fileReader.ReadAsText(fileInput);
+        fileText = string.IsNullOrEmpty(text) ? ""No file or empty content."" : text;
+    }
+}";
+
+    private readonly string readAsBytesExampleCode =
+@"@inject Bit.Butil.FileReader fileReader
+
+<input type=""file"" @ref=""fileInput"" multiple />
+
+<BitButton OnClick=""ReadAsBytes"">ReadAsBytes</BitButton>
+
+<div>@fileBytes</div>
+
+@code {
+    private ElementReference fileInput;
+    private string? fileBytes;
+
+    private async Task ReadAsBytes()
+    {
+        var bytes = await fileReader.ReadAsBytes(fileInput);
+        fileBytes = bytes is null ? ""No file selected."" : $""{bytes.Length} bytes"";
+    }
+}";
+
+    private readonly string readAsDataUrlExampleCode =
+@"@inject Bit.Butil.FileReader fileReader
+
+<input type=""file"" @ref=""fileInput"" multiple />
+
+<BitButton OnClick=""ReadAsDataUrl"">ReadAsDataUrl</BitButton>
+
+<div>@fileDataUrl</div>
+
+@if (imagePreviewUrl is not null)
+{
+    <img src=""@imagePreviewUrl"" alt=""Preview"" />
+}
+
+@code {
+    private ElementReference fileInput;
+    private string? fileDataUrl;
+    private string? imagePreviewUrl;
+
+    private async Task ReadAsDataUrl()
+    {
+        var dataUrl = await fileReader.ReadAsDataUrl(fileInput);
+        imagePreviewUrl = dataUrl.StartsWith(""data:image/"", StringComparison.OrdinalIgnoreCase)
+            ? dataUrl
+            : null;
+        fileDataUrl = dataUrl;
+    }
+}";
+
+    private readonly string clearExampleCode =
+@"@inject Bit.Butil.FileReader fileReader
+
+<input type=""file"" @ref=""fileInput"" multiple />
+
+<BitButton OnClick=""Clear"">Clear</BitButton>
+
+@code {
+    private ElementReference fileInput;
+
+    private async Task Clear()
+    {
+        await fileReader.Clear(fileInput);
+    }
+}";
+
+    private readonly string createExampleCode =
+@"@inject Bit.Butil.ObjectUrls objectUrls
+
+<BitTextField @bind-Value=""blobText"" Label=""Text to blob"" />
+
+<BitButton OnClick=""CreateObjectUrl"">Create</BitButton>
+
+@if (objectUrl is not null)
+{
+    <a href=""@objectUrl"" target=""_blank"" rel=""noopener"">Open blob URL</a>
+}
+
+@code {
+    private string? blobText;
+    private string? objectUrl;
+
+    private async Task CreateObjectUrl()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(blobText ?? string.Empty);
+        objectUrl = await objectUrls.Create(bytes, ""text/plain"");
+    }
+}";
+
+    private readonly string revokeExampleCode =
+@"@inject Bit.Butil.ObjectUrls objectUrls
+
+<BitButton OnClick=""RevokeObjectUrl"">Revoke</BitButton>
+
+@code {
+    private string? objectUrl;
+
+    private async Task RevokeObjectUrl()
+    {
+        if (objectUrl is null) return;
+        await objectUrls.Revoke(objectUrl);
+        objectUrl = null;
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil27FilesPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor
@@ -1,0 +1,186 @@
+@page "/butil/speech"
+@inherits AppComponentBase
+@inject Bit.Butil.SpeechSynthesis speechSynthesis
+@inject Bit.Butil.SpeechRecognition speechRecognition
+
+<PageOutlet Url="butil/speech"
+            Title="Speech - Butil"
+            Description="SpeechSynthesis and SpeechRecognition classes of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Speech</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the speech classes of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            The speech features are split across two classes. Inject the ones you need and use them like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.SpeechSynthesis speechSynthesis
+@@inject Bit.Butil.SpeechRecognition speechRecognition
+
+@@code {
+    await speechSynthesis.Speak("Hello from Butil!");
+    await using var rec = await speechRecognition.Start(options, onResult: r => { /* ... */ });
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>SpeechSynthesis</BitText>
+        <div class="section-card-txt">
+            The <b>SpeechSynthesis</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis" target="_blank">SpeechSynthesis API</a>
+            for text-to-speech.
+            <br /><br />
+
+            <b>GetVoices</b>: <br />
+            Returns the list of voices the platform makes available
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@getVoicesExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="GetVoices">GetVoices</BitButton>
+                        <br /><br />
+                        <div>Voices count: @voices.Length</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Speak</b>: <br />
+            Speaks the configured utterance with an optional voice, rate and pitch
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speak" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@speakExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitTextField @bind-Value="speakText" Label="Text" Multiline Rows="2" Style="max-width: 25rem;" />
+                        <br />
+                        <select @bind="voiceName">
+                            <option value="">Default voice</option>
+                            @foreach (var voice in voices)
+                            {
+                                <option value="@voice.Name">@voice.Name (@voice.Lang)</option>
+                            }
+                        </select>
+                        <br /><br />
+                        <BitButton OnClick="Speak">Speak</BitButton>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Pause / Resume / Cancel</b>: <br />
+            Pauses the current utterance, resumes a paused utterance, or cancels all pending utterances
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/pause" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@pauseResumeCancelExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="PauseSpeech">Pause</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="ResumeSpeech">Resume</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="CancelSpeech">Cancel</BitButton>
+                        <br /><br />
+                        <div>@speakResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>IsSpeaking</b>: <br />
+            Returns whether the engine is currently speaking (or paused)
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speaking" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@isSpeakingExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="IsSpeaking">IsSpeaking</BitButton>
+                        <br /><br />
+                        <div>Is speaking: @isSpeaking</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>SpeechRecognition</BitText>
+        <div class="section-card-txt">
+            The <b>SpeechRecognition</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition" target="_blank">SpeechRecognition API</a>
+            for speech-to-text (Chromium-based browsers).
+            <br /><br />
+
+            <b>Start</b>: <br />
+            Captures microphone input and reports interim and final transcripts through the onResult callback.
+            The Continuous and InterimResults options control the stream, and onError / onEnd surface errors and completion.
+            Returns an <b>IAsyncDisposable</b> handle that stops recognition when disposed
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/start" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@startExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StartRecognition" IsEnabled="@(recognizing is false)">Start</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopRecognition" IsEnabled="@(recognitionHandle is not null)">Stop</BitButton>
+                        <br /><br />
+                        <div>Transcript: @transcript</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>Stop</b>: <br />
+            Stops the recognition session early. Disposing the handle returned by <b>Start</b> is equivalent
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/stop" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@stopExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StopRecognition" IsEnabled="@(recognitionHandle is not null)">Stop</BitButton>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="Files" PrevUrl="/butil/files" Next="Observers" NextUrl="/butil/observers" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor
@@ -34,13 +34,13 @@
         <BitText Typography="BitTypography.H5" Gutter>SpeechSynthesis</BitText>
         <div class="section-card-txt">
             The <b>SpeechSynthesis</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis" target="_blank">SpeechSynthesis API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis" target="_blank" rel="noopener noreferrer">SpeechSynthesis API</a>
             for text-to-speech.
             <br /><br />
 
             <b>GetVoices</b>: <br />
             Returns the list of voices the platform makes available
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -52,6 +52,7 @@
                         <BitButton OnClick="GetVoices">GetVoices</BitButton>
                         <br /><br />
                         <div>Voices count: @voices.Length</div>
+                        <div>@getVoicesResult</div>
                         <br />
                     </BitPivotItem>
                 </BitPivot>
@@ -60,7 +61,7 @@
 
             <b>Speak</b>: <br />
             Speaks the configured utterance with an optional voice, rate and pitch
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speak" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speak" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -71,7 +72,7 @@
                         <br />
                         <BitTextField @bind-Value="speakText" Label="Text" Multiline Rows="2" Style="max-width: 25rem;" />
                         <br />
-                        <select @bind="voiceName">
+                        <select @bind="voiceName" aria-label="Voice">
                             <option value="">Default voice</option>
                             @foreach (var voice in voices)
                             {
@@ -88,7 +89,7 @@
 
             <b>Pause / Resume / Cancel</b>: <br />
             Pauses the current utterance, resumes a paused utterance, or cancels all pending utterances
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/pause" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/pause" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -112,7 +113,7 @@
 
             <b>IsSpeaking</b>: <br />
             Returns whether the engine is currently speaking (or paused)
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speaking" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/speaking" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -135,7 +136,7 @@
         <BitText Typography="BitTypography.H5" Gutter>SpeechRecognition</BitText>
         <div class="section-card-txt">
             The <b>SpeechRecognition</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition" target="_blank">SpeechRecognition API</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition" target="_blank" rel="noopener noreferrer">SpeechRecognition API</a>
             for speech-to-text (Chromium-based browsers).
             <br /><br />
 
@@ -143,7 +144,7 @@
             Captures microphone input and reports interim and final transcripts through the onResult callback.
             The Continuous and InterimResults options control the stream, and onError / onEnd surface errors and completion.
             Returns an <b>IAsyncDisposable</b> handle that stops recognition when disposed
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/start" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/start" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -165,7 +166,7 @@
 
             <b>Stop</b>: <br />
             Stops the recognition session early. Disposing the handle returned by <b>Start</b> is equivalent
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/stop" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/stop" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor.cs
@@ -7,6 +7,7 @@ public partial class Butil28SpeechPage
     private SpeechVoice[] voices = [];
     private string? speakText = "Hello from Bit.Butil speech synthesis!";
     private string? voiceName;
+    private string? getVoicesResult;
     private string? speakResult;
     private string? isSpeaking;
 
@@ -27,17 +28,24 @@ public partial class Butil28SpeechPage
     {
         if (await speechSynthesis.IsSupported() is false)
         {
-            speakResult = "Speech synthesis is not supported.";
+            getVoicesResult = "Speech synthesis is not supported.";
             return;
         }
 
         voices = await speechSynthesis.GetVoices();
+        getVoicesResult = $"{voices.Length} voice(s) available.";
         StateHasChanged();
     }
 
     private async Task Speak()
     {
         if (string.IsNullOrWhiteSpace(speakText)) return;
+
+        if (await speechSynthesis.IsSupported() is false)
+        {
+            speakResult = "Speech synthesis is not supported.";
+            return;
+        }
 
         await speechSynthesis.Speak(new SpeechUtterance
         {
@@ -50,24 +58,48 @@ public partial class Butil28SpeechPage
 
     private async Task PauseSpeech()
     {
+        if (await speechSynthesis.IsSupported() is false)
+        {
+            speakResult = "Speech synthesis is not supported.";
+            return;
+        }
+
         await speechSynthesis.Pause();
         speakResult = $"Paused (speaking={await speechSynthesis.IsSpeaking()}).";
     }
 
     private async Task ResumeSpeech()
     {
+        if (await speechSynthesis.IsSupported() is false)
+        {
+            speakResult = "Speech synthesis is not supported.";
+            return;
+        }
+
         await speechSynthesis.Resume();
         speakResult = "Resumed.";
     }
 
     private async Task CancelSpeech()
     {
+        if (await speechSynthesis.IsSupported() is false)
+        {
+            speakResult = "Speech synthesis is not supported.";
+            return;
+        }
+
         await speechSynthesis.Cancel();
         speakResult = "Cancelled.";
     }
 
     private async Task IsSpeaking()
     {
+        if (await speechSynthesis.IsSupported() is false)
+        {
+            isSpeaking = "Speech synthesis is not supported.";
+            return;
+        }
+
         isSpeaking = (await speechSynthesis.IsSpeaking()).ToString();
     }
 
@@ -121,6 +153,9 @@ public partial class Butil28SpeechPage
 
     protected override async ValueTask DisposeAsync(bool disposing)
     {
+        // Stop any active/pending speech so navigating away cancels ongoing utterances.
+        await speechSynthesis.Cancel();
+
         if (recognitionHandle is not null)
             await recognitionHandle.DisposeAsync();
 

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor.cs
@@ -1,0 +1,263 @@
+using Bit.Butil;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil28SpeechPage
+{
+    private SpeechVoice[] voices = [];
+    private string? speakText = "Hello from Bit.Butil speech synthesis!";
+    private string? voiceName;
+    private string? speakResult;
+    private string? isSpeaking;
+
+    private string? transcript;
+    private bool recognizing;
+    private IAsyncDisposable? recognitionHandle;
+
+
+    protected override async Task OnAfterFirstRenderAsync()
+    {
+        await base.OnAfterFirstRenderAsync();
+
+        await GetVoices();
+    }
+
+
+    private async Task GetVoices()
+    {
+        if (await speechSynthesis.IsSupported() is false)
+        {
+            speakResult = "Speech synthesis is not supported.";
+            return;
+        }
+
+        voices = await speechSynthesis.GetVoices();
+        StateHasChanged();
+    }
+
+    private async Task Speak()
+    {
+        if (string.IsNullOrWhiteSpace(speakText)) return;
+
+        await speechSynthesis.Speak(new SpeechUtterance
+        {
+            Text = speakText,
+            VoiceName = string.IsNullOrWhiteSpace(voiceName) ? null : voiceName,
+            Rate = 1,
+            Pitch = 1,
+        });
+    }
+
+    private async Task PauseSpeech()
+    {
+        await speechSynthesis.Pause();
+        speakResult = $"Paused (speaking={await speechSynthesis.IsSpeaking()}).";
+    }
+
+    private async Task ResumeSpeech()
+    {
+        await speechSynthesis.Resume();
+        speakResult = "Resumed.";
+    }
+
+    private async Task CancelSpeech()
+    {
+        await speechSynthesis.Cancel();
+        speakResult = "Cancelled.";
+    }
+
+    private async Task IsSpeaking()
+    {
+        isSpeaking = (await speechSynthesis.IsSpeaking()).ToString();
+    }
+
+    private async Task StartRecognition()
+    {
+        if (await speechRecognition.IsSupported() is false)
+        {
+            transcript = "Speech recognition is not supported.";
+            return;
+        }
+
+        await StopRecognitionInternal();
+
+        transcript = "";
+        recognizing = true;
+
+        recognitionHandle = await speechRecognition.Start(
+            new SpeechRecognitionOptions { Continuous = true, InterimResults = true },
+            onResult: result =>
+            {
+                transcript = result.IsFinal
+                    ? $"Final: {result.Transcript} ({result.Confidence:P0})"
+                    : $"Interim: {result.Transcript}";
+                InvokeAsync(StateHasChanged);
+            },
+            onError: err =>
+            {
+                transcript = $"Error: {err}";
+                InvokeAsync(StateHasChanged);
+            },
+            onEnd: () =>
+            {
+                recognizing = false;
+                InvokeAsync(StateHasChanged);
+            });
+    }
+
+    private async Task StopRecognition()
+    {
+        await StopRecognitionInternal();
+    }
+
+    private async Task StopRecognitionInternal()
+    {
+        if (recognitionHandle is null) return;
+        await recognitionHandle.DisposeAsync();
+        recognitionHandle = null;
+        recognizing = false;
+    }
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (recognitionHandle is not null)
+            await recognitionHandle.DisposeAsync();
+
+        await base.DisposeAsync(disposing);
+    }
+
+
+    private readonly string getVoicesExampleCode =
+@"@inject Bit.Butil.SpeechSynthesis speechSynthesis
+
+<BitButton OnClick=""GetVoices"">GetVoices</BitButton>
+
+<div>Voices count: @voices.Length</div>
+
+@code {
+    private SpeechVoice[] voices = [];
+
+    private async Task GetVoices()
+    {
+        if (await speechSynthesis.IsSupported() is false) return;
+        voices = await speechSynthesis.GetVoices();
+    }
+}";
+
+    private readonly string speakExampleCode =
+@"@inject Bit.Butil.SpeechSynthesis speechSynthesis
+
+<BitTextField @bind-Value=""speakText"" Label=""Text"" Multiline Rows=""2"" />
+
+<select @bind=""voiceName"">
+    <option value="""">Default voice</option>
+    @foreach (var voice in voices)
+    {
+        <option value=""@voice.Name"">@voice.Name (@voice.Lang)</option>
+    }
+</select>
+
+<BitButton OnClick=""Speak"">Speak</BitButton>
+
+@code {
+    private string? speakText = ""Hello from Bit.Butil speech synthesis!"";
+    private string? voiceName;
+
+    private async Task Speak()
+    {
+        await speechSynthesis.Speak(new SpeechUtterance
+        {
+            Text = speakText,
+            VoiceName = string.IsNullOrWhiteSpace(voiceName) ? null : voiceName,
+            Rate = 1,
+            Pitch = 1,
+        });
+    }
+}";
+
+    private readonly string pauseResumeCancelExampleCode =
+@"@inject Bit.Butil.SpeechSynthesis speechSynthesis
+
+<BitButton OnClick=""PauseSpeech"">Pause</BitButton>
+<BitButton OnClick=""ResumeSpeech"">Resume</BitButton>
+<BitButton OnClick=""CancelSpeech"">Cancel</BitButton>
+
+@code {
+    private async Task PauseSpeech()
+    {
+        await speechSynthesis.Pause();
+    }
+
+    private async Task ResumeSpeech()
+    {
+        await speechSynthesis.Resume();
+    }
+
+    private async Task CancelSpeech()
+    {
+        await speechSynthesis.Cancel();
+    }
+}";
+
+    private readonly string isSpeakingExampleCode =
+@"@inject Bit.Butil.SpeechSynthesis speechSynthesis
+
+<BitButton OnClick=""IsSpeaking"">IsSpeaking</BitButton>
+
+<div>Is speaking: @isSpeaking</div>
+
+@code {
+    private string? isSpeaking;
+
+    private async Task IsSpeaking()
+    {
+        isSpeaking = (await speechSynthesis.IsSpeaking()).ToString();
+    }
+}";
+
+    private readonly string startExampleCode =
+@"@inject Bit.Butil.SpeechRecognition speechRecognition
+
+<BitButton OnClick=""StartRecognition"">Start</BitButton>
+
+<div>Transcript: @transcript</div>
+
+@code {
+    private string? transcript;
+    private IAsyncDisposable? recognitionHandle;
+
+    private async Task StartRecognition()
+    {
+        if (await speechRecognition.IsSupported() is false) return;
+
+        recognitionHandle = await speechRecognition.Start(
+            new SpeechRecognitionOptions { Continuous = true, InterimResults = true },
+            onResult: result =>
+            {
+                transcript = result.IsFinal
+                    ? $""Final: {result.Transcript} ({result.Confidence:P0})""
+                    : $""Interim: {result.Transcript}"";
+                InvokeAsync(StateHasChanged);
+            },
+            onError: err => { InvokeAsync(StateHasChanged); },
+            onEnd: () => { InvokeAsync(StateHasChanged); });
+    }
+}";
+
+    private readonly string stopExampleCode =
+@"@inject Bit.Butil.SpeechRecognition speechRecognition
+
+<BitButton OnClick=""StopRecognition"">Stop</BitButton>
+
+@code {
+    private IAsyncDisposable? recognitionHandle;
+
+    private async Task StopRecognition()
+    {
+        if (recognitionHandle is null) return;
+        await recognitionHandle.DisposeAsync();
+        recognitionHandle = null;
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil28SpeechPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor
@@ -52,7 +52,7 @@
 
             <b>ObserveIntersection</b>: <br />
             Fires when the target enters or leaves the viewport, reporting the intersection ratio and visibility
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -74,7 +74,7 @@
 
             <b>ObserveResize</b>: <br />
             Reports size changes when the target is resized, surfacing the new content-rect dimensions
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -98,7 +98,7 @@
 
             <b>ObserveMutations</b>: <br />
             Logs DOM changes on the target element, such as attribute mutations
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -125,13 +125,13 @@
         <BitText Typography="BitTypography.H5" Gutter>Performance</BitText>
         <div class="section-card-txt">
             The <b>Performance</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance" target="_blank">Performance</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance" target="_blank" rel="noopener noreferrer">Performance</a>
             timing and marker API.
             <br /><br />
 
             <b>Mark / Measure / GetEntries</b>: <br />
             Adds named marks to the timeline, measures the elapsed time between them, and reads back the recorded entries
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -151,7 +151,7 @@
 
             <b>SubscribeObserver</b>: <br />
             Subscribes a <b>PerformanceObserver</b> to one or more entry types and reports each batch as it arrives
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -174,14 +174,14 @@
         <BitText Typography="BitTypography.H5" Gutter>StorageManager & NetworkInformation</BitText>
         <div class="section-card-txt">
             The <b>StorageManager</b> class wraps
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager" target="_blank">navigator.storage</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager" target="_blank" rel="noopener noreferrer">navigator.storage</a>
             and the <b>NetworkInformation</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank">Network Information API</a>.
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank" rel="noopener noreferrer">Network Information API</a>.
             <br /><br />
 
             <b>Estimate</b>: <br />
             Reports an estimate of the storage quota and current usage for the origin
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -201,7 +201,7 @@
 
             <b>GetStatus</b>: <br />
             Returns the online flag, effective connection type, downlink and round-trip-time estimates
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -224,14 +224,14 @@
         <BitText Typography="BitTypography.H5" Gutter>BroadcastChannel</BitText>
         <div class="section-card-txt">
             The <b>BroadcastChannel</b> class wraps the
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel" target="_blank">BroadcastChannel</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel" target="_blank" rel="noopener noreferrer">BroadcastChannel</a>
             API for cross-tab pub/sub on the same origin.
             <br /><br />
 
             <b>Subscribe / Post</b>: <br />
             Subscribes to a named channel and posts messages to every other listener on that channel in the same origin
             (the sender does not receive its own message). Open a second tab to see messages arrive
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>
@@ -256,12 +256,12 @@
         <BitText Typography="BitTypography.H5" Gutter>IndexedDB</BitText>
         <div class="section-card-txt">
             The <b>IndexedDb</b> class is a lightweight wrapper over
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API" target="_blank">IndexedDB</a>.
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API" target="_blank" rel="noopener noreferrer">IndexedDB</a>.
             <br /><br />
 
             <b>Open / Put / Get</b>: <br />
             Opens (and upgrades if needed) a database, stores a record and reads it back by key
-            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/put" target="_blank">MDN</a>).
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/put" target="_blank" rel="noopener noreferrer">MDN</a>).
             <br /><br />
             <BitAccordion Title="Sample">
                 <BitPivot>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor
@@ -1,0 +1,284 @@
+@page "/butil/observers"
+@inherits AppComponentBase
+@inject Bit.Butil.Performance performance
+@inject Bit.Butil.StorageManager storageManager
+@inject Bit.Butil.NetworkInformation networkInformation
+@inject Bit.Butil.BroadcastChannel broadcastChannel
+@inject Bit.Butil.IndexedDb indexedDb
+
+<PageOutlet Url="butil/observers"
+            Title="Observers - Butil"
+            Description="Observers and async browser APIs of the bit Butil" />
+
+<div class="page-container">
+    <BitText Typography="BitTypography.H3" Gutter>Observers</BitText>
+    <br />
+    <BitText Typography="BitTypography.Subtitle1" Gutter>
+        How to use the observers and async browser APIs of the bit Butil?
+    </BitText>
+    <br />
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Usage</BitText>
+        <div class="section-card-txt">
+            These reactive and async browser APIs are spread across a few classes and element extension methods.
+            Inject the ones you need (the element observers take the injected <b>IJSRuntime</b>) and use them like this:
+<CodeBox HideCopyButton>
+@@inject Bit.Butil.Performance performance
+@@inject Bit.Butil.StorageManager storageManager
+@@inject Bit.Butil.NetworkInformation networkInformation
+@@inject Bit.Butil.BroadcastChannel broadcastChannel
+@@inject Bit.Butil.IndexedDb indexedDb
+@@inject IJSRuntime js
+
+@@code {
+    var sub = await element.ObserveIntersection(js, entries => { /* ... */ });
+    await using var db = await indexedDb.Open("my-db", 1, [new IndexedDbStoreSchema { Name = "items", KeyPath = "id" }]);
+}</CodeBox>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Element observers</BitText>
+        <div class="section-card-txt">
+            The <b>ObserveIntersection</b>, <b>ObserveResize</b> and <b>ObserveMutations</b> extension methods wire the
+            matching browser observers onto an <b>ElementReference</b>. Each returns a <b>ButilSubscription</b> you
+            dispose to stop observing. The samples below all watch this shared target element:
+            <br /><br />
+            <div @ref="target" style="width:120px;height:48px;border:2px solid var(--bit-clr-pri);border-radius:6px;display:flex;align-items:center;justify-content:center">
+                target
+            </div>
+            <br />
+
+            <b>ObserveIntersection</b>: <br />
+            Fires when the target enters or leaves the viewport, reporting the intersection ratio and visibility
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@intersectionExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StartIntersection">Observe</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopIntersection">Stop</BitButton>
+                        <br /><br />
+                        <div>@intersectionResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>ObserveResize</b>: <br />
+            Reports size changes when the target is resized, surfacing the new content-rect dimensions
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@resizeExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StartResize">Observe</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="GrowTarget">Grow target</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopResize">Stop</BitButton>
+                        <br /><br />
+                        <div>@resizeResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>ObserveMutations</b>: <br />
+            Logs DOM changes on the target element, such as attribute mutations
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@mutationExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StartMutation">Observe</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="MutateTarget">Mutate attribute</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="StopMutation">Stop</BitButton>
+                        <br /><br />
+                        <div>@mutationResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>Performance</BitText>
+        <div class="section-card-txt">
+            The <b>Performance</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance" target="_blank">Performance</a>
+            timing and marker API.
+            <br /><br />
+
+            <b>Mark / Measure / GetEntries</b>: <br />
+            Adds named marks to the timeline, measures the elapsed time between them, and reads back the recorded entries
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@perfMeasureExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="PerfMarkMeasure">Mark + Measure</BitButton>
+                        <br /><br />
+                        <div>@perfMeasureResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>SubscribeObserver</b>: <br />
+            Subscribes a <b>PerformanceObserver</b> to one or more entry types and reports each batch as it arrives
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@perfObserverExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="PerfObserver">SubscribeObserver</BitButton>
+                        <br /><br />
+                        <div>@perfObserverResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>StorageManager & NetworkInformation</BitText>
+        <div class="section-card-txt">
+            The <b>StorageManager</b> class wraps
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager" target="_blank">navigator.storage</a>
+            and the <b>NetworkInformation</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank">Network Information API</a>.
+            <br /><br />
+
+            <b>Estimate</b>: <br />
+            Reports an estimate of the storage quota and current usage for the origin
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@storageExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="StorageEstimate">Estimate</BitButton>
+                        <br /><br />
+                        <div>@storageResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+            <br /><br />
+
+            <b>GetStatus</b>: <br />
+            Returns the online flag, effective connection type, downlink and round-trip-time estimates
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@networkExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="NetworkStatus">GetStatus</BitButton>
+                        <br /><br />
+                        <div>@networkResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>BroadcastChannel</BitText>
+        <div class="section-card-txt">
+            The <b>BroadcastChannel</b> class wraps the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel" target="_blank">BroadcastChannel</a>
+            API for cross-tab pub/sub on the same origin.
+            <br /><br />
+
+            <b>Subscribe / Post</b>: <br />
+            Subscribes to a named channel and posts messages to every other listener on that channel in the same origin
+            (the sender does not receive its own message). Open a second tab to see messages arrive
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@broadcastExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="BroadcastSubscribe">Subscribe</BitButton>
+                        &nbsp;
+                        <BitButton OnClick="BroadcastPost">Post</BitButton>
+                        <br /><br />
+                        <div>@broadcastResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+
+    <section class="section-card">
+        <BitText Typography="BitTypography.H5" Gutter>IndexedDB</BitText>
+        <div class="section-card-txt">
+            The <b>IndexedDb</b> class is a lightweight wrapper over
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API" target="_blank">IndexedDB</a>.
+            <br /><br />
+
+            <b>Open / Put / Get</b>: <br />
+            Opens (and upgrades if needed) a database, stores a record and reads it back by key
+            (<a href="https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/put" target="_blank">MDN</a>).
+            <br /><br />
+            <BitAccordion Title="Sample">
+                <BitPivot>
+                    <BitPivotItem HeaderText="Code">
+                        <CodeBox>@indexedDbExampleCode</CodeBox>
+                    </BitPivotItem>
+                    <BitPivotItem HeaderText="Result">
+                        <br />
+                        <BitButton OnClick="IndexedDbRoundTrip">Round-trip</BitButton>
+                        <br /><br />
+                        <div>@indexedDbResult</div>
+                        <br />
+                    </BitPivotItem>
+                </BitPivot>
+            </BitAccordion>
+        </div>
+    </section>
+</div>
+
+<NavigationButtons Prev="Speech" PrevUrl="/butil/speech" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor.cs
@@ -1,0 +1,454 @@
+using Bit.Butil;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Websites.Platform.Client.Pages.Butil;
+
+public partial class Butil29ObserversPage
+{
+    private ElementReference target;
+    private int targetWidth = 120;
+
+    private ButilSubscription? intersectionSub;
+    private ButilSubscription? resizeSub;
+    private ButilSubscription? mutationSub;
+    private ButilSubscription? perfObserverSub;
+    private ButilSubscription? broadcastSub;
+
+    private string? intersectionResult;
+    private string? resizeResult;
+    private string? mutationResult;
+    private string? perfMeasureResult;
+    private string? perfObserverResult;
+    private string? storageResult;
+    private string? networkResult;
+    private string? broadcastResult;
+    private string? indexedDbResult;
+
+
+    private async Task StartIntersection()
+    {
+        await StopIntersection();
+        intersectionSub = await target.ObserveIntersection(JSRuntime, entries =>
+        {
+            if (entries.Length > 0)
+            {
+                intersectionResult = $"ratio={entries[0].IntersectionRatio:F2}, visible={entries[0].IsIntersecting}";
+                InvokeAsync(StateHasChanged);
+            }
+        });
+        intersectionResult = "Intersection observer started.";
+    }
+
+    private async Task StopIntersection()
+    {
+        if (intersectionSub is null) return;
+        await intersectionSub.DisposeAsync();
+        intersectionSub = null;
+    }
+
+    private async Task StartResize()
+    {
+        await StopResize();
+        resizeSub = await target.ObserveResize(JSRuntime, entries =>
+        {
+            if (entries.Length > 0)
+            {
+                var rect = entries[0].ContentRect;
+                resizeResult = $"{rect?.Width:F0}x{rect?.Height:F0}";
+                InvokeAsync(StateHasChanged);
+            }
+        });
+        resizeResult = "Resize observer started.";
+    }
+
+    private async Task GrowTarget()
+    {
+        targetWidth += 40;
+        await target.SetAttribute("style",
+            $"width:{targetWidth}px;height:48px;border:2px solid var(--bit-clr-pri);border-radius:6px;display:flex;align-items:center;justify-content:center");
+    }
+
+    private async Task StopResize()
+    {
+        if (resizeSub is null) return;
+        await resizeSub.DisposeAsync();
+        resizeSub = null;
+    }
+
+    private async Task StartMutation()
+    {
+        await StopMutation();
+        mutationSub = await target.ObserveMutations(JSRuntime, records =>
+        {
+            if (records.Length > 0)
+            {
+                mutationResult = $"{records[0].Type} on {records[0].TargetId ?? "target"}";
+                InvokeAsync(StateHasChanged);
+            }
+        }, new MutationObserverOptions { Attributes = true });
+        mutationResult = "Mutation observer started.";
+    }
+
+    private async Task MutateTarget()
+    {
+        await target.SetAttribute("data-butil", Guid.NewGuid().ToString("N")[..8]);
+    }
+
+    private async Task StopMutation()
+    {
+        if (mutationSub is null) return;
+        await mutationSub.DisposeAsync();
+        mutationSub = null;
+    }
+
+    private async Task PerfMarkMeasure()
+    {
+        await performance.Mark("butil-demo-a");
+        await Task.Delay(50);
+        await performance.Mark("butil-demo-b");
+        await performance.Measure("butil-demo-measure", "butil-demo-a", "butil-demo-b");
+        var entries = await performance.GetEntries("butil-demo-measure", "measure");
+        perfMeasureResult = entries.Length > 0 ? entries[0].ToString() : "(no entry)";
+    }
+
+    private async Task PerfObserver()
+    {
+        await StopPerfObserver();
+        perfObserverSub = await performance.SubscribeObserver(["mark"], entries =>
+        {
+            if (entries.Length > 0)
+            {
+                perfObserverResult = entries[0].ToString();
+                InvokeAsync(StateHasChanged);
+            }
+        }, buffered: false);
+
+        await performance.Mark("butil-demo-observed");
+        perfObserverResult = "PerformanceObserver subscribed - mark created.";
+    }
+
+    private async Task StopPerfObserver()
+    {
+        if (perfObserverSub is null) return;
+        await perfObserverSub.DisposeAsync();
+        perfObserverSub = null;
+    }
+
+    private async Task StorageEstimate()
+    {
+        var est = await storageManager.Estimate();
+        storageResult = $"quota={est.Quota}, usage={est.Usage}";
+    }
+
+    private async Task NetworkStatus()
+    {
+        var status = await networkInformation.GetStatus();
+        networkResult = $"online={status.Online}, type={status.EffectiveType ?? status.Type ?? "n/a"}, downlink={status.Downlink}, rtt={status.Rtt}";
+    }
+
+    private async Task BroadcastSubscribe()
+    {
+        await StopBroadcast();
+        broadcastSub = await broadcastChannel.Subscribe("butil-demo-channel", msg =>
+        {
+            broadcastResult = $"received -> {msg}";
+            InvokeAsync(StateHasChanged);
+        });
+        broadcastResult = "Subscribed to butil-demo-channel.";
+    }
+
+    private async Task BroadcastPost()
+    {
+        await broadcastChannel.Post("butil-demo-channel", new { text = "hello from this tab", at = DateTimeOffset.Now });
+        broadcastResult = "Posted (same tab won't receive its own message; open a second tab).";
+    }
+
+    private async Task StopBroadcast()
+    {
+        if (broadcastSub is null) return;
+        await broadcastSub.DisposeAsync();
+        broadcastSub = null;
+    }
+
+    private async Task IndexedDbRoundTrip()
+    {
+        await using var db = await indexedDb.Open("butil-demo-db", 1,
+        [
+            new IndexedDbStoreSchema { Name = "items", KeyPath = "id" }
+        ]);
+
+        var item = new DemoIdbItem { Id = "demo-1", Value = "stored at " + DateTimeOffset.Now.ToString("HH:mm:ss") };
+        await db.Put("items", item);
+        var read = await db.Get<DemoIdbItem>("items", "demo-1");
+        indexedDbResult = read?.Value ?? "(null)";
+    }
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (intersectionSub is not null)
+            await intersectionSub.DisposeAsync();
+        if (resizeSub is not null)
+            await resizeSub.DisposeAsync();
+        if (mutationSub is not null)
+            await mutationSub.DisposeAsync();
+        if (perfObserverSub is not null)
+            await perfObserverSub.DisposeAsync();
+        if (broadcastSub is not null)
+            await broadcastSub.DisposeAsync();
+
+        await base.DisposeAsync(disposing);
+    }
+
+
+    private class DemoIdbItem
+    {
+        public string Id { get; set; } = "";
+        public string Value { get; set; } = "";
+    }
+
+
+    private readonly string intersectionExampleCode =
+@"@inject IJSRuntime js
+
+<div @ref=""target"">target</div>
+
+<BitButton OnClick=""StartIntersection"">Observe</BitButton>
+<BitButton OnClick=""StopIntersection"">Stop</BitButton>
+
+<div>@intersectionResult</div>
+
+@code {
+    private ElementReference target;
+    private ButilSubscription? intersectionSub;
+    private string? intersectionResult;
+
+    private async Task StartIntersection()
+    {
+        await StopIntersection();
+        intersectionSub = await target.ObserveIntersection(js, entries =>
+        {
+            if (entries.Length > 0)
+            {
+                intersectionResult = $""ratio={entries[0].IntersectionRatio:F2}, visible={entries[0].IsIntersecting}"";
+                InvokeAsync(StateHasChanged);
+            }
+        });
+    }
+
+    private async Task StopIntersection()
+    {
+        if (intersectionSub is null) return;
+        await intersectionSub.DisposeAsync();
+        intersectionSub = null;
+    }
+}";
+
+    private readonly string resizeExampleCode =
+@"@inject IJSRuntime js
+
+<div @ref=""target"">target</div>
+
+<BitButton OnClick=""StartResize"">Observe</BitButton>
+<BitButton OnClick=""GrowTarget"">Grow target</BitButton>
+<BitButton OnClick=""StopResize"">Stop</BitButton>
+
+<div>@resizeResult</div>
+
+@code {
+    private int targetWidth = 120;
+    private ElementReference target;
+    private ButilSubscription? resizeSub;
+    private string? resizeResult;
+
+    private async Task StartResize()
+    {
+        resizeSub = await target.ObserveResize(js, entries =>
+        {
+            if (entries.Length > 0)
+            {
+                var rect = entries[0].ContentRect;
+                resizeResult = $""{rect?.Width:F0}x{rect?.Height:F0}"";
+                InvokeAsync(StateHasChanged);
+            }
+        });
+    }
+
+    private async Task GrowTarget()
+    {
+        targetWidth += 40;
+        await target.SetAttribute(""style"", $""width:{targetWidth}px;height:48px"");
+    }
+}";
+
+    private readonly string mutationExampleCode =
+@"@inject IJSRuntime js
+
+<div @ref=""target"">target</div>
+
+<BitButton OnClick=""StartMutation"">Observe</BitButton>
+<BitButton OnClick=""MutateTarget"">Mutate attribute</BitButton>
+
+<div>@mutationResult</div>
+
+@code {
+    private ElementReference target;
+    private ButilSubscription? mutationSub;
+    private string? mutationResult;
+
+    private async Task StartMutation()
+    {
+        mutationSub = await target.ObserveMutations(js, records =>
+        {
+            if (records.Length > 0)
+            {
+                mutationResult = $""{records[0].Type} on {records[0].TargetId ?? ""target""}"";
+                InvokeAsync(StateHasChanged);
+            }
+        }, new MutationObserverOptions { Attributes = true });
+    }
+
+    private async Task MutateTarget()
+    {
+        await target.SetAttribute(""data-butil"", Guid.NewGuid().ToString(""N"")[..8]);
+    }
+}";
+
+    private readonly string perfMeasureExampleCode =
+@"@inject Bit.Butil.Performance performance
+
+<BitButton OnClick=""PerfMarkMeasure"">Mark + Measure</BitButton>
+
+<div>@perfMeasureResult</div>
+
+@code {
+    private string? perfMeasureResult;
+
+    private async Task PerfMarkMeasure()
+    {
+        await performance.Mark(""butil-demo-a"");
+        await Task.Delay(50);
+        await performance.Mark(""butil-demo-b"");
+        await performance.Measure(""butil-demo-measure"", ""butil-demo-a"", ""butil-demo-b"");
+        var entries = await performance.GetEntries(""butil-demo-measure"", ""measure"");
+        perfMeasureResult = entries.Length > 0 ? entries[0].ToString() : ""(no entry)"";
+    }
+}";
+
+    private readonly string perfObserverExampleCode =
+@"@inject Bit.Butil.Performance performance
+
+<BitButton OnClick=""PerfObserver"">SubscribeObserver</BitButton>
+
+<div>@perfObserverResult</div>
+
+@code {
+    private ButilSubscription? perfObserverSub;
+    private string? perfObserverResult;
+
+    private async Task PerfObserver()
+    {
+        perfObserverSub = await performance.SubscribeObserver([""mark""], entries =>
+        {
+            if (entries.Length > 0)
+            {
+                perfObserverResult = entries[0].ToString();
+                InvokeAsync(StateHasChanged);
+            }
+        }, buffered: false);
+
+        await performance.Mark(""butil-demo-observed"");
+    }
+}";
+
+    private readonly string storageExampleCode =
+@"@inject Bit.Butil.StorageManager storageManager
+
+<BitButton OnClick=""StorageEstimate"">Estimate</BitButton>
+
+<div>@storageResult</div>
+
+@code {
+    private string? storageResult;
+
+    private async Task StorageEstimate()
+    {
+        var est = await storageManager.Estimate();
+        storageResult = $""quota={est.Quota}, usage={est.Usage}"";
+    }
+}";
+
+    private readonly string networkExampleCode =
+@"@inject Bit.Butil.NetworkInformation networkInformation
+
+<BitButton OnClick=""NetworkStatus"">GetStatus</BitButton>
+
+<div>@networkResult</div>
+
+@code {
+    private string? networkResult;
+
+    private async Task NetworkStatus()
+    {
+        var status = await networkInformation.GetStatus();
+        networkResult = $""online={status.Online}, type={status.EffectiveType}, downlink={status.Downlink}, rtt={status.Rtt}"";
+    }
+}";
+
+    private readonly string broadcastExampleCode =
+@"@inject Bit.Butil.BroadcastChannel broadcastChannel
+
+<BitButton OnClick=""BroadcastSubscribe"">Subscribe</BitButton>
+<BitButton OnClick=""BroadcastPost"">Post</BitButton>
+
+<div>@broadcastResult</div>
+
+@code {
+    private ButilSubscription? broadcastSub;
+    private string? broadcastResult;
+
+    private async Task BroadcastSubscribe()
+    {
+        broadcastSub = await broadcastChannel.Subscribe(""butil-demo-channel"", msg =>
+        {
+            broadcastResult = $""received -> {msg}"";
+            InvokeAsync(StateHasChanged);
+        });
+    }
+
+    private async Task BroadcastPost()
+    {
+        await broadcastChannel.Post(""butil-demo-channel"", new { text = ""hello from this tab"", at = DateTime.Now });
+    }
+}";
+
+    private readonly string indexedDbExampleCode =
+@"@inject Bit.Butil.IndexedDb indexedDb
+
+<BitButton OnClick=""IndexedDbRoundTrip"">Round-trip</BitButton>
+
+<div>@indexedDbResult</div>
+
+@code {
+    private string? indexedDbResult;
+
+    private class DemoIdbItem
+    {
+        public string Id { get; set; } = """";
+        public string Value { get; set; } = """";
+    }
+
+    private async Task IndexedDbRoundTrip()
+    {
+        await using var db = await indexedDb.Open(""butil-demo-db"", 1,
+        [
+            new IndexedDbStoreSchema { Name = ""items"", KeyPath = ""id"" }
+        ]);
+
+        var item = new DemoIdbItem { Id = ""demo-1"", Value = ""stored at "" + DateTime.Now.ToString(""HH:mm:ss"") };
+        await db.Put(""items"", item);
+        var read = await db.Get<DemoIdbItem>(""items"", ""demo-1"");
+        indexedDbResult = read?.Value ?? ""(null)"";
+    }
+}";
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor.cs
@@ -201,7 +201,9 @@ public partial class Butil29ObserversPage
     }
 
 
-    private class DemoIdbItem
+    // Public so System.Text.Json can materialize it via its public parameterless
+    // constructor in trimmed/published builds when db.Get<DemoIdbItem> deserializes.
+    public class DemoIdbItem
     {
         public string Id { get; set; } = "";
         public string Value { get; set; } = "";
@@ -263,6 +265,7 @@ public partial class Butil29ObserversPage
 
     private async Task StartResize()
     {
+        await StopResize();
         resizeSub = await target.ObserveResize(js, entries =>
         {
             if (entries.Length > 0)
@@ -278,6 +281,13 @@ public partial class Butil29ObserversPage
     {
         targetWidth += 40;
         await target.SetAttribute(""style"", $""width:{targetWidth}px;height:48px"");
+    }
+
+    private async Task StopResize()
+    {
+        if (resizeSub is null) return;
+        await resizeSub.DisposeAsync();
+        resizeSub = null;
     }
 }";
 
@@ -298,6 +308,7 @@ public partial class Butil29ObserversPage
 
     private async Task StartMutation()
     {
+        await StopMutation();
         mutationSub = await target.ObserveMutations(js, records =>
         {
             if (records.Length > 0)
@@ -311,6 +322,13 @@ public partial class Butil29ObserversPage
     private async Task MutateTarget()
     {
         await target.SetAttribute(""data-butil"", Guid.NewGuid().ToString(""N"")[..8]);
+    }
+
+    private async Task StopMutation()
+    {
+        if (mutationSub is null) return;
+        await mutationSub.DisposeAsync();
+        mutationSub = null;
     }
 }";
 
@@ -348,6 +366,7 @@ public partial class Butil29ObserversPage
 
     private async Task PerfObserver()
     {
+        await StopPerfObserver();
         perfObserverSub = await performance.SubscribeObserver([""mark""], entries =>
         {
             if (entries.Length > 0)
@@ -358,6 +377,13 @@ public partial class Butil29ObserversPage
         }, buffered: false);
 
         await performance.Mark(""butil-demo-observed"");
+    }
+
+    private async Task StopPerfObserver()
+    {
+        if (perfObserverSub is null) return;
+        await perfObserverSub.DisposeAsync();
+        perfObserverSub = null;
     }
 }";
 
@@ -409,6 +435,7 @@ public partial class Butil29ObserversPage
 
     private async Task BroadcastSubscribe()
     {
+        await StopBroadcast();
         broadcastSub = await broadcastChannel.Subscribe(""butil-demo-channel"", msg =>
         {
             broadcastResult = $""received -> {msg}"";
@@ -419,6 +446,13 @@ public partial class Butil29ObserversPage
     private async Task BroadcastPost()
     {
         await broadcastChannel.Post(""butil-demo-channel"", new { text = ""hello from this tab"", at = DateTime.Now });
+    }
+
+    private async Task StopBroadcast()
+    {
+        if (broadcastSub is null) return;
+        await broadcastSub.DisposeAsync();
+        broadcastSub = null;
     }
 }";
 

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor.scss
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Butil/Butil29ObserversPage.razor.scss
@@ -1,0 +1,16 @@
+@import '../../Styles/abstracts/_colors.scss';
+@import '../../Styles/abstracts/_mixins.scss';
+@import '../../Styles/abstracts/_functions.scss';
+@import '../../Styles/abstracts/_media-queries.scss';
+
+.page-container {
+    @include PageContainer;
+}
+
+.section-card {
+    @include SectionCard;
+}
+
+.section-card-txt {
+    @include SectionCardText;
+}

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/MainLayout.razor.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Shared/MainLayout.razor.cs
@@ -138,6 +138,14 @@ public partial class MainLayout : IDisposable
         new BitNavItem { Text = "VisualViewport", Url = "/butil/visualViewport" },
         new BitNavItem { Text = "ScreenOrientation", Url = "/butil/screenOrientation" },
         new BitNavItem { Text = "UserAgent", Url = "/butil/userAgent" },
+        new BitNavItem { Text = "Device", Url = "/butil/device" },
+        new BitNavItem { Text = "Geolocation", Url = "/butil/geolocation" },
+        new BitNavItem { Text = "MediaDevices", Url = "/butil/mediaDevices" },
+        new BitNavItem { Text = "Permissions", Url = "/butil/permissions" },
+        new BitNavItem { Text = "Fetch", Url = "/butil/fetch" },
+        new BitNavItem { Text = "Files", Url = "/butil/files" },
+        new BitNavItem { Text = "Speech", Url = "/butil/speech" },
+        new BitNavItem { Text = "Observers", Url = "/butil/observers" },
     ];
 
 


### PR DESCRIPTION
closes #12561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Butil documentation pages for device sensors, geolocation, media devices, permissions, fetch, files, speech, and browser observers.
  * Expanded Butil navigation and enabled prev/next routing through the new flow.
* **Bug Fixes**
  * Improved lifecycle cleanup for active watches, subscriptions, wake locks, media streams, speech recognition, and in-flight fetch requests.
* **Documentation**
  * Updated many external MDN links to open safely in new tabs with improved link isolation (`rel="noopener noreferrer"`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->