### PR TITLE
Fix trimming issue of BitChart (#12586)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/Chart/BitChart.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/Chart/BitChart.razor.cs
@@ -123,8 +123,11 @@ public partial class BitChart : ComponentBase, IAsyncDisposable
         try
         {
             _dotRef ??= DotNetObjectReference.Create(this);
+            // A concrete class is required here (not an anonymous type): the trimmer strips
+            // anonymous type members in release builds, which breaks System.Text.Json
+            // serialization during the JS interop call.
             _zoomHandle = await JS.BitChartRegister(_plotEl, _dotRef,
-                new { wheel = z.Wheel, pan = z.Pan && !z.DragZoom, drag = z.DragZoom });
+                new BitChartZoomPayload { Wheel = z.Wheel, Pan = z.Pan && !z.DragZoom, Drag = z.DragZoom });
         }
         catch
         {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/Chart/BitChartJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/Chart/BitChartJsRuntimeExtensions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Bit.BlazorUI;
 
 internal static class BitChartJsRuntimeExtensions
@@ -9,10 +11,14 @@ internal static class BitChartJsRuntimeExtensions
         return jsRuntime.InvokeAsync<IJSObjectReference>("BitBlazorUI.BitChart.observe", element, dotnetObj);
     }
 
+    // The zoom payload is only ever constructed (never read) from C#, so without this hint the
+    // trimmer strips its property getters and the reflection-based interop serialization silently
+    // sends an empty object to the bridge in trimmed (release) builds.
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BitChartZoomPayload))]
     public static ValueTask<IJSObjectReference> BitChartRegister(this IJSRuntime jsRuntime,
                                                                       ElementReference element,
                                                                       DotNetObjectReference<BitChart> dotnetObj,
-                                                                      object options)
+                                                                      BitChartZoomPayload options)
     {
         return jsRuntime.InvokeAsync<IJSObjectReference>("BitBlazorUI.BitChart.register", element, dotnetObj, options);
     }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/Chart/BitChartZoomPayload.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/Chart/BitChartZoomPayload.cs
@@ -1,0 +1,10 @@
+namespace Bit.BlazorUI;
+
+// The zoom registration payload sent to the JS bridge. Property names are serialized to
+// camelCase by the JS interop serializer to match what the bridge reads (wheel, pan, drag).
+internal class BitChartZoomPayload
+{
+    public bool Wheel { get; set; }
+    public bool Pan { get; set; }
+    public bool Drag { get; set; }
+}

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/ComponentsSection.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Home/ComponentsSection.razor
@@ -272,6 +272,7 @@
             </BitLink>
             <BitLink Href="/components/chart" title="Chart" Style="display: flex">
                 <BitText Element="span" Typography="BitTypography.Subtitle1">Chart</BitText>
+                <BitText Element="span" Typography="BitTypography.Subtitle2" Class="featured">featured</BitText>
             </BitLink>
             <BitLink Href="/components/datagrid" title="DataGrid" Style="display: flex">
                 <BitText Element="span" Typography="BitTypography.Subtitle1">DataGrid</BitText>


### PR DESCRIPTION
closes #12586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart zoom behavior so zoom settings are reliably preserved in release builds.
  * Chart zoom interactions now work more consistently when the app is trimmed or optimized for production.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->