### PR TITLE
Fix pivot sticky style on demo pages of multi-api components (#12579)

### DIFF
--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/DemoPage.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/DemoPage.razor
@@ -15,12 +15,13 @@ else
 
             @if (SecondaryNames?.Length > 0)
             {
-                <BitStack Horizontal>
+                <BitStack Horizontal AutoHeight>
                     @foreach (var name in SecondaryNames)
                     {
                         <BitText Element="span" Typography="BitTypography.Subtitle1" Color="BitColor.Info">@name</BitText>
                     }
                 </BitStack>
+                <br />
             }
 
             @if (Description.HasValue() || DescriptionTemplate is not null)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/BitButtonGroupDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/ButtonGroup/BitButtonGroupDemo.razor
@@ -26,7 +26,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitButtonGroupItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/MenuButton/BitMenuButtonDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Buttons/MenuButton/BitMenuButtonDemo.razor
@@ -25,7 +25,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitMenuButtonItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/AccordionList/BitAccordionListDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/AccordionList/BitAccordionListDemo.razor
@@ -42,7 +42,7 @@
             BitAccordionList is a sugar component over the single-item <BitLink Href="/components/accordion">BitAccordion</BitLink> component. Instead of wiring multiple accordions manually, you provide a list of items and it handles rendering and expand/collapse state for you.
         </DescriptionTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitAccordionListItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/ChoiceGroup/BitChoiceGroupDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/ChoiceGroup/BitChoiceGroupDemo.razor
@@ -26,7 +26,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitChoiceGroupItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Inputs/Dropdown/BitDropdownDemo.razor
@@ -38,7 +38,7 @@
             </BitScrollablePane>
         </IntroductionTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitDropdownItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Lists/Timeline/BitTimelineDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Lists/Timeline/BitTimelineDemo.razor
@@ -25,7 +25,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitTimelineItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/BitBreadcrumbDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Breadcrumb/BitBreadcrumbDemo.razor
@@ -23,7 +23,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitBreadcrumbItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Nav/BitNavDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/Nav/BitNavDemo.razor
@@ -26,7 +26,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitNavItemDemo />
                 </BitPivotItem>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/NavBar/BitNavBarDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Navs/NavBar/BitNavBarDemo.razor
@@ -25,7 +25,7 @@
             </BitText>
         </NotesTemplate>
         <Examples>
-            <BitPivot Classes="@(new() { Header = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
+            <BitPivot Classes="@(new() { HeaderContainer = "pivot-sticky-header" })" MountAll="RenderForMcpClient">
                 <BitPivotItem HeaderText="Item">
                     <_BitNavBarItemDemo />
                 </BitPivotItem>


### PR DESCRIPTION
closes #12579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout spacing in a demo page so name items display more cleanly on one row.
  * Updated several demo pages so the sticky header styling applies consistently across navigation, input, list, and button examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->