### PR TITLE
Fix trimming issues of BitRichTextEditor (#12581)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.Sanitization.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.Sanitization.cs
@@ -11,13 +11,16 @@ public partial class BitRichTextEditor
     [Parameter] public BitRichTextEditorSanitizationPolicy? SanitizationPolicy { get; set; }
 
     /// <summary>Builds the policy object sent to the JS bridge, or null for the default.</summary>
-    private object? BuildPolicyPayload()
+    private BitRichTextEditorPolicyPayload? BuildPolicyPayload()
     {
         if (SanitizationPolicy is null) return null;
-        return new
+        // A concrete class is required here (not an anonymous type): the trimmer strips anonymous
+        // type constructor parameter names in release builds, which breaks System.Text.Json
+        // serialization during the JS interop call.
+        return new BitRichTextEditorPolicyPayload
         {
-            allowedTags = SanitizationPolicy.AllowedTags.Select(t => t.ToLowerInvariant()).ToArray(),
-            allowedAttributes = SanitizationPolicy.AllowedAttributes
+            AllowedTags = SanitizationPolicy.AllowedTags.Select(t => t.ToLowerInvariant()).ToArray(),
+            AllowedAttributes = SanitizationPolicy.AllowedAttributes
                 .GroupBy(kv => kv.Key.ToLowerInvariant())
                 .ToDictionary(
                     g => g.Key,
@@ -25,8 +28,8 @@ public partial class BitRichTextEditor
                           .Select(a => a.ToLowerInvariant())
                           .Distinct()
                           .ToArray()),
-            allowedUriSchemes = SanitizationPolicy.AllowedUriSchemes.Select(s => s.ToLowerInvariant()).ToArray(),
-            allowDataImageUris = SanitizationPolicy.AllowDataImageUris
+            AllowedUriSchemes = SanitizationPolicy.AllowedUriSchemes.Select(s => s.ToLowerInvariant()).ToArray(),
+            AllowDataImageUris = SanitizationPolicy.AllowDataImageUris
         };
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.razor.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.BlazorUI;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Bit.BlazorUI;
 
 /// <summary>
 /// BitRichTextEditor is a native WYSIWYG rich text editor. All component logic lives in C#;
@@ -138,6 +140,11 @@ public partial class BitRichTextEditor : BitComponentBase
 
     // ---- callbacks from JS ----
 
+    // Preserve the callback argument types under trimming: they are only ever produced by the JS
+    // bridge, so nothing in C# statically references their constructors/setters and the trimmer
+    // would otherwise break (facts: constructor parameter names) or silently default (state:
+    // property setters) their deserialization in release builds.
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorContentFacts))]
     [JSInvokable("OnContentChanged")]
     public async Task _OnContentChanged(string html, BitRichTextEditorContentFacts facts)
     {
@@ -158,6 +165,7 @@ public partial class BitRichTextEditor : BitComponentBase
     /// refreshes the cached content facts so count-dependent UI stays accurate, without treating
     /// the change as a user edit (no AssignValue / OnChange).
     /// </summary>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorContentFacts))]
     [JSInvokable("OnFactsChanged")]
     public void _OnFactsChanged(BitRichTextEditorContentFacts facts)
     {
@@ -168,6 +176,7 @@ public partial class BitRichTextEditor : BitComponentBase
         }
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorSelectionState))]
     [JSInvokable("OnSelectionChanged")]
     public void _OnSelectionChanged(BitRichTextEditorSelectionState state)
     {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorJsRuntimeExtensions.cs
@@ -1,7 +1,14 @@
-﻿namespace Bit.BlazorUI;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Bit.BlazorUI;
 
 internal static class BitRichTextEditorJsRuntimeExtensions
 {
+    // The setup payload types are only ever constructed (never read) from C#, so without these
+    // hints the trimmer strips their property getters and the reflection-based interop
+    // serialization silently sends empty objects to the bridge in trimmed (release) builds.
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorSetupOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorPolicyPayload))]
     public static ValueTask BitRichTextEditorSetup(this IJSRuntime jsRuntime,
                                                         ElementReference editor,
                                                         DotNetObjectReference<BitRichTextEditor>? dotnetObj,
@@ -10,6 +17,8 @@ internal static class BitRichTextEditorJsRuntimeExtensions
         return jsRuntime.InvokeVoid("BitBlazorUI.RichTextEditor.initialize", editor, dotnetObj, options);
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorSetupOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitRichTextEditorPolicyPayload))]
     public static ValueTask BitRichTextEditorUpdateOptions(this IJSRuntime jsRuntime,
                                                            ElementReference editor,
                                                            BitRichTextEditorSetupOptions options)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorPolicyPayload.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorPolicyPayload.cs
@@ -1,0 +1,11 @@
+namespace Bit.BlazorUI;
+
+// The sanitization policy payload sent to the JS bridge. Property names are serialized to
+// camelCase by the JS interop serializer to match what the bridge reads (allowedTags, ...).
+internal class BitRichTextEditorPolicyPayload
+{
+    public string[] AllowedTags { get; set; } = [];
+    public Dictionary<string, string[]> AllowedAttributes { get; set; } = [];
+    public string[] AllowedUriSchemes { get; set; } = [];
+    public bool AllowDataImageUris { get; set; }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorSetupOptions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorSetupOptions.cs
@@ -3,7 +3,7 @@ namespace Bit.BlazorUI;
 internal class BitRichTextEditorSetupOptions
 {
     public int Debounce { get; set; }
-    public object? Policy { get; set; }
+    public BitRichTextEditorPolicyPayload? Policy { get; set; }
     public bool HasUpload { get; set; }
     public bool PlainTextPaste { get; set; }
     public int? MaxLength { get; set; }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/SideRail.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Components/SideRail.razor.cs
@@ -13,6 +13,10 @@ public partial class SideRail
 
         if (ItemsChanged(sideRailItems, _sideRailItems))
         {
+            // Persist the snapshot the change-check compares against; otherwise ItemsChanged stays
+            // true forever and the StateHasChanged below schedules an endless render loop (which in
+            // WASM runs entirely in microtasks and freezes the browser tab).
+            _sideRailItems = sideRailItems;
             _items = [.. sideRailItems, new() { Id = "api-section", Title = "API" }, new() { Id = "feedback-section", Title = "Feedback" }];
 
             StateHasChanged();

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/RichTextEditor/BitRichTextEditorDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/RichTextEditor/BitRichTextEditorDemo.razor
@@ -340,7 +340,7 @@
                 <br />
                 <EditForm Model="formModel" OnValidSubmit="HandleValidSubmit">
                     <DataAnnotationsValidator />
-                    <BitRichTextEditor Value="formModel.Body" ValueChanged="HandleFormBodyChanged"
+                    <BitRichTextEditor Value="@formModel.Body" ValueChanged="HandleFormBodyChanged"
                                        Toolbar="BitRichTextEditorToolbar.All"
                                        ShowCount MaxLength="500" Height="10rem"
                                        Placeholder="Write at least 20 characters..." />


### PR DESCRIPTION
closes #12581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rich text editor sanitization handling so policy settings are passed reliably and work better in trimmed release builds.
  * Fixed a rich text editor demo form so the editor correctly binds to the form value instead of showing a literal text string.
  * Prevented repeated side rail updates by keeping the latest item snapshot in sync after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->