### PR TITLE
Add AppAcceptLanguageRequestCultureProvider to map neutral cultures to specific ones #12564

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
@@ -3,8 +3,10 @@ using Boilerplate.Server.Shared;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Localization.Routing;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Boilerplate.Server.Shared.Infrastructure.Services;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -81,6 +83,8 @@ public static class WebApplicationExtensions
                 ApplyCurrentCultureToResponseHeaders = true
             };
             options.SetDefaultCulture(CultureInfoManager.DefaultCulture.Name);
+            options.RequestCultureProviders.Remove(options.RequestCultureProviders.OfType<AcceptLanguageHeaderRequestCultureProvider>().Single());
+            options.RequestCultureProviders.Add(new AppAcceptLanguageRequestCultureProvider { Options = options });
             options.RequestCultureProviders.Insert(1, new RouteDataRequestCultureProvider() { Options = options });
             app.UseRequestLocalization(options);
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppAcceptLanguageRequestCultureProvider.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppAcceptLanguageRequestCultureProvider.cs
@@ -1,0 +1,65 @@
+﻿//+:cnd:noEmit
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Primitives;
+
+namespace Boilerplate.Server.Shared.Infrastructure.Services;
+
+/// <summary>
+/// Extends <see cref="AcceptLanguageHeaderRequestCultureProvider"/> to map neutral culture names
+/// (e.g. <c>fa</c>) to their supported specific counterparts (e.g. <c>fa-IR</c>).
+/// <para>
+/// The built-in provider returns the raw <c>Accept-Language</c> header values as-is.
+/// The middleware's <c>FallBackToParentCultures</c> only walks <em>up</em> the hierarchy
+/// (specific → neutral), so a browser that sends <c>fa</c> never matches the supported
+/// culture <c>fa-IR</c>. This provider handles the opposite direction by substituting
+/// each neutral culture name with the first supported culture whose parent chain contains it.
+/// </para>
+/// </summary>
+public class AppAcceptLanguageRequestCultureProvider : AcceptLanguageHeaderRequestCultureProvider
+{
+    public override async Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext)
+    {
+        var result = await base.DetermineProviderCultureResult(httpContext);
+
+        if (result is null || Options?.SupportedCultures is not { Count: > 0 } supportedCultures)
+            return result;
+
+        var uiSupportedCultures = Options.SupportedUICultures ?? supportedCultures;
+
+        var mappedCultures = result.Cultures
+            .Select(c => MapNeutralToSpecificCulture(c, supportedCultures))
+            .ToList();
+
+        var mappedUICultures = result.UICultures
+            .Select(c => MapNeutralToSpecificCulture(c, uiSupportedCultures))
+            .ToList();
+
+        return new ProviderCultureResult(mappedCultures, mappedUICultures);
+    }
+
+    /// <summary>
+    /// If <paramref name="cultureName"/> is a neutral culture (contains no <c>-</c>),
+    /// returns the name of the first supported culture whose parent chain includes it.
+    /// Otherwise returns the original value unchanged.
+    /// </summary>
+    private static StringSegment MapNeutralToSpecificCulture(StringSegment cultureName, IList<CultureInfo> supportedCultures)
+    {
+        if (cultureName.Value?.Contains('-') is true)
+            return cultureName;
+
+        var matched = supportedCultures.FirstOrDefault(c =>
+        {
+            var parent = c.Parent;
+            while (parent.Equals(CultureInfo.InvariantCulture) is false)
+            {
+                if (string.Equals(parent.Name, cultureName.Value, StringComparison.OrdinalIgnoreCase))
+                    return true;
+                parent = parent.Parent;
+            }
+            return false;
+        });
+
+        return matched is not null ? new StringSegment(matched.Name) : cultureName;
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppAcceptLanguageRequestCultureProvider.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppAcceptLanguageRequestCultureProvider.cs
@@ -48,6 +48,11 @@ public class AppAcceptLanguageRequestCultureProvider : AcceptLanguageHeaderReque
         if (cultureName.Value?.Contains('-') is true)
             return cultureName;
 
+        var exact = supportedCultures.FirstOrDefault(c =>
+            string.Equals(c.Name, cultureName.Value, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null)
+            return new StringSegment(exact.Name);
+
         var matched = supportedCultures.FirstOrDefault(c =>
         {
             var parent = c.Parent;


### PR DESCRIPTION
## Summary
Introduces `AppAcceptLanguageRequestCultureProvider` to correctly handle neutral culture names (e.g. `fa`) in the `Accept-Language` header by mapping them to the appropriate specific supported culture (e.g. `fa-IR`).

## Changes
- Added `AppAcceptLanguageRequestCultureProvider.cs`: extends the built-in `AcceptLanguageHeaderRequestCultureProvider` and walks the parent chain of supported cultures to map neutral → specific culture names.
- Updated `WebApplicationExtensions.cs`: replaced the default `AcceptLanguageHeaderRequestCultureProvider` registration with the new `AppAcceptLanguageRequestCultureProvider`.

## Related Issue
This closes #12564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced localization language detection to better honor users’ `Accept-Language` preferences.
  * Neutral language codes (e.g., `fa`) are now mapped to the first matching supported specific locale when available (e.g., `fa-IR`).

* **Bug Fixes**
  * Reduced cases where language selection could fall back to an unexpected locale.
  * Improved consistency when users provide broader language preferences, ensuring the closest supported culture is chosen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->