### PR TITLE
Remove Json.NET reference from bit BlazorUI as it's no longer needed by Chart (#12588)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Bit.BlazorUI.Extras.csproj
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Bit.BlazorUI.Extras.csproj
@@ -24,7 +24,6 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" PrivateAssets="all" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Maui/Bit.BlazorUI.Demo.Client.Maui.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Maui/Bit.BlazorUI.Demo.Client.Maui.csproj
@@ -108,7 +108,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <Content Remove="Properties\launchSettings.json" />
     </ItemGroup>
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj
@@ -29,7 +29,6 @@
 
     <ItemGroup>
         <PackageReference Include="Bit.Bswup" Version="10.5.0-pre-05" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Bit.CodeAnalyzers" Version="10.5.0-pre-05">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,12 +45,6 @@
         <Using Include="Microsoft.JSInterop" />
         <Using Include="Bit.BlazorUI.Demo.Client.Core.Services.Contracts" />
         <Using Include="Bit.BlazorUI.Demo.Client.Core.Services" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <BlazorWebAssemblyLazyLoad Include="Newtonsoft.Json.wasm" />
-        <BlazorWebAssemblyLazyLoad Include="System.Private.Xml.wasm" />
-        <BlazorWebAssemblyLazyLoad Include="System.Data.Common.wasm" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Windows/Bit.BlazorUI.Demo.Client.Windows.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Windows/Bit.BlazorUI.Demo.Client.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
@@ -43,7 +43,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.80" />
         <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
         <PackageReference Include="Velopack" Version="1.2.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <Content Include="..\Bit.BlazorUI.Demo.Client.Maui\wwwroot\index.html" Link="wwwroot\index.html">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>


### PR DESCRIPTION
closes #12588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused JSON package dependency from several UI projects.
  * Simplified the web client build setup by dropping an unused lazy-load entry.
  * Cleaned up a file header formatting issue in the Windows client project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->