### PR TITLE
Apply phase II of Bmotion improvements (#12605)

### DIFF
--- a/.github/workflows/bit.ci.Bmotion.yml
+++ b/.github/workflows/bit.ci.Bmotion.yml
@@ -53,3 +53,12 @@ jobs:
 
     - name: dotnet build
       run: dotnet build src/Bmotion/Bit.Bmotion.slnx
+
+    - name: dotnet test (C# engine + component tests)
+      run: dotnet test src/Bmotion/Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj -f net10.0
+
+    - name: JS tests (bit-bmotion.js drag/scroll math)
+      run: |
+        cd src/Bmotion/Tests/bit-bmotion-js
+        npm ci || npm install
+        npm test

--- a/.github/workflows/bit.ci.Bmotion.yml
+++ b/.github/workflows/bit.ci.Bmotion.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
 

--- a/.github/workflows/bit.ci.Bmotion.yml
+++ b/.github/workflows/bit.ci.Bmotion.yml
@@ -55,7 +55,9 @@ jobs:
       run: dotnet build src/Bmotion/Bit.Bmotion.slnx
 
     - name: dotnet test (C# engine + component tests)
-      run: dotnet test src/Bmotion/Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj -f net10.0
+      # Run from inside src so src/global.json's "test" runner setting applies
+      # (from the repo root the SDK falls back to the unsupported VSTest path).
+      run: cd src/Bmotion && dotnet test Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj -f net10.0
 
     - name: JS tests (bit-bmotion.js drag/scroll math)
       run: |

--- a/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
@@ -31,6 +31,9 @@
     @Body
 </main>
 
+@* Live engine debug overlay (plan item 3.5) — starts collapsed; click to expand. *@
+<BmotionInspector StartOpen="false" />
+
 @code {
     private bool _open;
 

--- a/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
@@ -1,20 +1,49 @@
 @inherits LayoutComponentBase
+@implements IDisposable
+@inject NavigationManager Nav
 
-<nav class="bm-nav" aria-label="Bmotion demos">
+<nav class="bm-nav @(_open ? "open" : null)" aria-label="Bmotion demos">
     <span class="logo">Bmotion</span>
-    <NavLink href="" Match="NavLinkMatch.All">Home</NavLink>
-    <NavLink href="basic">Basics</NavLink>
-    <NavLink href="springs">Springs</NavLink>
-    <NavLink href="gestures">Gestures</NavLink>
-    <NavLink href="variants">Variants</NavLink>
-    <NavLink href="keyframes">Keyframes</NavLink>
-    <NavLink href="presence">AnimatePresence</NavLink>
-    <NavLink href="drag">Drag</NavLink>
-    <NavLink href="reorder">Reorder</NavLink>
-    <NavLink href="scroll">Scroll</NavLink>
-    <NavLink href="layout">Layout</NavLink>
+    <button type="button" class="bm-nav-burger" @onclick="Toggle" aria-label="Toggle navigation" aria-expanded="@_open">
+        <span></span><span></span><span></span>
+    </button>
+    <div class="bm-nav-links">
+        <NavLink href="" Match="NavLinkMatch.All">Home</NavLink>
+        <NavLink href="basic">Basics</NavLink>
+        <NavLink href="springs">Springs</NavLink>
+        <NavLink href="easing">Easing</NavLink>
+        <NavLink href="gestures">Gestures</NavLink>
+        <NavLink href="variants">Variants</NavLink>
+        <NavLink href="keyframes">Keyframes</NavLink>
+        <NavLink href="presence">AnimatePresence</NavLink>
+        <NavLink href="drag">Drag</NavLink>
+        <NavLink href="reorder">Reorder</NavLink>
+        <NavLink href="scroll">Scroll</NavLink>
+        <NavLink href="layout">Layout</NavLink>
+        <NavLink href="color">Color</NavLink>
+        <NavLink href="motion-path">Motion Path</NavLink>
+        <NavLink href="view-transitions">View Transitions</NavLink>
+        <NavLink href="css-props">CSS Props</NavLink>
+    </div>
 </nav>
 
 <main class="bm-page">
     @Body
 </main>
+
+@code {
+    private bool _open;
+
+    private void Toggle() => _open = !_open;
+
+    protected override void OnInitialized() => Nav.LocationChanged += OnLocationChanged;
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        if (!_open) return;
+        _open = false;
+        StateHasChanged();
+    }
+
+    public void Dispose() => Nav.LocationChanged -= OnLocationChanged;
+}

--- a/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
@@ -31,7 +31,7 @@
     @Body
 </main>
 
-@* Live engine debug overlay (plan item 3.5) — starts collapsed; click to expand. *@
+@* Live engine debug overlay (plan item 3.5) - starts collapsed; click to expand. *@
 <BmotionInspector StartOpen="false" />
 
 @code {

--- a/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Layout/MainLayout.razor
@@ -4,10 +4,11 @@
 
 <nav class="bm-nav @(_open ? "open" : null)" aria-label="Bmotion demos">
     <span class="logo">Bmotion</span>
-    <button type="button" class="bm-nav-burger" @onclick="Toggle" aria-label="Toggle navigation" aria-expanded="@_open">
+    <button type="button" class="bm-nav-burger" @onclick="Toggle" aria-label="Toggle navigation"
+            aria-expanded="@(_open ? "true" : "false")" aria-controls="bm-nav-links">
         <span></span><span></span><span></span>
     </button>
-    <div class="bm-nav-links">
+    <div id="bm-nav-links" class="bm-nav-links">
         <NavLink href="" Match="NavLinkMatch.All">Home</NavLink>
         <NavLink href="basic">Basics</NavLink>
         <NavLink href="springs">Springs</NavLink>

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/ColorSpaces.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/ColorSpaces.razor
@@ -1,0 +1,61 @@
+@page "/color"
+
+<h1>Color spaces</h1>
+
+<div class="demo-section">
+    <h2>Perceptual OKLab vs sRGB</h2>
+    <p>
+        By default colors interpolate per-channel in <strong>sRGB</strong> (Framer Motion's default),
+        which drags complementary transitions through a muddy grey. Opt into
+        <strong>BmColorSpace.Oklab</strong> per-transition (or globally on
+        <code>&lt;BmotionConfig ColorSpace="…"&gt;</code>) to keep mid-points vivid.
+    </p>
+
+    <div class="demo-row">
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span style="font-size:.78rem; color:#888">sRGB — blue → yellow</span>
+            <Bmotion Animate="@(_on ? _yellow : _blue)"
+                     Transition="Bm.Tween(1.6)">
+                <div class="swatch" style="background:#0000ff" />
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span style="font-size:.78rem; color:#888">OKLab — blue → yellow</span>
+            <Bmotion Animate="@(_on ? _yellow : _blue)"
+                     Transition="Bm.Tween(1.6, colorSpace: BmColorSpace.Oklab)">
+                <div class="swatch" style="background:#0000ff" />
+            </Bmotion>
+        </div>
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="@(() => _on = !_on)">
+        @(_on ? "Back to blue" : "To yellow")
+    </button>
+
+    <CodeSnippet Code="@_code" />
+</div>
+
+<style>
+    .swatch { width: 160px; height: 80px; border-radius: 10px; }
+</style>
+
+@code {
+    private bool _on;
+
+    private static readonly BmProps _blue = Bm.To(backgroundColor: "#0000ff");
+    private static readonly BmProps _yellow = Bm.To(backgroundColor: "#ffdd00");
+
+    private const string _code = """
+        @* Per-transition color space (sRGB is the default) *@
+        <Bmotion Animate="Bm.To(backgroundColor: "#ffdd00")"
+                 Transition="Bm.Tween(1.6, colorSpace: BmColorSpace.Oklab)">
+            <div class="swatch" />
+        </Bmotion>
+
+        @* …or globally for a whole subtree *@
+        <BmotionConfig ColorSpace="BmColorSpace.Oklab">
+            ...
+        </BmotionConfig>
+        """;
+}

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/ColorSpaces.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/ColorSpaces.razor
@@ -13,7 +13,7 @@
 
     <div class="demo-row">
         <div class="demo-card" style="flex-direction:column; gap:1rem;">
-            <span style="font-size:.78rem; color:#888">sRGB — blue → yellow</span>
+            <span style="font-size:.78rem; color:#888">sRGB - blue → yellow</span>
             <Bmotion Animate="@(_on ? _yellow : _blue)"
                      Transition="Bm.Tween(1.6)">
                 <div class="swatch" style="background:#0000ff" />
@@ -21,7 +21,7 @@
         </div>
 
         <div class="demo-card" style="flex-direction:column; gap:1rem;">
-            <span style="font-size:.78rem; color:#888">OKLab — blue → yellow</span>
+            <span style="font-size:.78rem; color:#888">OKLab - blue → yellow</span>
             <Bmotion Animate="@(_on ? _yellow : _blue)"
                      Transition="Bm.Tween(1.6, colorSpace: BmColorSpace.Oklab)">
                 <div class="swatch" style="background:#0000ff" />

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/CssProps.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/CssProps.razor
@@ -1,0 +1,307 @@
+@page "/css-props"
+
+<h1>CSS properties</h1>
+
+<p class="page-intro">
+    Beyond transforms and colors, Bmotion's typed props reach across the whole style surface —
+    <strong>typography</strong>, <strong>spacing</strong>, <strong>positioning</strong>,
+    <strong>clipping &amp; backgrounds</strong> — and the generic <strong>Css</strong> bag animates
+    <em>any</em> property by name. Each group below toggles on its own.
+</p>
+
+@* ── Typography ─────────────────────────────────────────────────────────── *@
+<div class="demo-section">
+    <h2>Typography</h2>
+    <p><code>letterSpacing</code>, <code>fontSize</code> and <code>lineHeight</code> interpolate like any length.</p>
+
+    <button class="btn-bm" style="margin-bottom:1.5rem" @onclick="@(() => _typo = !_typo)">
+        @(_typo ? "Reset" : "Animate")
+    </button>
+
+    <div class="demo-row">
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">letterSpacing</span>
+            <Bmotion Animate="@(_typo ? Bm.To(letterSpacing: "0.4em") : Bm.To(letterSpacing: "0em"))"
+                     Transition="Bm.Tween(0.7)">
+                <div class="headline">BMOTION</div>
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">fontSize</span>
+            <Bmotion Animate="@(_typo ? Bm.To(fontSize: "2.2rem") : Bm.To(fontSize: "1rem"))"
+                     Transition="Bm.Tween(0.6)">
+                <div class="headline" style="font-size:1rem">Scale me</div>
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">lineHeight</span>
+            <Bmotion Animate="@(_typo ? Bm.To(lineHeight: "2.3") : Bm.To(lineHeight: "1.15"))"
+                     Transition="Bm.Tween(0.7)">
+                <div class="prose">Motion that reads well breathes between its lines.</div>
+            </Bmotion>
+        </div>
+    </div>
+
+    <CodeSnippet Code="@_typoCode" />
+</div>
+
+@* ── Spacing ────────────────────────────────────────────────────────────── *@
+<div class="demo-section">
+    <h2>Spacing</h2>
+    <p><code>gap</code> animates on a flex/grid container; <code>padding</code> grows a box from the inside; <code>margin</code> pushes it within its track.</p>
+
+    <button class="btn-bm" style="margin-bottom:1.5rem" @onclick="@(() => _spacing = !_spacing)">
+        @(_spacing ? "Reset" : "Animate")
+    </button>
+
+    <div class="demo-row">
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">gap (flex container)</span>
+            <Bmotion Animate="@(_spacing ? Bm.To(gap: "2.5rem") : Bm.To(gap: "0.4rem"))"
+                     Transition="Bm.Spring()">
+                <div class="row">
+                    <div class="box box-sm" /><div class="box box-sm" /><div class="box box-sm" />
+                </div>
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">padding</span>
+            <Bmotion Animate="@(_spacing ? Bm.To(padding: "1.8rem") : Bm.To(padding: "0.4rem"))"
+                     Transition="Bm.Tween(0.6)">
+                <div class="pad-box">PAD</div>
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">margin</span>
+            <div class="track">
+                <Bmotion Animate="@(_spacing ? Bm.To(margin: "1.6rem") : Bm.To(margin: "0.1rem"))"
+                         Transition="Bm.Tween(0.6)">
+                    <div class="box box-sm" />
+                </Bmotion>
+            </div>
+        </div>
+    </div>
+
+    <CodeSnippet Code="@_spacingCode" />
+</div>
+
+@* ── Positioning ────────────────────────────────────────────────────────── *@
+<div class="demo-section">
+    <h2>Positioning</h2>
+    <p>Animate <code>top</code>, <code>left</code>, <code>right</code> and <code>bottom</code> on a positioned element.</p>
+
+    <button class="btn-bm" style="margin-bottom:1.5rem" @onclick="@(() => _pos = !_pos)">
+        @(_pos ? "Reset" : "Animate")
+    </button>
+
+    <div class="demo-row">
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">left</span>
+            <div class="track track-wide">
+                <Bmotion Animate="@(_pos ? Bm.To(left: "150px") : Bm.To(left: "0px"))"
+                         Transition="Bm.Tween(0.7)">
+                    <div class="box box-sm" style="position:relative" />
+                </Bmotion>
+            </div>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">top + left</span>
+            <div class="track track-wide" style="min-height:120px">
+                <Bmotion Animate="@(_pos ? Bm.To(top: "60px", left: "150px") : Bm.To(top: "0px", left: "0px"))"
+                         Transition="Bm.Spring(stiffness: 200, damping: 18)">
+                    <div class="box box-sm" style="position:relative" />
+                </Bmotion>
+            </div>
+        </div>
+    </div>
+
+    <CodeSnippet Code="@_posCode" />
+</div>
+
+@* ── Clipping & backgrounds ─────────────────────────────────────────────── *@
+<div class="demo-section">
+    <h2>Clipping &amp; backgrounds</h2>
+    <p><code>clipPath</code>, <code>backgroundPosition</code> and <code>backgroundSize</code> interpolate their numeric parts frame by frame.</p>
+
+    <button class="btn-bm" style="margin-bottom:1.5rem" @onclick="@(() => _visual = !_visual)">
+        @(_visual ? "Reset" : "Animate")
+    </button>
+
+    <div class="demo-row">
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">clipPath</span>
+            <Bmotion Animate="@(_visual ? Bm.To(clipPath: "circle(30% at 50% 50%)") : Bm.To(clipPath: "circle(65% at 50% 50%)"))"
+                     Transition="Bm.Tween(0.7)">
+                <div class="fill-box grad-a" />
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">backgroundPosition</span>
+            <Bmotion Animate="@(_visual ? Bm.To(backgroundPosition: "100% 50%") : Bm.To(backgroundPosition: "0% 50%"))"
+                     Transition="Bm.Tween(1.0)">
+                <div class="fill-box grad-pos" />
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">backgroundSize</span>
+            <Bmotion Animate="@(_visual ? Bm.To(backgroundSize: "250%") : Bm.To(backgroundSize: "120%"))"
+                     Transition="Bm.Tween(0.8)">
+                <div class="fill-box grad-size" />
+            </Bmotion>
+        </div>
+    </div>
+
+    <CodeSnippet Code="@_visualCode" />
+</div>
+
+@* ── Generic escape hatch ───────────────────────────────────────────────── *@
+<div class="demo-section">
+    <h2>Generic <code>Css</code> escape hatch</h2>
+    <p>The <code>css</code> bag animates <em>any</em> CSS property by name (dash- or camelCase) — the equivalent of motion.dev's <code>animate()</code>.</p>
+
+    <button class="btn-bm" style="margin-bottom:1.5rem" @onclick="@(() => _escape = !_escape)">
+        @(_escape ? "Reset" : "Animate")
+    </button>
+
+    <div class="demo-row">
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">css: word-spacing</span>
+            <Bmotion Animate="@(_escape ? Bm.To(css: new() { ["word-spacing"] = "1.5rem" }) : Bm.To(css: new() { ["word-spacing"] = "0rem" }))"
+                     Transition="Bm.Tween(0.7)">
+                <div class="headline" style="font-size:1rem">the quick fox</div>
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="flex-direction:column; gap:1rem;">
+            <span class="label">css: text-indent</span>
+            <Bmotion Animate="@(_escape ? Bm.To(css: new() { ["text-indent"] = "48px" }) : Bm.To(css: new() { ["text-indent"] = "0px" }))"
+                     Transition="Bm.Tween(0.7)">
+                <div class="prose">Indented on demand.</div>
+            </Bmotion>
+        </div>
+    </div>
+
+    <CodeSnippet Code="@_escapeCode" />
+</div>
+
+@* ── Accessibility & safety ─────────────────────────────────────────────── *@
+<div class="demo-section">
+    <h2>Accessibility &amp; safety knobs</h2>
+    <p>These are configured once at registration in <code>Program.cs</code>:</p>
+    <ul class="feature-list">
+        <li>
+            <strong>Reduced motion</strong> —
+            <code>AddBitBmotionServices(o =&gt; o.ReducedMotion = BmReducedMotionMode.User)</code>
+            respects the OS <code>prefers-reduced-motion</code> everywhere. When reduced, transforms
+            snap while opacity/color still animate.
+        </li>
+        <li>
+            <strong>CSS-injection safe mode</strong> —
+            <code>o.CssSafeMode = BmCssSafeMode.Throw</code> validates string values before they reach
+            inline style (reject <code>;</code>, <code>}</code>, <code>javascript:</code>, …). Enable it
+            when binding untrusted input.
+        </li>
+        <li>
+            <strong>Capabilities</strong> — inject <code>BmotionCapabilities</code> to branch on
+            <code>SupportsFrameLoop</code> (false on Blazor Server, where per-frame features degrade).
+        </li>
+    </ul>
+</div>
+
+<style>
+    .page-intro { color: var(--bm-muted); margin-bottom: 2.5rem; line-height: 1.6; }
+    .label { font-size: .78rem; color: #888; }
+    .headline { font-weight: 800; font-size: 1.4rem; letter-spacing: 0; }
+    .prose { max-width: 190px; color: var(--bm-text); font-size: .95rem; text-align: left; }
+    .row { display: flex; }
+
+    /* A left/top-anchored track so margin / position offsets are visible against an edge. */
+    .track { width: 100%; display: flex; justify-content: flex-start; align-items: flex-start; }
+    .track-wide { min-height: 60px; }
+
+    .pad-box {
+        background: linear-gradient(135deg, var(--bm-primary), var(--bm-secondary));
+        border-radius: 10px; color: #fff; font-weight: 700; font-size: .8rem;
+        display: inline-flex; align-items: center; justify-content: center;
+    }
+
+    .fill-box { width: 120px; height: 120px; border-radius: 12px; }
+    .grad-a { background: linear-gradient(135deg, #6c47ff, #ff4785); }
+    .grad-pos { background: linear-gradient(90deg, #6c47ff, #ff4785, #ffb347); background-size: 300% 100%; }
+    .grad-size {
+        background: radial-gradient(circle at 50% 50%, #ff4785 0%, #6c47ff 60%);
+        background-repeat: no-repeat; background-position: center;
+    }
+
+    .feature-list { line-height: 1.9; color: #bbb; }
+    .feature-list code { background: #2a2a3a; padding: .1rem .35rem; border-radius: 4px; }
+</style>
+
+@code {
+    private bool _typo;
+    private bool _spacing;
+    private bool _pos;
+    private bool _visual;
+    private bool _escape;
+
+    private const string _typoCode = """
+        @* letterSpacing / fontSize / lineHeight all interpolate like any length *@
+        <Bmotion Animate='@(_on ? Bm.To(letterSpacing: "0.4em") : Bm.To(letterSpacing: "0em"))'
+                 Transition="Bm.Tween(0.7)">
+            <div class="headline">BMOTION</div>
+        </Bmotion>
+
+        <Bmotion Animate='@(_on ? Bm.To(fontSize: "2.2rem") : Bm.To(fontSize: "1rem"))'>...</Bmotion>
+        <Bmotion Animate='@(_on ? Bm.To(lineHeight: "2.3") : Bm.To(lineHeight: "1.15"))'>...</Bmotion>
+        """;
+
+    private const string _spacingCode = """
+        @* gap animates on the flex container itself (the first root element) *@
+        <Bmotion Animate='@(_on ? Bm.To(gap: "2.5rem") : Bm.To(gap: "0.4rem"))' Transition="Bm.Spring()">
+            <div class="row" style="display:flex"><div class="box" /><div class="box" /><div class="box" /></div>
+        </Bmotion>
+
+        @* padding grows the box from the inside; margin shifts it within its track *@
+        <Bmotion Animate='@(_on ? Bm.To(padding: "1.8rem") : Bm.To(padding: "0.4rem"))'>...</Bmotion>
+        <Bmotion Animate='@(_on ? Bm.To(margin: "1.6rem") : Bm.To(margin: "0.1rem"))'>...</Bmotion>
+        """;
+
+    private const string _posCode = """
+        @* top / left / right / bottom on a position:relative element *@
+        <Bmotion Animate='@(_on ? Bm.To(top: "60px", left: "150px") : Bm.To(top: "0px", left: "0px"))'
+                 Transition="Bm.Spring(stiffness: 200, damping: 18)">
+            <div class="box" style="position:relative" />
+        </Bmotion>
+        """;
+
+    private const string _visualCode = """
+        @* clipPath / backgroundPosition / backgroundSize interpolate their numeric parts *@
+        <Bmotion Animate='@(_on ? Bm.To(clipPath: "circle(30% at 50% 50%)")
+                                : Bm.To(clipPath: "circle(65% at 50% 50%)"))'
+                 Transition="Bm.Tween(0.7)">
+            <div class="fill-box grad-a" />
+        </Bmotion>
+
+        <Bmotion Animate='@(_on ? Bm.To(backgroundPosition: "100% 50%") : Bm.To(backgroundPosition: "0% 50%"))'>...</Bmotion>
+        <Bmotion Animate='@(_on ? Bm.To(backgroundSize: "250%") : Bm.To(backgroundSize: "120%"))'>...</Bmotion>
+        """;
+
+    private const string _escapeCode = """
+        @* Animate ANY CSS property by name (dash- or camelCase) via the css bag *@
+        <Bmotion Animate='@(_on ? Bm.To(css: new() { ["word-spacing"] = "1.5rem" })
+                                : Bm.To(css: new() { ["word-spacing"] = "0rem" }))'
+                 Transition="Bm.Tween(0.7)">
+            <div>the quick fox</div>
+        </Bmotion>
+
+        <Bmotion Animate='@(_on ? Bm.To(css: new() { ["text-indent"] = "48px" })
+                                : Bm.To(css: new() { ["text-indent"] = "0px" }))'>...</Bmotion>
+        """;
+}

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/CssProps.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/CssProps.razor
@@ -3,9 +3,9 @@
 <h1>CSS properties</h1>
 
 <p class="page-intro">
-    Beyond transforms and colors, Bmotion's typed props reach across the whole style surface —
+    Beyond transforms and colors, Bmotion's typed props reach across the whole style surface -
     <strong>typography</strong>, <strong>spacing</strong>, <strong>positioning</strong>,
-    <strong>clipping &amp; backgrounds</strong> — and the generic <strong>Css</strong> bag animates
+    <strong>clipping &amp; backgrounds</strong> - and the generic <strong>Css</strong> bag animates
     <em>any</em> property by name. Each group below toggles on its own.
 </p>
 
@@ -164,7 +164,7 @@
 @* ── Generic escape hatch ───────────────────────────────────────────────── *@
 <div class="demo-section">
     <h2>Generic <code>Css</code> escape hatch</h2>
-    <p>The <code>css</code> bag animates <em>any</em> CSS property by name (dash- or camelCase) — the equivalent of motion.dev's <code>animate()</code>.</p>
+    <p>The <code>css</code> bag animates <em>any</em> CSS property by name (dash- or camelCase) - the equivalent of motion.dev's <code>animate()</code>.</p>
 
     <button class="btn-bm" style="margin-bottom:1.5rem" @onclick="@(() => _escape = !_escape)">
         @(_escape ? "Reset" : "Animate")
@@ -197,19 +197,19 @@
     <p>These are configured once at registration in <code>Program.cs</code>:</p>
     <ul class="feature-list">
         <li>
-            <strong>Reduced motion</strong> —
+            <strong>Reduced motion</strong> -
             <code>AddBitBmotionServices(o =&gt; o.ReducedMotion = BmReducedMotionMode.User)</code>
             respects the OS <code>prefers-reduced-motion</code> everywhere. When reduced, transforms
             snap while opacity/color still animate.
         </li>
         <li>
-            <strong>CSS-injection safe mode</strong> —
+            <strong>CSS-injection safe mode</strong> -
             <code>o.CssSafeMode = BmCssSafeMode.Throw</code> validates string values before they reach
             inline style (reject <code>;</code>, <code>}</code>, <code>javascript:</code>, …). Enable it
             when binding untrusted input.
         </li>
         <li>
-            <strong>Capabilities</strong> — inject <code>BmotionCapabilities</code> to branch on
+            <strong>Capabilities</strong> - inject <code>BmotionCapabilities</code> to branch on
             <code>SupportsFrameLoop</code> (false on Blazor Server, where per-frame features degrade).
         </li>
     </ul>

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/DragPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/DragPage.razor
@@ -127,12 +127,71 @@
     <CodeSnippet Code="@_dragEventsCode" />
 </div>
 
+<div class="demo-section">
+    <h2>Nested drag &amp; propagation</h2>
+    <p>
+        By default a drag <strong>stops propagation</strong>, so dragging a nested element doesn't also
+        drag its draggable parent (motion.dev's default). Set <strong>DragPropagation="true"</strong> on
+        the child to let both move together. Constraints are also re-measured live if the container
+        resizes mid-drag.
+    </p>
+
+    <div class="demo-row">
+        <div class="demo-card" style="height:240px;">
+            <span style="position:absolute;top:.5rem;left:.75rem;font-size:.72rem;color:#888">child isolates (default)</span>
+            <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()" DragElastic="0.2">
+                <div class="drag-parent">
+                    <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()">
+                        <div class="drag-child" />
+                    </Bmotion>
+                </div>
+            </Bmotion>
+        </div>
+
+        <div class="demo-card" style="height:240px;">
+            <span style="position:absolute;top:.5rem;left:.75rem;font-size:.72rem;color:#888">child propagates</span>
+            <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()" DragElastic="0.2">
+                <div class="drag-parent">
+                    <Bmotion Drag="true" DragPropagation="true" DragConstraints="BmDragConstraints.Parent()">
+                        <div class="drag-child" />
+                    </Bmotion>
+                </div>
+            </Bmotion>
+        </div>
+    </div>
+
+    <CodeSnippet Code="@_nestedCode" />
+</div>
+
+<style>
+    .drag-parent {
+        width: 150px; height: 150px; border-radius: 12px; cursor: grab;
+        background: rgba(108,71,255,.12); border: 1px solid rgba(108,71,255,.3);
+        display: flex; align-items: center; justify-content: center;
+    }
+    .drag-child {
+        width: 54px; height: 54px; border-radius: 10px; cursor: grab;
+        background: linear-gradient(135deg, #6c47ff, #ff4785);
+    }
+</style>
+
 @code {
     private string _dragInfo = "Drag the box";
     private readonly BmDragControls _thumbControls = new();
 
     void HandleDragStart() => _dragInfo = "Dragging…";
     void HandleDragEnd()   => _dragInfo = "Released";
+
+    private const string _nestedCode = """
+        @* Default: child drag stops propagation (parent stays put) *@
+        <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()">
+            <div class="drag-parent">
+                <Bmotion Drag="true" DragPropagation="true">  @* opt in to move both *@
+                    <div class="drag-child" />
+                </Bmotion>
+            </div>
+        </Bmotion>
+        """;
 
     private const string _handleControlsCode = """
         @using Bit.Bmotion

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/DragPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/DragPage.razor
@@ -183,10 +183,19 @@
     void HandleDragEnd()   => _dragInfo = "Released";
 
     private const string _nestedCode = """
-        @* Default: child drag stops propagation (parent stays put) *@
+        @* Default: child drag stops propagation - only the child moves, parent stays put *@
         <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()">
             <div class="drag-parent">
-                <Bmotion Drag="true" DragPropagation="true">  @* opt in to move both *@
+                <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()">
+                    <div class="drag-child" />
+                </Bmotion>
+            </div>
+        </Bmotion>
+
+        @* Opt in with DragPropagation="true" - dragging the child moves both *@
+        <Bmotion Drag="true" DragConstraints="BmDragConstraints.Parent()">
+            <div class="drag-parent">
+                <Bmotion Drag="true" DragPropagation="true" DragConstraints="BmDragConstraints.Parent()">
                     <div class="drag-child" />
                 </Bmotion>
             </div>

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
@@ -19,7 +19,7 @@
                 <div style="flex:1; position:relative; height:32px;">
                     <Bmotion Animate="@(_on ? Bm.To(x: 240) : Bm.To(x: 0))"
                              Transition="Bm.Tween(0.9, e)">
-                        <div class="box-sm" style="width:28px;height:28px;" />
+                        <div class="box box-sm" style="width:28px;height:28px;" />
                     </Bmotion>
                 </div>
             </div>
@@ -47,7 +47,7 @@
                 <span style="font-size:.78rem; color:#888">steps(6, @s)</span>
                 <Bmotion Animate="@(_on2 ? Bm.To(x: 180) : Bm.To(x: 0))"
                          Transition="Bm.Tween(1.2, steps: 6, stepJump: s)">
-                    <div class="box-sm" />
+                    <div class="box box-sm" />
                 </Bmotion>
             </div>
         }
@@ -80,7 +80,7 @@
         {
             <Bmotion Animate="@(_on ? Bm.To(x: 240) : Bm.To(x: 0))"
                      Transition="Bm.Tween(0.9, e)">
-                <div class="box-sm" />
+                <div class="box box-sm" />
             </Bmotion>
         }
 
@@ -97,7 +97,7 @@
     private const string _stepsCode = """
         <Bmotion Animate="@(_on ? Bm.To(x: 180) : Bm.To(x: 0))"
                  Transition="Bm.Tween(1.2, steps: 6, stepJump: BmStepJump.End)">
-            <div class="box-sm" />
+            <div class="box box-sm" />
         </Bmotion>
         """;
 }

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
@@ -1,0 +1,103 @@
+@page "/easing"
+
+<h1>Easing</h1>
+
+<div class="demo-section">
+    <h2>Named easing presets</h2>
+    <p>
+        <strong>Bm.Tween(ease: BmEase.…)</strong> now covers the full easings.net family:
+        Sine, Quad, Quart, Quint, Expo, plus overshoot/oscillating
+        <em>Elastic</em> and <em>Bounce</em>. Elastic and bounce sample to <code>linear()</code>
+        for the compositor where supported, and run on the C# engine otherwise.
+    </p>
+
+    <div class="demo-row" style="flex-direction:column; align-items:stretch; gap:.5rem;">
+        @foreach (var e in _eases)
+        {
+            <div style="display:flex; align-items:center; gap:1rem;">
+                <span style="width:120px; font-size:.8rem; color:#888">@e</span>
+                <div style="flex:1; position:relative; height:32px;">
+                    <Bmotion Animate="@(_on ? Bm.To(x: 240) : Bm.To(x: 0))"
+                             Transition="Bm.Tween(0.9, e)">
+                        <div class="box-sm" style="width:28px;height:28px;" />
+                    </Bmotion>
+                </div>
+            </div>
+        }
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="@(() => _on = !_on)">
+        @(_on ? "Reset" : "Animate")
+    </button>
+
+    <CodeSnippet Code="@_easeCode" />
+</div>
+
+<div class="demo-section">
+    <h2>Stepped easing — <code>steps()</code></h2>
+    <p>
+        <strong>Bm.Tween(steps: n, stepJump: …)</strong> maps to CSS <code>steps()</code> — a
+        staircase progression, great for sprite-style motion. Jump term controls where the jumps fall.
+    </p>
+
+    <div class="demo-row">
+        @foreach (var s in _steps)
+        {
+            <div class="demo-card" style="flex-direction:column; gap:.75rem;">
+                <span style="font-size:.78rem; color:#888">steps(6, @s)</span>
+                <Bmotion Animate="@(_on2 ? Bm.To(x: 180) : Bm.To(x: 0))"
+                         Transition="Bm.Tween(1.2, steps: 6, stepJump: s)">
+                    <div class="box-sm" />
+                </Bmotion>
+            </div>
+        }
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="@(() => _on2 = !_on2)">
+        @(_on2 ? "Reset" : "Step")
+    </button>
+
+    <CodeSnippet Code="@_stepsCode" />
+</div>
+
+@code {
+    private bool _on;
+    private bool _on2;
+
+    private readonly BmEase[] _eases =
+    [
+        BmEase.SineInOut, BmEase.QuadInOut, BmEase.QuartInOut, BmEase.QuintInOut,
+        BmEase.ExpoOut, BmEase.BackOut, BmEase.ElasticOut, BmEase.BounceOut,
+    ];
+
+    private readonly BmStepJump[] _steps =
+    [
+        BmStepJump.End, BmStepJump.Start, BmStepJump.None, BmStepJump.Both,
+    ];
+
+    private const string _easeCode = """
+        @foreach (var e in _eases)
+        {
+            <Bmotion Animate="@(_on ? Bm.To(x: 240) : Bm.To(x: 0))"
+                     Transition="Bm.Tween(0.9, e)">
+                <div class="box-sm" />
+            </Bmotion>
+        }
+
+        @code {
+            private bool _on;
+            private readonly BmEase[] _eases =
+            [
+                BmEase.SineInOut, BmEase.QuadInOut, BmEase.ExpoOut,
+                BmEase.ElasticOut, BmEase.BounceOut,
+            ];
+        }
+        """;
+
+    private const string _stepsCode = """
+        <Bmotion Animate="@(_on ? Bm.To(x: 180) : Bm.To(x: 0))"
+                 Transition="Bm.Tween(1.2, steps: 6, stepJump: BmStepJump.End)">
+            <div class="box-sm" />
+        </Bmotion>
+        """;
+}

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
@@ -88,8 +88,8 @@
             private bool _on;
             private readonly BmEase[] _eases =
             [
-                BmEase.SineInOut, BmEase.QuadInOut, BmEase.ExpoOut,
-                BmEase.ElasticOut, BmEase.BounceOut,
+                BmEase.SineInOut, BmEase.QuadInOut, BmEase.QuartInOut, BmEase.QuintInOut,
+                BmEase.ExpoOut, BmEase.BackOut, BmEase.ElasticOut, BmEase.BounceOut,
             ];
         }
         """;

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/Easing.razor
@@ -34,9 +34,9 @@
 </div>
 
 <div class="demo-section">
-    <h2>Stepped easing — <code>steps()</code></h2>
+    <h2>Stepped easing - <code>steps()</code></h2>
     <p>
-        <strong>Bm.Tween(steps: n, stepJump: …)</strong> maps to CSS <code>steps()</code> — a
+        <strong>Bm.Tween(steps: n, stepJump: …)</strong> maps to CSS <code>steps()</code> - a
         staircase progression, great for sprite-style motion. Jump term controls where the jumps fall.
     </p>
 

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/LayoutPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/LayoutPage.razor
@@ -71,11 +71,11 @@
 </div>
 
 <div class="demo-section">
-    <h2>Size correction — no distortion</h2>
+    <h2>Size correction - no distortion</h2>
     <p>
         With <strong>Layout="true"</strong>, a resizing box scales for a smooth 60fps FLIP, but its
         text and child elements are <strong>counter-scaled</strong> and the <strong>border-radius is
-        corrected</strong> each frame — so nothing stretches and the corners stay round (Motion's
+        corrected</strong> each frame - so nothing stretches and the corners stay round (Motion's
         headline layout feature). Toggle the size and watch the label and inner dot stay crisp.
     </p>
 

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/LayoutPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/LayoutPage.razor
@@ -70,9 +70,59 @@
     <CodeSnippet Code="@_layoutIdCode" />
 </div>
 
+<div class="demo-section">
+    <h2>Size correction — no distortion</h2>
+    <p>
+        With <strong>Layout="true"</strong>, a resizing box scales for a smooth 60fps FLIP, but its
+        text and child elements are <strong>counter-scaled</strong> and the <strong>border-radius is
+        corrected</strong> each frame — so nothing stretches and the corners stay round (Motion's
+        headline layout feature). Toggle the size and watch the label and inner dot stay crisp.
+    </p>
+
+    <div class="demo-row">
+        <div class="demo-card" style="min-height:220px;">
+            <Bmotion Layout="true" Transition="Bm.Spring(stiffness: 350, damping: 30)">
+                <div class="@(_big ? "resize-card big" : "resize-card")">
+                    <span class="resize-label">Layout</span>
+                    <div class="resize-dot" />
+                </div>
+            </Bmotion>
+        </div>
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="@(() => _big = !_big)">
+        @(_big ? "Shrink" : "Grow")
+    </button>
+
+    <CodeSnippet Code="@_sizeCode" />
+</div>
+
+<style>
+    .resize-card {
+        width: 120px; height: 120px; border-radius: 20px;
+        background: linear-gradient(135deg, #6c47ff, #ff4785);
+        display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .6rem;
+    }
+    .resize-card.big { width: 260px; height: 180px; }
+    .resize-label { font-weight: 800; font-size: 1.3rem; color: #fff; }
+    .resize-dot { width: 34px; height: 34px; border-radius: 50%; background: rgba(255,255,255,.85); }
+</style>
+
 @code {
     private readonly string[] _tabs = ["Home", "Projects", "About", "Contact"];
     private string _activeTab = "Home";
+    private bool _big;
+
+    private const string _sizeCode = """
+        @* Layout="true" scales for a smooth FLIP; children counter-scale + border-radius is
+           corrected automatically so text/corners don't distort. *@
+        <Bmotion Layout="true" Transition="Bm.Spring(stiffness: 350, damping: 30)">
+            <div class="@(_big ? "resize-card big" : "resize-card")">
+                <span class="resize-label">Layout</span>
+                <div class="resize-dot" />
+            </div>
+        </Bmotion>
+        """;
 
     private const string _layoutIdCode = """
         @foreach (var tab in _tabs)

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
@@ -108,11 +108,16 @@
         """;
 
     private const string _code = """
-        <Bmotion Initial="Bm.To(offsetPath: "path('M20,150 C80,20 220,20 280,150')",
-                                offsetDistance: "0%")"
-                 Animate="Bm.To(offsetDistance: "100%")"
+        <Bmotion Initial="_initial"
+                 Animate="@(_on ? _travel : _initial)"
                  Transition="Bm.Tween(2.0, BmEase.InOut)">
             <div class="dot" />
         </Bmotion>
+
+        @code {
+            static readonly BmProps _initial =
+                Bm.To(offsetPath: "path('M20,150 C80,20 220,20 280,150')", offsetDistance: "0%");
+            static readonly BmProps _travel = Bm.To(offsetDistance: "100%");
+        }
         """;
 }

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
@@ -7,7 +7,7 @@
     <p>
         Set <strong>OffsetPath</strong> once (CSS <code>offset-path</code>) and animate
         <strong>OffsetDistance</strong> from <code>0%</code> to <code>100%</code> to move an element
-        along it — a standards-based, compositor-friendly alternative to hand-animating x/y.
+        along it - a standards-based, compositor-friendly alternative to hand-animating x/y.
     </p>
 
     <div class="demo-row">

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
@@ -1,0 +1,67 @@
+@page "/motion-path"
+
+<h1>Motion path</h1>
+
+<div class="demo-section">
+    <h2>Travel along an SVG path</h2>
+    <p>
+        Set <strong>OffsetPath</strong> once (CSS <code>offset-path</code>) and animate
+        <strong>OffsetDistance</strong> from <code>0%</code> to <code>100%</code> to move an element
+        along it — a standards-based, compositor-friendly alternative to hand-animating x/y.
+    </p>
+
+    <div class="demo-row">
+        <div class="demo-card" style="min-height:220px;">
+            <div class="mpath-stage">
+                <svg viewBox="0 0 300 180" style="position:absolute; inset:0; width:100%; height:100%; opacity:.35">
+                    <path d="M20,150 C80,20 220,20 280,150" fill="none" stroke="#6c47ff" stroke-width="2" stroke-dasharray="4 4" />
+                </svg>
+                <Bmotion Initial="_initial"
+                         Animate="@(_on ? _travel : _initial)"
+                         Transition="Bm.Tween(2.0, BmEase.InOut)">
+                    <div class="dot" />
+                </Bmotion>
+            </div>
+        </div>
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="@(() => _on = !_on)">
+        @(_on ? "Rewind" : "Travel")
+    </button>
+
+    <CodeSnippet Code="@_code" />
+</div>
+
+<style>
+    /* Fixed-size stage so the SVG guide (viewBox 0 0 300 180) and the dot's
+       pixel-based offset-path share one coordinate system, and position:relative
+       keeps the absolutely-positioned SVG contained within the card. */
+    .mpath-stage {
+        position: relative;
+        width: 300px;
+        height: 180px;
+        max-width: 100%;
+        margin: 0 auto;
+    }
+    .dot {
+        width: 24px; height: 24px; border-radius: 50%;
+        background: linear-gradient(135deg, #6c47ff, #ff4785);
+    }
+</style>
+
+@code {
+    private bool _on;
+
+    private static readonly BmProps _initial =
+        Bm.To(offsetPath: "path('M20,150 C80,20 220,20 280,150')", offsetDistance: "0%");
+    private static readonly BmProps _travel = Bm.To(offsetDistance: "100%");
+
+    private const string _code = """
+        <Bmotion Initial="Bm.To(offsetPath: "path('M20,150 C80,20 220,20 280,150')",
+                                offsetDistance: "0%")"
+                 Animate="Bm.To(offsetDistance: "100%")"
+                 Transition="Bm.Tween(2.0, BmEase.InOut)">
+            <div class="dot" />
+        </Bmotion>
+        """;
+}

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/MotionPath.razor
@@ -32,6 +32,39 @@
     <CodeSnippet Code="@_code" />
 </div>
 
+<div class="demo-section">
+    <h2>Shape morphing</h2>
+    <p>
+        Animate the SVG <strong>D</strong> (path <code>d</code>) attribute. Two paths with the
+        <strong>same command structure</strong> morph smoothly (control points interpolate);
+        mismatched paths snap. Put the <code>&lt;path&gt;</code> directly inside the Bmotion.
+    </p>
+
+    <div class="demo-row">
+        <div class="demo-card">
+            <svg viewBox="0 0 200 200" width="200" height="200">
+                <Bmotion Animate="@(_morph ? _blobB : _blobA)"
+                         Transition="Bm.Spring(stiffness: 120, damping: 14)">
+                    <path d="M100 30 C140 30 170 60 170 100 C170 140 140 170 100 170 C60 170 30 140 30 100 C30 60 60 30 100 30"
+                          fill="url(#morphGrad)" />
+                </Bmotion>
+                <defs>
+                    <linearGradient id="morphGrad" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0" stop-color="#6c47ff" />
+                        <stop offset="1" stop-color="#ff4785" />
+                    </linearGradient>
+                </defs>
+            </svg>
+        </div>
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="@(() => _morph = !_morph)">
+        Morph
+    </button>
+
+    <CodeSnippet Code="@_morphCode" />
+</div>
+
 <style>
     /* Fixed-size stage so the SVG guide (viewBox 0 0 300 180) and the dot's
        pixel-based offset-path share one coordinate system, and position:relative
@@ -51,10 +84,28 @@
 
 @code {
     private bool _on;
+    private bool _morph;
 
     private static readonly BmProps _initial =
         Bm.To(offsetPath: "path('M20,150 C80,20 220,20 280,150')", offsetDistance: "0%");
     private static readonly BmProps _travel = Bm.To(offsetDistance: "100%");
+
+    // Same command structure (M + 4 cubic segments) so the control points interpolate smoothly.
+    private static readonly BmProps _blobA = Bm.To(d: "M100 30 C140 30 170 60 170 100 C170 140 140 170 100 170 C60 170 30 140 30 100 C30 60 60 30 100 30");
+    private static readonly BmProps _blobB = Bm.To(d: "M100 50 C130 20 180 70 150 100 C180 130 130 180 100 150 C70 180 20 130 50 100 C20 70 70 20 100 50");
+
+    private const string _morphCode = """
+        <svg viewBox="0 0 200 200">
+            <Bmotion Animate="@(_morph ? _blobB : _blobA)" Transition="Bm.Spring(stiffness: 120, damping: 14)">
+                <path d="M100 30 C140 30 ..." fill="…" />
+            </Bmotion>
+        </svg>
+
+        @code {
+            static readonly BmProps _blobA = Bm.To(d: "M100 30 C140 30 170 60 170 100 …");
+            static readonly BmProps _blobB = Bm.To(d: "M100 50 C130 20 180 70 150 100 …");
+        }
+        """;
 
     private const string _code = """
         <Bmotion Initial="Bm.To(offsetPath: "path('M20,150 C80,20 220,20 280,150')",

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/Variants.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/Variants.razor
@@ -73,7 +73,7 @@
 <div class="demo-section">
     <h2>Grid stagger</h2>
     <p>
-        <strong>Bm.Stagger</strong> now radiates across a 2-D grid — pass
+        <strong>Bm.Stagger</strong> now radiates across a 2-D grid - pass
         <c>grid: (cols, rows)</c> and a <c>from</c> origin and the delay grows with Euclidean distance
         from that cell. Drive it imperatively with the <strong>BmotionAnimateService</strong>.
     </p>

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/Variants.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/Variants.razor
@@ -1,4 +1,5 @@
 @page "/variants"
+@inject BmotionAnimateService Motion
 
 <h1 class="demo-page-title">Variants</h1>
 
@@ -69,9 +70,47 @@
     <CodeSnippet Code="@_orchestrationCode" />
 </div>
 
+<div class="demo-section">
+    <h2>Grid stagger</h2>
+    <p>
+        <strong>Bm.Stagger</strong> now radiates across a 2-D grid — pass
+        <c>grid: (cols, rows)</c> and a <c>from</c> origin and the delay grows with Euclidean distance
+        from that cell. Drive it imperatively with the <strong>BmotionAnimateService</strong>.
+    </p>
+
+    <div class="demo-row">
+        <div class="demo-card">
+            <div class="stagger-grid">
+                @for (int i = 0; i < 36; i++)
+                {
+                    <div class="grid-dot"></div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <button class="btn-bm" style="margin-top:1rem" @onclick="RippleAsync">Ripple from center</button>
+
+    <CodeSnippet Code="@_gridStaggerCode" />
+</div>
+
+<style>
+    .stagger-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: .5rem; }
+    .grid-dot { width: 26px; height: 26px; border-radius: 6px; background: linear-gradient(135deg, #6c47ff, #ff4785); }
+</style>
+
 @code {
     private bool _visible = true;
     private bool _visible2 = true;
+
+    private async Task RippleAsync()
+    {
+        await Motion.AnimateAsync(
+            ".grid-dot",
+            Bm.To(scale: [1, 1.6, 1]),
+            Bm.Spring(stiffness: 400, damping: 18),
+            stagger: Bm.Stagger(0.04, from: BmStaggerFrom.Center, grid: (6, 6)));
+    }
 
     private readonly BmVariants _containerVariants = new()
     {
@@ -84,6 +123,22 @@
         ["hidden"]  = Bm.To(opacity: 0, x: -30),
         ["visible"] = Bm.To(opacity: 1, x: 0, transition: Bm.Spring(stiffness: 300, damping: 24)),
     };
+
+    private const string _gridStaggerCode = """
+        @inject BmotionAnimateService Motion
+
+        <div class="stagger-grid">
+            @for (int i = 0; i < 36; i++) { <div class="grid-dot"></div> }
+        </div>
+
+        @code {
+            async Task RippleAsync() =>
+                await Motion.AnimateAsync(".grid-dot",
+                    Bm.To(scale: [1, 1.6, 1]),
+                    Bm.Spring(stiffness: 400, damping: 18),
+                    stagger: Bm.Stagger(0.04, from: BmStaggerFrom.Center, grid: (6, 6)));
+        }
+        """;
 
     private const string _variantsCode = """
         @using Bit.Bmotion

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/ViewTransitions.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/ViewTransitions.razor
@@ -1,0 +1,67 @@
+@page "/view-transitions"
+@inject BmotionViewTransition ViewTransition
+
+<h1>View Transitions</h1>
+
+<div class="demo-section">
+    <h2>Native View Transitions API</h2>
+    <p>
+        <strong>BmotionViewTransition</strong> wraps <code>document.startViewTransition</code> around a
+        Blazor state change — the browser snapshots before/after and cross-fades. It's the
+        standards-based complement to <code>LayoutId</code> FLIP, and degrades gracefully (the state
+        change just applies without a transition) where the API isn't supported.
+    </p>
+
+    <div class="tab-bar">
+        @foreach (var t in _tabs)
+        {
+            <button class="tab @(t == _active ? "active" : "")" @onclick="@(() => SwitchAsync(t))">@t</button>
+        }
+    </div>
+
+    <div class="panel" style="view-transition-name: vt-panel">
+        <h3>@_active</h3>
+        <p>@_copy[_active]</p>
+    </div>
+
+    <CodeSnippet Code="@_code" />
+</div>
+
+<style>
+    .tab-bar { display: flex; gap: .5rem; margin-bottom: 1rem; }
+    .tab { background: #2a2a3a; color: #ccc; border: none; border-radius: 8px; padding: .5rem 1rem; cursor: pointer; }
+    .tab.active { background: #6c47ff; color: #fff; }
+    .panel { background: #1e1e2e; border: 1px solid rgba(255,255,255,.07); border-radius: 12px; padding: 2rem; min-height: 120px; }
+    ::view-transition-old(vt-panel), ::view-transition-new(vt-panel) { animation-duration: .4s; }
+</style>
+
+@code {
+    private readonly string[] _tabs = ["Overview", "Features", "Pricing"];
+    private string _active = "Overview";
+
+    private readonly Dictionary<string, string> _copy = new()
+    {
+        ["Overview"] = "A high-level tour. Switching tabs cross-fades this panel via the native View Transitions API.",
+        ["Features"] = "Independent transforms, springs, drag, layout FLIP, motion values and more.",
+        ["Pricing"] = "Free and open-source. Bring your own creativity.",
+    };
+
+    private async Task SwitchAsync(string tab)
+    {
+        if (tab == _active) return;
+        await ViewTransition.StartAsync(() => { _active = tab; StateHasChanged(); });
+    }
+
+    private const string _code = """
+        @inject BmotionViewTransition ViewTransition
+
+        <div class="panel" style="view-transition-name: vt-panel">@_active</div>
+
+        @code {
+            private string _active = "Overview";
+
+            private async Task SwitchAsync(string tab) =>
+                await ViewTransition.StartAsync(() => { _active = tab; StateHasChanged(); });
+        }
+        """;
+}

--- a/src/Bmotion/Bit.Bmotion.Demos/Pages/ViewTransitions.razor
+++ b/src/Bmotion/Bit.Bmotion.Demos/Pages/ViewTransitions.razor
@@ -7,7 +7,7 @@
     <h2>Native View Transitions API</h2>
     <p>
         <strong>BmotionViewTransition</strong> wraps <code>document.startViewTransition</code> around a
-        Blazor state change — the browser snapshots before/after and cross-fades. It's the
+        Blazor state change - the browser snapshots before/after and cross-fades. It's the
         standards-based complement to <code>LayoutId</code> FLIP, and degrades gracefully (the state
         change just applies without a transition) where the API isn't supported.
     </p>

--- a/src/Bmotion/Bit.Bmotion.Demos/wwwroot/css/motion-samples.css
+++ b/src/Bmotion/Bit.Bmotion.Demos/wwwroot/css/motion-samples.css
@@ -24,7 +24,8 @@ body {
     padding: .75rem 1.5rem;
     display: flex;
     align-items: center;
-    gap: 1.5rem;
+    flex-wrap: wrap;
+    gap: .5rem 1.25rem;
     position: sticky;
     top: 0;
     z-index: 100;
@@ -35,11 +36,20 @@ body {
     background: linear-gradient(135deg, var(--bm-primary), var(--bm-secondary));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+    margin-right: auto;
+}
+.bm-nav-links {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .5rem 1.25rem;
+    min-width: 0;
 }
 .bm-nav a {
     color: var(--bm-muted);
     text-decoration: none;
     font-size: .9rem;
+    white-space: nowrap;
     transition: color .2s;
 }
 .bm-nav a:hover, .bm-nav a.active { color: var(--bm-text); }
@@ -48,6 +58,55 @@ body {
     outline: 2px solid var(--bm-primary);
     outline-offset: 2px;
     border-radius: 4px;
+}
+
+/* Hamburger toggle — hidden until the nav collapses on narrow screens */
+.bm-nav-burger {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 8px;
+    cursor: pointer;
+}
+.bm-nav-burger span {
+    display: block;
+    width: 18px;
+    height: 2px;
+    margin: 0 auto;
+    background: var(--bm-text);
+    border-radius: 2px;
+    transition: transform .2s, opacity .2s;
+}
+.bm-nav-burger:focus-visible {
+    outline: 2px solid var(--bm-primary);
+    outline-offset: 2px;
+}
+
+@media (max-width: 860px) {
+    .bm-nav-burger { display: flex; }
+    .bm-nav-links {
+        display: none;
+        flex-direction: column;
+        align-items: stretch;
+        flex-basis: 100%;
+        gap: .25rem;
+        padding-top: .5rem;
+    }
+    .bm-nav.open .bm-nav-links { display: flex; }
+    .bm-nav-links a {
+        padding: .6rem .25rem;
+        font-size: 1rem;
+        border-radius: 6px;
+    }
+    .bm-nav.open .bm-nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+    .bm-nav.open .bm-nav-burger span:nth-child(2) { opacity: 0; }
+    .bm-nav.open .bm-nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
 }
 
 .bm-page {

--- a/src/Bmotion/Bit.Bmotion.Demos/wwwroot/css/motion-samples.css
+++ b/src/Bmotion/Bit.Bmotion.Demos/wwwroot/css/motion-samples.css
@@ -60,7 +60,7 @@ body {
     border-radius: 4px;
 }
 
-/* Hamburger toggle — hidden until the nav collapses on narrow screens */
+/* Hamburger toggle - hidden until the nav collapses on narrow screens */
 .bm-nav-burger {
     display: none;
     flex-direction: column;

--- a/src/Bmotion/Bit.Bmotion/BitBmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/BitBmotion.cs
@@ -30,8 +30,19 @@ public static class BitBmotion
     /// </para>
     /// </summary>
     public static IServiceCollection AddBitBmotionServices(this IServiceCollection services)
+        => services.AddBitBmotionServices(null);
+
+    /// <summary>
+    /// Registers all Bit.Bmotion services with library-wide options, e.g. the reduced-motion policy:
+    /// <code>builder.Services.AddBitBmotionServices(o =&gt; o.ReducedMotion = BmReducedMotionMode.User);</code>
+    /// </summary>
+    public static IServiceCollection AddBitBmotionServices(this IServiceCollection services, Action<BitBmotionOptions>? configure)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        var options = new BitBmotionOptions();
+        configure?.Invoke(options);
+        services.AddSingleton(options);
 
         // Keep the JSON-marshaled interop DTOs trim/AOT-safe. These types cross the JS↔.NET
         // boundary via reflection-based System.Text.Json (InvokeAsync<T>, [JSInvokable] params),
@@ -39,11 +50,15 @@ public static class BitBmotion
         // to empty/failed deserialization in published WebAssembly builds.
         PreserveInteropContracts();
 
-        // Slim browser-API interop bridge - one instance per DI scope
-        services.AddScoped<BmotionInterop>();
+        // Slim browser-API interop bridge - one instance per DI scope. Registered behind the
+        // IBmotionInterop seam so the engine and components can be unit-tested against a fake.
+        services.AddScoped<IBmotionInterop, BmotionInterop>();
 
         // C# animation engine - drives all animation math in WebAssembly
         services.AddScoped<BmotionAnimationEngine>();
+
+        // Queryable render-mode capability flags (WASM frame loop vs Server compositor-only).
+        services.AddScoped(sp => new BmotionCapabilities(sp.GetRequiredService<IBmotionInterop>()));
 
         // Shared-element (LayoutId) rect registry - one per scope, like the engine
         services.AddScoped<BmotionLayoutRegistry>();
@@ -56,6 +71,9 @@ public static class BitBmotion
         // causing ObjectDisposedException when another component re-observes.
         services.AddTransient<BmotionScrollTracker>();
         services.AddScoped<BmotionAnimateService>();
+
+        // Native View Transitions API wrapper (opt-in helper).
+        services.AddScoped<BmotionViewTransition>();
 
         return services;
     }

--- a/src/Bmotion/Bit.Bmotion/BitBmotionOptions.cs
+++ b/src/Bmotion/Bit.Bmotion/BitBmotionOptions.cs
@@ -1,0 +1,26 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// Library-wide options for Bit.Bmotion, configured at service registration:
+/// <code>
+/// builder.Services.AddBitBmotionServices(o =&gt; o.ReducedMotion = BmReducedMotionMode.User);
+/// </code>
+/// </summary>
+public sealed class BitBmotionOptions
+{
+    /// <summary>
+    /// How the library honors the OS <c>prefers-reduced-motion</c> accessibility preference.
+    /// Defaults to <see cref="BmReducedMotionMode.IgnoreUnlessConfigured"/> for back-compat;
+    /// <see cref="BmReducedMotionMode.User"/> is recommended for new apps (respects the OS setting
+    /// everywhere without requiring a <see cref="BmotionConfig"/>). A local
+    /// <c>&lt;BmotionConfig ReduceMotion="…"&gt;</c> always overrides this.
+    /// </summary>
+    public BmReducedMotionMode ReducedMotion { get; set; } = BmReducedMotionMode.IgnoreUnlessConfigured;
+
+    /// <summary>
+    /// Validation policy for string-valued CSS props written verbatim into inline style. Defaults to
+    /// <see cref="BmCssSafeMode.Off"/>; set to <see cref="BmCssSafeMode.Warn"/> or
+    /// <see cref="BmCssSafeMode.Throw"/> when binding untrusted end-user input to those props.
+    /// </summary>
+    public BmCssSafeMode CssSafeMode { get; set; } = BmCssSafeMode.Off;
+}

--- a/src/Bmotion/Bit.Bmotion/BmotionCapabilities.cs
+++ b/src/Bmotion/Bit.Bmotion/BmotionCapabilities.cs
@@ -1,0 +1,32 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// Queryable, DI-injected view of what the current Blazor render mode can animate. Use it to make
+/// degradation on Blazor Server explicit instead of silently collapsing to instant state changes:
+/// <code>
+/// [Inject] BmotionCapabilities Caps { get; set; } = default!;
+///
+/// @if (!Caps.SupportsFrameLoop) { &lt;text&gt;Drag/inertia are disabled on Server.&lt;/text&gt; }
+/// </code>
+/// </summary>
+public sealed class BmotionCapabilities
+{
+    internal BmotionCapabilities(IBmotionInterop interop)
+    {
+        ArgumentNullException.ThrowIfNull(interop);
+        SupportsFrameLoop = interop.IsInProcess;
+    }
+
+    /// <summary>
+    /// <c>true</c> on Blazor WebAssembly, where the synchronous per-frame rAF loop drives drag,
+    /// inertia, color/dimension interpolation, keyframe arrays and motion values. <c>false</c> on
+    /// Blazor Server, where those features degrade to instant state changes.
+    /// </summary>
+    public bool SupportsFrameLoop { get; }
+
+    /// <summary>
+    /// <c>true</c> everywhere: compositor-eligible tween/spring animations on transform and opacity
+    /// offload to the browser's Web Animations API over async interop, so they play on Server too.
+    /// </summary>
+    public bool SupportsCompositor => true;
+}

--- a/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
@@ -687,7 +687,9 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
         // Apply CSS safe mode to the imperative API too, matching the declarative ResolveProps path.
         props = GuardCss(props)!;
         var values = props.ToJsDictionary();
-        var config = transition?.ToConfig() ?? BuildEffectiveTransition(props);
+        // Inherit the global <BmotionConfig> color space into the explicit transition too, matching
+        // BuildNormalTransition - otherwise an explicit transition here resets color lerping to sRGB.
+        var config = transition?.ToConfig(ConfigCtx?.ColorSpace) ?? BuildEffectiveTransition(props);
         // Cancellation stops just the properties this call animates (Stop with null keys would
         // clobber unrelated animations on the same element). The registration is scoped to this
         // call so repeated calls with a long-lived token don't accumulate callbacks.

--- a/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
@@ -679,9 +679,11 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
         var values = props.ToJsDictionary();
         var config = transition?.ToConfig() ?? BuildEffectiveTransition(props);
         // Cancellation stops just the properties this call animates (Stop with null keys would
-        // clobber unrelated animations on the same element).
-        if (cancellationToken.CanBeCanceled)
-            cancellationToken.Register(() => Engine.Stop(_id, values.Keys.ToArray()));
+        // clobber unrelated animations on the same element). The registration is scoped to this
+        // call so repeated calls with a long-lived token don't accumulate callbacks.
+        using var registration = cancellationToken.CanBeCanceled
+            ? cancellationToken.Register(() => Engine.Stop(_id, values.Keys.ToArray()))
+            : default;
         await Engine.AnimateToAsync(_id, values, config);
     }
 

--- a/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
@@ -687,9 +687,10 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
         // Apply CSS safe mode to the imperative API too, matching the declarative ResolveProps path.
         props = GuardCss(props)!;
         var values = props.ToJsDictionary();
-        // Inherit the global <BmotionConfig> color space into the explicit transition too, matching
-        // BuildNormalTransition - otherwise an explicit transition here resets color lerping to sRGB.
-        var config = transition?.ToConfig(ConfigCtx?.ColorSpace) ?? BuildEffectiveTransition(props);
+        // Route the explicit transition through the same pipeline as the declarative path so it
+        // inherits the global color space AND respects reduced motion / TransitionSpeed - a raw
+        // transition.ToConfig() would bypass ShouldReduceMotion() and animate when it shouldn't.
+        var config = BuildEffectiveTransition(props, transition);
         // Cancellation stops just the properties this call animates (Stop with null keys would
         // clobber unrelated animations on the same element). The registration is scoped to this
         // call so repeated calls with a long-lived token don't accumulate callbacks.
@@ -999,18 +1000,18 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
         return reduced;
     }
 
-    private BmotionTransitionConfig? BuildEffectiveTransition(BmProps? props = null)
+    private BmotionTransitionConfig? BuildEffectiveTransition(BmProps? props = null, BmTransition? explicitTransition = null)
     {
-        var normal = BuildNormalTransition(props);
+        var normal = BuildNormalTransition(props, explicitTransition);
         // Reduced motion: snap transforms/layout but keep opacity/color animating.
         return ShouldReduceMotion() ? BuildReducedTransition(normal) : normal;
     }
 
-    private BmotionTransitionConfig? BuildNormalTransition(BmProps? props)
+    private BmotionTransitionConfig? BuildNormalTransition(BmProps? props, BmTransition? explicitTransition = null)
     {
-        // Resolution order: transition embedded in the target itself, then the component's
-        // Transition parameter, then the surrounding <BmotionConfig> default.
-        var t = props?.Transition ?? Transition ?? ConfigCtx?.DefaultTransition;
+        // Resolution order: an explicit transition (programmatic AnimateAsync) wins, then the one
+        // embedded in the target, then the component's Transition, then the <BmotionConfig> default.
+        var t = explicitTransition ?? props?.Transition ?? Transition ?? ConfigCtx?.DefaultTransition;
         if (t == null) return null;
         // ToConfig returns a fresh instance (safe to mutate below) and inherits the global
         // <BmotionConfig> color space wherever this transition - or any per-property override -

--- a/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
@@ -682,7 +682,10 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
 
     public async ValueTask AnimateAsync(BmProps props, BmTransition? transition = null, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(props);
         if (cancellationToken.IsCancellationRequested) return;
+        // Apply CSS safe mode to the imperative API too, matching the declarative ResolveProps path.
+        props = GuardCss(props)!;
         var values = props.ToJsDictionary();
         var config = transition?.ToConfig() ?? BuildEffectiveTransition(props);
         // Cancellation stops just the properties this call animates (Stop with null keys would
@@ -694,11 +697,17 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
         await Engine.AnimateToAsync(_id, values, config);
     }
 
-    public void Set(BmProps props) => Engine.SetInstant(_id, props.ToJsDictionary());
+    public void Set(BmProps props)
+    {
+        ArgumentNullException.ThrowIfNull(props);
+        Engine.SetInstant(_id, GuardCss(props)!.ToJsDictionary());
+    }
 
     public async ValueTask SetAsync(BmProps props, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(props);
         if (cancellationToken.IsCancellationRequested) return;
+        props = GuardCss(props)!;
         Engine.SetInstant(_id, props.ToJsDictionary());
         // Flush synchronous style update to DOM as individual declarations (never via cssText,
         // which would replace the element's entire inline style).

--- a/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
@@ -437,9 +437,16 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
 
     private async Task InitialiseAsync()
     {
-        // Probe the OS preference whenever it can affect this element: inside a <BmotionConfig>
-        // (legacy opt-in), or when the global ReducedMotion mode is User (respect the OS everywhere).
-        if (ConfigCtx is not null || Options.ReducedMotion == BmReducedMotionMode.User)
+        // Probe the OS preference only when it can actually change ShouldReduceMotion()'s result:
+        // a local <BmotionConfig ReduceMotion> wins outright, and Always/Never ignore the OS - so
+        // detection there is a wasted interop round-trip. This mirrors ShouldReduceMotion().
+        bool osPreferenceMatters = ConfigCtx?.ReduceMotion is null && Options.ReducedMotion switch
+        {
+            BmReducedMotionMode.User => true,
+            BmReducedMotionMode.Always or BmReducedMotionMode.Never => false,
+            _ => ConfigCtx is not null, // IgnoreUnlessConfigured: OS matters only inside a config
+        };
+        if (osPreferenceMatters)
             await Engine.EnsureReducedMotionDetectedAsync();
 
         // Register with C# engine (applies initial values synchronously)
@@ -994,11 +1001,12 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
         // Transition parameter, then the surrounding <BmotionConfig> default.
         var t = props?.Transition ?? Transition ?? ConfigCtx?.DefaultTransition;
         if (t == null) return null;
-        // ToConfig always returns a fresh instance, so it is safe to mutate below.
-        var config = t.ToConfig();
-        // The global <BmotionConfig> color space applies only when the transition didn't pick one.
-        if (t.ColorSpace is null && ConfigCtx?.ColorSpace is BmColorSpace globalColorSpace)
-            config.ColorSpace = globalColorSpace;
+        // ToConfig returns a fresh instance (safe to mutate below) and inherits the global
+        // <BmotionConfig> color space wherever this transition - or any per-property override -
+        // didn't set its own, so a per-property color override doesn't silently fall back to sRGB
+        // under a global OKLab config (the engine uses the per-key config verbatim, see
+        // BmotionElementAnimationState.AnimateTo).
+        var config = t.ToConfig(ConfigCtx?.ColorSpace);
         if (ConfigCtx?.TransitionSpeed is double speed && speed != 1.0)
         {
             // TransitionSpeed is a rate: 2 = twice as fast, 0.5 = half speed, <= 0 = instant.

--- a/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/Bmotion.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace Bit.Bmotion;
@@ -17,8 +18,10 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
 {
     // ── Injected services ──────────────────────────────────────────────────────
     [Inject] private BmotionAnimationEngine Engine { get; set; } = null!;
-    [Inject] private BmotionInterop Interop { get; set; } = null!;
+    [Inject] private IBmotionInterop Interop { get; set; } = null!;
     [Inject] private BmotionLayoutRegistry LayoutRegistry { get; set; } = null!;
+    [Inject] private BitBmotionOptions Options { get; set; } = null!;
+    [Inject] private ILogger<Bmotion>? Logger { get; set; }
 
     // ── Cascaded contexts ──────────────────────────────────────────────────────
     [CascadingParameter] private BmotionPresenceContext? PresenceCtx { get; set; }
@@ -160,13 +163,21 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
     /// <summary>Lock the drag to the dominant movement axis once detected.</summary>
     [Parameter] public bool DragDirectionLock { get; set; }
 
+    /// <summary>
+    /// Whether a drag on this element also propagates to draggable ancestors. Default <c>false</c>
+    /// (motion.dev's default): the drag stops propagation so a nested draggable doesn't also drag its
+    /// draggable parent. Set <c>true</c> to let both move together.
+    /// </summary>
+    [Parameter] public bool DragPropagation { get; set; }
+
     /// <summary>Transition used for constraint snap-back / snap-to-origin. Defaults to a spring.</summary>
     [Parameter] public BmTransition? DragTransition { get; set; }
 
     // ── Layout ─────────────────────────────────────────────────────────────────
     /// <summary>
-    /// Automatic FLIP layout animation: <c>Layout="true"</c> (position + size) or
-    /// <c>Layout="BmLayout.Position"</c> (position only, no scale distortion).
+    /// Automatic FLIP layout animation: <c>Layout="true"</c> (position + size, with direct children
+    /// counter-scaled and border-radius corrected so nothing distorts) or
+    /// <c>Layout="BmLayout.Position"</c> (position only, the cheapest option).
     /// </summary>
     [Parameter] public BmLayout Layout { get; set; }
 
@@ -210,6 +221,7 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
     private string _id = $"bm-{Guid.NewGuid():N}";
     private DotNetObjectReference<Bmotion>? _dotnet;
     private bool _initialized;
+    private bool _idChangeWarned;
     private bool _isExiting;
     private BmTarget? _prevAnimate;
     private BmotionVariantContext? _ownVariantCtx;
@@ -425,9 +437,9 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
 
     private async Task InitialiseAsync()
     {
-        // Reduced-motion is opt-in: only probe the OS preference when this element is
-        // inside a <BmotionConfig>. Elements without a config always animate normally.
-        if (ConfigCtx is not null)
+        // Probe the OS preference whenever it can affect this element: inside a <BmotionConfig>
+        // (legacy opt-in), or when the global ReducedMotion mode is User (respect the OS everywhere).
+        if (ConfigCtx is not null || Options.ReducedMotion == BmReducedMotionMode.User)
             await Engine.EnsureReducedMotionDetectedAsync();
 
         // Register with C# engine (applies initial values synchronously)
@@ -489,6 +501,16 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
     private async Task HandleParameterUpdateAsync()
     {
         if (_isExiting) return;
+
+        // The id is the element's engine identity, adopted once at first render; changing the Id
+        // parameter afterwards is unsupported and silently misbehaves. Warn once so it's diagnosable.
+        if (!_idChangeWarned && !string.IsNullOrWhiteSpace(Id) && Id != _id)
+        {
+            _idChangeWarned = true;
+            Logger?.LogWarning(
+                "Bit.Bmotion: the Id parameter changed from '{OldId}' to '{NewId}' after first render. " +
+                "The id is the element's immutable engine identity; the change is ignored.", _id, Id);
+        }
 
         // Recovery: if the engine evicted this element after a driver fault (see
         // BmotionAnimationEngine.ComputeFrame), it silently stopped animating. Re-register and
@@ -651,16 +673,23 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
     // Programmatic API
     // ════════════════════════════════════════════════════════════════════════════
 
-    public async ValueTask AnimateAsync(BmProps props, BmTransition? transition = null)
+    public async ValueTask AnimateAsync(BmProps props, BmTransition? transition = null, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested) return;
+        var values = props.ToJsDictionary();
         var config = transition?.ToConfig() ?? BuildEffectiveTransition(props);
-        await Engine.AnimateToAsync(_id, props.ToJsDictionary(), config);
+        // Cancellation stops just the properties this call animates (Stop with null keys would
+        // clobber unrelated animations on the same element).
+        if (cancellationToken.CanBeCanceled)
+            cancellationToken.Register(() => Engine.Stop(_id, values.Keys.ToArray()));
+        await Engine.AnimateToAsync(_id, values, config);
     }
 
     public void Set(BmProps props) => Engine.SetInstant(_id, props.ToJsDictionary());
 
-    public async ValueTask SetAsync(BmProps props)
+    public async ValueTask SetAsync(BmProps props, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested) return;
         Engine.SetInstant(_id, props.ToJsDictionary());
         // Flush synchronous style update to DOM as individual declarations (never via cssText,
         // which would replace the element's entire inline style).
@@ -867,13 +896,35 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
     private BmProps? ResolveProps(BmTarget? target)
     {
         if (target == null || target.IsDisabled) return null;
-        if (target.HasProps) return target.Props;
+        if (target.HasProps) return GuardCss(target.Props);
         if (target.IsVariant)
         {
             var name = target.Variant!;
-            return Variants?.Get(name, Custom) ?? VariantCtx?.Variants?.Get(name, Custom);
+            return GuardCss(Variants?.Get(name, Custom) ?? VariantCtx?.Variants?.Get(name, Custom));
         }
         return null;
+    }
+
+    /// <summary>
+    /// Opt-in CSS-injection safe mode (<see cref="BitBmotionOptions.CssSafeMode"/>): validates every
+    /// string-valued CSS declaration a target carries, warning or throwing on a rejected value. A
+    /// no-op (returns immediately) when the mode is Off, so the default path pays nothing.
+    /// </summary>
+    private BmProps? GuardCss(BmProps? props)
+    {
+        if (props is null || Options.CssSafeMode == BmCssSafeMode.Off) return props;
+        foreach (var (prop, value) in props.EnumerateCssStringValues())
+        {
+            if (BmotionCssValidator.IsSafe(value)) continue;
+            if (Options.CssSafeMode == BmCssSafeMode.Throw)
+                throw new InvalidOperationException(
+                    $"Bit.Bmotion CSS safe mode rejected the value for '{prop}': \"{value}\". " +
+                    "It contains characters/sequences that could break out of the inline style.");
+            Logger?.LogWarning(
+                "Bit.Bmotion CSS safe mode: rejected value for '{Prop}' on element '{Id}': {Value}",
+                prop, _id, value);
+        }
+        return props;
     }
 
     /// <summary>
@@ -889,25 +940,63 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
     /// </summary>
     private bool ShouldReduceMotion()
     {
-        if (ConfigCtx is null) return false;
-        return ConfigCtx.ReduceMotion ?? Engine.OsPrefersReducedMotion;
+        // A local <BmotionConfig ReduceMotion="true|false"> is always an explicit override.
+        if (ConfigCtx?.ReduceMotion is bool configReduce) return configReduce;
+
+        return Options.ReducedMotion switch
+        {
+            BmReducedMotionMode.Always => true,
+            BmReducedMotionMode.Never => false,
+            BmReducedMotionMode.User => Engine.OsPrefersReducedMotion,
+            // IgnoreUnlessConfigured (back-compat): OS preference matters only inside a config.
+            _ => ConfigCtx is not null && Engine.OsPrefersReducedMotion,
+        };
     }
+
+    // Under reduced motion we keep opacity and color animating (Motion's "user" semantics) while
+    // transform/layout/dimension changes snap instantly. These are the properties that survive.
+    private static readonly string[] _reducedRetainedProps =
+        ["opacity", "backgroundColor", "color", "borderColor", "outlineColor", "fill", "stroke"];
 
     /// <summary>An instant (zero-duration) transition used when motion is reduced.</summary>
     private static BmotionTransitionConfig InstantTransition()
         => new() { Type = BmotionTransitionType.Tween, Duration = 0, Delay = 0 };
 
+    /// <summary>
+    /// Builds the reduced-motion transition: an instant base (so transforms/layout/dimensions snap)
+    /// with per-property overrides that let opacity and color keep animating with their normal
+    /// transition. This is softer and more correct than collapsing every property to instant.
+    /// </summary>
+    internal static BmotionTransitionConfig BuildReducedTransition(BmotionTransitionConfig? normal)
+    {
+        // A default-constructed config matches the engine's null-transition fallback (see
+        // BmotionElementAnimationState.AnimateTo), so retained props animate with normal timing.
+        var retained = normal ?? new BmotionTransitionConfig();
+        var reduced = InstantTransition();
+        reduced.Properties = new Dictionary<string, BmotionTransitionConfig>(StringComparer.Ordinal);
+        foreach (var key in _reducedRetainedProps)
+            reduced.Properties[key] = retained;
+        return reduced;
+    }
+
     private BmotionTransitionConfig? BuildEffectiveTransition(BmProps? props = null)
     {
-        // Reduced motion: collapse every animation to an instant state change.
-        if (ShouldReduceMotion()) return InstantTransition();
+        var normal = BuildNormalTransition(props);
+        // Reduced motion: snap transforms/layout but keep opacity/color animating.
+        return ShouldReduceMotion() ? BuildReducedTransition(normal) : normal;
+    }
 
+    private BmotionTransitionConfig? BuildNormalTransition(BmProps? props)
+    {
         // Resolution order: transition embedded in the target itself, then the component's
         // Transition parameter, then the surrounding <BmotionConfig> default.
         var t = props?.Transition ?? Transition ?? ConfigCtx?.DefaultTransition;
         if (t == null) return null;
         // ToConfig always returns a fresh instance, so it is safe to mutate below.
         var config = t.ToConfig();
+        // The global <BmotionConfig> color space applies only when the transition didn't pick one.
+        if (t.ColorSpace is null && ConfigCtx?.ColorSpace is BmColorSpace globalColorSpace)
+            config.ColorSpace = globalColorSpace;
         if (ConfigCtx?.TransitionSpeed is double speed && speed != 1.0)
         {
             // TransitionSpeed is a rate: 2 = twice as fast, 0.5 = half speed, <= 0 = instant.
@@ -934,11 +1023,11 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
 
     private BmotionTransitionConfig BuildEffectiveTransitionWithDelay(double extraDelay, BmProps? props = null)
     {
-        // Reduced motion stays instant - stagger delays are skipped too.
-        if (ShouldReduceMotion()) return InstantTransition();
+        // Reduced motion: keep opacity/color animating but skip the stagger delay (accessibility).
+        if (ShouldReduceMotion()) return BuildReducedTransition(BuildNormalTransition(props));
 
-        // BuildEffectiveTransition returns a fresh instance (or none existed), so mutating is safe.
-        var t = BuildEffectiveTransition(props) ?? new BmotionTransitionConfig();
+        // BuildNormalTransition returns a fresh instance (or none existed), so mutating is safe.
+        var t = BuildNormalTransition(props) ?? new BmotionTransitionConfig();
         if (extraDelay > 0) t.Delay += extraDelay;
         return t;
     }
@@ -959,6 +1048,7 @@ public sealed class Bmotion : ComponentBase, IAsyncDisposable
             d["dragElastic"] = DragElastic.ToJsObject();
             if (DragConstraints != null) d["dragConstraints"] = DragConstraints.ToJsObject();
             if (DragDirectionLock) d["dragDirectionLock"] = true;
+            if (DragPropagation) d["dragPropagation"] = true;
             if (!string.IsNullOrWhiteSpace(DragHandle)) d["dragHandle"] = DragHandle;
             if (!DragListener) d["dragListener"] = false;
         }

--- a/src/Bmotion/Bit.Bmotion/Components/BmotionConfig.razor
+++ b/src/Bmotion/Bit.Bmotion/Components/BmotionConfig.razor
@@ -26,6 +26,13 @@
     /// </summary>
     [Parameter] public double TransitionSpeed { get; set; } = 1.0;
 
+    /// <summary>
+    /// Global color-interpolation space for this subtree. <c>null</c> leaves the default (sRGB);
+    /// set to <c>BmColorSpace.Oklab</c> for perceptual color transitions. A per-transition
+    /// <c>colorSpace</c> still wins.
+    /// </summary>
+    [Parameter] public BmColorSpace? ColorSpace { get; set; }
+
     private BmotionConfigContext _ctx = new();
 
     // Cache the last parameter values so OnParametersSet only swaps in a new context (and triggers
@@ -33,6 +40,7 @@
     private BmTransition? _lastTransition;
     private bool? _lastReduceMotion;
     private double _lastTransitionSpeed = 1.0;
+    private BmColorSpace? _lastColorSpace;
     private bool _ctxInitialized;
 
     protected override void OnParametersSet()
@@ -40,7 +48,8 @@
         if (_ctxInitialized &&
             ReferenceEquals(_lastTransition, Transition) &&
             _lastReduceMotion == ReduceMotion &&
-            _lastTransitionSpeed.Equals(TransitionSpeed))
+            _lastTransitionSpeed.Equals(TransitionSpeed) &&
+            _lastColorSpace == ColorSpace)
             return;
 
         // Replace the context with a fresh instance (rather than mutating in place) so the cascading
@@ -52,10 +61,12 @@
             DefaultTransition = Transition,
             ReduceMotion      = ReduceMotion,
             TransitionSpeed   = TransitionSpeed,
+            ColorSpace        = ColorSpace,
         };
         _lastTransition = Transition;
         _lastReduceMotion = ReduceMotion;
         _lastTransitionSpeed = TransitionSpeed;
+        _lastColorSpace = ColorSpace;
         _ctxInitialized = true;
     }
 }

--- a/src/Bmotion/Bit.Bmotion/Components/BmotionInspector.razor
+++ b/src/Bmotion/Bit.Bmotion/Components/BmotionInspector.razor
@@ -4,7 +4,7 @@
 
 @* A debug overlay that lists every element registered with the engine and its live animation state
    (active drivers, transform / numeric / string values). Drop it anywhere in a dev build:
-   <BmotionInspector /> — it polls the engine a few times a second and renders a floating panel. *@
+   <BmotionInspector /> - it polls the engine a few times a second and renders a floating panel. *@
 
 <div class="bm-inspector @(_open ? "open" : "closed")">
     <div class="bm-insp-bar" @onclick="Toggle" role="button" tabindex="0"

--- a/src/Bmotion/Bit.Bmotion/Components/BmotionInspector.razor
+++ b/src/Bmotion/Bit.Bmotion/Components/BmotionInspector.razor
@@ -1,0 +1,140 @@
+@namespace Bit.Bmotion
+@implements IAsyncDisposable
+@inject BmotionAnimationEngine Engine
+
+@* A debug overlay that lists every element registered with the engine and its live animation state
+   (active drivers, transform / numeric / string values). Drop it anywhere in a dev build:
+   <BmotionInspector /> — it polls the engine a few times a second and renders a floating panel. *@
+
+<div class="bm-inspector @(_open ? "open" : "closed")">
+    <div class="bm-insp-bar" @onclick="Toggle" role="button" tabindex="0"
+         @onkeydown="@(e => { if (e.Key is "Enter" or " ") Toggle(); })">
+        <span class="bm-insp-title">Bmotion</span>
+        <span class="bm-insp-count">@_snapshot.Count el · @_activeTotal active</span>
+        <span class="bm-insp-caret">@(_open ? "▾" : "▸")</span>
+    </div>
+
+    @if (_open)
+    {
+        <div class="bm-insp-body">
+            @if (_snapshot.Count == 0)
+            {
+                <div class="bm-insp-empty">No elements registered.</div>
+            }
+            @foreach (var d in _snapshot)
+            {
+                <div class="bm-insp-el @(d.HasActiveAnimations ? "live" : null)">
+                    <div class="bm-insp-elhead">
+                        <code class="bm-insp-id">@d.Id</code>
+                        @if (d.ActiveDriverCount > 0)
+                        {
+                            <span class="bm-insp-badge">@d.ActiveDriverCount driver@(d.ActiveDriverCount == 1 ? "" : "s")</span>
+                        }
+                        @if (d.IsDragging)
+                        {
+                            <span class="bm-insp-badge drag">drag</span>
+                        }
+                    </div>
+                    @if (d.ActiveProperties.Count > 0)
+                    {
+                        <div class="bm-insp-props">@string.Join(", ", d.ActiveProperties)</div>
+                    }
+                    <div class="bm-insp-vals">
+                        @foreach (var kv in d.Transforms)
+                        {
+                            <span class="bm-insp-chip">@kv.Key <b>@Fmt(kv.Value)</b></span>
+                        }
+                        @foreach (var kv in d.NumericValues)
+                        {
+                            <span class="bm-insp-chip">@kv.Key <b>@Fmt(kv.Value)</b></span>
+                        }
+                        @foreach (var kv in d.StringValues)
+                        {
+                            <span class="bm-insp-chip">@kv.Key <b>@kv.Value</b></span>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+<style>
+    .bm-inspector {
+        position: fixed; bottom: 12px; right: 12px; z-index: 2147483000;
+        width: 320px; max-height: 60vh; display: flex; flex-direction: column;
+        font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        background: rgba(20, 20, 30, .92); color: #e6e6f0; border: 1px solid rgba(255,255,255,.12);
+        border-radius: 10px; box-shadow: 0 8px 30px rgba(0,0,0,.45); backdrop-filter: blur(6px);
+        overflow: hidden;
+    }
+    .bm-insp-bar {
+        display: flex; align-items: center; gap: .5rem; padding: .5rem .7rem; cursor: pointer;
+        background: rgba(108,71,255,.18); border-bottom: 1px solid rgba(255,255,255,.08); user-select: none;
+    }
+    .bm-insp-title { font-weight: 700; }
+    .bm-insp-count { margin-left: auto; opacity: .7; font-size: 11px; }
+    .bm-insp-caret { opacity: .8; }
+    .bm-insp-body { overflow-y: auto; padding: .35rem; display: flex; flex-direction: column; gap: .35rem; }
+    .bm-insp-empty { opacity: .6; padding: .6rem; text-align: center; }
+    .bm-insp-el { border: 1px solid rgba(255,255,255,.07); border-radius: 7px; padding: .4rem .5rem; background: rgba(255,255,255,.02); }
+    .bm-insp-el.live { border-color: rgba(108,71,255,.5); }
+    .bm-insp-elhead { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; }
+    .bm-insp-id { color: #b9a7ff; }
+    .bm-insp-badge { font-size: 10px; background: rgba(108,71,255,.3); border-radius: 999px; padding: 0 .45rem; }
+    .bm-insp-badge.drag { background: rgba(255,71,133,.35); }
+    .bm-insp-props { opacity: .65; margin: .2rem 0; }
+    .bm-insp-vals { display: flex; flex-wrap: wrap; gap: .25rem; }
+    .bm-insp-chip { background: rgba(255,255,255,.06); border-radius: 5px; padding: .05rem .35rem; opacity: .9; }
+    .bm-insp-chip b { color: #fff; font-weight: 600; }
+</style>
+
+@code {
+    /// <summary>How often (ms) the panel polls the engine for live values. Clamped to ≥ 50 ms. Default 200.</summary>
+    [Parameter] public int RefreshMs { get; set; } = 200;
+
+    /// <summary>Whether the panel starts expanded. Default true.</summary>
+    [Parameter] public bool StartOpen { get; set; } = true;
+
+    private bool _open;
+    private IReadOnlyList<BmotionElementDiagnostics> _snapshot = [];
+    private int _activeTotal;
+    private PeriodicTimer? _timer;
+    private CancellationTokenSource? _cts;
+
+    protected override void OnInitialized() => _open = StartOpen;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (!firstRender) return;
+        _cts = new CancellationTokenSource();
+        _timer = new PeriodicTimer(TimeSpan.FromMilliseconds(Math.Max(50, RefreshMs)));
+        _ = PollAsync(_cts.Token);
+    }
+
+    private async Task PollAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (await _timer!.WaitForNextTickAsync(ct))
+            {
+                _snapshot = Engine.GetDiagnostics();
+                _activeTotal = _snapshot.Count(d => d.HasActiveAnimations);
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException) { /* disposed */ }
+    }
+
+    private void Toggle() => _open = !_open;
+
+    private static string Fmt(double v) => BmotionCssFormat.Num(v);
+
+    public ValueTask DisposeAsync()
+    {
+        _cts?.Cancel();
+        _timer?.Dispose();
+        _cts?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Bmotion/Bit.Bmotion/Components/BmotionInspector.razor
+++ b/src/Bmotion/Bit.Bmotion/Components/BmotionInspector.razor
@@ -123,7 +123,11 @@
                 await InvokeAsync(StateHasChanged);
             }
         }
+        // Disposal races the poll loop: the timer/CTS may be disposed, or the renderer torn down,
+        // between a tick and the StateHasChanged. Both are expected during teardown - swallow them
+        // so this fire-and-forget task never surfaces an unobserved exception.
         catch (OperationCanceledException) { /* disposed */ }
+        catch (ObjectDisposedException) { /* disposed mid-tick */ }
     }
 
     private void Toggle() => _open = !_open;

--- a/src/Bmotion/Bit.Bmotion/Components/BmotionReorderGroup.cs
+++ b/src/Bmotion/Bit.Bmotion/Components/BmotionReorderGroup.cs
@@ -20,7 +20,7 @@ namespace Bit.Bmotion;
 public sealed class BmotionReorderGroup<TItem> : ComponentBase
 {
     [Inject] private BmotionAnimationEngine Engine { get; set; } = null!;
-    [Inject] private BmotionInterop Interop { get; set; } = null!;
+    [Inject] private IBmotionInterop Interop { get; set; } = null!;
 
     /// <summary>The list being reordered. Supports <c>@bind-Items</c>.</summary>
     [Parameter, EditorRequired] public List<TItem> Items { get; set; } = null!;

--- a/src/Bmotion/Bit.Bmotion/Context/BmotionConfigContext.cs
+++ b/src/Bmotion/Bit.Bmotion/Context/BmotionConfigContext.cs
@@ -29,4 +29,10 @@ internal class BmotionConfigContext
         set => _transitionSpeed = double.IsFinite(value) && value >= 0 ? value : 0;
     }
     private double _transitionSpeed = 1.0;
+
+    /// <summary>
+    /// Global color-interpolation space for the subtree. <c>null</c> means no override (sRGB);
+    /// a per-transition <c>ColorSpace</c> always wins over this.
+    /// </summary>
+    public BmColorSpace? ColorSpace { get; set; }
 }

--- a/src/Bmotion/Bit.Bmotion/Context/BmotionPresenceContext.cs
+++ b/src/Bmotion/Bit.Bmotion/Context/BmotionPresenceContext.cs
@@ -47,7 +47,7 @@ internal class BmotionPresenceContext
 
     /// <summary>
     /// Clears exit-completion bookkeeping for a fresh enter cycle. Registered children are left
-    /// intact — they remove themselves via <see cref="Unregister"/> when disposed, so clearing the
+    /// intact - they remove themselves via <see cref="Unregister"/> when disposed, so clearing the
     /// list here would desynchronise the count for any children that are reused across a toggle.
     /// </summary>
     internal void Reset() { _completedChildren.Clear(); }

--- a/src/Bmotion/Bit.Bmotion/Engine/BmEaseFunctions.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmEaseFunctions.cs
@@ -168,6 +168,8 @@ internal static class BmEaseFunctions
     /// </summary>
     public static bool HasFaithfulCssEasing(BmotionTransitionConfig config)
     {
+        // A Length-4 EaseCubicBezier is always finite: the setter (ValidateCubicBezier) rejects any
+        // non-finite / wrong-length array, so ToCssString emits it verbatim. Steps are exact too.
         if (config.StepCount > 0 || config.EaseCubicBezier is { Length: 4 }) return true;
         // Only these presets are byte-for-byte reproduced by ToCssString: the linear/ease* keywords
         // and Back* (whose runtime delegate is literally the same cubic-bezier ToCssString emits).

--- a/src/Bmotion/Bit.Bmotion/Engine/BmEaseFunctions.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmEaseFunctions.cs
@@ -158,15 +158,22 @@ internal static class BmEaseFunctions
     }
 
     /// <summary>
-    /// Whether the easing has a faithful CSS representation (keyword / cubic-bezier / steps). Elastic
-    /// and bounce do not - they must be sampled to <c>linear()</c> for the compositor, or run on rAF.
+    /// Whether the easing has a CSS representation that <b>exactly</b> reproduces the runtime curve
+    /// (so it can be shipped to the compositor via <see cref="ToCssString"/> without drift). Only
+    /// <c>steps()</c>, an explicit cubic-bezier, and the presets whose runtime function IS that CSS
+    /// keyword/bezier qualify. Curves that <see cref="ToCssString"/> serializes as an <i>approximate</i>
+    /// cubic-bezier (Circ*, Anticipate, Sine/Quad/Quart/Quint/Expo) are NOT faithful - the runtime
+    /// uses exact math there, so they must be sampled to <c>linear()</c> or run on rAF instead of
+    /// offloading a subtly-wrong curve. Elastic/bounce have no CSS form at all.
     /// </summary>
     public static bool HasFaithfulCssEasing(BmotionTransitionConfig config)
     {
         if (config.StepCount > 0 || config.EaseCubicBezier is { Length: 4 }) return true;
-        return config.Ease is not (
-            BmEase.ElasticIn or BmEase.ElasticOut or BmEase.ElasticInOut or
-            BmEase.BounceIn or BmEase.BounceOut or BmEase.BounceInOut);
+        // Only these presets are byte-for-byte reproduced by ToCssString: the linear/ease* keywords
+        // and Back* (whose runtime delegate is literally the same cubic-bezier ToCssString emits).
+        return config.Ease is
+            BmEase.Linear or BmEase.In or BmEase.Out or BmEase.InOut or
+            BmEase.BackIn or BmEase.BackOut or BmEase.BackInOut;
     }
 
     /// <summary>Returns a CSS easing string for use with the Web Animations API (FLIP).</summary>
@@ -175,10 +182,15 @@ internal static class BmEaseFunctions
         if (config == null) return "ease";
         if (config.StepCount > 0)
         {
+            // steps(1,jump-none) is invalid CSS (jump-none needs >= 2 steps). For a single step it
+            // is behaviourally identical to jump-end (hold 0, then snap to 1 at the end), which is
+            // exactly what Steps(1, None) produces at runtime - so normalize it rather than emit
+            // a string the browser rejects (which would throw when passed to element.animate).
             var jump = config.StepJump switch
             {
                 BmStepJump.Start => "jump-start",
-                BmStepJump.None => "jump-none",
+                BmStepJump.None when config.StepCount >= 2 => "jump-none",
+                BmStepJump.None => "jump-end",
                 BmStepJump.Both => "jump-both",
                 _ => "jump-end",
             };

--- a/src/Bmotion/Bit.Bmotion/Engine/BmEaseFunctions.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmEaseFunctions.cs
@@ -17,6 +17,9 @@ internal static class BmEaseFunctions
     /// <summary>Returns an easing function for the given transition config.</summary>
     public static Func<double, double> Get(BmotionTransitionConfig config)
     {
+        // A stepped easing overrides both the named preset and any cubic-bezier.
+        if (config.StepCount > 0) return Steps(config.StepCount, config.StepJump);
+
         if (config.EaseCubicBezier is { Length: 4 } cb &&
             double.IsFinite(cb[0]) && double.IsFinite(cb[1]) && double.IsFinite(cb[2]) && double.IsFinite(cb[3]))
             return CubicBezier(cb[0], cb[1], cb[2], cb[3]);
@@ -67,14 +70,120 @@ internal static class BmEaseFunctions
             BmEase.Anticipate => t => t < 0.5
                 ? _backIn(t * 2) / 2
                 : _easeOut(t * 2 - 1) / 2 + 0.5,
+
+            // ── Sine ──
+            BmEase.SineIn    => t => 1 - Math.Cos((t * Math.PI) / 2),
+            BmEase.SineOut   => t => Math.Sin((t * Math.PI) / 2),
+            BmEase.SineInOut => t => -(Math.Cos(Math.PI * t) - 1) / 2,
+
+            // ── Quad (power 2) ──
+            BmEase.QuadIn    => t => t * t,
+            BmEase.QuadOut   => t => 1 - (1 - t) * (1 - t),
+            BmEase.QuadInOut => t => t < 0.5 ? 2 * t * t : 1 - Math.Pow(-2 * t + 2, 2) / 2,
+
+            // ── Quart (power 4) ──
+            BmEase.QuartIn    => t => t * t * t * t,
+            BmEase.QuartOut   => t => 1 - Math.Pow(1 - t, 4),
+            BmEase.QuartInOut => t => t < 0.5 ? 8 * t * t * t * t : 1 - Math.Pow(-2 * t + 2, 4) / 2,
+
+            // ── Quint (power 5) ──
+            BmEase.QuintIn    => t => t * t * t * t * t,
+            BmEase.QuintOut   => t => 1 - Math.Pow(1 - t, 5),
+            BmEase.QuintInOut => t => t < 0.5 ? 16 * t * t * t * t * t : 1 - Math.Pow(-2 * t + 2, 5) / 2,
+
+            // ── Expo ──
+            BmEase.ExpoIn    => t => t <= 0 ? 0 : Math.Pow(2, 10 * t - 10),
+            BmEase.ExpoOut   => t => t >= 1 ? 1 : 1 - Math.Pow(2, -10 * t),
+            BmEase.ExpoInOut => t => t <= 0 ? 0 : t >= 1 ? 1
+                : t < 0.5 ? Math.Pow(2, 20 * t - 10) / 2 : (2 - Math.Pow(2, -20 * t + 10)) / 2,
+
+            // ── Elastic (oscillating overshoot) ──
+            BmEase.ElasticIn => t => t <= 0 ? 0 : t >= 1 ? 1
+                : -Math.Pow(2, 10 * t - 10) * Math.Sin((10 * t - 10.75) * ElasticC4),
+            BmEase.ElasticOut => t => t <= 0 ? 0 : t >= 1 ? 1
+                : Math.Pow(2, -10 * t) * Math.Sin((10 * t - 0.75) * ElasticC4) + 1,
+            BmEase.ElasticInOut => t => t <= 0 ? 0 : t >= 1 ? 1
+                : t < 0.5
+                    ? -(Math.Pow(2, 20 * t - 10) * Math.Sin((20 * t - 11.125) * ElasticC5)) / 2
+                    : (Math.Pow(2, -20 * t + 10) * Math.Sin((20 * t - 11.125) * ElasticC5)) / 2 + 1,
+
+            // ── Bounce ──
+            BmEase.BounceIn    => t => 1 - BounceOut(1 - t),
+            BmEase.BounceOut   => BounceOut,
+            BmEase.BounceInOut => t => t < 0.5
+                ? (1 - BounceOut(1 - 2 * t)) / 2
+                : (1 + BounceOut(2 * t - 1)) / 2,
+
             _                => _easeOut,
         };
+    }
+
+    // Elastic period constants (easings.net): 2π/3 for in/out, 2π/4.5 for in-out.
+    private const double ElasticC4 = 2 * Math.PI / 3;
+    private const double ElasticC5 = 2 * Math.PI / 4.5;
+
+    /// <summary>The classic four-segment "bounce out" curve (easings.net).</summary>
+    private static double BounceOut(double t)
+    {
+        const double n1 = 7.5625, d1 = 2.75;
+        if (t < 1 / d1) return n1 * t * t;
+        if (t < 2 / d1) { t -= 1.5 / d1; return n1 * t * t + 0.75; }
+        if (t < 2.5 / d1) { t -= 2.25 / d1; return n1 * t * t + 0.9375; }
+        t -= 2.625 / d1;
+        return n1 * t * t + 0.984375;
+    }
+
+    /// <summary>
+    /// A stepped easing matching CSS <c>steps(count, jumpTerm)</c>. Produces a staircase from 0→1.
+    /// </summary>
+    public static Func<double, double> Steps(int count, BmStepJump jump)
+    {
+        int n = Math.Max(1, count);
+        return t =>
+        {
+            if (t <= 0) t = 0;
+            else if (t >= 1) t = 1;
+
+            double v = jump switch
+            {
+                BmStepJump.Start => Math.Ceiling(t * n) / n,
+                BmStepJump.None => n > 1 ? Math.Min(Math.Floor(t * n), n - 1) / (n - 1) : 0,
+                BmStepJump.Both => (Math.Floor(Math.Min(t, 0.9999999999) * n) + 1) / (n + 1),
+                _ => Math.Floor(t * n) / n, // End (jump-end)
+            };
+            // Every jump-term lands exactly on 1 at the end of the interval.
+            if (t >= 1) v = 1;
+            return Math.Clamp(v, 0, 1);
+        };
+    }
+
+    /// <summary>
+    /// Whether the easing has a faithful CSS representation (keyword / cubic-bezier / steps). Elastic
+    /// and bounce do not - they must be sampled to <c>linear()</c> for the compositor, or run on rAF.
+    /// </summary>
+    public static bool HasFaithfulCssEasing(BmotionTransitionConfig config)
+    {
+        if (config.StepCount > 0 || config.EaseCubicBezier is { Length: 4 }) return true;
+        return config.Ease is not (
+            BmEase.ElasticIn or BmEase.ElasticOut or BmEase.ElasticInOut or
+            BmEase.BounceIn or BmEase.BounceOut or BmEase.BounceInOut);
     }
 
     /// <summary>Returns a CSS easing string for use with the Web Animations API (FLIP).</summary>
     public static string ToCssString(BmotionTransitionConfig? config)
     {
         if (config == null) return "ease";
+        if (config.StepCount > 0)
+        {
+            var jump = config.StepJump switch
+            {
+                BmStepJump.Start => "jump-start",
+                BmStepJump.None => "jump-none",
+                BmStepJump.Both => "jump-both",
+                _ => "jump-end",
+            };
+            return $"steps({config.StepCount},{jump})";
+        }
         if (config.EaseCubicBezier is { Length: 4 } cb &&
             double.IsFinite(cb[0]) && double.IsFinite(cb[1]) && double.IsFinite(cb[2]) && double.IsFinite(cb[3]))
             return $"cubic-bezier({BmotionCssFormat.Num(cb[0])},{BmotionCssFormat.Num(cb[1])},{BmotionCssFormat.Num(cb[2])},{BmotionCssFormat.Num(cb[3])})";
@@ -94,6 +203,24 @@ internal static class BmEaseFunctions
             BmEase.BackInOut => "cubic-bezier(0.68987,-0.45,0.32,1.45)",
             // Anticipate has no CSS equivalent; use the backIn curve as the nearest fallback.
             BmEase.Anticipate => "cubic-bezier(0.31455,-0.37755,0.69245,1.37755)",
+            // Power curves → standard cubic-bezier approximations (easings.net).
+            BmEase.SineIn    => "cubic-bezier(0.12,0,0.39,0)",
+            BmEase.SineOut   => "cubic-bezier(0.61,1,0.88,1)",
+            BmEase.SineInOut => "cubic-bezier(0.37,0,0.63,1)",
+            BmEase.QuadIn    => "cubic-bezier(0.11,0,0.5,0)",
+            BmEase.QuadOut   => "cubic-bezier(0.5,1,0.89,1)",
+            BmEase.QuadInOut => "cubic-bezier(0.45,0,0.55,1)",
+            BmEase.QuartIn    => "cubic-bezier(0.5,0,0.75,0)",
+            BmEase.QuartOut   => "cubic-bezier(0.25,1,0.5,1)",
+            BmEase.QuartInOut => "cubic-bezier(0.76,0,0.24,1)",
+            BmEase.QuintIn    => "cubic-bezier(0.64,0,0.78,0)",
+            BmEase.QuintOut   => "cubic-bezier(0.22,1,0.36,1)",
+            BmEase.QuintInOut => "cubic-bezier(0.83,0,0.17,1)",
+            BmEase.ExpoIn    => "cubic-bezier(0.7,0,0.84,0)",
+            BmEase.ExpoOut   => "cubic-bezier(0.16,1,0.3,1)",
+            BmEase.ExpoInOut => "cubic-bezier(0.87,0,0.13,1)",
+            // Elastic/Bounce have no faithful CSS curve; sampled to linear() for the compositor
+            // (see HasFaithfulCssEasing). This keyword is only a last-resort fallback.
             _                => "ease",
         };
     }

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionAnimationEngine.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionAnimationEngine.cs
@@ -232,6 +232,10 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
             return;
         }
 
+        // No compositor offload: on Blazor Server this collapses to an instant change. Warn once
+        // so the degradation is diagnosable instead of silent (matches AnimateToAsync).
+        WarnIfDegradingOnServer(elementId, values, transition);
+
         // Same concurrent-plan sweep as AnimateToAsync's rAF branch (see comment there).
         InterruptWaapiOverlapsSync(elementId, state, values.Keys);
         state.AnimateTo(values, transition, tcs);

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionAnimationEngine.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionAnimationEngine.cs
@@ -279,6 +279,29 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
     public bool IsRegistered(string elementId) => _elements.ContainsKey(elementId);
 
     /// <summary>
+    /// A read-only snapshot of every registered element's live animation state, for the
+    /// <c>&lt;BmotionInspector&gt;</c> debug overlay. Each element reports its active drivers and
+    /// current transform / numeric / string values. Call from the UI thread (like all engine APIs).
+    /// </summary>
+    public IReadOnlyList<BmotionElementDiagnostics> GetDiagnostics()
+    {
+        var list = new List<BmotionElementDiagnostics>(_elements.Count);
+        foreach (var (id, state) in _elements)
+        {
+            list.Add(new BmotionElementDiagnostics(
+                id,
+                state.ActiveDriverCount,
+                state.HasActiveAnimations,
+                state.IsDragging,
+                state.ActiveDriverKeys.ToArray(),
+                new Dictionary<string, double>(state.Transforms),
+                new Dictionary<string, double>(state.NumericValues),
+                new Dictionary<string, string>(state.StringValues)));
+        }
+        return list;
+    }
+
+    /// <summary>
     /// Sets (or clears) a per-frame callback invoked with the CSS declarations flushed to the
     /// element each frame. Used by the <c>Bmotion.OnUpdate</c> parameter.
     /// </summary>
@@ -618,32 +641,57 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
         // Every animated property must be a transform component or opacity with a single
         // finite numeric target.
         var targets = new Dictionary<string, (double From, double To)>(StringComparer.OrdinalIgnoreCase);
+        // Per-key frames (uniform offsets). Scalars become [from, to]; keyframe arrays keep their
+        // frames. All keyframe keys must share one length (mixed lengths ⇒ rAF) so the WAAPI
+        // keyframes and the C# interruption mirror stay on one aligned, exact grid.
+        var frameArrays = new Dictionary<string, double[]>(StringComparer.OrdinalIgnoreCase);
         bool touchesTransform = false;
+        int keyframeLen = 0;
         foreach (var (key, raw) in values)
         {
             if (raw == null) continue;
             bool isTransform = BmotionTransformComposer.IsTransformProp(key);
             if (!isTransform && !string.Equals(key, "opacity", StringComparison.OrdinalIgnoreCase)) return null;
 
-            double to;
-            switch (raw)
-            {
-                case double d: to = d; break;
-                case int i: to = i; break;
-                case float f: to = f; break;
-                case long l: to = l; break;
-                default: return null; // keyframe arrays / strings stay on the rAF path
-            }
-            if (!double.IsFinite(to)) return null;
-
             double from = isTransform
                 ? state.Transforms.GetValueOrDefault(key,
                     key is "scale" or "scaleX" or "scaleY" ? 1.0 : 0.0)
                 : state.NumericValues.GetValueOrDefault(key, 1.0); // opacity defaults to 1
-            targets[key] = (from, to);
+
+            double[] frames;
+            switch (raw)
+            {
+                case double d: frames = [from, d]; break;
+                case int i: frames = [from, i]; break;
+                case float f: frames = [from, f]; break;
+                case long l: frames = [from, l]; break;
+                case double[] { Length: >= 2 } arr:
+                    frames = (double[])arr.Clone();
+                    // A leading Bm.Current (NaN) wildcard resolves to the element's current value.
+                    if (double.IsNaN(frames[0])) frames[0] = from;
+                    foreach (var v in frames) if (!double.IsFinite(v)) return null;
+                    if (keyframeLen == 0) keyframeLen = frames.Length;
+                    else if (keyframeLen != frames.Length) return null; // mixed keyframe lengths ⇒ rAF
+                    break;
+                case double[] { Length: 1 } one: frames = [from, one[0]]; break;
+                default: return null; // string keyframes stay on the rAF path
+            }
+            if (!double.IsFinite(frames[^1])) return null;
+            targets[key] = (frames[0], frames[^1]);
+            frameArrays[key] = frames;
             touchesTransform |= isTransform;
         }
         if (targets.Count == 0) return null;
+
+        // Per-segment eases can't be expressed by a single WAAPI timeline easing.
+        if (keyframeLen > 0 && config.Eases is { Length: > 0 }) return null;
+
+        // Resample every key onto a common uniform grid of N frames (identity for keys already at N;
+        // scalars/2-frame keys expand linearly). N stays 2 for a plain tween (the fast endpoint path).
+        int frameCount = Math.Max(2, keyframeLen);
+        if (frameCount > 2)
+            foreach (var key in frameArrays.Keys.ToArray())
+                frameArrays[key] = ResampleUniform(frameArrays[key], frameCount);
 
         // transform is a single CSS property: the compositor can't own it while rAF drivers
         // are animating other transform components on the same element.
@@ -682,28 +730,25 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
             }
         }
 
-        // Two keyframes composed from the FULL transform state so untouched components persist,
-        // with identical function order in both frames (required for piecewise interpolation).
-        var fromStyles = new Dictionary<string, object>();
-        var toStyles = new Dictionary<string, object>();
-        if (touchesTransform)
+        // N keyframes composed from the FULL transform state so untouched components persist, with
+        // identical function order across frames (required for piecewise interpolation). frameCount
+        // is 2 for a plain tween (from/to) and the keyframe length otherwise.
+        var frameStyles = new Dictionary<string, object>[frameCount];
+        var opacityKey = targets.Keys.FirstOrDefault(k => k.Equals("opacity", StringComparison.OrdinalIgnoreCase));
+        for (int j = 0; j < frameCount; j++)
         {
-            var fromT = new Dictionary<string, double>(state.Transforms, StringComparer.OrdinalIgnoreCase);
-            foreach (var (key, (from, _)) in targets)
-                if (BmotionTransformComposer.IsTransformProp(key)) fromT[key] = from;
-            var toT = new Dictionary<string, double>(fromT, StringComparer.OrdinalIgnoreCase);
-            foreach (var (key, (_, to)) in targets)
-                if (BmotionTransformComposer.IsTransformProp(key)) toT[key] = to;
-
-            var fromStr = BmotionTransformComposer.Build(fromT);
-            var toStr = BmotionTransformComposer.Build(toT);
-            fromStyles["transform"] = string.IsNullOrEmpty(fromStr) ? "none" : fromStr;
-            toStyles["transform"] = string.IsNullOrEmpty(toStr) ? "none" : toStr;
-        }
-        if (targets.TryGetValue("opacity", out var opacity))
-        {
-            fromStyles["opacity"] = BmotionCssFormat.Num(opacity.From);
-            toStyles["opacity"] = BmotionCssFormat.Num(opacity.To);
+            var frame = new Dictionary<string, object>();
+            if (touchesTransform)
+            {
+                var tj = new Dictionary<string, double>(state.Transforms, StringComparer.OrdinalIgnoreCase);
+                foreach (var (key, frames) in frameArrays)
+                    if (BmotionTransformComposer.IsTransformProp(key)) tj[key] = frames[j];
+                var str = BmotionTransformComposer.Build(tj);
+                frame["transform"] = string.IsNullOrEmpty(str) ? "none" : str;
+            }
+            if (opacityKey != null)
+                frame["opacity"] = BmotionCssFormat.Num(frameArrays[opacityKey][j]);
+            frameStyles[j] = frame;
         }
 
         bool infinite = config.IsInfiniteRepeat;
@@ -718,6 +763,7 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
             DurationMs = durationMs,
             Progress = samples,
             Values = targets,
+            Frames = frameCount > 2 ? frameArrays : null,
             Iterations = infinite ? -1 : config.Repeat,
             Mirror = direction == "alternate",
         };
@@ -731,7 +777,19 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
             ["direction"] = direction,
         };
 
-        return new WaapiOffload(plan, [fromStyles, toStyles], timing);
+        return new WaapiOffload(plan, frameStyles, timing);
+    }
+
+    // Resamples a keyframe array onto <paramref name="n"/> uniformly-spaced points via linear
+    // interpolation. Identity for arrays already at n uniform frames; expands a 2-frame [from,to]
+    // to n linear points. Keeps every animated key on one aligned grid for the WAAPI keyframes.
+    private static double[] ResampleUniform(double[] frames, int n)
+    {
+        if (frames.Length == n) return frames;
+        var result = new double[n];
+        for (int j = 0; j < n; j++)
+            result[j] = BmotionElementAnimationState.WaapiPlan.KeyframeLerp(frames, (double)j / (n - 1));
+        return result;
     }
 
     /// <summary>

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionAnimationEngine.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionAnimationEngine.cs
@@ -25,7 +25,7 @@ namespace Bit.Bmotion;
 /// </remarks>
 public sealed class BmotionAnimationEngine : IAsyncDisposable
 {
-    private readonly BmotionInterop _interop;
+    private readonly IBmotionInterop _interop;
     private readonly ILogger<BmotionAnimationEngine>? _logger;
     private readonly Dictionary<string, BmotionElementAnimationState> _elements = new();
     private DotNetObjectReference<BmotionAnimationEngine>? _dotnet;
@@ -41,7 +41,7 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
     // Marshaled synchronously to JS before the next ComputeFrame runs (single-threaded Blazor WASM).
     private readonly Dictionary<string, Dictionary<string, string>> _frameResult = new();
 
-    public BmotionAnimationEngine(BmotionInterop interop, ILogger<BmotionAnimationEngine>? logger = null)
+    public BmotionAnimationEngine(IBmotionInterop interop, ILogger<BmotionAnimationEngine>? logger = null)
     {
         _interop = interop;
         _logger = logger;
@@ -195,6 +195,11 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
             _ = SuperviseOffloadAsync(elementId, state, values, transition, offload, tcs);
             return;
         }
+
+        // No compositor offload was possible: on Blazor Server (no frame loop) this animation
+        // collapses to an instant change. Warn once so the degradation is diagnosable instead of
+        // silent - see BmotionCapabilities.SupportsFrameLoop.
+        WarnIfDegradingOnServer(elementId, values, transition);
 
         // The awaits above can interleave with a concurrent caller that registered a compositor
         // plan on the same keys after this call's interrupt pass (see RegisterWaapiPlan, which
@@ -498,6 +503,25 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
     /// <summary>Whether this environment can run the per-frame rAF loop (Blazor WebAssembly).</summary>
     internal bool SupportsFrameLoop => _interop.IsInProcess;
 
+    private bool _serverDegradationWarned;
+
+    // Warns once (per engine) when a non-offloadable animation degrades to an instant change on
+    // Blazor Server. Skips genuinely-instant transitions (duration-0 tweens) so a set()-like call
+    // doesn't produce a false positive.
+    private void WarnIfDegradingOnServer(
+        string elementId, Dictionary<string, object?> values, BmotionTransitionConfig? transition)
+    {
+        if (_interop.IsInProcess || _serverDegradationWarned || _logger is null) return;
+        bool instant = transition is { Type: BmotionTransitionType.Tween, Duration: <= 0 };
+        if (instant || values.Count == 0) return;
+        _serverDegradationWarned = true;
+        _logger.LogWarning(
+            "Bit.Bmotion: an animation on '{ElementId}' collapsed to an instant change on Blazor Server "
+            + "(no per-frame loop; properties {Properties} are not compositor-eligible). Inject "
+            + "BmotionCapabilities to detect this - SupportsFrameLoop is false here.",
+            elementId, string.Join(", ", values.Keys));
+    }
+
     /// <summary>
     /// rAF-loop start on WebAssembly; on Blazor Server (no sync interop) drives the element's
     /// zero-duration drivers to completion and flushes the result through async interop instead.
@@ -642,9 +666,20 @@ public sealed class BmotionAnimationEngine : IAsyncDisposable
         {
             samples = SampleTweenProgress(config);
             durationMs = config.Duration * 1000;
-            easing = await LinearEasingSupportedAsync()
-                ? BuildLinearEasing(samples)
-                : BmEaseFunctions.ToCssString(config);
+            if (await LinearEasingSupportedAsync())
+            {
+                easing = BuildLinearEasing(samples);
+            }
+            else if (BmEaseFunctions.HasFaithfulCssEasing(config))
+            {
+                easing = BmEaseFunctions.ToCssString(config);
+            }
+            else
+            {
+                // Elastic/bounce can't be expressed as a CSS curve and the browser lacks linear()
+                // support - run it exactly on the rAF engine instead of shipping a wrong easing.
+                return null;
+            }
         }
 
         // Two keyframes composed from the FULL transform state so untouched components persist,

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionColorInterpolator.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionColorInterpolator.cs
@@ -39,13 +39,80 @@ internal static partial class BmotionColorInterpolator
     /// regex/parse cost of the string overload.
     /// </summary>
     public static string Lerp(double[] from, double[] to, double t)
+        => Lerp(from, to, t, BmColorSpace.Srgb);
+
+    /// <summary>
+    /// Interpolates between two pre-parsed RGBA channel arrays in the given color space. sRGB mixes
+    /// per-channel; OKLab converts to a perceptual space first so mid-points stay saturated.
+    /// </summary>
+    public static string Lerp(double[] from, double[] to, double t, BmColorSpace space)
     {
+        if (space == BmColorSpace.Oklab)
+            return LerpOklab(from, to, t);
+
         int r = (int)Math.Round(Math.Clamp(from[0] + (to[0] - from[0]) * t, 0, 255));
         int g = (int)Math.Round(Math.Clamp(from[1] + (to[1] - from[1]) * t, 0, 255));
         int b = (int)Math.Round(Math.Clamp(from[2] + (to[2] - from[2]) * t, 0, 255));
         double a = Math.Clamp(from[3] + (to[3] - from[3]) * t, 0, 1);
         return $"rgba({r},{g},{b},{BmotionCssFormat.Num(a, "G4")})";
     }
+
+    // ── OKLab perceptual interpolation (Björn Ottosson) ───────────────────────
+
+    private static string LerpOklab(double[] from, double[] to, double t)
+    {
+        var (l1, a1, b1) = RgbToOklab(from[0], from[1], from[2]);
+        var (l2, a2, b2) = RgbToOklab(to[0], to[1], to[2]);
+        double l = l1 + (l2 - l1) * t;
+        double aa = a1 + (a2 - a1) * t;
+        double bb = b1 + (b2 - b1) * t;
+        double alpha = Math.Clamp(from[3] + (to[3] - from[3]) * t, 0, 1);
+
+        var (r, g, b) = OklabToRgb(l, aa, bb);
+        return $"rgba({r},{g},{b},{BmotionCssFormat.Num(alpha, "G4")})";
+    }
+
+    private static (double L, double A, double B) RgbToOklab(double r255, double g255, double b255)
+    {
+        double r = LinearizeSrgb(r255 / 255.0);
+        double g = LinearizeSrgb(g255 / 255.0);
+        double b = LinearizeSrgb(b255 / 255.0);
+
+        double l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+        double m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+        double s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+
+        double l_ = Math.Cbrt(l), m_ = Math.Cbrt(m), s_ = Math.Cbrt(s);
+
+        return (
+            0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
+            1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+            0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_);
+    }
+
+    private static (int R, int G, int B) OklabToRgb(double L, double A, double B)
+    {
+        double l_ = L + 0.3963377774 * A + 0.2158037573 * B;
+        double m_ = L - 0.1055613458 * A - 0.0638541728 * B;
+        double s_ = L - 0.0894841775 * A - 1.2914855480 * B;
+
+        double l = l_ * l_ * l_, m = m_ * m_ * m_, s = s_ * s_ * s_;
+
+        double r = +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+        double g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+        double b = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+        return (
+            (int)Math.Round(Math.Clamp(DelinearizeSrgb(r) * 255, 0, 255)),
+            (int)Math.Round(Math.Clamp(DelinearizeSrgb(g) * 255, 0, 255)),
+            (int)Math.Round(Math.Clamp(DelinearizeSrgb(b) * 255, 0, 255)));
+    }
+
+    private static double LinearizeSrgb(double c)
+        => c <= 0.04045 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+
+    private static double DelinearizeSrgb(double c)
+        => c <= 0.0031308 ? c * 12.92 : 1.055 * Math.Pow(c, 1.0 / 2.4) - 0.055;
 
     /// <summary>Returns true if the CSS string looks like a color value.</summary>
     public static bool LooksLikeColor(string? value)

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionColorKeyframesDriver.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionColorKeyframesDriver.cs
@@ -11,6 +11,7 @@ internal sealed class BmotionColorKeyframesDriver : IBmotionAnimationDriver
     private readonly bool _isInfinite;
     private readonly BmRepeatType _repeatType;
     private readonly double _repeatDelayMs;
+    private readonly BmColorSpace _colorSpace;
     private readonly Action<string> _apply;
 
     private double _startTime = -1;
@@ -63,6 +64,7 @@ internal sealed class BmotionColorKeyframesDriver : IBmotionAnimationDriver
         _isInfinite = config.IsInfiniteRepeat;
         _repeatType = config.RepeatType;
         _repeatDelayMs = config.RepeatDelay * 1000;
+        _colorSpace = config.ColorSpace;
         _apply = apply;
 
         int n = frames.Length;
@@ -103,7 +105,7 @@ internal sealed class BmotionColorKeyframesDriver : IBmotionAnimationDriver
         // Fall back to the raw target frame string when a color couldn't be parsed
         // (matches the string Lerp returning 'to' for unparseable input).
         _apply(ca != null && cb != null
-            ? BmotionColorInterpolator.Lerp(ca, cb, easedT)
+            ? BmotionColorInterpolator.Lerp(ca, cb, easedT, _colorSpace)
             : _curFrames[seg + 1]);
 
         if (t >= 1.0)

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionColorTweenDriver.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionColorTweenDriver.cs
@@ -12,6 +12,7 @@ internal sealed class BmotionColorTweenDriver : IBmotionAnimationDriver
     private readonly bool _isInfinite;
     private readonly BmRepeatType _repeatType;
     private readonly double _repeatDelayMs;
+    private readonly BmColorSpace _colorSpace;
     private readonly Action<string> _apply;
 
     private double _startTime = -1;
@@ -45,6 +46,7 @@ internal sealed class BmotionColorTweenDriver : IBmotionAnimationDriver
         _isInfinite = config.IsInfiniteRepeat;
         _repeatType = config.RepeatType;
         _repeatDelayMs = config.RepeatDelay * 1000;
+        _colorSpace = config.ColorSpace;
         _apply = apply;
     }
 
@@ -61,7 +63,7 @@ internal sealed class BmotionColorTweenDriver : IBmotionAnimationDriver
         // Fall back to the raw target string when a color couldn't be parsed (matches the
         // string Lerp's behaviour of returning 'to' for unparseable input).
         _apply(_curFromCh != null && _curToCh != null
-            ? BmotionColorInterpolator.Lerp(_curFromCh, _curToCh, p)
+            ? BmotionColorInterpolator.Lerp(_curFromCh, _curToCh, p, _colorSpace)
             : _curTo);
 
         if (t >= 1.0)

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionCssValidator.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionCssValidator.cs
@@ -1,0 +1,34 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// A conservative validator for the string-valued CSS props Bit.Bmotion writes verbatim into an
+/// element's inline <c>style</c> (colors, dimensions, box-shadow, filter, CSS custom properties).
+/// It is a defence-in-depth guard for apps that bind <b>untrusted</b> input to these props; it is
+/// intentionally strict and off by default (see <see cref="BmCssSafeMode"/>).
+/// </summary>
+internal static class BmotionCssValidator
+{
+    // Characters that never legitimately appear inside a single CSS *value* but are the primary
+    // vectors for breaking out of an inline-style declaration.
+    private static readonly char[] _forbiddenChars = { ';', '{', '}', '<', '>', '\n', '\r' };
+
+    // Case-insensitive substrings that indicate a scripting / structural injection attempt.
+    private static readonly string[] _forbiddenSequences = { "javascript:", "expression(", "/*", "*/", "</", "@import" };
+
+    /// <summary>
+    /// Returns <c>true</c> when the value is safe to write into inline style. A <c>null</c> value is
+    /// treated as safe (nothing is written). CSS custom-property values are subject to the same rules.
+    /// </summary>
+    public static bool IsSafe(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return true;
+
+        foreach (var c in _forbiddenChars)
+            if (value.IndexOf(c) >= 0) return false;
+
+        foreach (var seq in _forbiddenSequences)
+            if (value.Contains(seq, StringComparison.OrdinalIgnoreCase)) return false;
+
+        return true;
+    }
+}

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionCssValidator.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionCssValidator.cs
@@ -9,8 +9,10 @@ namespace Bit.Bmotion;
 internal static class BmotionCssValidator
 {
     // Characters that never legitimately appear inside a single CSS *value* but are the primary
-    // vectors for breaking out of an inline-style declaration.
-    private static readonly char[] _forbiddenChars = { ';', '{', '}', '<', '>', '\n', '\r' };
+    // vectors for breaking out of an inline-style declaration. Backslash is rejected outright:
+    // CSS escape sequences (e.g. "\3C" for '<', "\6A avascript:") would otherwise smuggle any
+    // forbidden character or sequence past the substring checks below.
+    private static readonly char[] _forbiddenChars = { ';', '{', '}', '<', '>', '\\' };
 
     // Case-insensitive substrings that indicate a scripting / structural injection attempt.
     private static readonly string[] _forbiddenSequences = { "javascript:", "expression(", "/*", "*/", "</", "@import" };
@@ -23,8 +25,8 @@ internal static class BmotionCssValidator
     {
         if (string.IsNullOrEmpty(value)) return true;
 
-        foreach (var c in _forbiddenChars)
-            if (value.IndexOf(c) >= 0) return false;
+        foreach (var c in value)
+            if (char.IsControl(c) || Array.IndexOf(_forbiddenChars, c) >= 0) return false;
 
         foreach (var seq in _forbiddenSequences)
             if (value.Contains(seq, StringComparison.OrdinalIgnoreCase)) return false;

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionDiagnostics.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionDiagnostics.cs
@@ -1,0 +1,23 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// A read-only snapshot of one element's live animation state, produced by
+/// <see cref="BmotionAnimationEngine.GetDiagnostics"/> and rendered by <c>&lt;BmotionInspector&gt;</c>.
+/// </summary>
+/// <param name="Id">The element's engine id.</param>
+/// <param name="ActiveDriverCount">Number of per-property drivers currently animating the element.</param>
+/// <param name="HasActiveAnimations">Whether the element is animating or being dragged.</param>
+/// <param name="IsDragging">Whether the element is mid-drag.</param>
+/// <param name="ActiveProperties">The property keys with an active driver this frame.</param>
+/// <param name="Transforms">Current transform-component values (x, y, scale, rotate, …).</param>
+/// <param name="NumericValues">Current non-transform numeric values (opacity, pathLength, …).</param>
+/// <param name="StringValues">Current string values (colors, dimensions, filter, …).</param>
+public sealed record BmotionElementDiagnostics(
+    string Id,
+    int ActiveDriverCount,
+    bool HasActiveAnimations,
+    bool IsDragging,
+    IReadOnlyList<string> ActiveProperties,
+    IReadOnlyDictionary<string, double> Transforms,
+    IReadOnlyDictionary<string, double> NumericValues,
+    IReadOnlyDictionary<string, string> StringValues);

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionElementAnimationState.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionElementAnimationState.cs
@@ -70,6 +70,11 @@ internal sealed class BmotionElementAnimationState
 
     public bool HasActiveAnimations => _activeAnims.Count > 0 || _isDragging;
 
+    // Read-only diagnostics surface (consumed by BmotionInspector via the engine).
+    internal int ActiveDriverCount => _activeAnims.Count;
+    internal IReadOnlyCollection<string> ActiveDriverKeys => _activeAnims.Keys;
+    internal bool IsDragging => _isDragging;
+
     /// <summary>
     /// Optional per-frame callback invoked with the CSS declarations flushed this frame
     /// (the <c>Bmotion.OnUpdate</c> parameter).
@@ -850,6 +855,22 @@ internal sealed class BmotionElementAnimationState
         public required int Iterations { get; init; }       // -1 = infinite
         public required bool Mirror { get; init; }          // alternate direction per iteration
 
+        // Per-key keyframe values (uniform offsets, one entry per animated key) when the offload is a
+        // multi-keyframe animation. Null for a simple two-endpoint tween/spring. WAAPI warps the
+        // timeline by the eased Progress and interpolates linearly between keyframes, so the C# mirror
+        // reproduces the same value with KeyframeLerp(frames, easedProgress) - see RealizePlanValues.
+        public Dictionary<string, double[]>? Frames { get; init; }
+
+        /// <summary>Linear interpolation across uniformly-spaced keyframes at eased progress <paramref name="p"/>.</summary>
+        internal static double KeyframeLerp(double[] frames, double p)
+        {
+            if (frames.Length == 1) return frames[0];
+            double pos = Math.Clamp(p, 0, 1) * (frames.Length - 1);
+            int i = (int)pos;
+            if (i >= frames.Length - 1) return frames[^1];
+            return frames[i] + (frames[i + 1] - frames[i]) * (pos - i);
+        }
+
         public bool AnimatesTransform
         {
             get
@@ -1012,7 +1033,12 @@ internal sealed class BmotionElementAnimationState
     {
         var (progress, _) = plan.SampleAt(nowMs);
         foreach (var (key, (from, to)) in plan.Values)
-            WriteRealizedValue(key, from + (to - from) * progress, markDirty: true);
+        {
+            double value = plan.Frames != null && plan.Frames.TryGetValue(key, out var frames)
+                ? WaapiPlan.KeyframeLerp(frames, progress)
+                : from + (to - from) * progress;
+            WriteRealizedValue(key, value, markDirty: true);
+        }
     }
 
     private void WriteRealizedValue(string key, double value, bool markDirty)

--- a/src/Bmotion/Bit.Bmotion/Engine/BmotionTransformComposer.cs
+++ b/src/Bmotion/Bit.Bmotion/Engine/BmotionTransformComposer.cs
@@ -57,4 +57,58 @@ internal static class BmotionTransformComposer
 
         return string.Join(" ", parts);
     }
+
+    // Components that map cleanly to the individual CSS transform properties (Transforms Level 2:
+    // `translate`, `scale`, `rotate`), letting the compositor animate them independently without
+    // fighting over one `transform` string. The rest (rotateX/Y, skew, perspective) have no
+    // individual property and stay composed in `transform`.
+    private static readonly HashSet<string> _individualProps = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "x", "y", "z", "scale", "scaleX", "scaleY", "rotate", "rotateZ",
+    };
+
+    /// <summary>Whether <paramref name="key"/> can be emitted as an individual CSS transform property.</summary>
+    public static bool IsIndividualProp(string key) => _individualProps.Contains(key);
+
+    /// <summary>
+    /// Emits the transform components as the individual CSS <c>translate</c>/<c>scale</c>/<c>rotate</c>
+    /// properties where possible (so each can animate independently on the compositor), with any
+    /// remaining components (rotateX/Y, skew, perspective) left in a composed <c>transform</c> entry.
+    /// This is the reusable core for independent transforms (plan item 2.1); identity components are
+    /// omitted so callers only write what actually changed.
+    /// </summary>
+    public static Dictionary<string, string> BuildIndividual(Dictionary<string, double> t)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (t.Count == 0) return result;
+
+        double x = t.GetValueOrDefault("x"), y = t.GetValueOrDefault("y"), z = t.GetValueOrDefault("z");
+        if (x != 0 || y != 0 || z != 0)
+            result["translate"] = z != 0
+                ? $"{BmotionCssFormat.Num(x)}px {BmotionCssFormat.Num(y)}px {BmotionCssFormat.Num(z)}px"
+                : $"{BmotionCssFormat.Num(x)}px {BmotionCssFormat.Num(y)}px";
+
+        // scale: uniform wins; otherwise per-axis (CSS `scale` takes `sx sy`).
+        if (t.TryGetValue("scale", out double s) && s != 1)
+            result["scale"] = BmotionCssFormat.Num(s);
+        else
+        {
+            double sx = t.GetValueOrDefault("scaleX", 1), sy = t.GetValueOrDefault("scaleY", 1);
+            if (sx != 1 || sy != 1) result["scale"] = $"{BmotionCssFormat.Num(sx)} {BmotionCssFormat.Num(sy)}";
+        }
+
+        double rz = t.TryGetValue("rotateZ", out double rz2) && rz2 != 0 ? rz2 : t.GetValueOrDefault("rotate");
+        if (rz != 0) result["rotate"] = $"{BmotionCssFormat.Num(rz)}deg";
+
+        // Anything without an individual property stays in a composed transform string.
+        var composed = new List<string>(4);
+        if (t.TryGetValue("perspective", out double persp) && persp != 0) composed.Add($"perspective({BmotionCssFormat.Num(persp)}px)");
+        if (t.TryGetValue("rotateX", out double rx) && rx != 0) composed.Add($"rotateX({BmotionCssFormat.Num(rx)}deg)");
+        if (t.TryGetValue("rotateY", out double ry) && ry != 0) composed.Add($"rotateY({BmotionCssFormat.Num(ry)}deg)");
+        if (t.TryGetValue("skewX", out double skx) && skx != 0) composed.Add($"skewX({BmotionCssFormat.Num(skx)}deg)");
+        if (t.TryGetValue("skewY", out double sky) && sky != 0) composed.Add($"skewY({BmotionCssFormat.Num(sky)}deg)");
+        if (composed.Count > 0) result["transform"] = string.Join(" ", composed);
+
+        return result;
+    }
 }

--- a/src/Bmotion/Bit.Bmotion/Interop/BmotionInterop.cs
+++ b/src/Bmotion/Bit.Bmotion/Interop/BmotionInterop.cs
@@ -11,14 +11,6 @@ public sealed class BmotionInterop : IBmotionInterop
 {
     private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
 
-    // Generic JS-interop helpers forward DotNetObjectReference<T> to JS, where T is always a
-    // concrete component/service whose [JSInvokable] members are kept by the runtime, so the
-    // unannotated generic T raises no real trim/AOT concern. Scoped to these call sites instead
-    // of a project-wide NoWarn so genuine IL2091 regressions elsewhere stay visible.
-    private const string JsRefTrimJustification =
-        "DotNetObjectReference<T> only marshals a [JSInvokable]-annotated component/service ref to JS; " +
-        "the runtime preserves those members, so the unannotated generic T is safe under trimming.";
-
     public BmotionInterop(IJSRuntime js)
     {
         ArgumentNullException.ThrowIfNull(js);
@@ -43,13 +35,11 @@ public sealed class BmotionInterop : IBmotionInterop
     /// Start the JS rAF loop. The loop calls <c>dotnetRef.invokeMethod('ComputeFrame', timestamp)</c>
     /// synchronously each tick (Blazor WASM) and applies the returned style updates.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask StartRafLoopAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    public async ValueTask StartRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
         => await (await Module()).InvokeVoidAsync("startRafLoop", dotnetRef);
 
     /// <summary>Stop the JS rAF loop for the given engine reference (or all engines when null).</summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask StopRafLoopAsync<T>(DotNetObjectReference<T>? dotnetRef = null) where T : class
+    public async ValueTask StopRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T>? dotnetRef = null) where T : class
     {
         if (!_moduleTask.IsValueCreated) return;
         await (await Module()).InvokeVoidAsync("stopRafLoop", dotnetRef);
@@ -67,13 +57,11 @@ public sealed class BmotionInterop : IBmotionInterop
     /// Subscribes to live changes of the <c>prefers-reduced-motion</c> media query. JS calls
     /// <c>OnReducedMotionChanged(bool)</c> on the engine ref whenever the OS preference changes.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask WatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    public async ValueTask WatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
         => await (await Module()).InvokeVoidAsync("watchReducedMotion", dotnetRef);
 
     /// <summary>Unsubscribes the engine ref from <c>prefers-reduced-motion</c> change notifications.</summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask UnwatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    public async ValueTask UnwatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
     {
         if (!_moduleTask.IsValueCreated) return;
         await (await Module()).InvokeVoidAsync("unwatchReducedMotion", dotnetRef);
@@ -115,8 +103,7 @@ public sealed class BmotionInterop : IBmotionInterop
     /// Attach pointer / focus / drag event listeners to an element.
     /// JS forwards raw browser events to the DotNet ref via async callbacks.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask AttachEventListenersAsync<T>(
+    public async ValueTask AttachEventListenersAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class
         => await (await Module()).InvokeVoidAsync("attachEventListeners", elementId, events, dotnetRef);
 
@@ -129,14 +116,12 @@ public sealed class BmotionInterop : IBmotionInterop
 
     // ── Viewport observation ──────────────────────────────────────────────────
 
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask ObserveViewportAsync<T>(
+    public async ValueTask ObserveViewportAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class
         => await (await Module()).InvokeVoidAsync("observeViewport", elementId, dotnetRef,
                new Dictionary<string, object?> { ["once"] = once, ["margin"] = "0px", ["threshold"] = 0.0 });
 
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask ObserveViewportWithOptionsAsync<T>(
+    public async ValueTask ObserveViewportWithOptionsAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class
         => await (await Module()).InvokeVoidAsync("observeViewport", elementId, dotnetRef, options.ToJsObject());
 
@@ -182,8 +167,7 @@ public sealed class BmotionInterop : IBmotionInterop
 
     // ── Scroll ────────────────────────────────────────────────────────────────
 
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask<string?> ObserveScrollAsync<T>(
+    public async ValueTask<string?> ObserveScrollAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class
         => await (await Module()).InvokeAsync<string?>("observeScroll", containerId, dotnetRef, options);
 
@@ -212,8 +196,7 @@ public sealed class BmotionInterop : IBmotionInterop
     // ── View Transitions API ───────────────────────────────────────────────────
 
     /// <summary>Wraps <c>document.startViewTransition</c> around a C# DOM-update callback.</summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
-    public async ValueTask<bool> StartViewTransitionAsync<T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
+    public async ValueTask<bool> StartViewTransitionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
         => await (await Module()).InvokeAsync<bool>("startViewTransition", dotnetRef, callbackName);
 
     // ── Dispose ───────────────────────────────────────────────────────────────

--- a/src/Bmotion/Bit.Bmotion/Interop/BmotionInterop.cs
+++ b/src/Bmotion/Bit.Bmotion/Interop/BmotionInterop.cs
@@ -7,7 +7,7 @@ namespace Bit.Bmotion;
 /// Slim C# wrapper around the browser-API bridge in <c>BitBmotion.js</c>.
 /// Only calls browser-native APIs; all animation logic lives in the C# engine.
 /// </summary>
-public sealed class BmotionInterop : IAsyncDisposable
+public sealed class BmotionInterop : IBmotionInterop
 {
     private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
 
@@ -208,6 +208,13 @@ public sealed class BmotionInterop : IAsyncDisposable
     /// </summary>
     public async ValueTask<string> ResolveOrRegisterByRefAsync(ElementReference elementReference)
         => await (await Module()).InvokeAsync<string>("resolveOrRegisterByRef", elementReference);
+
+    // ── View Transitions API ───────────────────────────────────────────────────
+
+    /// <summary>Wraps <c>document.startViewTransition</c> around a C# DOM-update callback.</summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2091", Justification = JsRefTrimJustification)]
+    public async ValueTask<bool> StartViewTransitionAsync<T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
+        => await (await Module()).InvokeAsync<bool>("startViewTransition", dotnetRef, callbackName);
 
     // ── Dispose ───────────────────────────────────────────────────────────────
 

--- a/src/Bmotion/Bit.Bmotion/Interop/IBmotionInterop.cs
+++ b/src/Bmotion/Bit.Bmotion/Interop/IBmotionInterop.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Bit.Bmotion;
+
+/// <summary>
+/// Test/DI seam over the browser-API bridge in <c>bit-bmotion.js</c>. Every animation-engine and
+/// component interaction with JS flows through this interface, so tests can inject a scriptable
+/// fake that records interop calls and simulates JS→.NET callbacks without a real browser.
+/// The production implementation is <see cref="BmotionInterop"/>, registered in
+/// <see cref="BitBmotion.AddBitBmotionServices(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>.
+/// </summary>
+public interface IBmotionInterop : IAsyncDisposable
+{
+    /// <summary>
+    /// <c>true</c> when the JS runtime supports synchronous interop (Blazor WebAssembly). The
+    /// per-frame rAF engine and drag handlers rely on synchronous JS↔.NET calls; on Server this
+    /// is <c>false</c> and only the async compositor (WAAPI) path is available.
+    /// </summary>
+    bool IsInProcess { get; }
+
+    // ── rAF loop ──────────────────────────────────────────────────────────────
+    ValueTask StartRafLoopAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask StopRafLoopAsync<T>(DotNetObjectReference<T>? dotnetRef = null) where T : class;
+
+    // ── Reduced motion (accessibility) ────────────────────────────────────────
+    ValueTask<bool> PrefersReducedMotionAsync();
+    ValueTask WatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask UnwatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class;
+
+    // ── Style application ─────────────────────────────────────────────────────
+    ValueTask ApplyStylesAsync(string elementId, object styles);
+    ValueTask PopLayoutAsync(string elementId, double currentX, double currentY);
+    ValueTask UnpopLayoutAsync(string elementId);
+
+    // ── Element registration ──────────────────────────────────────────────────
+    ValueTask<bool> RegisterElementAsync(string elementId);
+    ValueTask UnregisterElementAsync(string elementId);
+
+    // ── Gesture event listeners ───────────────────────────────────────────────
+    ValueTask AttachEventListenersAsync<T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask StartDragAsync(string elementId, long pointerId, double clientX, double clientY);
+
+    // ── Viewport observation ──────────────────────────────────────────────────
+    ValueTask ObserveViewportAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class;
+    ValueTask ObserveViewportWithOptionsAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class;
+    ValueTask UnobserveViewportAsync(string elementId);
+
+    // ── FLIP layout ───────────────────────────────────────────────────────────
+    ValueTask<BmotionBoundingRect?> GetBoundingRectAsync(string elementId);
+    ValueTask PlayWaapiFlipAsync(string elementId, double dx, double dy, double sx, double sy, double durationMs, string easingStr, string? finalTransform);
+
+    // ── WAAPI compositor offload ──────────────────────────────────────────────
+    ValueTask<bool> SupportsLinearEasingAsync();
+    ValueTask<bool> PlayWaapiAnimationAsync(string elementId, int token, object keyframes, object timing);
+    ValueTask CancelWaapiAnimationAsync(string elementId, int token, bool commit);
+
+    // ── Scroll ────────────────────────────────────────────────────────────────
+    ValueTask<string?> ObserveScrollAsync<T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class;
+    ValueTask UnobserveScrollAsync(string key);
+
+    // ── Programmatic animate() API ─────────────────────────────────────────────
+    ValueTask<string[]> ResolveOrRegisterBySelectorAsync(string selector);
+    ValueTask<string> ResolveOrRegisterByRefAsync(ElementReference elementReference);
+
+    // ── View Transitions API ───────────────────────────────────────────────────
+    /// <summary>
+    /// Wraps <c>document.startViewTransition</c> around a C# DOM-update callback (invoked by name
+    /// on <paramref name="dotnetRef"/>). Returns <c>true</c> when the native API drove the
+    /// transition, <c>false</c> when it isn't supported and the callback ran without one.
+    /// </summary>
+    ValueTask<bool> StartViewTransitionAsync<T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class;
+}

--- a/src/Bmotion/Bit.Bmotion/Interop/IBmotionInterop.cs
+++ b/src/Bmotion/Bit.Bmotion/Interop/IBmotionInterop.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Bit.Bmotion;
 
@@ -19,14 +20,17 @@ public interface IBmotionInterop : IAsyncDisposable
     /// </summary>
     bool IsInProcess { get; }
 
+    // Every generic T below propagates DotNetObjectReference<T>'s trim annotation so trimmed/AOT
+    // apps keep T's public ([JSInvokable]) methods for the JS→.NET callbacks.
+
     // ── rAF loop ──────────────────────────────────────────────────────────────
-    ValueTask StartRafLoopAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class;
-    ValueTask StopRafLoopAsync<T>(DotNetObjectReference<T>? dotnetRef = null) where T : class;
+    ValueTask StartRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask StopRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T>? dotnetRef = null) where T : class;
 
     // ── Reduced motion (accessibility) ────────────────────────────────────────
     ValueTask<bool> PrefersReducedMotionAsync();
-    ValueTask WatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class;
-    ValueTask UnwatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask WatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask UnwatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class;
 
     // ── Style application ─────────────────────────────────────────────────────
     ValueTask ApplyStylesAsync(string elementId, object styles);
@@ -38,12 +42,12 @@ public interface IBmotionInterop : IAsyncDisposable
     ValueTask UnregisterElementAsync(string elementId);
 
     // ── Gesture event listeners ───────────────────────────────────────────────
-    ValueTask AttachEventListenersAsync<T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class;
+    ValueTask AttachEventListenersAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class;
     ValueTask StartDragAsync(string elementId, long pointerId, double clientX, double clientY);
 
     // ── Viewport observation ──────────────────────────────────────────────────
-    ValueTask ObserveViewportAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class;
-    ValueTask ObserveViewportWithOptionsAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class;
+    ValueTask ObserveViewportAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class;
+    ValueTask ObserveViewportWithOptionsAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class;
     ValueTask UnobserveViewportAsync(string elementId);
 
     // ── FLIP layout ───────────────────────────────────────────────────────────
@@ -56,7 +60,7 @@ public interface IBmotionInterop : IAsyncDisposable
     ValueTask CancelWaapiAnimationAsync(string elementId, int token, bool commit);
 
     // ── Scroll ────────────────────────────────────────────────────────────────
-    ValueTask<string?> ObserveScrollAsync<T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class;
+    ValueTask<string?> ObserveScrollAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class;
     ValueTask UnobserveScrollAsync(string key);
 
     // ── Programmatic animate() API ─────────────────────────────────────────────
@@ -69,5 +73,5 @@ public interface IBmotionInterop : IAsyncDisposable
     /// on <paramref name="dotnetRef"/>). Returns <c>true</c> when the native API drove the
     /// transition, <c>false</c> when it isn't supported and the callback ran without one.
     /// </summary>
-    ValueTask<bool> StartViewTransitionAsync<T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class;
+    ValueTask<bool> StartViewTransitionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class;
 }

--- a/src/Bmotion/Bit.Bmotion/Models/Bm.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/Bm.cs
@@ -55,6 +55,8 @@ public static class Bm
         BmStringKeyframes? backgroundPosition = null, BmStringKeyframes? backgroundSize = null,
         // ── Motion path ──
         BmStringKeyframes? offsetPath = null, BmStringKeyframes? offsetDistance = null,
+        // ── SVG shape morph ──
+        BmStringKeyframes? d = null,
         // ── SVG path drawing ──
         BmKeyframes? pathLength = null, BmKeyframes? pathOffset = null, BmKeyframes? pathSpacing = null,
         // ── Extras ──
@@ -81,6 +83,7 @@ public static class Bm
             LetterSpacing = letterSpacing, LineHeight = lineHeight, FontSize = fontSize,
             ClipPath = clipPath, BackgroundPosition = backgroundPosition, BackgroundSize = backgroundSize,
             OffsetPath = offsetPath, OffsetDistance = offsetDistance,
+            D = d,
             PathLength = pathLength, PathOffset = pathOffset, PathSpacing = pathSpacing,
             CssVars = cssVars,
             Css = css,

--- a/src/Bmotion/Bit.Bmotion/Models/Bm.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/Bm.cs
@@ -42,10 +42,24 @@ public static class Bm
         BmStringKeyframes? width = null, BmStringKeyframes? height = null,
         BmStringKeyframes? borderRadius = null, BmStringKeyframes? boxShadow = null,
         BmStringKeyframes? filter = null,
+        // ── Layout / box-model ──
+        BmStringKeyframes? top = null, BmStringKeyframes? left = null,
+        BmStringKeyframes? right = null, BmStringKeyframes? bottom = null,
+        BmStringKeyframes? margin = null, BmStringKeyframes? padding = null,
+        BmStringKeyframes? gap = null,
+        // ── Typography ──
+        BmStringKeyframes? letterSpacing = null, BmStringKeyframes? lineHeight = null,
+        BmStringKeyframes? fontSize = null,
+        // ── Misc CSS ──
+        BmStringKeyframes? clipPath = null,
+        BmStringKeyframes? backgroundPosition = null, BmStringKeyframes? backgroundSize = null,
+        // ── Motion path ──
+        BmStringKeyframes? offsetPath = null, BmStringKeyframes? offsetDistance = null,
         // ── SVG path drawing ──
         BmKeyframes? pathLength = null, BmKeyframes? pathOffset = null, BmKeyframes? pathSpacing = null,
         // ── Extras ──
         Dictionary<string, string>? cssVars = null,
+        Dictionary<string, BmStringKeyframes>? css = null,
         BmTransition? transition = null)
         => new()
         {
@@ -62,8 +76,14 @@ public static class Bm
             Width = width, Height = height,
             BorderRadius = borderRadius, BoxShadow = boxShadow,
             Filter = filter,
+            Top = top, Left = left, Right = right, Bottom = bottom,
+            Margin = margin, Padding = padding, Gap = gap,
+            LetterSpacing = letterSpacing, LineHeight = lineHeight, FontSize = fontSize,
+            ClipPath = clipPath, BackgroundPosition = backgroundPosition, BackgroundSize = backgroundSize,
+            OffsetPath = offsetPath, OffsetDistance = offsetDistance,
             PathLength = pathLength, PathOffset = pathOffset, PathSpacing = pathSpacing,
             CssVars = cssVars,
+            Css = css,
             Transition = transition,
         };
 
@@ -76,12 +96,14 @@ public static class Bm
         double stiffness = 100, double damping = 10, double mass = 1,
         double? bounce = null, double? duration = null,
         double velocity = 0, double delay = 0, BmRepeat? repeat = null,
+        BmColorSpace? colorSpace = null,
         double? staggerChildren = null, double? delayChildren = null)
         => new()
         {
             Stiffness = stiffness, Damping = damping, Mass = mass,
             Bounce = bounce, Duration = duration,
             Velocity = velocity, Delay = delay, Repeat = repeat,
+            ColorSpace = colorSpace,
             StaggerChildren = staggerChildren, DelayChildren = delayChildren,
         };
 
@@ -90,12 +112,16 @@ public static class Bm
         double duration = 0.3, BmEase ease = BmEase.Out,
         double delay = 0, BmRepeat? repeat = null,
         double[]? times = null, double[]? bezier = null, BmEase[]? eases = null,
+        int steps = 0, BmStepJump stepJump = BmStepJump.End,
+        BmColorSpace? colorSpace = null,
         double? staggerChildren = null, double? delayChildren = null)
         => new()
         {
             Duration = duration, Ease = ease,
             Delay = delay, Repeat = repeat,
             Times = times, Bezier = bezier, Eases = eases,
+            Steps = steps, StepJump = stepJump,
+            ColorSpace = colorSpace,
             StaggerChildren = staggerChildren, DelayChildren = delayChildren,
         };
 
@@ -103,8 +129,16 @@ public static class Bm
     /// A stagger delay generator for multi-element animations:
     /// <c>Motion.AnimateAsync(".item", Bm.To(y: 0), stagger: Bm.Stagger(0.08, from: BmStaggerFrom.Center))</c>.
     /// </summary>
-    public static BmStagger Stagger(double each, BmStaggerFrom from = BmStaggerFrom.First, double startDelay = 0)
-        => new(each, from, startDelay);
+    public static BmStagger Stagger(double each, BmStaggerFrom from = BmStaggerFrom.First, double startDelay = 0,
+        (int Cols, int Rows)? grid = null)
+        => new(each, from, startDelay, grid);
+
+    /// <summary>
+    /// A stagger driven entirely by a custom <c>(index, total) =&gt; delaySeconds</c> function:
+    /// <c>Bm.Stagger((i, total) =&gt; i * 0.05)</c>.
+    /// </summary>
+    public static BmStagger Stagger(Func<int, int, double> custom)
+        => new(custom);
 
     /// <summary>
     /// Creates a reactive motion value (motion.dev's <c>motionValue()</c>) that can be bound to

--- a/src/Bmotion/Bit.Bmotion/Models/BmColorSpace.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmColorSpace.cs
@@ -1,0 +1,20 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// The color space used to interpolate between two colors. Set per-transition
+/// (<c>Bm.Tween(colorSpace: BmColorSpace.Oklab)</c>) or globally via <c>&lt;BmotionConfig&gt;</c>.
+/// </summary>
+public enum BmColorSpace
+{
+    /// <summary>
+    /// Per-channel sRGB interpolation (default, matching Framer Motion). Fast and predictable, but
+    /// complementary colors can pass through a desaturated grey mid-point.
+    /// </summary>
+    Srgb = 0,
+
+    /// <summary>
+    /// Perceptual OKLab interpolation. Keeps mid-points saturated (e.g. blue→yellow stays vivid) at
+    /// a small extra cost per frame.
+    /// </summary>
+    Oklab = 1,
+}

--- a/src/Bmotion/Bit.Bmotion/Models/BmCssSafeMode.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmCssSafeMode.cs
@@ -1,0 +1,18 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// How Bit.Bmotion treats string-valued CSS props (colors, dimensions, shadows, filters, CSS vars)
+/// that fail the conservative injection check. Set via <see cref="BitBmotionOptions.CssSafeMode"/>.
+/// Off by default for performance/parity; enable it when binding untrusted end-user input.
+/// </summary>
+public enum BmCssSafeMode
+{
+    /// <summary>No validation. String values are written verbatim (the default and historical behavior).</summary>
+    Off = 0,
+
+    /// <summary>Validate and log a warning for a rejected value, but still apply it.</summary>
+    Warn = 1,
+
+    /// <summary>Validate and throw for a rejected value.</summary>
+    Throw = 2,
+}

--- a/src/Bmotion/Bit.Bmotion/Models/BmEase.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmEase.cs
@@ -8,4 +8,15 @@ public enum BmEase
     CircIn, CircOut, CircInOut,
     BackIn, BackOut, BackInOut,
     Anticipate,
+
+    // ── Power curves ──────────────────────────────────────────────────────────
+    SineIn, SineOut, SineInOut,
+    QuadIn, QuadOut, QuadInOut,
+    QuartIn, QuartOut, QuartInOut,
+    QuintIn, QuintOut, QuintInOut,
+    ExpoIn, ExpoOut, ExpoInOut,
+
+    // ── Overshoot / oscillating (rAF path; sampled to linear() for the compositor) ──
+    ElasticIn, ElasticOut, ElasticInOut,
+    BounceIn, BounceOut, BounceInOut,
 }

--- a/src/Bmotion/Bit.Bmotion/Models/BmLayout.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmLayout.cs
@@ -3,17 +3,20 @@ namespace Bit.Bmotion;
 /// <summary>What a layout (FLIP) animation animates.</summary>
 public enum BmLayoutMode
 {
-    /// <summary>Animate both position and size (translate + scale).</summary>
+    /// <summary>
+    /// Animate both position and size (translate + scale). Direct children are counter-scaled and the
+    /// border-radius is corrected each frame, so text/children don't stretch and corners stay round.
+    /// </summary>
     Full,
-    /// <summary>Animate position only - avoids scale distortion on aspect-ratio-sensitive content.</summary>
+    /// <summary>Animate position only - the cheapest, always-distortion-free option.</summary>
     Position,
 }
 
 /// <summary>
 /// Layout-animation activation for a Bmotion element, motion.dev-style:
 /// <code>
-/// Layout="true"                 // animate position + size (implicit bool conversion)
-/// Layout="BmLayout.Position"    // animate position only (no scale distortion)
+/// Layout="true"                 // animate position + size, with child counter-scale + radius correction
+/// Layout="BmLayout.Position"    // animate position only (cheapest, no scaling at all)
 /// </code>
 /// </summary>
 public readonly struct BmLayout : IEquatable<BmLayout>

--- a/src/Bmotion/Bit.Bmotion/Models/BmProps.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmProps.cs
@@ -362,7 +362,14 @@ public class BmProps
         }
 
         foreach (var (_, cssProp, value) in ExtendedStringProps())
+        {
+            // `d` is an SVG geometry attribute, not a CSS property: an inline `d:<path>` needs a
+            // path() wrapper and isn't universally supported, so JS applies it via setAttribute
+            // (see _svgGeomAttrs in bit-bmotion.js). The element's own `d` attribute already
+            // renders it server-side, so omit it from the initial inline-style string.
+            if (cssProp == "d") continue;
             if (CssStr(value) is { } s) sb.Append($"{cssProp}:{s};");
+        }
 
         if (Css != null)
             foreach (var kv in Css)

--- a/src/Bmotion/Bit.Bmotion/Models/BmProps.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmProps.cs
@@ -110,6 +110,15 @@ public class BmProps
     /// <summary>Position along <see cref="OffsetPath"/> (CSS <c>offset-distance</c>), e.g. <c>"0%"</c> → <c>"100%"</c>.</summary>
     public BmStringKeyframes? OffsetDistance { get; set; }
 
+    // ── SVG shape morphing ─────────────────────────────────────────────────────
+    /// <summary>
+    /// The SVG path <c>d</c> attribute, for shape morphing on a <c>&lt;path&gt;</c> element. Two
+    /// paths with the <b>same command structure</b> morph smoothly (control points interpolate);
+    /// incompatible paths snap. Put the <c>&lt;path&gt;</c> directly inside the Bmotion so it is the
+    /// animated element: <c>&lt;Bmotion Animate="Bm.To(d: "…")"&gt;&lt;path d="…" /&gt;&lt;/Bmotion&gt;</c>.
+    /// </summary>
+    public BmStringKeyframes? D { get; set; }
+
     // ── CSS custom properties (e.g. "--my-var") ───────────────────────────────
     /// <summary>Animate arbitrary CSS custom properties. Keys must start with "--".</summary>
     public Dictionary<string, string>? CssVars { get; set; }
@@ -148,6 +157,7 @@ public class BmProps
         yield return ("backgroundSize", "background-size", BackgroundSize);
         yield return ("offsetPath", "offset-path", OffsetPath);
         yield return ("offsetDistance", "offset-distance", OffsetDistance);
+        yield return ("d", "d", D);
     }
 
     // "background-position" → "backgroundPosition"; leaves camelCase and "--custom" keys untouched.
@@ -458,7 +468,7 @@ public class BmProps
             Equals(Margin, o.Margin) && Equals(Padding, o.Padding) && Equals(Gap, o.Gap) &&
             Equals(LetterSpacing, o.LetterSpacing) && Equals(LineHeight, o.LineHeight) && Equals(FontSize, o.FontSize) &&
             Equals(ClipPath, o.ClipPath) && Equals(BackgroundPosition, o.BackgroundPosition) && Equals(BackgroundSize, o.BackgroundSize) &&
-            Equals(OffsetPath, o.OffsetPath) && Equals(OffsetDistance, o.OffsetDistance) &&
+            Equals(OffsetPath, o.OffsetPath) && Equals(OffsetDistance, o.OffsetDistance) && Equals(D, o.D) &&
             Equals(PathLength, o.PathLength) && Equals(PathOffset, o.PathOffset) && Equals(PathSpacing, o.PathSpacing);
 
         return values && DictEquals(CssVars, o.CssVars) && StringKeyframesDictEquals(Css, o.Css)

--- a/src/Bmotion/Bit.Bmotion/Models/BmProps.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmProps.cs
@@ -80,9 +80,46 @@ public class BmProps
     /// <summary>Spacing between dash/gap pairs (0-1).</summary>
     public BmKeyframes? PathSpacing { get; set; }
 
+    // ── Layout / box-model (bare numbers default to px; CSS strings pass through) ──
+    public BmStringKeyframes? Top { get; set; }
+    public BmStringKeyframes? Left { get; set; }
+    public BmStringKeyframes? Right { get; set; }
+    public BmStringKeyframes? Bottom { get; set; }
+    public BmStringKeyframes? Margin { get; set; }
+    public BmStringKeyframes? Padding { get; set; }
+    public BmStringKeyframes? Gap { get; set; }
+
+    // ── Typography ─────────────────────────────────────────────────────────────
+    public BmStringKeyframes? LetterSpacing { get; set; }
+    public BmStringKeyframes? LineHeight { get; set; }
+    public BmStringKeyframes? FontSize { get; set; }
+
+    // ── Misc CSS ───────────────────────────────────────────────────────────────
+    public BmStringKeyframes? ClipPath { get; set; }
+    public BmStringKeyframes? BackgroundPosition { get; set; }
+    public BmStringKeyframes? BackgroundSize { get; set; }
+
+    // ── Motion path (CSS offset-*) ─────────────────────────────────────────────
+    /// <summary>
+    /// The path an element travels along, mapping to CSS <c>offset-path</c>, e.g.
+    /// <c>OffsetPath = "path('M0,0 C50,100 150,-50 200,50')"</c>. Usually set once; animate
+    /// <see cref="OffsetDistance"/> to move the element along it (both are compositor-friendly).
+    /// </summary>
+    public BmStringKeyframes? OffsetPath { get; set; }
+
+    /// <summary>Position along <see cref="OffsetPath"/> (CSS <c>offset-distance</c>), e.g. <c>"0%"</c> → <c>"100%"</c>.</summary>
+    public BmStringKeyframes? OffsetDistance { get; set; }
+
     // ── CSS custom properties (e.g. "--my-var") ───────────────────────────────
     /// <summary>Animate arbitrary CSS custom properties. Keys must start with "--".</summary>
     public Dictionary<string, string>? CssVars { get; set; }
+
+    /// <summary>
+    /// Animate any CSS property not covered by a typed member (motion.dev's <c>animate()</c> escape
+    /// hatch), e.g. <c>Css = new() { ["gap"] = "2rem", ["letter-spacing"] = "0.1em" }</c>. Keys accept
+    /// dash-case or camelCase. Layout-triggering properties won't be compositor-accelerated.
+    /// </summary>
+    public Dictionary<string, BmStringKeyframes>? Css { get; set; }
 
     // ── Embedded transition ───────────────────────────────────────────────────
     /// <summary>
@@ -90,6 +127,56 @@ public class BmProps
     /// <c>Transition</c>. Lets variants and one-off targets carry their own timing/physics.
     /// </summary>
     public BmTransition? Transition { get; set; }
+
+    // The extended string-valued props (layout/typography/misc), listed once so the runtime,
+    // initial-style and instant-set paths all emit them consistently. EngineKey is the camelCase
+    // key JS applies via style[key]; CssProp is the dash-case name for the initial inline style.
+    private IEnumerable<(string EngineKey, string CssProp, BmStringKeyframes? Value)> ExtendedStringProps()
+    {
+        yield return ("top", "top", Top);
+        yield return ("left", "left", Left);
+        yield return ("right", "right", Right);
+        yield return ("bottom", "bottom", Bottom);
+        yield return ("margin", "margin", Margin);
+        yield return ("padding", "padding", Padding);
+        yield return ("gap", "gap", Gap);
+        yield return ("letterSpacing", "letter-spacing", LetterSpacing);
+        yield return ("lineHeight", "line-height", LineHeight);
+        yield return ("fontSize", "font-size", FontSize);
+        yield return ("clipPath", "clip-path", ClipPath);
+        yield return ("backgroundPosition", "background-position", BackgroundPosition);
+        yield return ("backgroundSize", "background-size", BackgroundSize);
+        yield return ("offsetPath", "offset-path", OffsetPath);
+        yield return ("offsetDistance", "offset-distance", OffsetDistance);
+    }
+
+    // "background-position" → "backgroundPosition"; leaves camelCase and "--custom" keys untouched.
+    internal static string ToCamelCase(string prop)
+    {
+        if (prop.StartsWith("--", StringComparison.Ordinal) || !prop.Contains('-')) return prop;
+        var sb = new System.Text.StringBuilder(prop.Length);
+        bool upper = false;
+        foreach (var c in prop)
+        {
+            if (c == '-') { upper = true; continue; }
+            sb.Append(upper ? char.ToUpperInvariant(c) : c);
+            upper = false;
+        }
+        return sb.ToString();
+    }
+
+    // "letterSpacing" → "letter-spacing"; leaves dash-case and "--custom" keys untouched.
+    internal static string ToDashCase(string prop)
+    {
+        if (prop.StartsWith("--", StringComparison.Ordinal)) return prop;
+        var sb = new System.Text.StringBuilder(prop.Length + 4);
+        foreach (var c in prop)
+        {
+            if (char.IsUpper(c)) { sb.Append('-'); sb.Append(char.ToLowerInvariant(c)); }
+            else sb.Append(c);
+        }
+        return sb.ToString();
+    }
 
     /// <summary>
     /// Serialise to a plain dictionary the animation engine understands: single values as
@@ -129,6 +216,13 @@ public class BmProps
         if (PathOffset is not null) d["pathOffset"] = PathOffset.ToEngineValue();
         if (PathSpacing is not null) d["pathSpacing"] = PathSpacing.ToEngineValue();
 
+        foreach (var (engineKey, _, value) in ExtendedStringProps())
+            if (value is not null) d[engineKey] = value.ToEngineValue();
+
+        if (Css != null)
+            foreach (var kv in Css)
+                if (kv.Value is not null) d[ToCamelCase(kv.Key)] = kv.Value.ToEngineValue();
+
         if (CssVars != null)
             foreach (var kv in CssVars)
             {
@@ -137,6 +231,43 @@ public class BmProps
             }
 
         return d;
+    }
+
+    /// <summary>
+    /// Enumerates every string-valued CSS declaration this target carries (all keyframes of each
+    /// string prop, plus CSS-var values) as <c>(prop, value)</c> pairs. Used by the opt-in
+    /// CSS-injection safe mode to validate values written verbatim into inline style.
+    /// </summary>
+    internal IEnumerable<(string Prop, string Value)> EnumerateCssStringValues()
+    {
+        foreach (var pair in Frames("backgroundColor", BackgroundColor)) yield return pair;
+        foreach (var pair in Frames("color", Color)) yield return pair;
+        foreach (var pair in Frames("borderColor", BorderColor)) yield return pair;
+        foreach (var pair in Frames("outlineColor", OutlineColor)) yield return pair;
+        foreach (var pair in Frames("fill", Fill)) yield return pair;
+        foreach (var pair in Frames("stroke", Stroke)) yield return pair;
+        foreach (var pair in Frames("width", Width)) yield return pair;
+        foreach (var pair in Frames("height", Height)) yield return pair;
+        foreach (var pair in Frames("borderRadius", BorderRadius)) yield return pair;
+        foreach (var pair in Frames("boxShadow", BoxShadow)) yield return pair;
+        foreach (var pair in Frames("filter", Filter)) yield return pair;
+
+        foreach (var (engineKey, _, value) in ExtendedStringProps())
+            foreach (var pair in Frames(engineKey, value)) yield return pair;
+
+        if (Css != null)
+            foreach (var kv in Css)
+                foreach (var pair in Frames(kv.Key, kv.Value)) yield return pair;
+
+        if (CssVars != null)
+            foreach (var kv in CssVars)
+                yield return (kv.Key, kv.Value);
+
+        static IEnumerable<(string, string)> Frames(string prop, BmStringKeyframes? k)
+        {
+            if (k is null) yield break;
+            foreach (var f in k.Frames) yield return (prop, f);
+        }
     }
 
     // ── First-frame accessors for the initial inline style ────────────────────
@@ -154,6 +285,38 @@ public class BmProps
     private string TransformOriginCss()
         => $"{BmotionCssFormat.Num((OriginX ?? 0.5) * 100)}% {BmotionCssFormat.Num((OriginY ?? 0.5) * 100)}%";
 
+    // Collects the present + finite transform components into the engine's transform-component
+    // dictionary, then lets BmotionTransformComposer.Build own the ordering/aliasing/formatting.
+    // This is the single source of truth for transform syntax: the runtime per-frame path already
+    // calls Build directly, and both initial-style (ToCssStyleString) and instant-set
+    // (ToCssStyleDictionary) now route through it too - no more hand-synced duplicate logic.
+    // <paramref name="useLast"/> selects which keyframe to sample: the first frame for the initial
+    // inline style (where the animation starts) or the last frame for an instant set (where it settles).
+    private Dictionary<string, double> CollectTransformComponents(bool useLast)
+    {
+        var t = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        void Add(string key, BmKeyframes? k)
+        {
+            if (k is null) return;
+            if (useLast)
+            {
+                var v = k.Last;
+                if (double.IsFinite(v)) t[key] = v;
+            }
+            else if (k.TryGetCssNumber(out var v))
+            {
+                t[key] = v;
+            }
+        }
+
+        Add("perspective", Perspective);
+        Add("x", X); Add("y", Y); Add("z", Z);
+        Add("scale", Scale); Add("scaleX", ScaleX); Add("scaleY", ScaleY);
+        Add("rotate", Rotate); Add("rotateZ", RotateZ); Add("rotateX", RotateX); Add("rotateY", RotateY);
+        Add("skewX", SkewX); Add("skewY", SkewY);
+        return t;
+    }
+
     /// <summary>
     /// Render these props as an inline CSS style string - used server-side to avoid a
     /// flash of un-styled content before the JS interop layer initialises.
@@ -162,36 +325,9 @@ public class BmProps
     {
         var sb = new System.Text.StringBuilder();
 
-        var transforms = new List<string>();
-        bool hasX = CssNum(X, out double x), hasY = CssNum(Y, out double y), hasZ = CssNum(Z, out double z);
-        if (hasX || hasY || hasZ)
-        {
-            if (z != 0)
-                transforms.Add($"translate3d({BmotionCssFormat.Num(x)}px,{BmotionCssFormat.Num(y)}px,{BmotionCssFormat.Num(z)}px)");
-            else
-                transforms.Add($"translate({BmotionCssFormat.Num(x)}px,{BmotionCssFormat.Num(y)}px)");
-        }
-        if (CssNum(Scale, out double scale) && scale != 1)
-        {
-            transforms.Add($"scale({BmotionCssFormat.Num(scale)})");
-        }
-        else
-        {
-            if (CssNum(ScaleX, out double sx) && sx != 1) transforms.Add($"scaleX({BmotionCssFormat.Num(sx)})");
-            if (CssNum(ScaleY, out double sy) && sy != 1) transforms.Add($"scaleY({BmotionCssFormat.Num(sy)})");
-        }
-        // Prefer a non-zero rotateZ, otherwise fall back to rotate, so an explicit RotateZ = 0
-        // doesn't mask a meaningful Rotate value (matches BmotionTransformComposer).
-        CssNum(Rotate, out double rot);
-        double rotateZ = CssNum(RotateZ, out double rz) && rz != 0 ? rz : rot;
-        if (rotateZ != 0) transforms.Add($"rotate({BmotionCssFormat.Num(rotateZ)}deg)");
-        if (CssNum(RotateX, out double rx) && rx != 0) transforms.Add($"rotateX({BmotionCssFormat.Num(rx)}deg)");
-        if (CssNum(RotateY, out double ry) && ry != 0) transforms.Add($"rotateY({BmotionCssFormat.Num(ry)}deg)");
-        if (CssNum(SkewX, out double kx) && kx != 0) transforms.Add($"skewX({BmotionCssFormat.Num(kx)}deg)");
-        if (CssNum(SkewY, out double ky) && ky != 0) transforms.Add($"skewY({BmotionCssFormat.Num(ky)}deg)");
-        if (CssNum(Perspective, out double persp)) transforms.Insert(0, $"perspective({BmotionCssFormat.Num(persp)}px)");
-
-        if (transforms.Count > 0) sb.Append($"transform:{string.Join(" ", transforms)};");
+        // The initial inline style renders each transform component's FIRST keyframe.
+        var transform = BmotionTransformComposer.Build(CollectTransformComponents(useLast: false));
+        if (transform.Length > 0) sb.Append($"transform:{transform};");
         if (OriginX.HasValue || OriginY.HasValue) sb.Append($"transform-origin:{TransformOriginCss()};");
 
         if (CssNum(Opacity, out double opacity)) sb.Append($"opacity:{BmotionCssFormat.Num(opacity)};");
@@ -214,6 +350,13 @@ public class BmProps
             sb.Append($"stroke-dasharray:{BmotionCssFormat.Num(clamped)} {BmotionCssFormat.Num(spacing)};");
             sb.Append($"stroke-dashoffset:{BmotionCssFormat.Num(1 - clamped - offset)};");
         }
+
+        foreach (var (_, cssProp, value) in ExtendedStringProps())
+            if (CssStr(value) is { } s) sb.Append($"{cssProp}:{s};");
+
+        if (Css != null)
+            foreach (var kv in Css)
+                if (kv.Value?.First is { } s) sb.Append($"{ToDashCase(kv.Key)}:{s};");
 
         if (CssVars != null)
             foreach (var kv in CssVars)
@@ -247,34 +390,9 @@ public class BmProps
 
         var d = new Dictionary<string, string>();
 
-        var transforms = new List<string>();
-        if (Num(Perspective, out double persp)) transforms.Add($"perspective({BmotionCssFormat.Num(persp)}px)");
-        bool hasX = Num(X, out double x), hasY = Num(Y, out double y), hasZ = Num(Z, out double z);
-        if (hasX || hasY || hasZ)
-        {
-            transforms.Add(z != 0
-                ? $"translate3d({BmotionCssFormat.Num(x)}px,{BmotionCssFormat.Num(y)}px,{BmotionCssFormat.Num(z)}px)"
-                : $"translate({BmotionCssFormat.Num(x)}px,{BmotionCssFormat.Num(y)}px)");
-        }
-        if (Num(Scale, out double scale) && scale != 1)
-        {
-            transforms.Add($"scale({BmotionCssFormat.Num(scale)})");
-        }
-        else
-        {
-            if (Num(ScaleX, out double sx) && sx != 1) transforms.Add($"scaleX({BmotionCssFormat.Num(sx)})");
-            if (Num(ScaleY, out double sy) && sy != 1) transforms.Add($"scaleY({BmotionCssFormat.Num(sy)})");
-        }
-        // Prefer a non-zero rotateZ, otherwise fall back to rotate, so an explicit RotateZ = 0
-        // doesn't mask a meaningful Rotate value (matches BmotionTransformComposer).
-        Num(Rotate, out double rot);
-        double rotateZ = Num(RotateZ, out double rz) && rz != 0 ? rz : rot;
-        if (rotateZ != 0) transforms.Add($"rotate({BmotionCssFormat.Num(rotateZ)}deg)");
-        if (Num(RotateX, out double rx) && rx != 0) transforms.Add($"rotateX({BmotionCssFormat.Num(rx)}deg)");
-        if (Num(RotateY, out double ry) && ry != 0) transforms.Add($"rotateY({BmotionCssFormat.Num(ry)}deg)");
-        if (Num(SkewX, out double kx) && kx != 0) transforms.Add($"skewX({BmotionCssFormat.Num(kx)}deg)");
-        if (Num(SkewY, out double ky) && ky != 0) transforms.Add($"skewY({BmotionCssFormat.Num(ky)}deg)");
-        if (transforms.Count > 0) d["transform"] = string.Join(" ", transforms);
+        // For an instant Set, each transform component collapses to its LAST keyframe.
+        var transform = BmotionTransformComposer.Build(CollectTransformComponents(useLast: true));
+        if (transform.Length > 0) d["transform"] = transform;
         if (OriginX.HasValue || OriginY.HasValue) d["transformOrigin"] = TransformOriginCss();
 
         if (Num(Opacity, out double opacity)) d["opacity"] = BmotionCssFormat.Num(opacity);
@@ -297,6 +415,13 @@ public class BmProps
             d["strokeDasharray"] = $"{BmotionCssFormat.Num(clamped)} {BmotionCssFormat.Num(spacing)}";
             d["strokeDashoffset"] = BmotionCssFormat.Num(1 - clamped - offset);
         }
+
+        foreach (var (engineKey, _, value) in ExtendedStringProps())
+            if (Str(value) is { } s) d[engineKey] = s;
+
+        if (Css != null)
+            foreach (var kv in Css)
+                if (kv.Value?.Last is { } s) d[ToCamelCase(kv.Key)] = s;
 
         if (CssVars != null)
             foreach (var kv in CssVars)
@@ -329,9 +454,15 @@ public class BmProps
             Equals(BackgroundColor, o.BackgroundColor) && Equals(Color, o.Color) && Equals(BorderColor, o.BorderColor) &&
             Equals(OutlineColor, o.OutlineColor) && Equals(Fill, o.Fill) && Equals(Stroke, o.Stroke) &&
             Equals(Width, o.Width) && Equals(Height, o.Height) && Equals(BorderRadius, o.BorderRadius) && Equals(BoxShadow, o.BoxShadow) && Equals(Filter, o.Filter) &&
+            Equals(Top, o.Top) && Equals(Left, o.Left) && Equals(Right, o.Right) && Equals(Bottom, o.Bottom) &&
+            Equals(Margin, o.Margin) && Equals(Padding, o.Padding) && Equals(Gap, o.Gap) &&
+            Equals(LetterSpacing, o.LetterSpacing) && Equals(LineHeight, o.LineHeight) && Equals(FontSize, o.FontSize) &&
+            Equals(ClipPath, o.ClipPath) && Equals(BackgroundPosition, o.BackgroundPosition) && Equals(BackgroundSize, o.BackgroundSize) &&
+            Equals(OffsetPath, o.OffsetPath) && Equals(OffsetDistance, o.OffsetDistance) &&
             Equals(PathLength, o.PathLength) && Equals(PathOffset, o.PathOffset) && Equals(PathSpacing, o.PathSpacing);
 
-        return values && DictEquals(CssVars, o.CssVars) && BmTransition.AreEquivalent(Transition, o.Transition);
+        return values && DictEquals(CssVars, o.CssVars) && StringKeyframesDictEquals(Css, o.Css)
+            && BmTransition.AreEquivalent(Transition, o.Transition);
     }
 
     private static bool DictEquals(Dictionary<string, string>? a, Dictionary<string, string>? b)
@@ -340,6 +471,15 @@ public class BmProps
         if (a is null || b is null || a.Count != b.Count) return false;
         foreach (var kv in a)
             if (!b.TryGetValue(kv.Key, out var v) || v != kv.Value) return false;
+        return true;
+    }
+
+    private static bool StringKeyframesDictEquals(Dictionary<string, BmStringKeyframes>? a, Dictionary<string, BmStringKeyframes>? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null || a.Count != b.Count) return false;
+        foreach (var kv in a)
+            if (!b.TryGetValue(kv.Key, out var v) || !Equals(v, kv.Value)) return false;
         return true;
     }
 }

--- a/src/Bmotion/Bit.Bmotion/Models/BmReducedMotionMode.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmReducedMotionMode.cs
@@ -1,0 +1,30 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// Controls how Bit.Bmotion honors the user's <c>prefers-reduced-motion</c> accessibility setting,
+/// set globally via <see cref="BitBmotionOptions.ReducedMotion"/>. A local
+/// <c>&lt;BmotionConfig ReduceMotion="true|false"&gt;</c> always overrides this for its subtree.
+/// </summary>
+public enum BmReducedMotionMode
+{
+    /// <summary>
+    /// <b>Back-compat default.</b> The OS <c>prefers-reduced-motion</c> preference is respected only
+    /// for elements inside a <see cref="BmotionConfig"/>; elements without one always animate. This
+    /// is the behavior of Bit.Bmotion before the option existed.
+    /// </summary>
+    IgnoreUnlessConfigured = 0,
+
+    /// <summary>
+    /// <b>Recommended.</b> Respect the OS <c>prefers-reduced-motion</c> preference everywhere, with
+    /// no <see cref="BmotionConfig"/> required - matching the web-platform default and Motion's
+    /// <c>"user"</c> semantics. When reduced, transforms/layout are suppressed (they snap to their
+    /// target) while opacity and color still animate.
+    /// </summary>
+    User = 1,
+
+    /// <summary>Always reduce motion, regardless of the OS preference.</summary>
+    Always = 2,
+
+    /// <summary>Never reduce motion, regardless of the OS preference (an explicit override off).</summary>
+    Never = 3,
+}

--- a/src/Bmotion/Bit.Bmotion/Models/BmStagger.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmStagger.cs
@@ -9,19 +9,34 @@ public enum BmStaggerFrom { First, Last, Center }
 /// await Motion.AnimateAsync(".item", Bm.To(opacity: 1, y: 0),
 ///     Bm.Spring(), stagger: Bm.Stagger(0.08, from: BmStaggerFrom.Center));
 /// </code>
+/// <para>
+/// Pass <c>grid: (cols, rows)</c> to stagger radially across a 2-D grid (Euclidean distance from the
+/// <see cref="From"/> origin), or construct with a <c>Func&lt;int, int, double&gt;</c> for a fully
+/// custom per-index delay.
+/// </para>
 /// </summary>
 public sealed class BmStagger
 {
-    public BmStagger(double each, BmStaggerFrom from = BmStaggerFrom.First, double startDelay = 0)
+    private readonly Func<int, int, double>? _custom;
+
+    public BmStagger(double each, BmStaggerFrom from = BmStaggerFrom.First, double startDelay = 0,
+        (int Cols, int Rows)? grid = null)
     {
         if (!double.IsFinite(each) || each < 0)
             throw new ArgumentException("Stagger interval must be a finite, non-negative number of seconds.", nameof(each));
         if (!double.IsFinite(startDelay) || startDelay < 0)
             throw new ArgumentException("Stagger start delay must be a finite, non-negative number of seconds.", nameof(startDelay));
+        if (grid is (int cols, int rows) && (cols <= 0 || rows <= 0))
+            throw new ArgumentException("Stagger grid dimensions must be positive.", nameof(grid));
         Each = each;
         From = from;
         StartDelay = startDelay;
+        Grid = grid;
     }
+
+    /// <summary>Creates a stagger driven entirely by a custom <c>(index, total) =&gt; delaySeconds</c> function.</summary>
+    public BmStagger(Func<int, int, double> custom)
+        => _custom = custom ?? throw new ArgumentNullException(nameof(custom));
 
     /// <summary>Seconds between each element's start.</summary>
     public double Each { get; }
@@ -32,10 +47,18 @@ public sealed class BmStagger
     /// <summary>Extra delay before the first element starts.</summary>
     public double StartDelay { get; }
 
+    /// <summary>Optional grid dimensions for 2-D radial staggering.</summary>
+    public (int Cols, int Rows)? Grid { get; }
+
     /// <summary>The delay (seconds) for the element at <paramref name="index"/> of <paramref name="total"/>.</summary>
     public double DelayFor(int index, int total)
     {
+        if (_custom is not null) return _custom(index, total);
         if (total <= 0) return StartDelay;
+
+        if (Grid is (int cols, int rows))
+            return StartDelay + GridDistance(index, cols, rows) * Each;
+
         double origin = From switch
         {
             BmStaggerFrom.Last => total - 1,
@@ -43,5 +66,20 @@ public sealed class BmStagger
             _ => 0,
         };
         return StartDelay + Math.Abs(index - origin) * Each;
+    }
+
+    // Euclidean distance (in cells) from the From-origin cell to element `index`'s cell.
+    private double GridDistance(int index, int cols, int rows)
+    {
+        int row = index / cols;
+        int col = index % cols;
+        (double originRow, double originCol) = From switch
+        {
+            BmStaggerFrom.Last => (rows - 1.0, cols - 1.0),
+            BmStaggerFrom.Center => ((rows - 1) / 2.0, (cols - 1) / 2.0),
+            _ => (0.0, 0.0),
+        };
+        double dr = row - originRow, dc = col - originCol;
+        return Math.Sqrt(dr * dr + dc * dc);
     }
 }

--- a/src/Bmotion/Bit.Bmotion/Models/BmStepJump.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmStepJump.cs
@@ -1,0 +1,20 @@
+namespace Bit.Bmotion;
+
+/// <summary>
+/// Where the jumps of a stepped easing occur, mirroring the CSS <c>steps()</c> jump-terms. Use via
+/// <c>Bm.Tween(steps: 5, stepJump: BmStepJump.End)</c>.
+/// </summary>
+public enum BmStepJump
+{
+    /// <summary>Jump at the end of each interval (CSS <c>jump-end</c>, the default).</summary>
+    End = 0,
+
+    /// <summary>Jump at the start of each interval (CSS <c>jump-start</c>).</summary>
+    Start = 1,
+
+    /// <summary>No jump at either end (CSS <c>jump-none</c>); reaches both 0 and 1.</summary>
+    None = 2,
+
+    /// <summary>Jump at both ends (CSS <c>jump-both</c>).</summary>
+    Both = 3,
+}

--- a/src/Bmotion/Bit.Bmotion/Models/BmTransition.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmTransition.cs
@@ -42,11 +42,21 @@ public abstract class BmTransition
     public Action<double>? OnUpdate { get; set; }
 
     /// <summary>Lowers this transition into the internal flat engine configuration.</summary>
-    internal BmotionTransitionConfig ToConfig()
+    internal BmotionTransitionConfig ToConfig() => ToConfig(null);
+
+    /// <summary>
+    /// Lowers this transition, inheriting <paramref name="ambientColorSpace"/> (the enclosing
+    /// <c>&lt;BmotionConfig&gt;</c> setting) wherever this transition didn't set its own
+    /// <see cref="ColorSpace"/>. The resolved space then cascades as the ambient for nested
+    /// per-property configs, so a per-property color override doesn't reset to sRGB.
+    /// </summary>
+    internal BmotionTransitionConfig ToConfig(BmColorSpace? ambientColorSpace)
     {
         var c = CreateConfig();
         c.Delay = Delay;
-        if (ColorSpace is BmColorSpace cs) c.ColorSpace = cs;
+        // Explicit per-transition space wins; otherwise inherit the ambient (global) space.
+        var resolvedColorSpace = ColorSpace ?? ambientColorSpace;
+        if (resolvedColorSpace is BmColorSpace cs) c.ColorSpace = cs;
         if (Repeat is { } r)
         {
             c.RepeatInfinite = r.IsForever;
@@ -64,7 +74,7 @@ public abstract class BmTransition
             {
                 if (value is null)
                     throw new InvalidOperationException($"Per-property transition override for '{key}' must not be null.");
-                c.Properties[key] = value.ToConfig();
+                c.Properties[key] = value.ToConfig(resolvedColorSpace);
             }
         }
         return c;

--- a/src/Bmotion/Bit.Bmotion/Models/BmTransition.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmTransition.cs
@@ -11,6 +11,12 @@ public abstract class BmTransition
     /// <summary>Delay before the animation starts, in seconds.</summary>
     public double Delay { get; set; }
 
+    /// <summary>
+    /// Color space for interpolating color properties. <c>null</c> inherits the global
+    /// <c>&lt;BmotionConfig&gt;</c> setting (or sRGB when none). See <see cref="BmColorSpace"/>.
+    /// </summary>
+    public BmColorSpace? ColorSpace { get; set; }
+
     /// <summary>Repeat configuration. E.g. <c>Repeat = 3</c> or <c>Repeat = BmRepeat.Mirror()</c>.</summary>
     public BmRepeat? Repeat { get; set; }
 
@@ -40,6 +46,7 @@ public abstract class BmTransition
     {
         var c = CreateConfig();
         c.Delay = Delay;
+        if (ColorSpace is BmColorSpace cs) c.ColorSpace = cs;
         if (Repeat is { } r)
         {
             c.RepeatInfinite = r.IsForever;
@@ -74,6 +81,7 @@ public abstract class BmTransition
     internal virtual bool ValueEquals(BmTransition other)
     {
         if (Delay != other.Delay) return false;
+        if (ColorSpace != other.ColorSpace) return false;
         if (!Nullable.Equals(Repeat, other.Repeat)) return false;
         if (StaggerChildren != other.StaggerChildren || DelayChildren != other.DelayChildren) return false;
         // OnUpdate is deliberately excluded: inline callbacks are recreated on every render and
@@ -126,6 +134,15 @@ public sealed class BmTween : BmTransition
     public double[]? Bezier { get; set; }
 
     /// <summary>
+    /// Number of discrete steps for a stepped (CSS <c>steps()</c>) easing. When greater than zero,
+    /// this overrides <see cref="Ease"/> and <see cref="Bezier"/>. Default: 0 (not stepped).
+    /// </summary>
+    public int Steps { get; set; }
+
+    /// <summary>Where a stepped easing's jumps occur (see <see cref="Steps"/>). Default: End.</summary>
+    public BmStepJump StepJump { get; set; } = BmStepJump.End;
+
+    /// <summary>
     /// Progress offsets (0-1) for each keyframe value; evenly distributed when omitted.
     /// Length must match the keyframe array being animated.
     /// </summary>
@@ -144,6 +161,8 @@ public sealed class BmTween : BmTransition
         Duration = Duration,
         Ease = Ease,
         EaseCubicBezier = Bezier,
+        StepCount = Steps,
+        StepJump = StepJump,
         Times = Times,
         Eases = Eases,
     };
@@ -151,6 +170,7 @@ public sealed class BmTween : BmTransition
     internal override bool ValueEquals(BmTransition other)
         => other is BmTween t
            && Duration == t.Duration && Ease == t.Ease
+           && Steps == t.Steps && StepJump == t.StepJump
            && ArraysEqual(Bezier, t.Bezier) && ArraysEqual(Times, t.Times)
            && EasesEqual(Eases, t.Eases)
            && base.ValueEquals(other);

--- a/src/Bmotion/Bit.Bmotion/Models/BmotionTransitionConfig.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmotionTransitionConfig.cs
@@ -35,6 +35,18 @@ internal sealed class BmotionTransitionConfig
     }
     private double[]? _easeCubicBezier;
 
+    /// <summary>
+    /// Number of steps for a stepped (CSS <c>steps()</c>) easing. When greater than zero, this
+    /// overrides <see cref="Ease"/> and <see cref="EaseCubicBezier"/>. Default: 0 (not stepped).
+    /// </summary>
+    public int StepCount { get; set; }
+
+    /// <summary>Where a stepped easing's jumps occur. See <see cref="BmStepJump"/>.</summary>
+    public BmStepJump StepJump { get; set; } = BmStepJump.End;
+
+    /// <summary>Color space used when interpolating color properties. Default: sRGB.</summary>
+    public BmColorSpace ColorSpace { get; set; } = BmColorSpace.Srgb;
+
     private static double[]? ValidateCubicBezier(double[]? value)
     {
         if (value is null) return null;
@@ -212,6 +224,9 @@ internal sealed class BmotionTransitionConfig
         // Read the backing field directly: the EaseCubicBezier getter already returns a defensive
         // clone, so cloning it again here would allocate a redundant second copy.
         EaseCubicBezier = _easeCubicBezier is null ? null : (double[])_easeCubicBezier.Clone(),
+        StepCount = StepCount,
+        StepJump = StepJump,
+        ColorSpace = ColorSpace,
         Repeat = Repeat,
         RepeatInfinite = RepeatInfinite,
         RepeatType = RepeatType,

--- a/src/Bmotion/Bit.Bmotion/Models/BmotionTransitionConfig.cs
+++ b/src/Bmotion/Bit.Bmotion/Models/BmotionTransitionConfig.cs
@@ -2,7 +2,7 @@
 /// <summary>
 /// Internal flat transition representation consumed by the animation engine and drivers.
 /// The public API is the <see cref="BmTransition"/> hierarchy, which lowers into this
-/// via <see cref="BmTransition.ToConfig"/>.
+/// via <see cref="BmTransition.ToConfig()"/>.
 /// </summary>
 internal sealed class BmotionTransitionConfig
 {

--- a/src/Bmotion/Bit.Bmotion/README.md
+++ b/src/Bmotion/Bit.Bmotion/README.md
@@ -2,7 +2,7 @@
 
 A Blazor-native animation library inspired by [Motion](https://motion.dev) (Framer Motion):
 springs, gestures, keyframes, variants, drag, layout (FLIP) animations, shared-element
-transitions and exit animations — no manual JavaScript wiring required. All animation math
+transitions and exit animations - no manual JavaScript wiring required. All animation math
 (spring, tween, inertia, keyframes, easing, color interpolation, gesture state, transform
 composition) runs in C#; JavaScript is used only as a thin bridge to browser-native APIs.
 
@@ -38,15 +38,15 @@ and `BmotionAnimateService` for the complete API surface.
 
 ## Platform support
 
-- ✅ **Blazor WebAssembly** — fully supported. Compositor-eligible animations (tweens and
+- ✅ **Blazor WebAssembly** - fully supported. Compositor-eligible animations (tweens and
   zero-velocity springs on transform/opacity) are pre-sampled in C# and run on the browser's
   Web Animations API off the main thread; everything else runs on the C# rAF engine over
   synchronous interop.
-- ⚠️ **Blazor Server** — the compositor path works (it needs only async interop), so
+- ⚠️ **Blazor Server** - the compositor path works (it needs only async interop), so
   enter/exit/hover/tap/variant animations on transform + opacity play normally. Features that
-  require the per-frame loop — inertia, color/dimension interpolation, keyframe arrays, drag,
-  motion values — degrade to instant state changes.
-- ⏸️ **Server-side prerendering** — components render their initial styles; animations start
+  require the per-frame loop - inertia, color/dimension interpolation, keyframe arrays, drag,
+  motion values - degrade to instant state changes.
+- ⏸️ **Server-side prerendering** - components render their initial styles; animations start
   once the circuit/runtime becomes interactive.
 
 Inject **`BmotionCapabilities`** to detect the current mode instead of guessing:
@@ -65,12 +65,12 @@ builder.Services.AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMod
 | `BmReducedMotionMode`      | Behaviour |
 |----------------------------|-----------|
 | `IgnoreUnlessConfigured`   | **Default (back-compat).** OS preference respected only inside a `<BmotionConfig>`. |
-| `User`                     | **Recommended.** Respect the OS preference everywhere — the web-platform default. |
+| `User`                     | **Recommended.** Respect the OS preference everywhere - the web-platform default. |
 | `Always`                   | Always reduce, regardless of the OS. |
 | `Never`                    | Never reduce, regardless of the OS. |
 
 When motion is reduced, Bit.Bmotion follows Motion's `"user"` semantics: **transforms, layout and
-dimension changes snap to their target instantly, while opacity and colour still animate** — a
+dimension changes snap to their target instantly, while opacity and colour still animate** - a
 softer, more correct reduction than collapsing every property to instant.
 
 A local `<BmotionConfig ReduceMotion="true|false">` always overrides the global mode for its subtree
@@ -110,6 +110,6 @@ Do **not** enable WebAssembly multithreading (`<WasmEnableThreads>`) with this l
 ## Disposing the programmatic helpers
 
 `BmotionScrollTracker` is registered `Transient` and is owned by the consuming component. When
-obtained via `@inject`, Blazor does **not** dispose it per component — the consuming component
+obtained via `@inject`, Blazor does **not** dispose it per component - the consuming component
 must dispose it itself (call its `DisposeAsync` from the component's own `DisposeAsync`),
 otherwise its JS subscription leaks until the app shuts down.

--- a/src/Bmotion/Bit.Bmotion/README.md
+++ b/src/Bmotion/Bit.Bmotion/README.md
@@ -49,21 +49,42 @@ and `BmotionAnimateService` for the complete API surface.
 - ⏸️ **Server-side prerendering** — components render their initial styles; animations start
   once the circuit/runtime becomes interactive.
 
-## Accessibility: reduced motion is opt-in
+Inject **`BmotionCapabilities`** to detect the current mode instead of guessing:
+`Caps.SupportsFrameLoop` is `false` on Server (drag/inertia/interpolation degrade to instant),
+`Caps.SupportsCompositor` is always `true`. On Server, the first animation that collapses to an
+instant change also logs a one-time warning so the degradation is diagnosable.
 
-`prefers-reduced-motion` is **only** honoured for elements inside a `<BmotionConfig>`. Elements
-with no surrounding config always animate, even when the OS requests reduced motion. This is a
-deliberate choice (so the OS setting never silently disables animations an app didn't opt into),
-but it is the opposite of the web-platform default — if you care about reduced-motion
-accessibility, wrap your app (or the relevant subtree) in a config:
+## Accessibility: reduced motion
+
+Choose how the library honours the OS `prefers-reduced-motion` setting **globally** at registration:
+
+```csharp
+builder.Services.AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMode.User);
+```
+
+| `BmReducedMotionMode`      | Behaviour |
+|----------------------------|-----------|
+| `IgnoreUnlessConfigured`   | **Default (back-compat).** OS preference respected only inside a `<BmotionConfig>`. |
+| `User`                     | **Recommended.** Respect the OS preference everywhere — the web-platform default. |
+| `Always`                   | Always reduce, regardless of the OS. |
+| `Never`                    | Never reduce, regardless of the OS. |
+
+When motion is reduced, Bit.Bmotion follows Motion's `"user"` semantics: **transforms, layout and
+dimension changes snap to their target instantly, while opacity and colour still animate** — a
+softer, more correct reduction than collapsing every property to instant.
+
+A local `<BmotionConfig ReduceMotion="true|false">` always overrides the global mode for its subtree
+(`null` = follow the mode):
 
 ```razor
-<BmotionConfig>           @* ReduceMotion defaults to null = follow the OS setting *@
+<BmotionConfig ReduceMotion="true">   @* force-reduce this subtree *@
     ...
 </BmotionConfig>
 ```
 
-Set `ReduceMotion="true"`/`"false"` to force it on or off regardless of the OS preference.
+> **Migration note.** The default remains `IgnoreUnlessConfigured` so existing apps are unaffected.
+> New apps should set `ReducedMotion = BmReducedMotionMode.User` to match the platform default; this
+> is planned to become the default in a future major version.
 
 ## Security note
 
@@ -71,6 +92,15 @@ String-valued animation properties (`backgroundColor`, `width`, `boxShadow`, `co
 `cssVars`, …) are written verbatim into the element's inline style. They are meant for
 developer-authored values. Do **not** bind untrusted end-user input to them, or you risk CSS
 injection into the element's `style`.
+
+If you must bind untrusted input, enable **CSS safe mode** to validate those values against a
+conservative injection check (rejecting `;`, `}`, `<`, `javascript:`, `expression(`, comments, …):
+
+```csharp
+builder.Services.AddBitBmotionServices(o => o.CssSafeMode = BmCssSafeMode.Throw); // or .Warn
+```
+
+It is `Off` by default (for performance/parity); `Warn` logs and still applies, `Throw` rejects.
 
 ## Threading
 

--- a/src/Bmotion/Bit.Bmotion/Services/BmAnimationControls.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmAnimationControls.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 namespace Bit.Bmotion;
 /// <summary>
 /// Controls for an in-flight programmatic animation started by
-/// <see cref="BmotionAnimateService.AnimateAsync(string,BmProps,BmTransition?,BmStagger?)"/>.
+/// <see cref="BmotionAnimateService"/>.
 /// <para>The object is directly awaitable - <c>await controls</c> waits for the animation to complete.</para>
 /// <para>
 /// <see cref="Stop"/> freezes the animation at its current (intermediate) values; <see cref="Complete"/>

--- a/src/Bmotion/Bit.Bmotion/Services/BmotionAnimateService.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmotionAnimateService.cs
@@ -65,9 +65,15 @@ public sealed class BmotionAnimateService
         if (string.IsNullOrWhiteSpace(selector))
             throw new ArgumentException("Selector must not be null or whitespace.", nameof(selector));
         ArgumentNullException.ThrowIfNull(keyframes);
+        // Skip interop + engine registration when already cancelled (see Bmotion.AnimateAsync).
+        if (cancellationToken.IsCancellationRequested) return CancelledControls();
         var ids = await _interop.ResolveOrRegisterBySelectorAsync(selector);
         return WithCancellation(StartAnimations(ids, keyframes, transition, stagger), cancellationToken);
     }
+
+    // A resolved, no-op controls for a pre-cancelled call: no elements registered, already settled.
+    private BmAnimationControls CancelledControls()
+        => new(Array.Empty<string>(), _engine, Task.CompletedTask, static () => { });
 
     // Wires a CancellationToken to an in-flight animation: cancelling stops it (and resolves the
     // controls). The registration is disposed once the animation settles so it doesn't leak.
@@ -100,6 +106,7 @@ public sealed class BmotionAnimateService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(keyframes);
+        if (cancellationToken.IsCancellationRequested) return CancelledControls();
         var id = await _interop.ResolveOrRegisterByRefAsync(elementReference);
         return WithCancellation(StartAnimations([id], keyframes, transition, stagger: null), cancellationToken);
     }
@@ -191,6 +198,7 @@ public sealed class BmotionAnimateService
     public async ValueTask<BmAnimationControls> RunAsync(BmSequence sequence, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(sequence);
+        if (cancellationToken.IsCancellationRequested) return CancelledControls();
 
         // Resolve every segment's targets up front so registration/refcounting is symmetric.
         var starts = new List<(string[] ids, Dictionary<string, object?> values, BmotionTransitionConfig config, double start)>();

--- a/src/Bmotion/Bit.Bmotion/Services/BmotionAnimateService.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmotionAnimateService.cs
@@ -24,9 +24,9 @@ namespace Bit.Bmotion;
 public sealed class BmotionAnimateService
 {
     private readonly BmotionAnimationEngine _engine;
-    private readonly BmotionInterop _interop;
+    private readonly IBmotionInterop _interop;
 
-    public BmotionAnimateService(BmotionAnimationEngine engine, BmotionInterop interop)
+    public BmotionAnimateService(BmotionAnimationEngine engine, IBmotionInterop interop)
     {
         ArgumentNullException.ThrowIfNull(engine);
         ArgumentNullException.ThrowIfNull(interop);
@@ -48,9 +48,10 @@ public sealed class BmotionAnimateService
     /// Falls back to the global <see cref="BmotionConfig"/> default when omitted.
     /// </param>
     /// <param name="stagger">
-    /// Optional per-element start-delay generator (see <see cref="Bm.Stagger"/>) applied in
+    /// Optional per-element start-delay generator (see <see cref="BmStagger"/>) applied in
     /// document order across the matched elements.
     /// </param>
+    /// <param name="cancellationToken">Cancelling stops the animation and resolves the controls.</param>
     /// <returns>
     /// An <see cref="BmAnimationControls"/> that can be <c>await</c>ed or stopped early.
     /// </returns>
@@ -58,13 +59,25 @@ public sealed class BmotionAnimateService
         string selector,
         BmProps keyframes,
         BmTransition? transition = null,
-        BmStagger? stagger = null)
+        BmStagger? stagger = null,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(selector))
             throw new ArgumentException("Selector must not be null or whitespace.", nameof(selector));
         ArgumentNullException.ThrowIfNull(keyframes);
         var ids = await _interop.ResolveOrRegisterBySelectorAsync(selector);
-        return StartAnimations(ids, keyframes, transition, stagger);
+        return WithCancellation(StartAnimations(ids, keyframes, transition, stagger), cancellationToken);
+    }
+
+    // Wires a CancellationToken to an in-flight animation: cancelling stops it (and resolves the
+    // controls). The registration is disposed once the animation settles so it doesn't leak.
+    private static BmAnimationControls WithCancellation(BmAnimationControls controls, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled) return controls;
+        if (cancellationToken.IsCancellationRequested) { controls.Stop(); return controls; }
+        var registration = cancellationToken.Register(controls.Stop);
+        controls.WhenCompleteAsync().ContinueWith(_ => registration.Dispose(), TaskScheduler.Default);
+        return controls;
     }
 
     /// <summary>
@@ -76,17 +89,19 @@ public sealed class BmotionAnimateService
     /// </param>
     /// <param name="keyframes">Target animation properties.</param>
     /// <param name="transition">Optional transition configuration.</param>
+    /// <param name="cancellationToken">Cancelling stops the animation and resolves the controls.</param>
     /// <returns>
     /// An <see cref="BmAnimationControls"/> that can be <c>await</c>ed or stopped early.
     /// </returns>
     public async ValueTask<BmAnimationControls> AnimateAsync(
         ElementReference elementReference,
         BmProps keyframes,
-        BmTransition? transition = null)
+        BmTransition? transition = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(keyframes);
         var id = await _interop.ResolveOrRegisterByRefAsync(elementReference);
-        return StartAnimations([id], keyframes, transition, stagger: null);
+        return WithCancellation(StartAnimations([id], keyframes, transition, stagger: null), cancellationToken);
     }
 
     /// <summary>
@@ -173,7 +188,7 @@ public sealed class BmotionAnimateService
     /// Runs a multi-step <see cref="BmSequence"/> timeline. Segments start at their computed
     /// timeline positions; the returned controls can await, stop, pause or speed up the whole run.
     /// </summary>
-    public async ValueTask<BmAnimationControls> RunAsync(BmSequence sequence)
+    public async ValueTask<BmAnimationControls> RunAsync(BmSequence sequence, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(sequence);
 
@@ -233,7 +248,7 @@ public sealed class BmotionAnimateService
             _ => controls.OnCompletionSettled(),
             TaskScheduler.Default);
 
-        return controls;
+        return WithCancellation(controls, cancellationToken);
     }
 
     // ────────────────────────────────────────────────────────────────────────────

--- a/src/Bmotion/Bit.Bmotion/Services/BmotionScrollTracker.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmotionScrollTracker.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace Bit.Bmotion;
@@ -31,16 +32,18 @@ namespace Bit.Bmotion;
 public sealed class BmotionScrollTracker : IAsyncDisposable
 {
     private readonly IBmotionInterop _interop;
+    private readonly ILogger<BmotionScrollTracker>? _logger;
     private readonly List<string> _subscriptionKeys = new();
     private DotNetObjectReference<BmotionScrollTracker>? _dotnet;
 
     private Func<BmScrollInfo, Task>? _onScroll;
     private bool _disposed;
 
-    public BmotionScrollTracker(IBmotionInterop interop)
+    public BmotionScrollTracker(IBmotionInterop interop, ILogger<BmotionScrollTracker>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(interop);
         _interop = interop;
+        _logger = logger;
     }
 
     // Created on first use so an injected-but-unused tracker doesn't allocate a JS-object reference.
@@ -163,9 +166,10 @@ public sealed class BmotionScrollTracker : IAsyncDisposable
         if (_onScroll != null)
         {
             // Guard the user callback so a faulting handler can't fault the JS-invokable flow
-            // (which would destabilise the interop bridge / host circuit).
+            // (which would destabilise the interop bridge / host circuit). Log at debug so the
+            // failure is still diagnosable instead of vanishing silently.
             try { await _onScroll(info); }
-            catch { /* swallow user-callback failures to keep the scroll bridge alive */ }
+            catch (Exception ex) { _logger?.LogDebug(ex, "Bmotion scroll callback threw; swallowed to keep the scroll bridge alive."); }
         }
     }
 
@@ -186,7 +190,7 @@ public sealed class BmotionScrollTracker : IAsyncDisposable
             _subscriptionKeys.Clear();
             _onScroll = null;
             _dotnet?.Dispose();
-            // Note: BmotionInterop itself is DI-scoped and disposed by the DI container
+            // Note: IBmotionInterop itself is DI-scoped and disposed by the DI container
         }
     }
 }

--- a/src/Bmotion/Bit.Bmotion/Services/BmotionScrollTracker.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmotionScrollTracker.cs
@@ -30,14 +30,14 @@ namespace Bit.Bmotion;
 /// </summary>
 public sealed class BmotionScrollTracker : IAsyncDisposable
 {
-    private readonly BmotionInterop _interop;
+    private readonly IBmotionInterop _interop;
     private readonly List<string> _subscriptionKeys = new();
     private DotNetObjectReference<BmotionScrollTracker>? _dotnet;
 
     private Func<BmScrollInfo, Task>? _onScroll;
     private bool _disposed;
 
-    public BmotionScrollTracker(BmotionInterop interop)
+    public BmotionScrollTracker(IBmotionInterop interop)
     {
         ArgumentNullException.ThrowIfNull(interop);
         _interop = interop;

--- a/src/Bmotion/Bit.Bmotion/Services/BmotionViewTransition.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmotionViewTransition.cs
@@ -1,0 +1,70 @@
+using Microsoft.JSInterop;
+
+namespace Bit.Bmotion;
+
+/// <summary>
+/// A thin wrapper over the browser's native <b>View Transitions API</b>
+/// (<c>document.startViewTransition</c>) - the standards-based route/shared-element alternative that
+/// complements Bmotion's <c>LayoutId</c> FLIP. Inject it and wrap a state change:
+/// <code>
+/// [Inject] BmotionViewTransition ViewTransition { get; set; } = default!;
+///
+/// await ViewTransition.StartAsync(() => { _selectedTab = tab; StateHasChanged(); });
+/// </code>
+/// The browser snapshots the DOM before and after the callback and cross-fades between them
+/// (name shared elements with the CSS <c>view-transition-name</c> property to morph them). When the
+/// API is unsupported the callback simply runs without a transition, so it degrades cleanly.
+/// </summary>
+public sealed class BmotionViewTransition : IAsyncDisposable
+{
+    private readonly IBmotionInterop _interop;
+    private DotNetObjectReference<BmotionViewTransition>? _dotnet;
+    private Func<Task>? _pending;
+
+    public BmotionViewTransition(IBmotionInterop interop)
+    {
+        ArgumentNullException.ThrowIfNull(interop);
+        _interop = interop;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="updateDom"/> inside a native view transition where supported.
+    /// Returns <c>true</c> when the native API drove the transition, <c>false</c> when it isn't
+    /// supported and the update ran without one.
+    /// </summary>
+    public async ValueTask<bool> StartAsync(Func<Task> updateDom)
+    {
+        ArgumentNullException.ThrowIfNull(updateDom);
+        _pending = updateDom;
+        _dotnet ??= DotNetObjectReference.Create(this);
+        try
+        {
+            return await _interop.StartViewTransitionAsync(_dotnet, nameof(RunUpdateAsync));
+        }
+        finally
+        {
+            _pending = null;
+        }
+    }
+
+    /// <summary>Synchronous-callback overload of <see cref="StartAsync(Func{Task})"/>.</summary>
+    public ValueTask<bool> StartAsync(Action updateDom)
+    {
+        ArgumentNullException.ThrowIfNull(updateDom);
+        return StartAsync(() => { updateDom(); return Task.CompletedTask; });
+    }
+
+    /// <summary>Invoked by JS during the transition's DOM-update phase. Not for direct use.</summary>
+    [JSInvokable]
+    public async Task RunUpdateAsync()
+    {
+        if (_pending is { } update) await update();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _dotnet?.Dispose();
+        _dotnet = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Bmotion/Bit.Bmotion/Services/BmotionViewTransition.cs
+++ b/src/Bmotion/Bit.Bmotion/Services/BmotionViewTransition.cs
@@ -20,6 +20,7 @@ public sealed class BmotionViewTransition : IAsyncDisposable
     private readonly IBmotionInterop _interop;
     private DotNetObjectReference<BmotionViewTransition>? _dotnet;
     private Func<Task>? _pending;
+    private bool _inProgress;
 
     public BmotionViewTransition(IBmotionInterop interop)
     {
@@ -35,6 +36,12 @@ public sealed class BmotionViewTransition : IAsyncDisposable
     public async ValueTask<bool> StartAsync(Func<Task> updateDom)
     {
         ArgumentNullException.ThrowIfNull(updateDom);
+        // One transition at a time: _pending is shared state read back by RunUpdateAsync, so an
+        // overlapping StartAsync would clobber the in-flight callback. Reject rather than corrupt.
+        if (_inProgress)
+            throw new InvalidOperationException(
+                "A view transition is already in progress; await the previous StartAsync before starting another.");
+        _inProgress = true;
         _pending = updateDom;
         _dotnet ??= DotNetObjectReference.Create(this);
         try
@@ -44,6 +51,7 @@ public sealed class BmotionViewTransition : IAsyncDisposable
         finally
         {
             _pending = null;
+            _inProgress = false;
         }
     }
 

--- a/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
+++ b/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
@@ -15,9 +15,73 @@
  *    Web Animations API      FLIP playback
  */
 
-// 
+//
+// Pure drag / scroll math — no DOM access, so it is unit-tested directly (Tests/bit-bmotion-js).
+// The exports are an internal testing surface; the C# interop only calls the named bridge functions.
+//
+
+/** Elastic give past a constraint edge: 0 = rigid, 1 = fully elastic. */
+export function applyElastic(overflow, edge) {
+    return edge > 0 ? overflow * edge : 0;
+}
+
+/**
+ * Turns a container rect + element rect (and the element's current transform x/y) into the allowed
+ * transform bounds. An element larger than its container collapses to the centered offset so the
+ * drag pins in place instead of oscillating between contradictory bounds.
+ */
+export function resolveConstraintBounds(cRect, eRect, curX, curY) {
+    const baseLeft = eRect.left - curX;
+    const baseTop  = eRect.top  - curY;
+    let left   = cRect.left   - baseLeft;
+    let right  = cRect.right  - (baseLeft + eRect.width);
+    let top    = cRect.top    - baseTop;
+    let bottom = cRect.bottom - (baseTop + eRect.height);
+    if (right < left) { const mid = (left + right) / 2; left = right = mid; }
+    if (bottom < top) { const mid = (top + bottom) / 2; top = bottom = mid; }
+    return { left, right, top, bottom };
+}
+
+/** Clamps a drag position to its constraints, applying per-edge elastic overflow. */
+export function clampToConstraints(x, y, c, elastic) {
+    if (!c) return { x, y };
+    if (c.left   != null && x < c.left)   x = c.left   - applyElastic(c.left   - x, elastic.left);
+    if (c.right  != null && x > c.right)  x = c.right  + applyElastic(x - c.right,  elastic.right);
+    if (c.top    != null && y < c.top)    y = c.top    - applyElastic(c.top    - y, elastic.top);
+    if (c.bottom != null && y > c.bottom) y = c.bottom + applyElastic(y - c.bottom, elastic.bottom);
+    return { x, y };
+}
+
+/** Normalised 0→1 scroll progress along one axis (0 when the content doesn't overflow). */
+export function scrollFraction(scroll, size, client) {
+    return size > client ? scroll / (size - client) : 0;
+}
+
+/**
+ * Layout FLIP child counter-scale (plan item 1.2). When a `layout` element scales by (sx,sy) about
+ * its top-left, a direct child stretches with it. To keep the child crisp, counter-scale it by the
+ * inverse about the SAME physical point (the parent's top-left) — expressed in the child's own box
+ * coordinates that point is (-offsetX, -offsetY). Returns the transform-origin and the start
+ * (inverse) scale to animate from; the child animates back to scale 1 in lockstep with the parent.
+ */
+export function flipChildCorrection(parentRect, childRect, sx, sy) {
+    const offsetX = childRect.left - parentRect.left;
+    const offsetY = childRect.top - parentRect.top;
+    return { originX: -offsetX, originY: -offsetY, fromScaleX: 1 / sx, fromScaleY: 1 / sy };
+}
+
+/**
+ * Border-radius that, once scaled by (sx,sy), renders as the target radius — so corners stay a
+ * constant visual size while the box scales (Motion's border-radius correction). Uses the CSS
+ * elliptical `h / v` form so non-uniform scale still yields round corners.
+ */
+export function correctedRadius(radius, sx, sy) {
+    return { fromX: radius / sx, fromY: radius / sy };
+}
+
+//
 // rAF loop  C# ComputeFrame is called synchronously each tick (Blazor WASM)
-// 
+//
 
 let _rafId = null;
 // Set of engine DotNetObjectReferences. Using a set (rather than a single global) means
@@ -359,6 +423,9 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
     const constraintsCfg = opts.dragConstraints ?? null;
     const dirLock        = !!opts.dragDirectionLock;
     const handleSel      = opts.dragHandle ?? null;
+    // Default false (motion.dev semantics): a nested drag stops propagation so it doesn't also
+    // start a draggable ancestor. Set dragPropagation to let both move together.
+    const propagate      = !!opts.dragPropagation;
 
     // Elasticity is per-edge ({ left, right, top, bottom }); a plain number still means uniform.
     const elasticCfg = opts.dragElastic;
@@ -374,10 +441,6 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
     let lockedAxis = null; // null = not yet locked, 'x' or 'y' once detected
     let startPX, startPY, startElX, startElY;
     let lastPX, lastPY, lastT, velX = 0, velY = 0;
-
-    function applyElastic(overflow, edge) {
-        return edge > 0 ? overflow * edge : 0;
-    }
 
     // Shared drag-start body: called by the element's own pointerdown listener and by the
     // external startDrag entry point (BmDragControls).
@@ -396,16 +459,42 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
         dragging = true;
         lockedAxis = null;
         constraints = _resolveDragConstraints(constraintsCfg, el, startElX, startElY);
+        // Re-measure element-bounds constraints if the layout changes mid-drag (container resize
+        // or scroll). Static pixel bounds have nothing to re-measure, so skip the observers.
+        _observeConstraintChanges();
         // Capture on the target element so move/up events route here even when the drag was
         // started from another element. May throw for an already-released pointer.
         try { el.setPointerCapture(pointerId); } catch { /* stale pointer - drag still tracks moves */ }
         dotnetRef.invokeMethodAsync('OnPointerDown_Drag');
     };
 
+    // Live constraint re-measurement (element-bounds only), active only while dragging.
+    let _resizeObserver = null;
+    const _remeasure = () => {
+        if (dragging) constraints = _resolveDragConstraints(constraintsCfg, el, startElX, startElY);
+    };
+    const _needsRemeasure = () =>
+        !!constraintsCfg && (!!constraintsCfg.parent || typeof constraintsCfg.selector === 'string');
+    function _observeConstraintChanges() {
+        if (!_needsRemeasure() || typeof ResizeObserver !== 'function') return;
+        _resizeObserver = new ResizeObserver(_remeasure);
+        _resizeObserver.observe(el);
+        if (el.parentElement) _resizeObserver.observe(el.parentElement);
+        window.addEventListener('scroll', _remeasure, true);
+        window.addEventListener('resize', _remeasure);
+    }
+    function _stopObservingConstraintChanges() {
+        if (_resizeObserver) { _resizeObserver.disconnect(); _resizeObserver = null; }
+        window.removeEventListener('scroll', _remeasure, true);
+        window.removeEventListener('resize', _remeasure);
+    }
+
     const onDown = (e) => {
         if (e.button !== 0 && e.pointerType !== 'touch') return;
         // Handle mode: only start when the press lands on (or inside) a matching descendant.
         if (handleSel && !(e.target instanceof Element && e.target.closest(handleSel))) return;
+        // Isolate nested draggables unless propagation is opted in (motion.dev's dragPropagation).
+        if (!propagate) e.stopPropagation();
         begin(e.pointerId, e.clientX, e.clientY);
     };
 
@@ -427,10 +516,8 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
         let y = startElY + (effectiveAxis === 'x' ? 0 : e.clientY - startPY);
 
         if (constraints) {
-            if (constraints.left   != null && x < constraints.left)   x = constraints.left   - applyElastic(constraints.left   - x, elastic.left);
-            if (constraints.right  != null && x > constraints.right)  x = constraints.right  + applyElastic(x - constraints.right,  elastic.right);
-            if (constraints.top    != null && y < constraints.top)    y = constraints.top    - applyElastic(constraints.top    - y, elastic.top);
-            if (constraints.bottom != null && y > constraints.bottom) y = constraints.bottom + applyElastic(y - constraints.bottom, elastic.bottom);
+            const clamped = clampToConstraints(x, y, constraints, elastic);
+            x = clamped.x; y = clamped.y;
         }
 
         // Sync drag position into C# state synchronously so ComputeFrame picks it up
@@ -441,6 +528,7 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
     const onUp = (e) => {
         if (!dragging) return;
         dragging = false;
+        _stopObservingConstraintChanges();
         // Report the constraints actually used for this drag so C#'s release logic (momentum
         // clamping / snap-back) uses the same bounds - essential for element-bounds constraints,
         // which only exist in resolved form here.
@@ -465,6 +553,7 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
         el.removeEventListener('pointermove',   onMove);
         el.removeEventListener('pointerup',     onUp);
         el.removeEventListener('pointercancel', onUp);
+        _stopObservingConstraintChanges();
         _dragStarters.delete(elementId);
         el.style.cursor = el.style.userSelect = el.style.touchAction = '';
     });
@@ -536,21 +625,7 @@ function _resolveDragConstraints(cfg, el, curX, curY) {
 
     const cRect = container.getBoundingClientRect();
     const eRect = el.getBoundingClientRect();
-    // The element's layout position with zero transform applied.
-    const baseLeft = eRect.left - curX;
-    const baseTop  = eRect.top  - curY;
-
-    let left   = cRect.left   - baseLeft;
-    let right  = cRect.right  - (baseLeft + eRect.width);
-    let top    = cRect.top    - baseTop;
-    let bottom = cRect.bottom - (baseTop + eRect.height);
-
-    // An element larger than its container inverts the range; collapse to the centered offset
-    // so the drag pins in place instead of oscillating between contradictory bounds.
-    if (right < left) { const mid = (left + right) / 2; left = right = mid; }
-    if (bottom < top) { const mid = (top + bottom) / 2; top = bottom = mid; }
-
-    return { left, right, top, bottom };
+    return resolveConstraintBounds(cRect, eRect, curX, curY);
 }
 
 //
@@ -724,16 +799,57 @@ export function playWaapiFlip(elementId, dx, dy, sx, sy, durationMs, easingStr, 
     const el = document.getElementById(elementId);
     if (!el) return;
     el.style.transformOrigin = '0 0';
+    const timing = { duration: durationMs, easing: easingStr || 'ease', fill: 'forwards' };
     const anim = el.animate(
         [
             { transform: `translate(${dx}px,${dy}px) scaleX(${sx}) scaleY(${sy})` },
             { transform: 'translate(0px,0px) scaleX(1) scaleY(1)' },
         ],
-        { duration: durationMs, easing: easingStr || 'ease', fill: 'forwards' }
+        timing
     );
+
+    // Size-mode correction (plan item 1.2): while the box scales, counter-scale direct children and
+    // correct the border-radius so text/children don't stretch and corners stay round. Position-mode
+    // FLIP passes sx=sy=1, so this whole block is skipped and behaviour is unchanged there.
+    // These end at their natural values, so they use fill:'none' and leave no persistent override.
+    const cleanups = [];
+    if (Math.abs(sx - 1) > 1e-4 || Math.abs(sy - 1) > 1e-4) {
+        const correctTiming = { duration: durationMs, easing: easingStr || 'ease', fill: 'none' };
+
+        const radius = parseFloat(getComputedStyle(el).borderTopLeftRadius) || 0;
+        if (radius > 0) {
+            const r = correctedRadius(radius, sx, sy);
+            el.animate(
+                [
+                    { borderRadius: `${r.fromX}px / ${r.fromY}px` },
+                    { borderRadius: `${radius}px / ${radius}px` },
+                ],
+                correctTiming
+            );
+        }
+
+        // Measure children relative to the (untransformed) parent before the transform takes hold.
+        const pRect = el.getBoundingClientRect();
+        for (const child of el.children) {
+            if (!(child instanceof HTMLElement)) continue;
+            const c = flipChildCorrection(pRect, child.getBoundingClientRect(), sx, sy);
+            const prevOrigin = child.style.transformOrigin;
+            child.style.transformOrigin = `${c.originX}px ${c.originY}px`;
+            child.animate(
+                [
+                    { transform: `scaleX(${c.fromScaleX}) scaleY(${c.fromScaleY})` },
+                    { transform: 'scaleX(1) scaleY(1)' },
+                ],
+                correctTiming
+            );
+            cleanups.push(() => { child.style.transformOrigin = prevOrigin; });
+        }
+    }
+
     anim.onfinish = () => {
         el.style.transform = finalTransform || '';
         el.style.transformOrigin = '';
+        for (const done of cleanups) done();
     };
 }
 
@@ -763,8 +879,8 @@ export function observeScroll(containerId, dotnetRef, options) {
             sW = el.scrollWidth; sH = el.scrollHeight;
             cW = el.clientWidth; cH = el.clientHeight;
         }
-        const pX = sW > cW ? sX / (sW - cW) : 0;
-        const pY = sH > cH ? sY / (sH - cH) : 0;
+        const pX = scrollFraction(sX, sW, cW);
+        const pY = scrollFraction(sY, sH, cH);
 
         // Target progress: 0 when the target sits at the first configured alignment, 1 at the
         // second. Both alignment "distances" shift equally per scrolled pixel, so the current
@@ -807,4 +923,20 @@ export function observeScroll(containerId, dotnetRef, options) {
 export function unobserveScroll(key) {
     _scrollSubs.get(key)?.();
     _scrollSubs.delete(key);
+}
+
+// ── View Transitions API ────────────────────────────────────────────────────
+
+// Wrap document.startViewTransition around a C# DOM-update callback. The callback (invoked by
+// name on the dotnet ref) performs the Blazor state change; the browser snapshots before/after and
+// cross-fades. Falls back to running the callback directly when the API is unsupported.
+export async function startViewTransition(dotnetRef, callbackName) {
+    const runUpdate = () => dotnetRef.invokeMethodAsync(callbackName);
+    if (typeof document.startViewTransition !== 'function') {
+        await runUpdate();
+        return false;
+    }
+    const transition = document.startViewTransition(() => runUpdate());
+    try { await transition.finished; } catch { /* skipped/aborted transition is not an error */ }
+    return true;
 }

--- a/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
+++ b/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
@@ -16,7 +16,7 @@
  */
 
 //
-// Pure drag / scroll math — no DOM access, so it is unit-tested directly (Tests/bit-bmotion-js).
+// Pure drag / scroll math - no DOM access, so it is unit-tested directly (Tests/bit-bmotion-js).
 // The exports are an internal testing surface; the C# interop only calls the named bridge functions.
 //
 
@@ -59,14 +59,14 @@ export function scrollFraction(scroll, size, client) {
 
 /**
  * Layout FLIP child counter-transform (plan item 1.2). The parent element FLIPs with the transform
- * `translate(dx,dy) scale(sx,sy)` about its top-left (origin O). A direct child would ride along —
+ * `translate(dx,dy) scale(sx,sy)` about its top-left (origin O). A direct child would ride along -
  * stretched by the scale AND shifted by the translate. To keep the child crisp and in place, apply
  * the exact inverse of the parent transform about the SAME physical point (the parent's top-left);
  * in the child's own box coordinates that point is (-offsetX, -offsetY).
  *
  * Deriving the inverse: the parent maps x → sx·x + (dx + O(1-sx)). Its inverse, written as a CSS
- * `translate(t) scale(k)` about O, is k = 1/sx and t = -dx/sx. Counter-scaling alone (t = 0) — the
- * previous behaviour — left a residual translation of exactly (dx,dy) on the child, so it visibly
+ * `translate(t) scale(k)` about O, is k = 1/sx and t = -dx/sx. Counter-scaling alone (t = 0) - the
+ * previous behaviour - left a residual translation of exactly (dx,dy) on the child, so it visibly
  * jumped toward the FLIP corner at the start and slid back to centre. Including the -d/s translate
  * cancels that: net is identity at both endpoints, so children stay put and undistorted.
  */
@@ -81,7 +81,7 @@ export function flipChildCorrection(parentRect, childRect, sx, sy, dx = 0, dy = 
 }
 
 /**
- * Border-radius that, once scaled by (sx,sy), renders as the target radius — so corners stay a
+ * Border-radius that, once scaled by (sx,sy), renders as the target radius - so corners stay a
  * constant visual size while the box scales (Motion's border-radius correction). Uses the CSS
  * elliptical `h / v` form so non-uniform scale still yields round corners.
  */
@@ -865,7 +865,7 @@ export function playWaapiFlip(elementId, dx, dy, sx, sy, durationMs, easingStr, 
             const c = flipChildCorrection(pRect, child.getBoundingClientRect(), sx, sy, dx, dy);
             const prevOrigin = child.style.transformOrigin;
             child.style.transformOrigin = `${c.originX}px ${c.originY}px`;
-            // translate first (outermost), then the inverse scale — the exact inverse of the
+            // translate first (outermost), then the inverse scale - the exact inverse of the
             // parent's `translate(dx,dy) scale(sx,sy)`, so the child neither stretches nor jumps.
             child.animate(
                 [

--- a/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
+++ b/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
@@ -502,6 +502,9 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
         !!constraintsCfg && (!!constraintsCfg.parent || typeof constraintsCfg.selector === 'string');
     function _observeConstraintChanges() {
         if (!_needsRemeasure() || typeof ResizeObserver !== 'function') return;
+        // A programmatic begin() can re-arm the observers mid-drag (no intervening onUp); tear the
+        // previous ones down first so repeated begins don't leak observers or duplicate listeners.
+        _stopObservingConstraintChanges();
         _resizeObserver = new ResizeObserver(_remeasure);
         _resizeObserver.observe(el);
         // Observe the SAME container _resolveDragConstraints measures against - the parent element

--- a/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
+++ b/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
@@ -70,7 +70,13 @@ export function scrollFraction(scroll, size, client) {
  * jumped toward the FLIP corner at the start and slid back to centre. Including the -d/s translate
  * cancels that: net is identity at both endpoints, so children stay put and undistorted.
  */
+// FLIP scale factors come from width/height ratios, so they are non-negative; clamp them away
+// from zero so a collapsed (0-sized) start rect can't turn the inverse math into Infinity/NaN.
+const MIN_FLIP_SCALE = 1e-4;
+
 export function flipChildCorrection(parentRect, childRect, sx, sy, dx = 0, dy = 0) {
+    sx = Math.max(sx, MIN_FLIP_SCALE);
+    sy = Math.max(sy, MIN_FLIP_SCALE);
     const offsetX = childRect.left - parentRect.left;
     const offsetY = childRect.top - parentRect.top;
     return {
@@ -86,7 +92,10 @@ export function flipChildCorrection(parentRect, childRect, sx, sy, dx = 0, dy = 
  * elliptical `h / v` form so non-uniform scale still yields round corners.
  */
 export function correctedRadius(radius, sx, sy) {
-    return { fromX: radius / sx, fromY: radius / sy };
+    return {
+        fromX: radius / Math.max(sx, MIN_FLIP_SCALE),
+        fromY: radius / Math.max(sy, MIN_FLIP_SCALE),
+    };
 }
 
 //
@@ -878,11 +887,15 @@ export function playWaapiFlip(elementId, dx, dy, sx, sy, durationMs, easingStr, 
         }
     }
 
-    anim.onfinish = () => {
+    // Run on finish AND cancel: a cancelled flip must not leave the '0 0' transform-origin (or
+    // the children's counter-transform origins) stuck on the elements.
+    const settle = () => {
         el.style.transform = finalTransform || '';
         el.style.transformOrigin = '';
         for (const done of cleanups) done();
     };
+    anim.onfinish = settle;
+    anim.oncancel = settle;
 }
 
 // 
@@ -969,6 +982,12 @@ export async function startViewTransition(dotnetRef, callbackName) {
         return false;
     }
     const transition = document.startViewTransition(() => runUpdate());
-    try { await transition.finished; } catch { /* skipped/aborted transition is not an error */ }
+    try { await transition.finished; }
+    catch {
+        // `finished` also rejects when the C# update callback threw - that IS an error and must
+        // reach the caller. Re-awaiting updateCallbackDone rethrows the callback failure, while a
+        // merely skipped/aborted transition (callback succeeded) resolves and stays swallowed.
+        await transition.updateCallbackDone;
+    }
     return true;
 }

--- a/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
+++ b/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
@@ -504,7 +504,12 @@ function _attachDrag(elementId, el, opts, dotnetRef, cleanups) {
         if (!_needsRemeasure() || typeof ResizeObserver !== 'function') return;
         _resizeObserver = new ResizeObserver(_remeasure);
         _resizeObserver.observe(el);
-        if (el.parentElement) _resizeObserver.observe(el.parentElement);
+        // Observe the SAME container _resolveDragConstraints measures against - the parent element
+        // for { parent: true }, or the selector target (which may be a distant ancestor, not
+        // el.parentElement) for { selector }. Otherwise a mid-drag resize of a selector container
+        // wouldn't re-measure the bounds.
+        const container = constraintsCfg.parent ? el.parentElement : document.querySelector(constraintsCfg.selector);
+        if (container) _resizeObserver.observe(container);
         window.addEventListener('scroll', _remeasure, true);
         window.addEventListener('resize', _remeasure);
     }

--- a/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
+++ b/src/Bmotion/Bit.Bmotion/wwwroot/bit-bmotion.js
@@ -58,16 +58,26 @@ export function scrollFraction(scroll, size, client) {
 }
 
 /**
- * Layout FLIP child counter-scale (plan item 1.2). When a `layout` element scales by (sx,sy) about
- * its top-left, a direct child stretches with it. To keep the child crisp, counter-scale it by the
- * inverse about the SAME physical point (the parent's top-left) — expressed in the child's own box
- * coordinates that point is (-offsetX, -offsetY). Returns the transform-origin and the start
- * (inverse) scale to animate from; the child animates back to scale 1 in lockstep with the parent.
+ * Layout FLIP child counter-transform (plan item 1.2). The parent element FLIPs with the transform
+ * `translate(dx,dy) scale(sx,sy)` about its top-left (origin O). A direct child would ride along —
+ * stretched by the scale AND shifted by the translate. To keep the child crisp and in place, apply
+ * the exact inverse of the parent transform about the SAME physical point (the parent's top-left);
+ * in the child's own box coordinates that point is (-offsetX, -offsetY).
+ *
+ * Deriving the inverse: the parent maps x → sx·x + (dx + O(1-sx)). Its inverse, written as a CSS
+ * `translate(t) scale(k)` about O, is k = 1/sx and t = -dx/sx. Counter-scaling alone (t = 0) — the
+ * previous behaviour — left a residual translation of exactly (dx,dy) on the child, so it visibly
+ * jumped toward the FLIP corner at the start and slid back to centre. Including the -d/s translate
+ * cancels that: net is identity at both endpoints, so children stay put and undistorted.
  */
-export function flipChildCorrection(parentRect, childRect, sx, sy) {
+export function flipChildCorrection(parentRect, childRect, sx, sy, dx = 0, dy = 0) {
     const offsetX = childRect.left - parentRect.left;
     const offsetY = childRect.top - parentRect.top;
-    return { originX: -offsetX, originY: -offsetY, fromScaleX: 1 / sx, fromScaleY: 1 / sy };
+    return {
+        originX: -offsetX, originY: -offsetY,
+        fromScaleX: 1 / sx, fromScaleY: 1 / sy,
+        fromTranslateX: -dx / sx, fromTranslateY: -dy / sy,
+    };
 }
 
 /**
@@ -129,9 +139,15 @@ function _tick(timestamp) {
 // Style helpers
 // 
 
+// SVG geometry presentation attributes are set on the element, not via inline style: the CSS `d`
+// property needs a path() wrapper and isn't universally supported, so setAttribute is the reliable
+// path for shape morphing (`d`) and polygon/polyline morphing (`points`).
+const _svgGeomAttrs = new Set(['d', 'points']);
+
 function _applyStyles(el, styles) {
     for (const prop in styles) {
         if (prop.startsWith('--')) el.style.setProperty(prop, styles[prop]);
+        else if (_svgGeomAttrs.has(prop)) el.setAttribute(prop, styles[prop]);
         else el.style[prop] = styles[prop];
     }
 }
@@ -782,12 +798,26 @@ export function unobserveViewport(elementId) {
 // FLIP layout animation support
 // 
 
-/** Returns the element's DOMRect as a plain object for C# to snapshot. */
+/**
+ * Returns the element's rect in DOCUMENT-relative coordinates (viewport rect + page scroll)
+ * for C# to snapshot.
+ *
+ * FLIP deltas (snap - cur) and the shared-element (LayoutId) registry may capture a rect at
+ * one scroll position and consume it at another - e.g. the user scrolls the page before
+ * clicking a new tab. Raw getBoundingClientRect values are viewport-relative, so the recorded
+ * position goes stale by exactly the scroll amount and the animation starts from the wrong
+ * place. Document coordinates are scroll-invariant, which keeps the FLIP start position correct
+ * across an intervening page scroll. (Widths/heights are unaffected by scrolling.)
+ */
 export function getBoundingRect(elementId) {
     const el = document.getElementById(elementId);
     if (!el) return null;
     const r = el.getBoundingClientRect();
-    return { x: r.x, y: r.y, width: r.width, height: r.height, top: r.top, left: r.left };
+    const sx = window.scrollX, sy = window.scrollY;
+    return {
+        x: r.x + sx, y: r.y + sy, width: r.width, height: r.height,
+        top: r.top + sy, left: r.left + sx,
+    };
 }
 
 /**
@@ -832,13 +862,15 @@ export function playWaapiFlip(elementId, dx, dy, sx, sy, durationMs, easingStr, 
         const pRect = el.getBoundingClientRect();
         for (const child of el.children) {
             if (!(child instanceof HTMLElement)) continue;
-            const c = flipChildCorrection(pRect, child.getBoundingClientRect(), sx, sy);
+            const c = flipChildCorrection(pRect, child.getBoundingClientRect(), sx, sy, dx, dy);
             const prevOrigin = child.style.transformOrigin;
             child.style.transformOrigin = `${c.originX}px ${c.originY}px`;
+            // translate first (outermost), then the inverse scale — the exact inverse of the
+            // parent's `translate(dx,dy) scale(sx,sy)`, so the child neither stretches nor jumps.
             child.animate(
                 [
-                    { transform: `scaleX(${c.fromScaleX}) scaleY(${c.fromScaleY})` },
-                    { transform: 'scaleX(1) scaleY(1)' },
+                    { transform: `translate(${c.fromTranslateX}px,${c.fromTranslateY}px) scaleX(${c.fromScaleX}) scaleY(${c.fromScaleY})` },
+                    { transform: 'translate(0px,0px) scaleX(1) scaleY(1)' },
                 ],
                 correctTiming
             );

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="bunit" Version="1.40.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/BmotionComponentTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/BmotionComponentTests.cs
@@ -101,8 +101,13 @@ public class BmotionComponentTests
             .Add(p => p.Initial, Bm.To(opacity: 0))
             .Add(p => p.ChildContent, Div(style: "opacity:0.7;")));
 
-        // Motion style is emitted first, author's second, so author's opacity wins (last wins).
+        // Motion style is emitted first, author's second, so author's opacity wins (CSS last-wins).
+        // Parse the LAST opacity declaration's value rather than a fragile prefix-substring compare
+        // ("opacity:0" is also a prefix of "opacity:0.7").
         var style = cut.Find("div").GetAttribute("style")!;
-        Assert.IsTrue(style.IndexOf("opacity:0.7", StringComparison.Ordinal) > style.IndexOf("opacity:0", StringComparison.Ordinal));
+        var idx = style.LastIndexOf("opacity:", StringComparison.Ordinal);
+        Assert.IsTrue(idx >= 0, $"expected an opacity declaration in: {style}");
+        var lastOpacity = style[(idx + "opacity:".Length)..].Split(';', 2)[0].Trim();
+        Assert.AreEqual("0.7", lastOpacity, $"authored opacity must be the effective (last) one: {style}");
     }
 }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/BmotionComponentTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/BmotionComponentTests.cs
@@ -1,0 +1,108 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Tests.Components;
+
+/// <summary>
+/// bUnit render/interaction tests for the <see cref="Bmotion"/> component: attribute injection,
+/// authored-id adoption, engine registration and the child-content invariants.
+/// </summary>
+[TestClass]
+public class BmotionComponentTests
+{
+    private static RenderFragment Div(string @class = "box", string? id = null, string? style = null)
+        => b =>
+        {
+            b.OpenElement(0, "div");
+            b.AddAttribute(1, "class", @class);
+            if (id != null) b.AddAttribute(2, "id", id);
+            if (style != null) b.AddAttribute(3, "style", style);
+            b.AddContent(4, "hi");
+            b.CloseElement();
+        };
+
+    [TestMethod]
+    public void Injects_Id_And_InitialStyle_IntoFirstRootElement()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.Initial, Bm.To(opacity: 0))
+            .Add(p => p.ChildContent, Div()));
+
+        var div = cut.Find("div");
+        Assert.AreEqual("box", div.Id);
+        StringAssert.Contains(div.GetAttribute("style"), "opacity");
+        Assert.AreEqual("box", div.GetAttribute("class"));
+    }
+
+    [TestMethod]
+    public void Adopts_AuthoredId_WhenNoIdParameter()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Animate, Bm.To(opacity: 1))
+            .Add(p => p.ChildContent, Div(id: "authored")));
+
+        Assert.AreEqual("authored", cut.Find("div").Id);
+        // The engine must register the adopted id, not a generated one.
+        Assert.IsTrue(ctx.Interop.Calls.Any(c => c.Method == "registerElement" && (string?)c.Args[0] == "authored"));
+    }
+
+    [TestMethod]
+    public void RegistersElement_WithEngine_OnFirstRender()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.Animate, Bm.To(x: 100))
+            .Add(p => p.ChildContent, Div()));
+
+        Assert.IsTrue(ctx.Interop.WasCalled("registerElement"));
+    }
+
+    [TestMethod]
+    public void GeneratesStableId_WhenNoneAuthored()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Animate, Bm.To(opacity: 1))
+            .Add(p => p.ChildContent, Div()));
+
+        var id = cut.Find("div").Id;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(id));
+    }
+
+    [TestMethod]
+    public void Throws_WhenNoChildContent()
+    {
+        using var ctx = new BmotionTestContext();
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            ctx.RenderComponent<Bmotion>(ps => ps.Add(p => p.Animate, Bm.To(x: 1))));
+    }
+
+    [TestMethod]
+    public void Throws_WhenChildContentHasNoRootElement()
+    {
+        using var ctx = new BmotionTestContext();
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            ctx.RenderComponent<Bmotion>(ps => ps
+                .Add(p => p.Animate, Bm.To(x: 1))
+                .Add(p => p.ChildContent, b => b.AddContent(0, "just text"))));
+    }
+
+    [TestMethod]
+    public void AuthoredStyle_WinsOver_MotionStyle_OnConflict()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.Initial, Bm.To(opacity: 0))
+            .Add(p => p.ChildContent, Div(style: "opacity:0.7;")));
+
+        // Motion style is emitted first, author's second, so author's opacity wins (last wins).
+        var style = cut.Find("div").GetAttribute("style")!;
+        Assert.IsTrue(style.IndexOf("opacity:0.7", StringComparison.Ordinal) > style.IndexOf("opacity:0", StringComparison.Ordinal));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/DragEdgesTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/DragEdgesTests.cs
@@ -1,0 +1,52 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Tests.Components;
+
+/// <summary>Tests for the drag-edge improvements (plan item 2.5): the DragPropagation flag wiring.</summary>
+[TestClass]
+public class DragEdgesTests
+{
+    private static RenderFragment Div => b =>
+    {
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", "box");
+        b.CloseElement();
+    };
+
+    private static IReadOnlyDictionary<string, object?> AttachedFlags(FakeBmotionInterop interop)
+    {
+        var call = interop.Calls.First(c => c.Method == "attachEventListeners");
+        return (IReadOnlyDictionary<string, object?>)call.Args[1]!;
+    }
+
+    [TestMethod]
+    public void DragPropagation_True_FlagsPropagation()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.Drag, BmDrag.Both)
+            .Add(p => p.DragPropagation, true)
+            .Add(p => p.ChildContent, Div));
+
+        var flags = AttachedFlags(ctx.Interop);
+        Assert.AreEqual(true, flags["drag"]);
+        Assert.AreEqual(true, flags["dragPropagation"]);
+    }
+
+    [TestMethod]
+    public void DragPropagation_DefaultFalse_OmitsFlag()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.Drag, BmDrag.Both)
+            .Add(p => p.ChildContent, Div));
+
+        var flags = AttachedFlags(ctx.Interop);
+        Assert.IsFalse(flags.ContainsKey("dragPropagation"),
+            "propagation must default off (nested drags isolated) and not emit the flag");
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/DxTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/DxTests.cs
@@ -1,0 +1,67 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Tests.Components;
+
+/// <summary>Tests for the DX improvements (plan item 3.5): cancellation and the immutable-id guard.</summary>
+[TestClass]
+public class DxTests
+{
+    private static RenderFragment Div => b =>
+    {
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", "box");
+        b.CloseElement();
+    };
+
+    [TestMethod]
+    public void ChangingIdAfterFirstRender_IsIgnored()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "first")
+            .Add(p => p.Animate, Bm.To(opacity: 1))
+            .Add(p => p.ChildContent, Div));
+
+        Assert.AreEqual("first", cut.Find("div").Id);
+
+        // Changing Id after first render must be ignored: the id is the engine identity.
+        cut.SetParametersAndRender(ps => ps.Add(p => p.Id, "second"));
+        Assert.AreEqual("first", cut.Find("div").Id);
+    }
+
+    [TestMethod]
+    public async Task AnimateAsync_PreCancelledToken_DoesNotStartOffload()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.ChildContent, Div));
+
+        var before = ctx.Interop.CountOf("playWaapiAnimation") + ctx.Interop.CountOf("supportsLinearEasing");
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await cut.InvokeAsync(() =>
+            cut.Instance.AnimateAsync(Bm.To(opacity: 0.5), Bm.Tween(0.5), cts.Token).AsTask());
+
+        var after = ctx.Interop.CountOf("playWaapiAnimation") + ctx.Interop.CountOf("supportsLinearEasing");
+        Assert.AreEqual(before, after, "a pre-cancelled token must not start the animation");
+    }
+
+    [TestMethod]
+    public async Task AnimateAsync_LiveToken_StartsAnimation()
+    {
+        using var ctx = new BmotionTestContext();
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.ChildContent, Div));
+
+        await cut.InvokeAsync(() =>
+            cut.Instance.AnimateAsync(Bm.To(opacity: 0.5), Bm.Tween(0.5), CancellationToken.None).AsTask());
+
+        // An offload-eligible opacity tween probes the compositor path.
+        Assert.IsTrue(ctx.Interop.WasCalled("supportsLinearEasing") || ctx.Interop.WasCalled("playWaapiAnimation"));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/GestureCallbackTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/GestureCallbackTests.cs
@@ -1,0 +1,89 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Tests.Components;
+
+/// <summary>
+/// Exercises the JS→C# gesture/viewport callback paths (plan item 0.1 breadth) by invoking the
+/// component's [JSInvokable] entry points on the DotNetObjectReference the fake interop captured —
+/// the same call a real browser event would make.
+/// </summary>
+[TestClass]
+public class GestureCallbackTests
+{
+    private static RenderFragment Div => b =>
+    {
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", "box");
+        b.CloseElement();
+    };
+
+    private static Bmotion EventRef(BmotionTestContext ctx, string id) => (Bmotion)ctx.Interop.EventListenerRefs[id];
+    private static Bmotion ViewportRef(BmotionTestContext ctx, string id) => (Bmotion)ctx.Interop.ViewportRefs[id];
+
+    [TestMethod]
+    public async Task PointerEnter_FiresHoverStart()
+    {
+        using var ctx = new BmotionTestContext();
+        var started = false;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.WhileHover, Bm.To(scale: 1.1))
+            .Add(p => p.OnHoverStart, EventCallback.Factory.Create(this, () => started = true))
+            .Add(p => p.ChildContent, Div));
+
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerEnter());
+        Assert.IsTrue(started);
+    }
+
+    [TestMethod]
+    public async Task PointerEnterThenLeave_FiresBothHoverEvents()
+    {
+        using var ctx = new BmotionTestContext();
+        bool started = false, ended = false;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.WhileHover, Bm.To(scale: 1.1))
+            .Add(p => p.OnHoverStart, EventCallback.Factory.Create(this, () => started = true))
+            .Add(p => p.OnHoverEnd, EventCallback.Factory.Create(this, () => ended = true))
+            .Add(p => p.ChildContent, Div));
+
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerEnter());
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerLeave());
+        Assert.IsTrue(started && ended);
+    }
+
+    [TestMethod]
+    public async Task PointerUp_InsideElement_FiresTap_OutsideFiresCancel()
+    {
+        using var ctx = new BmotionTestContext();
+        bool tapped = false, cancelled = false;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.WhileTap, Bm.To(scale: 0.95))
+            .Add(p => p.OnTap, EventCallback.Factory.Create(this, () => tapped = true))
+            .Add(p => p.OnTapCancel, EventCallback.Factory.Create(this, () => cancelled = true))
+            .Add(p => p.ChildContent, Div));
+
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerDown());
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerUp(isInsideElement: true));
+        Assert.IsTrue(tapped);
+        Assert.IsFalse(cancelled);
+    }
+
+    [TestMethod]
+    public async Task Intersect_FiresViewportEnter()
+    {
+        using var ctx = new BmotionTestContext();
+        var entered = false;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.WhileInView, Bm.To(opacity: 1))
+            .Add(p => p.OnViewportEnter, EventCallback.Factory.Create(this, () => entered = true))
+            .Add(p => p.ChildContent, Div));
+
+        await cut.InvokeAsync(() => ViewportRef(ctx, "box").OnIntersect(isIntersecting: true));
+        Assert.IsTrue(entered);
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/GestureCallbackTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/GestureCallbackTests.cs
@@ -6,7 +6,7 @@ namespace Bit.Bmotion.Tests.Components;
 
 /// <summary>
 /// Exercises the JS→C# gesture/viewport callback paths (plan item 0.1 breadth) by invoking the
-/// component's [JSInvokable] entry points on the DotNetObjectReference the fake interop captured —
+/// component's [JSInvokable] entry points on the DotNetObjectReference the fake interop captured -
 /// the same call a real browser event would make.
 /// </summary>
 [TestClass]

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/GestureCallbackTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/GestureCallbackTests.cs
@@ -55,7 +55,7 @@ public class GestureCallbackTests
     }
 
     [TestMethod]
-    public async Task PointerUp_InsideElement_FiresTap_OutsideFiresCancel()
+    public async Task PointerUp_InsideElement_FiresTap_NotCancel()
     {
         using var ctx = new BmotionTestContext();
         bool tapped = false, cancelled = false;
@@ -70,6 +70,25 @@ public class GestureCallbackTests
         await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerUp(isInsideElement: true));
         Assert.IsTrue(tapped);
         Assert.IsFalse(cancelled);
+    }
+
+    [TestMethod]
+    public async Task PointerUp_OutsideElement_FiresCancel_NotTap()
+    {
+        using var ctx = new BmotionTestContext();
+        bool tapped = false, cancelled = false;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.WhileTap, Bm.To(scale: 0.95))
+            .Add(p => p.OnTap, EventCallback.Factory.Create(this, () => tapped = true))
+            .Add(p => p.OnTapCancel, EventCallback.Factory.Create(this, () => cancelled = true))
+            .Add(p => p.ChildContent, Div));
+
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerDown());
+        // Released outside the element (pointer left before release) ⇒ tap cancelled, not fired.
+        await cut.InvokeAsync(() => EventRef(ctx, "box").OnPointerUp(isInsideElement: false));
+        Assert.IsTrue(cancelled);
+        Assert.IsFalse(tapped);
     }
 
     [TestMethod]

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/ReducedMotionTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/ReducedMotionTests.cs
@@ -1,0 +1,77 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Tests.Components;
+
+/// <summary>
+/// Tests for the reduced-motion policy (plan item 1.3): the global <see cref="BmReducedMotionMode"/>
+/// option, OS-preference probing, and the softer selective reduction (transforms snap, opacity/color
+/// still animate).
+/// </summary>
+[TestClass]
+public class ReducedMotionTests
+{
+    private static RenderFragment Div => b =>
+    {
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", "box");
+        b.CloseElement();
+    };
+
+    // ── Selective reduction shape ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void BuildReducedTransition_SnapsBase_ButRetainsOpacityAndColor()
+    {
+        var normal = new BmotionTransitionConfig { Type = BmotionTransitionType.Tween, Duration = 0.5 };
+        var reduced = Bmotion.BuildReducedTransition(normal);
+
+        // Base is instant → transform/layout/dimension props snap.
+        Assert.AreEqual(0, reduced.Duration);
+        Assert.IsNotNull(reduced.Properties);
+        // Retained visual props animate with the normal transition.
+        Assert.AreSame(normal, reduced.Properties["opacity"]);
+        Assert.AreSame(normal, reduced.Properties["color"]);
+        Assert.AreSame(normal, reduced.Properties["backgroundColor"]);
+        // Transform props are NOT retained (they fall back to the instant base).
+        Assert.IsFalse(reduced.Properties.ContainsKey("x"));
+        Assert.IsFalse(reduced.Properties.ContainsKey("scale"));
+    }
+
+    [TestMethod]
+    public void BuildReducedTransition_NullNormal_UsesDefaultForRetained()
+    {
+        var reduced = Bmotion.BuildReducedTransition(null);
+        Assert.AreEqual(0, reduced.Duration);
+        // A default config matches the engine's null-transition fallback, so opacity still animates.
+        Assert.IsNotNull(reduced.Properties!["opacity"]);
+    }
+
+    // ── OS-preference probing wiring ──────────────────────────────────────────
+
+    [TestMethod]
+    public void UserMode_ProbesOsPreference_WithoutConfig()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.Options.ReducedMotion = BmReducedMotionMode.User;
+
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Animate, Bm.To(x: 100))
+            .Add(p => p.ChildContent, Div));
+
+        Assert.IsTrue(ctx.Interop.WasCalled("prefersReducedMotion"));
+    }
+
+    [TestMethod]
+    public void IgnoreUnlessConfigured_DoesNotProbe_WithoutConfig()
+    {
+        using var ctx = new BmotionTestContext(); // default mode = IgnoreUnlessConfigured
+
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Animate, Bm.To(x: 100))
+            .Add(p => p.ChildContent, Div));
+
+        Assert.IsFalse(ctx.Interop.WasCalled("prefersReducedMotion"));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/ReducedMotionTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Components/ReducedMotionTests.cs
@@ -74,4 +74,26 @@ public class ReducedMotionTests
 
         Assert.IsFalse(ctx.Interop.WasCalled("prefersReducedMotion"));
     }
+
+    // ── Programmatic API honours reduced motion ───────────────────────────────
+
+    [TestMethod]
+    public async Task AnimateAsync_ExplicitTransition_RespectsReducedMotion()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.Options.ReducedMotion = BmReducedMotionMode.Always;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Id, "box")
+            .Add(p => p.ChildContent, Div));
+
+        // An explicit transition passed to the imperative API must still be reduced (the transform
+        // snaps) instead of bypassing ShouldReduceMotion() and running the full 1s tween.
+        await cut.InvokeAsync(async () => await cut.Instance.AnimateAsync(Bm.To(x: 100), Bm.Tween(1.0)));
+
+        ctx.Engine.ComputeFrame(0);
+        ctx.Engine.ComputeFrame(16);
+
+        var el = ctx.Engine.GetDiagnostics().Single(d => d.Id == "box");
+        Assert.AreEqual(100.0, el.Transforms["x"], "reduced motion must snap the transform, not animate it");
+    }
 }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/BmPropsCompositionGoldenTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/BmPropsCompositionGoldenTests.cs
@@ -1,0 +1,101 @@
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>
+/// Golden tests pinning the exact transform/CSS output of <see cref="BmProps.ToCssStyleString"/>
+/// and <see cref="BmProps.ToCssStyleDictionary"/>. These lock current behavior so the
+/// single-source-of-truth refactor (plan item 1.4) can route both paths through
+/// <see cref="BmotionTransformComposer"/> without drifting.
+/// </summary>
+[TestClass]
+public class BmPropsCompositionGoldenTests
+{
+    // ── ToCssStyleString: samples the FIRST keyframe ──────────────────────────
+
+    [TestMethod]
+    public void StyleString_Translate2D()
+        => Assert.AreEqual("transform:translate(10px,20px);",
+            new BmProps { X = 10, Y = 20 }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_Translate3D()
+        => Assert.AreEqual("transform:translate3d(10px,20px,30px);",
+            new BmProps { X = 10, Y = 20, Z = 30 }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_UniformScale()
+        => Assert.AreEqual("transform:scale(2);", new BmProps { Scale = 2 }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_ScaleXY()
+        => Assert.AreEqual("transform:scaleX(1.5) scaleY(0.5);",
+            new BmProps { ScaleX = 1.5, ScaleY = 0.5 }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_RotateZAlias_FallsBackToRotate()
+        => Assert.AreEqual("transform:rotate(45deg);", new BmProps { Rotate = 45 }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_RotateZWins()
+        => Assert.AreEqual("transform:rotate(90deg);",
+            new BmProps { Rotate = 45, RotateZ = 90 }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_FullOrdering_PerspectiveFirst()
+        => Assert.AreEqual(
+            "transform:perspective(500px) translate(100px,50px) scale(1.5) rotate(45deg) rotateX(30deg) rotateY(60deg) skewX(15deg) skewY(10deg);",
+            new BmProps
+            {
+                Perspective = 500, X = 100, Y = 50, Scale = 1.5, Rotate = 45,
+                RotateX = 30, RotateY = 60, SkewX = 15, SkewY = 10,
+            }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_FirstKeyframeSampled()
+        => Assert.AreEqual("transform:translate(1px,0px);",
+            new BmProps { X = new BmKeyframes([1, 2, 3]) }.ToCssStyleString());
+
+    [TestMethod]
+    public void StyleString_IncludesOpacityAndOrigin()
+    {
+        var css = new BmProps { X = 5, Opacity = 0.5, OriginX = 0, OriginY = 0.5 }.ToCssStyleString();
+        StringAssert.Contains(css, "transform:translate(5px,0px);");
+        StringAssert.Contains(css, "transform-origin:0% 50%;");
+        StringAssert.Contains(css, "opacity:0.5;");
+    }
+
+    // ── ToCssStyleDictionary: samples the LAST keyframe ───────────────────────
+
+    [TestMethod]
+    public void StyleDict_Translate2D()
+    {
+        var d = new BmProps { X = 10, Y = 20 }.ToCssStyleDictionary();
+        Assert.AreEqual("translate(10px,20px)", d["transform"]);
+    }
+
+    [TestMethod]
+    public void StyleDict_FullOrdering_PerspectiveFirst()
+    {
+        var d = new BmProps
+        {
+            Perspective = 500, X = 100, Y = 50, Scale = 1.5, Rotate = 45,
+            RotateX = 30, RotateY = 60, SkewX = 15, SkewY = 10,
+        }.ToCssStyleDictionary();
+        Assert.AreEqual(
+            "perspective(500px) translate(100px,50px) scale(1.5) rotate(45deg) rotateX(30deg) rotateY(60deg) skewX(15deg) skewY(10deg)",
+            d["transform"]);
+    }
+
+    [TestMethod]
+    public void StyleDict_LastKeyframeSampled()
+    {
+        var d = new BmProps { X = new BmKeyframes([1, 2, 3]) }.ToCssStyleDictionary();
+        Assert.AreEqual("translate(3px,0px)", d["transform"]);
+    }
+
+    [TestMethod]
+    public void StyleDict_ScaleXY()
+    {
+        var d = new BmProps { ScaleX = 1.5, ScaleY = 0.5 }.ToCssStyleDictionary();
+        Assert.AreEqual("scaleX(1.5) scaleY(0.5)", d["transform"]);
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/BmPropsCompositionGoldenTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/BmPropsCompositionGoldenTests.cs
@@ -98,4 +98,24 @@ public class BmPropsCompositionGoldenTests
         var d = new BmProps { ScaleX = 1.5, ScaleY = 0.5 }.ToCssStyleDictionary();
         Assert.AreEqual("scaleX(1.5) scaleY(0.5)", d["transform"]);
     }
+
+    // ── SVG `d` is an attribute, not a CSS property ───────────────────────────
+
+    [TestMethod]
+    public void StyleString_ExcludesSvgD()
+    {
+        // `d` in an inline style string is invalid CSS (needs a path() wrapper); it must not appear.
+        // Other string props are unaffected.
+        var css = new BmProps { D = "M0 0 L10 10", Left = "5px" }.ToCssStyleString();
+        StringAssert.Contains(css, "left:5px;");
+        Assert.IsFalse(css.Contains("d:"), $"d must be omitted from the inline style string: {css}");
+    }
+
+    [TestMethod]
+    public void StyleDict_IncludesSvgD_ForSetAttribute()
+    {
+        // The instant-set dictionary keeps `d`; JS applies it via setAttribute (_svgGeomAttrs).
+        var d = new BmProps { D = "M0 0 L10 10" }.ToCssStyleDictionary();
+        Assert.AreEqual("M0 0 L10 10", d["d"]);
+    }
 }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CapabilitiesTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CapabilitiesTests.cs
@@ -1,0 +1,69 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Microsoft.Extensions.Logging;
+
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>Tests for the Blazor Server capability flags + degradation warning (plan item 1.1, stage 1).</summary>
+[TestClass]
+public class CapabilitiesTests
+{
+    [TestMethod]
+    public void Capabilities_ReflectInteropMode()
+    {
+        var wasm = new BmotionCapabilities(new FakeBmotionInterop { IsInProcess = true });
+        Assert.IsTrue(wasm.SupportsFrameLoop);
+        Assert.IsTrue(wasm.SupportsCompositor);
+
+        var server = new BmotionCapabilities(new FakeBmotionInterop { IsInProcess = false });
+        Assert.IsFalse(server.SupportsFrameLoop);
+        Assert.IsTrue(server.SupportsCompositor, "compositor works on Server via async interop");
+    }
+
+    [TestMethod]
+    public async Task Server_NonOffloadableAnimation_LogsDegradationWarningOnce()
+    {
+        var interop = new FakeBmotionInterop { IsInProcess = false, SupportsLinearEasing = false };
+        var logger = new ListLogger<BmotionAnimationEngine>();
+        var engine = new BmotionAnimationEngine(interop, logger);
+        engine.RegisterElement("el", null);
+
+        // A color animation is never compositor-eligible, so on Server it degrades to instant.
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["backgroundColor"] = "#ff0000" },
+            Bm.Tween(0.5).ToConfig());
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["backgroundColor"] = "#00ff00" },
+            Bm.Tween(0.5).ToConfig());
+
+        var warnings = logger.Warnings.Count(w => w.Contains("instant change on Blazor Server"));
+        Assert.AreEqual(1, warnings, "degradation should warn exactly once");
+    }
+
+    [TestMethod]
+    public async Task Wasm_DoesNotWarn()
+    {
+        var interop = new FakeBmotionInterop { IsInProcess = true };
+        var logger = new ListLogger<BmotionAnimationEngine>();
+        var engine = new BmotionAnimationEngine(interop, logger);
+        engine.RegisterElement("el", null);
+
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["backgroundColor"] = "#ff0000" },
+            Bm.Tween(0.5).ToConfig());
+
+        Assert.IsFalse(logger.Warnings.Any(w => w.Contains("Blazor Server")));
+    }
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<string> Warnings { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning) Warnings.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CssValidatorTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CssValidatorTests.cs
@@ -1,0 +1,78 @@
+using Bit.Bmotion.Tests.TestInfra;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>Tests for the opt-in CSS-injection safe mode (plan item 3.4).</summary>
+[TestClass]
+public class CssValidatorTests
+{
+    // ── The validator ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    [DataRow("red")]
+    [DataRow("#ff0000")]
+    [DataRow("rgba(255, 0, 0, 0.5)")]
+    [DataRow("50%")]
+    [DataRow("2rem")]
+    [DataRow("0 4px 8px rgba(0,0,0,0.2)")]
+    [DataRow("blur(8px) brightness(1.2)")]
+    [DataRow(null)]
+    [DataRow("")]
+    public void IsSafe_AllowsLegitimateValues(string? value)
+        => Assert.IsTrue(BmotionCssValidator.IsSafe(value));
+
+    [TestMethod]
+    [DataRow("red; } body{display:none")]
+    [DataRow("red;")]
+    [DataRow("url(javascript:alert(1))")]
+    [DataRow("expression(alert(1))")]
+    [DataRow("red /* comment */")]
+    [DataRow("</style>")]
+    [DataRow("@import 'x'")]
+    [DataRow("red\n color:blue")]
+    public void IsSafe_RejectsInjection(string value)
+        => Assert.IsFalse(BmotionCssValidator.IsSafe(value));
+
+    // ── Integration with the component ────────────────────────────────────────
+
+    private static RenderFragment Div => b =>
+    {
+        b.OpenElement(0, "div");
+        b.CloseElement();
+    };
+
+    [TestMethod]
+    public void ThrowMode_RejectsInjectedValue()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.Options.CssSafeMode = BmCssSafeMode.Throw;
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            ctx.RenderComponent<Bmotion>(ps => ps
+                .Add(p => p.Animate, Bm.To(backgroundColor: "red; } body{display:none"))
+                .Add(p => p.ChildContent, Div)));
+    }
+
+    [TestMethod]
+    public void OffMode_AllowsAnyValue()
+    {
+        using var ctx = new BmotionTestContext(); // default Off
+        // Should not throw even with a dangerous value.
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Animate, Bm.To(backgroundColor: "red; } body{display:none"))
+            .Add(p => p.ChildContent, Div));
+    }
+
+    [TestMethod]
+    public void ThrowMode_AllowsCleanValue()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.Options.CssSafeMode = BmCssSafeMode.Throw;
+        // A legitimate color must pass.
+        ctx.RenderComponent<Bmotion>(ps => ps
+            .Add(p => p.Animate, Bm.To(backgroundColor: "#ff0000"))
+            .Add(p => p.ChildContent, Div));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CssValidatorTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CssValidatorTests.cs
@@ -80,4 +80,16 @@ public class CssValidatorTests
             .Add(p => p.Animate, Bm.To(backgroundColor: "#ff0000"))
             .Add(p => p.ChildContent, Div));
     }
+
+    [TestMethod]
+    public void ThrowMode_ProgrammaticSet_RejectsInjectedValue()
+    {
+        using var ctx = new BmotionTestContext();
+        ctx.Options.CssSafeMode = BmCssSafeMode.Throw;
+        var cut = ctx.RenderComponent<Bmotion>(ps => ps.Add(p => p.ChildContent, Div));
+
+        // The imperative API must enforce safe mode just like the declarative Animate path.
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            cut.Instance.Set(Bm.To(backgroundColor: "red; } body{display:none")));
+    }
 }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CssValidatorTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/CssValidatorTests.cs
@@ -1,4 +1,4 @@
-using Bit.Bmotion.Tests.TestInfra;
+﻿using Bit.Bmotion.Tests.TestInfra;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 
@@ -32,6 +32,11 @@ public class CssValidatorTests
     [DataRow("</style>")]
     [DataRow("@import 'x'")]
     [DataRow("red\n color:blue")]
+    [DataRow("url(\\6A avascript:alert(1))")] // CSS-escaped "javascript:"
+    [DataRow("\\3C /style\\3E")]              // CSS-escaped "</style>"
+    [DataRow("red\\;")]
+    [DataRow("red\0blue")]
+    [DataRow("red\tblue")]
     public void IsSafe_RejectsInjection(string value)
         => Assert.IsFalse(BmotionCssValidator.IsSafe(value));
 

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/DiagnosticsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/DiagnosticsTests.cs
@@ -49,8 +49,7 @@ public class DiagnosticsTests
         engine.RegisterElement("el", new Dictionary<string, object?> { ["x"] = 1.0 });
 
         var first = engine.GetDiagnostics()[0];
-        // Mutating the snapshot must not affect the engine; a later snapshot is independent.
-        Assert.IsFalse(first.Transforms is Dictionary<string, double> live && ReferenceEquals(live, first.Transforms) && live.Count == 0);
+        // A later registration must not mutate an earlier snapshot: it captured its own copy.
         engine.RegisterElement("el2", null);
         Assert.AreEqual(1, first.Transforms.Count, "earlier snapshot must be unaffected by later registrations");
     }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/DiagnosticsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/DiagnosticsTests.cs
@@ -28,7 +28,8 @@ public class DiagnosticsTests
     [TestMethod]
     public async Task GetDiagnostics_ShowsActiveDriversWhileAnimating()
     {
-        // Server mode (no compositor for color) keeps a rAF driver on the engine so it stays active.
+        // In-process/WASM engine: color properties never offload to the compositor, so a rAF
+        // driver stays active on the engine and the diagnostics report it mid-animation.
         var engine = NewEngine(inProcess: true);
         engine.RegisterElement("el", null);
 

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/DiagnosticsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/DiagnosticsTests.cs
@@ -1,0 +1,61 @@
+using Bit.Bmotion.Tests.TestInfra;
+
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>Tests for the engine diagnostics snapshot behind &lt;BmotionInspector&gt; (plan item 3.5).</summary>
+[TestClass]
+public class DiagnosticsTests
+{
+    private static BmotionAnimationEngine NewEngine(bool inProcess = true)
+        => new(new FakeBmotionInterop { IsInProcess = inProcess });
+
+    [TestMethod]
+    public void GetDiagnostics_ReportsRegisteredElementsAndSeededValues()
+    {
+        var engine = NewEngine();
+        engine.RegisterElement("el", new Dictionary<string, object?> { ["x"] = 10.0, ["opacity"] = 0.5 });
+
+        var diag = engine.GetDiagnostics();
+        Assert.AreEqual(1, diag.Count);
+        var el = diag[0];
+        Assert.AreEqual("el", el.Id);
+        Assert.AreEqual(10.0, el.Transforms["x"]);
+        Assert.AreEqual(0.5, el.NumericValues["opacity"]);
+        Assert.IsFalse(el.HasActiveAnimations);
+        Assert.AreEqual(0, el.ActiveDriverCount);
+    }
+
+    [TestMethod]
+    public async Task GetDiagnostics_ShowsActiveDriversWhileAnimating()
+    {
+        // Server mode (no compositor for color) keeps a rAF driver on the engine so it stays active.
+        var engine = NewEngine(inProcess: true);
+        engine.RegisterElement("el", null);
+
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["backgroundColor"] = "#ff0000" },
+            Bm.Tween(1.0).ToConfig());
+
+        var el = engine.GetDiagnostics().Single(d => d.Id == "el");
+        Assert.IsTrue(el.HasActiveAnimations);
+        Assert.IsTrue(el.ActiveProperties.Contains("backgroundColor"));
+        Assert.IsTrue(el.ActiveDriverCount >= 1);
+    }
+
+    [TestMethod]
+    public void GetDiagnostics_ReturnsSnapshotCopies_NotLiveDictionaries()
+    {
+        var engine = NewEngine();
+        engine.RegisterElement("el", new Dictionary<string, object?> { ["x"] = 1.0 });
+
+        var first = engine.GetDiagnostics()[0];
+        // Mutating the snapshot must not affect the engine; a later snapshot is independent.
+        Assert.IsFalse(first.Transforms is Dictionary<string, double> live && ReferenceEquals(live, first.Transforms) && live.Count == 0);
+        engine.RegisterElement("el2", null);
+        Assert.AreEqual(1, first.Transforms.Count, "earlier snapshot must be unaffected by later registrations");
+    }
+
+    [TestMethod]
+    public void GetDiagnostics_Empty_WhenNothingRegistered()
+        => Assert.AreEqual(0, NewEngine().GetDiagnostics().Count);
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/EasingPresetsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/EasingPresetsTests.cs
@@ -1,0 +1,142 @@
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>
+/// Tests for the expanded easing presets (plan item 2.2): Sine/Quad/Quart/Quint/Expo/Elastic/Bounce
+/// and stepped easings, plus their compositor (CSS/linear) representations.
+/// </summary>
+[TestClass]
+public class EasingPresetsTests
+{
+    private const double Tol = 1e-6;
+
+    private static Func<double, double> Ease(BmEase e) => BmEaseFunctions.Get(e);
+
+    [TestMethod]
+    [DataRow(BmEase.SineIn)]
+    [DataRow(BmEase.SineOut)]
+    [DataRow(BmEase.SineInOut)]
+    [DataRow(BmEase.QuadIn)]
+    [DataRow(BmEase.QuadOut)]
+    [DataRow(BmEase.QuadInOut)]
+    [DataRow(BmEase.QuartIn)]
+    [DataRow(BmEase.QuartOut)]
+    [DataRow(BmEase.QuartInOut)]
+    [DataRow(BmEase.QuintIn)]
+    [DataRow(BmEase.QuintOut)]
+    [DataRow(BmEase.QuintInOut)]
+    [DataRow(BmEase.ExpoIn)]
+    [DataRow(BmEase.ExpoOut)]
+    [DataRow(BmEase.ExpoInOut)]
+    [DataRow(BmEase.ElasticIn)]
+    [DataRow(BmEase.ElasticOut)]
+    [DataRow(BmEase.ElasticInOut)]
+    [DataRow(BmEase.BounceIn)]
+    [DataRow(BmEase.BounceOut)]
+    [DataRow(BmEase.BounceInOut)]
+    public void AllPresets_HitEndpoints(BmEase e)
+    {
+        var f = Ease(e);
+        Assert.AreEqual(0, f(0), Tol, $"{e} at 0");
+        Assert.AreEqual(1, f(1), Tol, $"{e} at 1");
+    }
+
+    [TestMethod]
+    public void PowerCurves_MatchReferenceValues()
+    {
+        Assert.AreEqual(0.25, Ease(BmEase.QuadIn)(0.5), Tol);
+        Assert.AreEqual(0.75, Ease(BmEase.QuadOut)(0.5), Tol);
+        Assert.AreEqual(0.0625, Ease(BmEase.QuartIn)(0.5), Tol);
+        Assert.AreEqual(0.03125, Ease(BmEase.QuintIn)(0.5), Tol);
+        Assert.AreEqual(0.5, Ease(BmEase.SineInOut)(0.5), Tol);
+    }
+
+    [TestMethod]
+    public void Elastic_And_Bounce_OvershootWithinBounds()
+    {
+        // Bounce is always within [0,1]; elastic overshoots but starts/ends clamped.
+        for (double t = 0; t <= 1.0001; t += 0.05)
+        {
+            var b = Ease(BmEase.BounceOut)(t);
+            Assert.IsTrue(b >= -Tol && b <= 1 + Tol, $"bounce {t}={b}");
+        }
+        // ElasticOut overshoots above 1 somewhere in the middle.
+        var peak = 0.0;
+        for (double t = 0; t <= 1; t += 0.01) peak = Math.Max(peak, Ease(BmEase.ElasticOut)(t));
+        Assert.IsTrue(peak > 1.0, "elastic-out should overshoot past 1");
+    }
+
+    // ── Steps ─────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Steps_JumpEnd_Staircase()
+    {
+        var f = BmEaseFunctions.Steps(4, BmStepJump.End);
+        Assert.AreEqual(0, f(0), Tol);
+        Assert.AreEqual(0, f(0.24), Tol);
+        Assert.AreEqual(0.25, f(0.25), Tol);
+        Assert.AreEqual(0.5, f(0.5), Tol);
+        Assert.AreEqual(0.75, f(0.99), Tol);
+        Assert.AreEqual(1, f(1), Tol);
+    }
+
+    [TestMethod]
+    public void Steps_JumpStart_JumpsImmediately()
+    {
+        var f = BmEaseFunctions.Steps(4, BmStepJump.Start);
+        Assert.AreEqual(0, f(0), Tol);
+        Assert.AreEqual(0.25, f(0.01), Tol);
+        Assert.AreEqual(1, f(1), Tol);
+    }
+
+    [TestMethod]
+    public void Steps_JumpNone_ReachesBothEnds()
+    {
+        var f = BmEaseFunctions.Steps(5, BmStepJump.None);
+        Assert.AreEqual(0, f(0), Tol);
+        Assert.AreEqual(0.25, f(0.25), Tol); // floor(1.25)/4 = 1/4
+        Assert.AreEqual(1, f(1), Tol);
+    }
+
+    [TestMethod]
+    public void Steps_JumpBoth_OffsetsBothEnds()
+    {
+        var f = BmEaseFunctions.Steps(4, BmStepJump.Both);
+        Assert.AreEqual(0.2, f(0), Tol);   // 1/(4+1)
+        Assert.AreEqual(1, f(1), Tol);
+    }
+
+    [TestMethod]
+    public void Steps_ConfiguredViaTween_OverridesEase()
+    {
+        var config = Bm.Tween(steps: 3, stepJump: BmStepJump.End).ToConfig();
+        Assert.AreEqual(3, config.StepCount);
+        var f = BmEaseFunctions.Get(config);
+        Assert.AreEqual(0, f(0), Tol);
+        Assert.AreEqual(1.0 / 3, f(0.4), Tol);
+    }
+
+    // ── CSS / compositor representation ───────────────────────────────────────
+
+    [TestMethod]
+    public void ToCssString_Steps_EmitsCssSteps()
+    {
+        Assert.AreEqual("steps(3,jump-end)", BmEaseFunctions.ToCssString(Bm.Tween(steps: 3).ToConfig()));
+        Assert.AreEqual("steps(3,jump-start)", BmEaseFunctions.ToCssString(Bm.Tween(steps: 3, stepJump: BmStepJump.Start).ToConfig()));
+    }
+
+    [TestMethod]
+    public void ToCssString_PowerCurves_EmitCubicBezier()
+    {
+        Assert.AreEqual("cubic-bezier(0.37,0,0.63,1)",
+            BmEaseFunctions.ToCssString(Bm.Tween(ease: BmEase.SineInOut).ToConfig()));
+    }
+
+    [TestMethod]
+    public void HasFaithfulCssEasing_FalseOnlyForElasticAndBounce()
+    {
+        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.SineInOut).ToConfig()));
+        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(steps: 4).ToConfig()));
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.ElasticOut).ToConfig()));
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.BounceInOut).ToConfig()));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/EasingPresetsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/EasingPresetsTests.cs
@@ -125,6 +125,17 @@ public class EasingPresetsTests
     }
 
     [TestMethod]
+    public void ToCssString_SingleStepJumpNone_NormalizesToJumpEnd()
+    {
+        // steps(1,jump-none) is invalid CSS; a single step is identical to jump-end at runtime.
+        Assert.AreEqual("steps(1,jump-end)",
+            BmEaseFunctions.ToCssString(Bm.Tween(steps: 1, stepJump: BmStepJump.None).ToConfig()));
+        // >= 2 steps keep jump-none (valid CSS).
+        Assert.AreEqual("steps(2,jump-none)",
+            BmEaseFunctions.ToCssString(Bm.Tween(steps: 2, stepJump: BmStepJump.None).ToConfig()));
+    }
+
+    [TestMethod]
     public void ToCssString_PowerCurves_EmitCubicBezier()
     {
         Assert.AreEqual("cubic-bezier(0.37,0,0.63,1)",
@@ -132,10 +143,22 @@ public class EasingPresetsTests
     }
 
     [TestMethod]
-    public void HasFaithfulCssEasing_FalseOnlyForElasticAndBounce()
+    public void HasFaithfulCssEasing_TrueOnlyForExactCssCurves()
     {
-        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.SineInOut).ToConfig()));
+        // Faithful: keyword/back presets, explicit bezier, and steps (ToCssString reproduces them exactly).
+        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.Linear).ToConfig()));
+        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.InOut).ToConfig()));
+        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.BackOut).ToConfig()));
+        Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(bezier: [0.1, 0.2, 0.3, 0.4]).ToConfig()));
         Assert.IsTrue(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(steps: 4).ToConfig()));
+
+        // NOT faithful: these serialize as APPROXIMATE cubic-beziers while the runtime uses exact
+        // math, so offloading their CSS curve would drift from the rAF result.
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.SineInOut).ToConfig()));
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.QuartOut).ToConfig()));
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.ExpoIn).ToConfig()));
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.CircInOut).ToConfig()));
+        Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.Anticipate).ToConfig()));
         Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.ElasticOut).ToConfig()));
         Assert.IsFalse(BmEaseFunctions.HasFaithfulCssEasing(Bm.Tween(ease: BmEase.BounceInOut).ToConfig()));
     }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/EngineFrameTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/EngineFrameTests.cs
@@ -1,0 +1,104 @@
+using Bit.Bmotion.Tests.TestInfra;
+
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>
+/// Drives the engine's <see cref="BmotionAnimationEngine.ComputeFrame"/> tick directly with
+/// synthetic timestamps (plan item 0.1 - engine concurrency) to pin the highest-risk behaviours:
+/// per-frame progression, natural completion, and interruption folding a running animation back
+/// into state without raising its completion callback.
+/// </summary>
+[TestClass]
+public class EngineFrameTests
+{
+    private static BmotionAnimationEngine NewEngine()
+        => new(new FakeBmotionInterop { IsInProcess = true });
+
+    // Colors never offload to the compositor, so they stay on the rAF path we can tick by hand.
+    private static readonly Dictionary<string, object?> ToRed = new() { ["backgroundColor"] = "#ff0000" };
+
+    private static string? ColorOf(Dictionary<string, Dictionary<string, string>>? frame, string id)
+        => frame is not null && frame.TryGetValue(id, out var s) && s.TryGetValue("backgroundColor", out var c) ? c : null;
+
+    [TestMethod]
+    public async Task Frame_ProgressesAColorTween_AndCompletesNaturally()
+    {
+        var engine = NewEngine();
+        engine.RegisterElement("el", new Dictionary<string, object?> { ["backgroundColor"] = "#000000" });
+
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await engine.AnimateToAsync("el", ToRed, Bm.Tween(0.1).ToConfig(),
+            onComplete: () => { done.TrySetResult(); return Task.CompletedTask; });
+
+        engine.ComputeFrame(0);                    // seeds start time, applies the from-color
+        var mid = engine.ComputeFrame(50);         // ~halfway
+        Assert.IsNotNull(ColorOf(mid, "el"), "the color tween should emit a frame value");
+
+        engine.ComputeFrame(100);                  // reaches the target
+        engine.ComputeFrame(101);                  // settles / resolves the completion batch
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.IsTrue(done.Task.IsCompletedSuccessfully, "a tween that runs to its end completes naturally");
+    }
+
+    [TestMethod]
+    public async Task Interruption_FoldsRunningAnimation_WithoutRaisingItsCompletion()
+    {
+        var engine = NewEngine();
+        engine.RegisterElement("el", new Dictionary<string, object?> { ["backgroundColor"] = "#000000" });
+
+        var firstCompleted = false;
+        await engine.AnimateToAsync("el", ToRed, Bm.Tween(0.5).ToConfig(),
+            onComplete: () => { firstCompleted = true; return Task.CompletedTask; });
+
+        engine.ComputeFrame(0);
+        engine.ComputeFrame(100); // 20% through the first animation
+
+        // Interrupt with a new animation on the same property before the first finishes.
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["backgroundColor"] = "#00ff00" },
+            Bm.Tween(0.1).ToConfig());
+
+        engine.ComputeFrame(150);
+        engine.ComputeFrame(260); // let the second animation finish
+
+        await Task.Delay(50); // give any (incorrect) continuation a chance to run
+        Assert.IsFalse(firstCompleted, "a superseded animation must not raise OnAnimationComplete");
+    }
+
+    [TestMethod]
+    public async Task Frame_IsIdle_WhenNothingIsAnimating_AndAfterCompletion()
+    {
+        var engine = NewEngine();
+        engine.RegisterElement("el", null); // no seeded values ⇒ nothing to flush
+
+        // No animation started → an idle tick produces no updates.
+        Assert.IsNull(engine.ComputeFrame(0));
+
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await engine.AnimateToAsync("el", ToRed, Bm.Tween(0.05).ToConfig(),
+            onComplete: () => { done.TrySetResult(); return Task.CompletedTask; });
+
+        engine.ComputeFrame(0);
+        engine.ComputeFrame(60); // finishes
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // The element is no longer animating once the tween has settled.
+        Assert.IsFalse(engine.GetDiagnostics().Single(d => d.Id == "el").HasActiveAnimations);
+    }
+
+    [TestMethod]
+    public async Task Stop_HaltsAnAnimationMidFlight()
+    {
+        var engine = NewEngine();
+        engine.RegisterElement("el", new Dictionary<string, object?> { ["backgroundColor"] = "#000000" });
+
+        await engine.AnimateToAsync("el", ToRed, Bm.Tween(1.0).ToConfig());
+        engine.ComputeFrame(0);
+        engine.ComputeFrame(100);
+
+        engine.Stop("el", null);
+        var after = engine.GetDiagnostics().Single(d => d.Id == "el");
+        Assert.IsFalse(after.HasActiveAnimations, "Stop() must halt the running driver");
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/IndividualTransformTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/IndividualTransformTests.cs
@@ -1,0 +1,66 @@
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>
+/// Tests for the individual CSS transform-property emit mode (plan item 2.1 core:
+/// <see cref="BmotionTransformComposer.BuildIndividual"/>).
+/// </summary>
+[TestClass]
+public class IndividualTransformTests
+{
+    [TestMethod]
+    public void Translate_ScaleUniform_Rotate_EmitAsIndividualProps()
+    {
+        var d = BmotionTransformComposer.BuildIndividual(new()
+        {
+            ["x"] = 10, ["y"] = 20, ["scale"] = 2, ["rotate"] = 45,
+        });
+        Assert.AreEqual("10px 20px", d["translate"]);
+        Assert.AreEqual("2", d["scale"]);
+        Assert.AreEqual("45deg", d["rotate"]);
+        Assert.IsFalse(d.ContainsKey("transform")); // nothing needs composing
+    }
+
+    [TestMethod]
+    public void Translate3D_UsesThreeComponents()
+    {
+        var d = BmotionTransformComposer.BuildIndividual(new() { ["x"] = 1, ["y"] = 2, ["z"] = 3 });
+        Assert.AreEqual("1px 2px 3px", d["translate"]);
+    }
+
+    [TestMethod]
+    public void PerAxisScale_EmitsBothFactors()
+    {
+        var d = BmotionTransformComposer.BuildIndividual(new() { ["scaleX"] = 1.5, ["scaleY"] = 0.5 });
+        Assert.AreEqual("1.5 0.5", d["scale"]);
+    }
+
+    [TestMethod]
+    public void NonIndividualComponents_StayComposedInTransform()
+    {
+        var d = BmotionTransformComposer.BuildIndividual(new()
+        {
+            ["x"] = 10, ["skewX"] = 15, ["rotateY"] = 30, ["perspective"] = 500,
+        });
+        Assert.AreEqual("10px 0px", d["translate"]);
+        // rotateY/skewX/perspective have no individual property → composed, perspective first.
+        Assert.AreEqual("perspective(500px) rotateY(30deg) skewX(15deg)", d["transform"]);
+    }
+
+    [TestMethod]
+    public void IdentityComponents_AreOmitted()
+    {
+        var d = BmotionTransformComposer.BuildIndividual(new() { ["x"] = 0, ["scale"] = 1, ["rotate"] = 0 });
+        Assert.AreEqual(0, d.Count);
+    }
+
+    [TestMethod]
+    [DataRow("x", true)]
+    [DataRow("scale", true)]
+    [DataRow("rotate", true)]
+    [DataRow("rotateZ", true)]
+    [DataRow("skewX", false)]
+    [DataRow("rotateX", false)]
+    [DataRow("perspective", false)]
+    public void IsIndividualProp_Classifies(string key, bool expected)
+        => Assert.AreEqual(expected, BmotionTransformComposer.IsIndividualProp(key));
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/KeyframeOffloadTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/KeyframeOffloadTests.cs
@@ -1,0 +1,119 @@
+using Bit.Bmotion.Tests.TestInfra;
+
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>
+/// Tests for multi-keyframe compositor offload (plan item 1.1 widening): the interruption-mirror
+/// math and that eligible keyframe animations reach the compositor with N keyframes.
+/// </summary>
+[TestClass]
+public class KeyframeOffloadTests
+{
+    // ── Mirror interpolation (interruption-critical) ──────────────────────────
+
+    [TestMethod]
+    public void KeyframeLerp_HitsEndpointsAndMidpoints()
+    {
+        double[] f = [1, 2, 1]; // pulse
+        Assert.AreEqual(1, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, 0), 1e-9);
+        Assert.AreEqual(2, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, 0.5), 1e-9);
+        Assert.AreEqual(1, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, 1), 1e-9);
+        Assert.AreEqual(1.5, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, 0.25), 1e-9); // first segment
+        Assert.AreEqual(1.5, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, 0.75), 1e-9); // second segment
+    }
+
+    [TestMethod]
+    public void KeyframeLerp_ClampsOutOfRangeProgress()
+    {
+        double[] f = [0, 10];
+        Assert.AreEqual(0, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, -0.5), 1e-9);
+        Assert.AreEqual(10, BmotionElementAnimationState.WaapiPlan.KeyframeLerp(f, 1.5), 1e-9);
+    }
+
+    [TestMethod]
+    public void KeyframeLerp_SingleFrame_IsConstant()
+        => Assert.AreEqual(7, BmotionElementAnimationState.WaapiPlan.KeyframeLerp([7], 0.3), 1e-9);
+
+    // ── Integration: eligibility ──────────────────────────────────────────────
+
+    private static (BmotionAnimationEngine engine, FakeBmotionInterop interop) NewEngine()
+    {
+        var interop = new FakeBmotionInterop { IsInProcess = true, SupportsLinearEasing = true };
+        return (new BmotionAnimationEngine(interop), interop);
+    }
+
+    private static object[]? OffloadedKeyframes(FakeBmotionInterop interop)
+    {
+        var call = interop.Calls.LastOrDefault(c => c.Method == "playWaapiAnimation");
+        return call is null ? null : (object[])call.Args[2]!;
+    }
+
+    [TestMethod]
+    public async Task KeyframeTransform_OffloadsWithNKeyframes()
+    {
+        var (engine, interop) = NewEngine();
+        engine.RegisterElement("el", null);
+
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["scale"] = new double[] { 1, 1.4, 0.8, 1 } },
+            Bm.Tween(0.6).ToConfig());
+
+        var kf = OffloadedKeyframes(interop);
+        Assert.IsNotNull(kf, "an eligible keyframe transform should offload to the compositor");
+        Assert.AreEqual(4, kf!.Length, "one WAAPI keyframe per array frame");
+    }
+
+    [TestMethod]
+    public async Task ScalarPlusKeyframe_AlignOntoCommonGrid()
+    {
+        var (engine, interop) = NewEngine();
+        engine.RegisterElement("el", null);
+
+        // opacity is a scalar (2 frames); y is a 3-frame keyframe → both align to 3 keyframes.
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["opacity"] = 0.5, ["y"] = new double[] { 0, -20, 0 } },
+            Bm.Tween(0.5).ToConfig());
+
+        var kf = OffloadedKeyframes(interop);
+        Assert.IsNotNull(kf);
+        Assert.AreEqual(3, kf!.Length);
+    }
+
+    [TestMethod]
+    public async Task MixedKeyframeLengths_StayOnRafPath()
+    {
+        var (engine, interop) = NewEngine();
+        engine.RegisterElement("el", null);
+
+        // x has 2 frames, scale has 3 → mismatched keyframe lengths → not offloaded.
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?>
+            {
+                ["x"] = new double[] { 0, 100 },
+                ["scale"] = new double[] { 1, 2, 1 },
+            },
+            Bm.Tween(0.5).ToConfig());
+
+        Assert.IsNull(OffloadedKeyframes(interop), "mixed keyframe lengths must fall back to rAF");
+    }
+
+    [TestMethod]
+    public async Task InterruptingKeyframeOffload_RealizesMidKeyframeValue()
+    {
+        var (engine, interop) = NewEngine();
+        engine.RegisterElement("el", null);
+
+        // Start a keyframe offload, then immediately animate the same prop again: the interrupt
+        // must fold the compositor plan back into state (via the keyframe mirror) without throwing.
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["scale"] = new double[] { 1, 2, 1 } },
+            Bm.Tween(1.0).ToConfig());
+        await engine.AnimateToAsync("el",
+            new Dictionary<string, object?> { ["scale"] = 0.5 },
+            Bm.Tween(0.3).ToConfig());
+
+        // The scale value is finite and within the plausible range the keyframe mirror could realize.
+        var scale = engine.GetDiagnostics().Single(d => d.Id == "el").Transforms["scale"];
+        Assert.IsTrue(double.IsFinite(scale));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/OklabColorTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/OklabColorTests.cs
@@ -1,0 +1,67 @@
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>Tests for perceptual OKLab color interpolation (plan item 3.1).</summary>
+[TestClass]
+public class OklabColorTests
+{
+    private static double[] Rgb(int r, int g, int b, double a = 1) => [r, g, b, a];
+
+    private static (int R, int G, int B) ParseRgb(string rgba)
+    {
+        var inner = rgba[rgba.IndexOf('(')..].Trim('(', ')');
+        var parts = inner.Split(',');
+        return (int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]));
+    }
+
+    [TestMethod]
+    public void Oklab_Endpoints_MatchInput()
+    {
+        var start = BmotionColorInterpolator.Lerp(Rgb(0, 0, 255), Rgb(255, 255, 0), 0, BmColorSpace.Oklab);
+        var end = BmotionColorInterpolator.Lerp(Rgb(0, 0, 255), Rgb(255, 255, 0), 1, BmColorSpace.Oklab);
+        var (sr, sg, sb) = ParseRgb(start);
+        var (er, eg, eb) = ParseRgb(end);
+        // Round-trip through OKLab should reproduce the endpoints within rounding tolerance.
+        Assert.IsTrue(Math.Abs(sr - 0) <= 1 && Math.Abs(sg - 0) <= 1 && Math.Abs(sb - 255) <= 1, $"start={start}");
+        Assert.IsTrue(Math.Abs(er - 255) <= 1 && Math.Abs(eg - 255) <= 1 && Math.Abs(eb - 0) <= 1, $"end={end}");
+    }
+
+    [TestMethod]
+    public void Oklab_BlueToYellow_MidpointStaysSaturated()
+    {
+        // sRGB blue→yellow mid is a muddy grey (all channels near 128). OKLab keeps it saturated,
+        // so the mid-point must NOT be near-grey (channels should differ substantially).
+        var srgbMid = ParseRgb(BmotionColorInterpolator.Lerp(Rgb(0, 0, 255), Rgb(255, 255, 0), 0.5, BmColorSpace.Srgb));
+        var oklabMid = ParseRgb(BmotionColorInterpolator.Lerp(Rgb(0, 0, 255), Rgb(255, 255, 0), 0.5, BmColorSpace.Oklab));
+
+        int SrgbSpread = Math.Max(srgbMid.R, Math.Max(srgbMid.G, srgbMid.B)) - Math.Min(srgbMid.R, Math.Min(srgbMid.G, srgbMid.B));
+        int OklabSpread = Math.Max(oklabMid.R, Math.Max(oklabMid.G, oklabMid.B)) - Math.Min(oklabMid.R, Math.Min(oklabMid.G, oklabMid.B));
+
+        // sRGB midpoint is near-grey (low channel spread); OKLab is more colorful (higher spread).
+        Assert.IsTrue(OklabSpread > SrgbSpread, $"oklab spread {OklabSpread} should exceed srgb {SrgbSpread}");
+    }
+
+    [TestMethod]
+    public void Oklab_SameColor_IsStable()
+    {
+        var mid = ParseRgb(BmotionColorInterpolator.Lerp(Rgb(100, 150, 200), Rgb(100, 150, 200), 0.5, BmColorSpace.Oklab));
+        Assert.IsTrue(Math.Abs(mid.R - 100) <= 1 && Math.Abs(mid.G - 150) <= 1 && Math.Abs(mid.B - 200) <= 1);
+    }
+
+    [TestMethod]
+    public void Srgb_RemainsDefault()
+    {
+        // The 3-arg overload keeps sRGB behavior for back-compat.
+        var mid = BmotionColorInterpolator.Lerp(Rgb(0, 0, 0), Rgb(255, 255, 255), 0.5);
+        Assert.AreEqual("rgba(128,128,128,1)", mid);
+    }
+
+    [TestMethod]
+    public void Tween_ColorSpace_FlowsToConfig()
+    {
+        var config = Bm.Tween(colorSpace: BmColorSpace.Oklab).ToConfig();
+        Assert.AreEqual(BmColorSpace.Oklab, config.ColorSpace);
+
+        var defaultConfig = Bm.Tween().ToConfig();
+        Assert.AreEqual(BmColorSpace.Srgb, defaultConfig.ColorSpace);
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/OklabColorTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/OklabColorTests.cs
@@ -64,4 +64,51 @@ public class OklabColorTests
         var defaultConfig = Bm.Tween().ToConfig();
         Assert.AreEqual(BmColorSpace.Srgb, defaultConfig.ColorSpace);
     }
+
+    [TestMethod]
+    public void AmbientColorSpace_CascadesToTopLevelAndPerProperty()
+    {
+        var t = new BmTween
+        {
+            Properties = new()
+            {
+                ["backgroundColor"] = new BmTween(),                         // inherits ambient
+                ["color"] = new BmTween { ColorSpace = BmColorSpace.Srgb },  // explicit wins
+            },
+        };
+
+        var config = t.ToConfig(BmColorSpace.Oklab);
+
+        Assert.AreEqual(BmColorSpace.Oklab, config.ColorSpace, "top-level inherits the ambient space");
+        Assert.AreEqual(BmColorSpace.Oklab, config.Properties!["backgroundColor"].ColorSpace,
+            "a per-property override without its own space inherits the ambient - not sRGB");
+        Assert.AreEqual(BmColorSpace.Srgb, config.Properties!["color"].ColorSpace,
+            "an explicit per-property space is preserved");
+    }
+
+    [TestMethod]
+    public void NoAmbientColorSpace_KeepsSrgbDefaultEverywhere()
+    {
+        var t = new BmTween { Properties = new() { ["backgroundColor"] = new BmTween() } };
+
+        var config = t.ToConfig();
+
+        Assert.AreEqual(BmColorSpace.Srgb, config.ColorSpace);
+        Assert.AreEqual(BmColorSpace.Srgb, config.Properties!["backgroundColor"].ColorSpace);
+    }
+
+    [TestMethod]
+    public void ExplicitTopLevelColorSpace_CascadesToPerProperty()
+    {
+        // A parent transition's explicit space is the ambient for its per-property children.
+        var t = new BmTween
+        {
+            ColorSpace = BmColorSpace.Oklab,
+            Properties = new() { ["backgroundColor"] = new BmTween() },
+        };
+
+        var config = t.ToConfig();
+
+        Assert.AreEqual(BmColorSpace.Oklab, config.Properties!["backgroundColor"].ColorSpace);
+    }
 }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/PathMorphTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Engine/PathMorphTests.cs
@@ -1,0 +1,55 @@
+namespace Bit.Bmotion.Tests.Engine;
+
+/// <summary>
+/// Tests for SVG shape morphing (plan item 3.2). Same-structure <c>d</c> paths interpolate through
+/// the string mixer; incompatible paths return null (the driver then snaps to the target).
+/// </summary>
+[TestClass]
+public class PathMorphTests
+{
+    [TestMethod]
+    public void SameStructurePaths_MorphControlPoints()
+    {
+        var mix = BmotionStringMixer.TryCreateMix("M0 0 L10 10", "M10 10 L20 20");
+        Assert.IsNotNull(mix);
+        Assert.AreEqual("M0 0 L10 10", mix!(0));
+        Assert.AreEqual("M5 5 L15 15", mix(0.5));
+        Assert.AreEqual("M10 10 L20 20", mix(1));
+    }
+
+    [TestMethod]
+    public void CubicBezierPaths_MorphAllControlPoints()
+    {
+        var mix = BmotionStringMixer.TryCreateMix(
+            "M0 0 C10 0 20 10 30 10",
+            "M0 0 C20 0 40 20 60 20");
+        Assert.IsNotNull(mix);
+        Assert.AreEqual("M0 0 C15 0 30 15 45 15", mix!(0.5));
+    }
+
+    [TestMethod]
+    public void IncompatiblePaths_ReturnNull_SoTheDriverSnaps()
+    {
+        // Different command structure (L vs C) → different literal skeletons → not mixable.
+        Assert.IsNull(BmotionStringMixer.TryCreateMix("M0 0 L10 10", "M0 0 C1 1 2 2 3 3"));
+        // Different number of segments → not mixable.
+        Assert.IsNull(BmotionStringMixer.TryCreateMix("M0 0 L10 10", "M0 0 L10 10 L20 20"));
+    }
+
+    [TestMethod]
+    public void DProp_FlowsToEngineDictionary()
+    {
+        var single = Bm.To(d: "M0 0 L10 10").ToJsDictionary();
+        Assert.AreEqual("M0 0 L10 10", single["d"]);
+
+        var frames = Bm.To(d: new BmStringKeyframes("M0 0", "M10 10")).ToJsDictionary();
+        CollectionAssert.AreEqual(new[] { "M0 0", "M10 10" }, (string[])frames["d"]!);
+    }
+
+    [TestMethod]
+    public void DProp_ParticipatesInValueEquality()
+    {
+        Assert.IsFalse(Bm.To(d: "M0 0").ValueEquals(Bm.To(d: "M1 1")));
+        Assert.IsTrue(Bm.To(d: "M0 0").ValueEquals(Bm.To(d: "M0 0")));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/MotionPathTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/MotionPathTests.cs
@@ -1,0 +1,29 @@
+namespace Bit.Bmotion.Tests.Models;
+
+/// <summary>Tests for CSS motion-path props (plan item 3.2, motion-path half).</summary>
+[TestClass]
+public class MotionPathTests
+{
+    [TestMethod]
+    public void OffsetPathAndDistance_FlowToEngineDictionary()
+    {
+        var d = Bm.To(offsetPath: "path('M0,0 L100,100')", offsetDistance: "50%").ToJsDictionary();
+        Assert.AreEqual("path('M0,0 L100,100')", d["offsetPath"]);
+        Assert.AreEqual("50%", d["offsetDistance"]);
+    }
+
+    [TestMethod]
+    public void OffsetDistance_Keyframes_AnimateThroughEngine()
+    {
+        var d = Bm.To(offsetDistance: new BmStringKeyframes("0%", "100%")).ToJsDictionary();
+        CollectionAssert.AreEqual(new[] { "0%", "100%" }, (string[])d["offsetDistance"]!);
+    }
+
+    [TestMethod]
+    public void InitialStyle_EmitsDashCaseOffsetProps()
+    {
+        var css = Bm.To(offsetPath: "path('M0,0 L10,10')", offsetDistance: "0%").ToCssStyleString();
+        StringAssert.Contains(css, "offset-path:path('M0,0 L10,10');");
+        StringAssert.Contains(css, "offset-distance:0%;");
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/PerPropertyTransitionTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/PerPropertyTransitionTests.cs
@@ -2,7 +2,7 @@ namespace Bit.Bmotion.Tests.Models;
 
 /// <summary>
 /// Verifies per-property transitions flow to the engine config for transform components
-/// (plan item 2.1, step 1 — independent transforms via <see cref="BmTransition.Properties"/>).
+/// (plan item 2.1, step 1 - independent transforms via <see cref="BmTransition.Properties"/>).
 /// </summary>
 [TestClass]
 public class PerPropertyTransitionTests

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/PerPropertyTransitionTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/PerPropertyTransitionTests.cs
@@ -1,0 +1,41 @@
+namespace Bit.Bmotion.Tests.Models;
+
+/// <summary>
+/// Verifies per-property transitions flow to the engine config for transform components
+/// (plan item 2.1, step 1 — independent transforms via <see cref="BmTransition.Properties"/>).
+/// </summary>
+[TestClass]
+public class PerPropertyTransitionTests
+{
+    [TestMethod]
+    public void TransformComponents_CanCarryIndependentTransitions()
+    {
+        var transition = new BmTween
+        {
+            Duration = 0.3,
+            Properties = new()
+            {
+                ["x"] = Bm.Spring(stiffness: 300),
+                ["scale"] = Bm.Tween(1.2, BmEase.BounceOut),
+            },
+        };
+
+        var config = transition.ToConfig();
+        Assert.IsNotNull(config.Properties);
+        Assert.AreEqual(BmotionTransitionType.Spring, config.Properties!["x"].Type);
+        Assert.AreEqual(BmEase.BounceOut, config.Properties["scale"].Ease);
+        // The base transition still applies to any component without an override (e.g. rotate).
+        Assert.AreEqual(0.3, config.Duration);
+    }
+
+    [TestMethod]
+    public void PerPropertyTransition_IncludedInValueEquality()
+    {
+        var a = new BmTween { Properties = new() { ["x"] = Bm.Spring(stiffness: 300) } };
+        var b = new BmTween { Properties = new() { ["x"] = Bm.Spring(stiffness: 300) } };
+        var c = new BmTween { Properties = new() { ["x"] = Bm.Spring(stiffness: 100) } };
+
+        Assert.IsTrue(BmTransition.AreEquivalent(a, b));
+        Assert.IsFalse(BmTransition.AreEquivalent(a, c));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/PropertySurfaceTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/PropertySurfaceTests.cs
@@ -1,0 +1,71 @@
+namespace Bit.Bmotion.Tests.Models;
+
+/// <summary>Tests for the wider animatable property surface (plan item 2.4).</summary>
+[TestClass]
+public class PropertySurfaceTests
+{
+    [TestMethod]
+    public void TypedLayoutProps_FlowToEngineDictionary()
+    {
+        var d = Bm.To(top: "20px", left: "0", gap: "2rem", letterSpacing: "0.1em").ToJsDictionary();
+        Assert.AreEqual("20px", d["top"]);
+        Assert.AreEqual("0", d["left"]);
+        Assert.AreEqual("2rem", d["gap"]);
+        Assert.AreEqual("0.1em", d["letterSpacing"]);
+    }
+
+    [TestMethod]
+    public void GenericCssBag_DashCaseKey_BecomesCamelCaseEngineKey()
+    {
+        var d = Bm.To(css: new() { ["background-position"] = "0 0", ["gap"] = "1rem" }).ToJsDictionary();
+        Assert.AreEqual("0 0", d["backgroundPosition"]);
+        Assert.AreEqual("1rem", d["gap"]);
+    }
+
+    [TestMethod]
+    public void GenericCssBag_CustomProperty_PassesThroughUnchanged()
+    {
+        var d = Bm.To(css: new() { ["--my-var"] = "5px" }).ToJsDictionary();
+        Assert.AreEqual("5px", d["--my-var"]);
+    }
+
+    [TestMethod]
+    public void InitialStyle_EmitsDashCaseForExtendedProps()
+    {
+        var css = Bm.To(top: "20px", gap: "2rem", css: new() { ["letterSpacing"] = "0.1em" }).ToCssStyleString();
+        StringAssert.Contains(css, "top:20px;");
+        StringAssert.Contains(css, "gap:2rem;");
+        StringAssert.Contains(css, "letter-spacing:0.1em;");
+    }
+
+    [TestMethod]
+    public void InstantSet_EmitsCamelCaseForExtendedProps()
+    {
+        var d = Bm.To(letterSpacing: "0.1em", css: new() { ["background-size"] = "cover" }).ToCssStyleDictionary();
+        Assert.AreEqual("0.1em", d["letterSpacing"]);
+        Assert.AreEqual("cover", d["backgroundSize"]);
+    }
+
+    [TestMethod]
+    [DataRow("background-position", "backgroundPosition")]
+    [DataRow("gap", "gap")]
+    [DataRow("letterSpacing", "letterSpacing")]
+    [DataRow("--my-var", "--my-var")]
+    public void ToCamelCase_Converts(string input, string expected)
+        => Assert.AreEqual(expected, BmProps.ToCamelCase(input));
+
+    [TestMethod]
+    [DataRow("letterSpacing", "letter-spacing")]
+    [DataRow("gap", "gap")]
+    [DataRow("--my-var", "--my-var")]
+    public void ToDashCase_Converts(string input, string expected)
+        => Assert.AreEqual(expected, BmProps.ToDashCase(input));
+
+    [TestMethod]
+    public void ValueEquals_DetectsExtendedPropChange()
+    {
+        Assert.IsFalse(Bm.To(gap: "1rem").ValueEquals(Bm.To(gap: "2rem")));
+        Assert.IsTrue(Bm.To(gap: "1rem").ValueEquals(Bm.To(gap: "1rem")));
+        Assert.IsFalse(Bm.To(css: new() { ["gap"] = "1rem" }).ValueEquals(Bm.To(css: new() { ["gap"] = "2rem" })));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/StaggerTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Models/StaggerTests.cs
@@ -1,0 +1,74 @@
+namespace Bit.Bmotion.Tests.Models;
+
+/// <summary>Tests for 1-D, grid and custom staggering (plan item 2.3).</summary>
+[TestClass]
+public class StaggerTests
+{
+    private const double Tol = 1e-9;
+
+    // ── 1-D (unchanged behavior) ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void OneD_First_IsLinear()
+    {
+        var s = Bm.Stagger(0.1);
+        Assert.AreEqual(0, s.DelayFor(0, 5), Tol);
+        Assert.AreEqual(0.2, s.DelayFor(2, 5), Tol);
+        Assert.AreEqual(0.4, s.DelayFor(4, 5), Tol);
+    }
+
+    [TestMethod]
+    public void OneD_Center_RadiatesFromMiddle()
+    {
+        var s = Bm.Stagger(0.1, BmStaggerFrom.Center);
+        Assert.AreEqual(0.2, s.DelayFor(0, 5), Tol);
+        Assert.AreEqual(0, s.DelayFor(2, 5), Tol);
+        Assert.AreEqual(0.2, s.DelayFor(4, 5), Tol);
+    }
+
+    [TestMethod]
+    public void OneD_StartDelay_IsAdded()
+    {
+        var s = Bm.Stagger(0.1, BmStaggerFrom.First, startDelay: 0.5);
+        Assert.AreEqual(0.5, s.DelayFor(0, 5), Tol);
+        Assert.AreEqual(0.7, s.DelayFor(2, 5), Tol);
+    }
+
+    // ── Grid (2-D radial) ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Grid_Center_RadiatesRadially()
+    {
+        // 3x3 grid, radiate from the center cell (1,1).
+        var s = Bm.Stagger(0.1, BmStaggerFrom.Center, grid: (3, 3));
+        Assert.AreEqual(0, s.DelayFor(4, 9), Tol);                    // center cell
+        Assert.AreEqual(0.1, s.DelayFor(1, 9), Tol);                 // one cell up (distance 1)
+        Assert.AreEqual(0.1 * Math.Sqrt(2), s.DelayFor(0, 9), Tol);  // corner (distance √2)
+    }
+
+    [TestMethod]
+    public void Grid_First_RadiatesFromTopLeft()
+    {
+        var s = Bm.Stagger(0.1, BmStaggerFrom.First, grid: (3, 3));
+        Assert.AreEqual(0, s.DelayFor(0, 9), Tol);                    // top-left origin
+        Assert.AreEqual(0.1 * Math.Sqrt(8), s.DelayFor(8, 9), Tol);  // bottom-right (√8)
+    }
+
+    [TestMethod]
+    public void Grid_RejectsNonPositiveDimensions()
+        => Assert.ThrowsExactly<ArgumentException>(() => Bm.Stagger(0.1, grid: (0, 3)));
+
+    // ── Custom function ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Custom_Function_IsHonored()
+    {
+        var s = Bm.Stagger((i, total) => i * 0.05 + total * 0.001);
+        Assert.AreEqual(0 + 10 * 0.001, s.DelayFor(0, 10), Tol);
+        Assert.AreEqual(3 * 0.05 + 10 * 0.001, s.DelayFor(3, 10), Tol);
+    }
+
+    [TestMethod]
+    public void Custom_NullThrows()
+        => Assert.ThrowsExactly<ArgumentNullException>(() => Bm.Stagger((Func<int, int, double>)null!));
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Services/ViewTransitionTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Services/ViewTransitionTests.cs
@@ -1,0 +1,44 @@
+using Bit.Bmotion.Tests.TestInfra;
+
+namespace Bit.Bmotion.Tests.Services;
+
+/// <summary>Tests for the View Transitions API wrapper (plan item 3.3).</summary>
+[TestClass]
+public class ViewTransitionTests
+{
+    [TestMethod]
+    public async Task StartAsync_RunsUpdate_AndReportsNativeSupport()
+    {
+        var interop = new FakeBmotionInterop { SupportsViewTransitions = true };
+        await using var vt = new BmotionViewTransition(interop);
+
+        var ran = false;
+        var usedNative = await vt.StartAsync(() => { ran = true; return Task.CompletedTask; });
+
+        Assert.IsTrue(ran, "the DOM-update callback must run");
+        Assert.IsTrue(usedNative);
+        Assert.IsTrue(interop.WasCalled("startViewTransition"));
+    }
+
+    [TestMethod]
+    public async Task StartAsync_Unsupported_StillRunsUpdate_ReturnsFalse()
+    {
+        var interop = new FakeBmotionInterop { SupportsViewTransitions = false };
+        await using var vt = new BmotionViewTransition(interop);
+
+        var ran = false;
+        var usedNative = await vt.StartAsync(() => ran = true);
+
+        Assert.IsTrue(ran, "the callback must run even without native support");
+        Assert.IsFalse(usedNative);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_NullUpdate_Throws()
+    {
+        var interop = new FakeBmotionInterop();
+        await using var vt = new BmotionViewTransition(interop);
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(
+            async () => await vt.StartAsync((Func<Task>)null!));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/Services/ViewTransitionTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/Services/ViewTransitionTests.cs
@@ -41,4 +41,29 @@ public class ViewTransitionTests
         await Assert.ThrowsExactlyAsync<ArgumentNullException>(
             async () => await vt.StartAsync((Func<Task>)null!));
     }
+
+    [TestMethod]
+    public async Task StartAsync_WhileInProgress_Throws()
+    {
+        var interop = new FakeBmotionInterop { SupportsViewTransitions = true };
+        await using var vt = new BmotionViewTransition(interop);
+
+        // A re-entrant StartAsync (from inside the running update callback) must be rejected rather
+        // than clobber the in-flight _pending callback.
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+            await vt.StartAsync(async () => await vt.StartAsync(() => Task.CompletedTask)));
+    }
+
+    [TestMethod]
+    public async Task StartAsync_AfterCompletion_CanStartAgain()
+    {
+        var interop = new FakeBmotionInterop { SupportsViewTransitions = true };
+        await using var vt = new BmotionViewTransition(interop);
+
+        // The in-progress guard must reset after each transition settles.
+        await vt.StartAsync(() => Task.CompletedTask);
+        var ran = false;
+        await vt.StartAsync(() => { ran = true; return Task.CompletedTask; });
+        Assert.IsTrue(ran);
+    }
 }

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/TestInfra/BmotionTestContext.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/TestInfra/BmotionTestContext.cs
@@ -1,0 +1,29 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Bmotion.Tests.TestInfra;
+
+/// <summary>
+/// A bUnit <see cref="TestContext"/> pre-wired with the Bmotion engine, layout registry and animate
+/// service, all backed by a <see cref="FakeBmotionInterop"/> so component render/interaction logic
+/// can be exercised without a browser. Access the fake through <see cref="Interop"/>.
+/// </summary>
+internal class BmotionTestContext : Bunit.TestContext
+{
+    public FakeBmotionInterop Interop { get; } = new();
+
+    /// <summary>Library options exposed to components; mutate before rendering to adjust policy.</summary>
+    public BitBmotionOptions Options { get; } = new();
+
+    public BmotionTestContext()
+    {
+        Services.AddLogging();
+        Services.AddSingleton<IBmotionInterop>(Interop);
+        Services.AddSingleton(Options);
+        Services.AddScoped<BmotionAnimationEngine>();
+        Services.AddScoped<BmotionLayoutRegistry>();
+        Services.AddScoped<BmotionAnimateService>();
+    }
+
+    public BmotionAnimationEngine Engine => Services.GetRequiredService<BmotionAnimationEngine>();
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/TestInfra/FakeBmotionInterop.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/TestInfra/FakeBmotionInterop.cs
@@ -1,0 +1,236 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Bit.Bmotion.Tests.TestInfra;
+
+/// <summary>
+/// A scriptable, browser-free <see cref="IBmotionInterop"/> for unit/bUnit tests. It records every
+/// interop call and captures the <see cref="DotNetObjectReference{T}"/> instances the engine and
+/// components hand to JS, so a test can synthesize the JS→.NET callbacks
+/// (<c>ComputeFrame</c>, <c>OnPointerEnter</c>, <c>OnIntersect</c>, …) that a real browser would fire.
+/// </summary>
+internal sealed class FakeBmotionInterop : IBmotionInterop
+{
+    /// <summary>One recorded interop call: the JS method name and its non-ref arguments.</summary>
+    public sealed record Call(string Method, object?[] Args);
+
+    private readonly List<Call> _calls = new();
+
+    /// <summary>All interop calls in order, for assertions.</summary>
+    public IReadOnlyList<Call> Calls => _calls;
+
+    /// <summary>Simulates WASM (synchronous interop) when true, Blazor Server when false.</summary>
+    public bool IsInProcess { get; set; } = true;
+
+    /// <summary>Value returned by <see cref="PrefersReducedMotionAsync"/>.</summary>
+    public bool PrefersReducedMotion { get; set; }
+
+    /// <summary>Value returned by <see cref="SupportsLinearEasingAsync"/>.</summary>
+    public bool SupportsLinearEasing { get; set; } = true;
+
+    /// <summary>Value returned by <see cref="RegisterElementAsync"/>.</summary>
+    public bool RegisterElementResult { get; set; } = true;
+
+    /// <summary>Optional rect provider for <see cref="GetBoundingRectAsync"/> keyed by element id.</summary>
+    public Func<string, BmotionBoundingRect?>? BoundingRectProvider { get; set; }
+
+    /// <summary>
+    /// Hook invoked when the engine starts a WAAPI compositor animation. Return the completion
+    /// result (<c>true</c> = natural finish, <c>false</c> = cancelled/failed). Defaults to a pending
+    /// task so a test can decide when/if the offload resolves; return a completed task for eager finish.
+    /// </summary>
+    public Func<string, int, object, object, Task<bool>>? PlayWaapiHandler { get; set; }
+
+    // Captured DotNet references, so tests can invoke [JSInvokable] callbacks directly.
+    public object? RafLoopRef { get; private set; }
+    public object? ReducedMotionRef { get; private set; }
+    public readonly Dictionary<string, object> EventListenerRefs = new();
+    public readonly Dictionary<string, object> ViewportRefs = new();
+
+    private void Record(string method, params object?[] args) => _calls.Add(new Call(method, args));
+
+    /// <summary>True if any recorded call used <paramref name="method"/>.</summary>
+    public bool WasCalled(string method) => _calls.Any(c => c.Method == method);
+
+    /// <summary>Number of recorded calls to <paramref name="method"/>.</summary>
+    public int CountOf(string method) => _calls.Count(c => c.Method == method);
+
+    // ── rAF loop ──────────────────────────────────────────────────────────────
+    public ValueTask StartRafLoopAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    {
+        RafLoopRef = dotnetRef.Value;
+        Record("startRafLoop");
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopRafLoopAsync<T>(DotNetObjectReference<T>? dotnetRef = null) where T : class
+    {
+        Record("stopRafLoop");
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Reduced motion ────────────────────────────────────────────────────────
+    public ValueTask<bool> PrefersReducedMotionAsync()
+    {
+        Record("prefersReducedMotion");
+        return ValueTask.FromResult(PrefersReducedMotion);
+    }
+
+    public ValueTask WatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    {
+        ReducedMotionRef = dotnetRef.Value;
+        Record("watchReducedMotion");
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask UnwatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    {
+        Record("unwatchReducedMotion");
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Style application ─────────────────────────────────────────────────────
+    public ValueTask ApplyStylesAsync(string elementId, object styles)
+    {
+        Record("applyStyles", elementId, styles);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask PopLayoutAsync(string elementId, double currentX, double currentY)
+    {
+        Record("popLayout", elementId, currentX, currentY);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask UnpopLayoutAsync(string elementId)
+    {
+        Record("unpopLayout", elementId);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Element registration ──────────────────────────────────────────────────
+    public ValueTask<bool> RegisterElementAsync(string elementId)
+    {
+        Record("registerElement", elementId);
+        return ValueTask.FromResult(RegisterElementResult);
+    }
+
+    public ValueTask UnregisterElementAsync(string elementId)
+    {
+        Record("unregisterElement", elementId);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Gesture event listeners ───────────────────────────────────────────────
+    public ValueTask AttachEventListenersAsync<T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class
+    {
+        EventListenerRefs[elementId] = dotnetRef.Value;
+        Record("attachEventListeners", elementId, events);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StartDragAsync(string elementId, long pointerId, double clientX, double clientY)
+    {
+        Record("startDrag", elementId, pointerId, clientX, clientY);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Viewport observation ──────────────────────────────────────────────────
+    public ValueTask ObserveViewportAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class
+    {
+        ViewportRefs[elementId] = dotnetRef.Value;
+        Record("observeViewport", elementId, once);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask ObserveViewportWithOptionsAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class
+    {
+        ViewportRefs[elementId] = dotnetRef.Value;
+        Record("observeViewport", elementId, options);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask UnobserveViewportAsync(string elementId)
+    {
+        Record("unobserveViewport", elementId);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── FLIP layout ───────────────────────────────────────────────────────────
+    public ValueTask<BmotionBoundingRect?> GetBoundingRectAsync(string elementId)
+    {
+        Record("getBoundingRect", elementId);
+        return ValueTask.FromResult(BoundingRectProvider?.Invoke(elementId));
+    }
+
+    public ValueTask PlayWaapiFlipAsync(string elementId, double dx, double dy, double sx, double sy, double durationMs, string easingStr, string? finalTransform)
+    {
+        Record("playWaapiFlip", elementId, dx, dy, sx, sy, durationMs, easingStr, finalTransform);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── WAAPI compositor offload ──────────────────────────────────────────────
+    public ValueTask<bool> SupportsLinearEasingAsync()
+    {
+        Record("supportsLinearEasing");
+        return ValueTask.FromResult(SupportsLinearEasing);
+    }
+
+    public ValueTask<bool> PlayWaapiAnimationAsync(string elementId, int token, object keyframes, object timing)
+    {
+        Record("playWaapiAnimation", elementId, token, keyframes, timing);
+        var task = PlayWaapiHandler?.Invoke(elementId, token, keyframes, timing);
+        // Default: never resolves on its own (mirrors a still-running compositor animation).
+        return new ValueTask<bool>(task ?? new TaskCompletionSource<bool>().Task);
+    }
+
+    public ValueTask CancelWaapiAnimationAsync(string elementId, int token, bool commit)
+    {
+        Record("cancelWaapiAnimation", elementId, token, commit);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Scroll ────────────────────────────────────────────────────────────────
+    public ValueTask<string?> ObserveScrollAsync<T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class
+    {
+        Record("observeScroll", containerId, options);
+        return ValueTask.FromResult<string?>("scroll-key-" + (_calls.Count));
+    }
+
+    public ValueTask UnobserveScrollAsync(string key)
+    {
+        Record("unobserveScroll", key);
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Programmatic animate() API ─────────────────────────────────────────────
+    public ValueTask<string[]> ResolveOrRegisterBySelectorAsync(string selector)
+    {
+        Record("resolveOrRegisterBySelector", selector);
+        return ValueTask.FromResult(new[] { "bm-sel-1" });
+    }
+
+    public ValueTask<string> ResolveOrRegisterByRefAsync(ElementReference elementReference)
+    {
+        Record("resolveOrRegisterByRef");
+        return ValueTask.FromResult("bm-ref-1");
+    }
+
+    /// <summary>Simulates native support for the View Transitions API (false = fallback path).</summary>
+    public bool SupportsViewTransitions { get; set; }
+
+    public async ValueTask<bool> StartViewTransitionAsync<T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
+    {
+        Record("startViewTransition", callbackName);
+        // Simulate the browser invoking the C# DOM-update callback during the transition.
+        var method = typeof(T).GetMethod(callbackName);
+        if (method?.Invoke(dotnetRef.Value, null) is Task task) await task;
+        return SupportsViewTransitions;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Record("dispose");
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests/TestInfra/FakeBmotionInterop.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests/TestInfra/FakeBmotionInterop.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Bit.Bmotion.Tests.TestInfra;
 
@@ -56,14 +57,14 @@ internal sealed class FakeBmotionInterop : IBmotionInterop
     public int CountOf(string method) => _calls.Count(c => c.Method == method);
 
     // ── rAF loop ──────────────────────────────────────────────────────────────
-    public ValueTask StartRafLoopAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    public ValueTask StartRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
     {
         RafLoopRef = dotnetRef.Value;
         Record("startRafLoop");
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask StopRafLoopAsync<T>(DotNetObjectReference<T>? dotnetRef = null) where T : class
+    public ValueTask StopRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T>? dotnetRef = null) where T : class
     {
         Record("stopRafLoop");
         return ValueTask.CompletedTask;
@@ -76,14 +77,14 @@ internal sealed class FakeBmotionInterop : IBmotionInterop
         return ValueTask.FromResult(PrefersReducedMotion);
     }
 
-    public ValueTask WatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    public ValueTask WatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
     {
         ReducedMotionRef = dotnetRef.Value;
         Record("watchReducedMotion");
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask UnwatchReducedMotionAsync<T>(DotNetObjectReference<T> dotnetRef) where T : class
+    public ValueTask UnwatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
     {
         Record("unwatchReducedMotion");
         return ValueTask.CompletedTask;
@@ -122,7 +123,7 @@ internal sealed class FakeBmotionInterop : IBmotionInterop
     }
 
     // ── Gesture event listeners ───────────────────────────────────────────────
-    public ValueTask AttachEventListenersAsync<T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class
+    public ValueTask AttachEventListenersAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class
     {
         EventListenerRefs[elementId] = dotnetRef.Value;
         Record("attachEventListeners", elementId, events);
@@ -136,14 +137,14 @@ internal sealed class FakeBmotionInterop : IBmotionInterop
     }
 
     // ── Viewport observation ──────────────────────────────────────────────────
-    public ValueTask ObserveViewportAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class
+    public ValueTask ObserveViewportAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class
     {
         ViewportRefs[elementId] = dotnetRef.Value;
         Record("observeViewport", elementId, once);
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask ObserveViewportWithOptionsAsync<T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class
+    public ValueTask ObserveViewportWithOptionsAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class
     {
         ViewportRefs[elementId] = dotnetRef.Value;
         Record("observeViewport", elementId, options);
@@ -191,7 +192,7 @@ internal sealed class FakeBmotionInterop : IBmotionInterop
     }
 
     // ── Scroll ────────────────────────────────────────────────────────────────
-    public ValueTask<string?> ObserveScrollAsync<T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class
+    public ValueTask<string?> ObserveScrollAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class
     {
         Record("observeScroll", containerId, options);
         return ValueTask.FromResult<string?>("scroll-key-" + (_calls.Count));
@@ -219,7 +220,7 @@ internal sealed class FakeBmotionInterop : IBmotionInterop
     /// <summary>Simulates native support for the View Transitions API (false = fallback path).</summary>
     public bool SupportsViewTransitions { get; set; }
 
-    public async ValueTask<bool> StartViewTransitionAsync<T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
+    public async ValueTask<bool> StartViewTransitionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
     {
         Record("startViewTransition", callbackName);
         // Simulate the browser invoking the C# DOM-update callback during the transition.

--- a/src/Bmotion/Tests/bit-bmotion-js/.gitignore
+++ b/src/Bmotion/Tests/bit-bmotion-js/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/Bmotion/Tests/bit-bmotion-js/drag-math.test.js
+++ b/src/Bmotion/Tests/bit-bmotion-js/drag-math.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+    applyElastic,
+    resolveConstraintBounds,
+    clampToConstraints,
+    scrollFraction,
+} from '../../Bit.Bmotion/wwwroot/bit-bmotion.js';
+
+const rect = (left, top, width, height) => ({
+    left, top, width, height, right: left + width, bottom: top + height,
+    x: left, y: top,
+});
+
+describe('applyElastic', () => {
+    it('scales overflow by the edge factor', () => {
+        expect(applyElastic(100, 0.5)).toBe(50);
+        expect(applyElastic(100, 1)).toBe(100);
+    });
+    it('is rigid (0) for a non-positive edge', () => {
+        expect(applyElastic(100, 0)).toBe(0);
+        expect(applyElastic(100, -1)).toBe(0);
+    });
+});
+
+describe('resolveConstraintBounds', () => {
+    it('computes bounds from container/element rects (no active transform)', () => {
+        // 300x200 container, 50x50 element at its top-left, no transform applied.
+        const c = rect(0, 0, 300, 200);
+        const e = rect(0, 0, 50, 50);
+        const b = resolveConstraintBounds(c, e, 0, 0);
+        expect(b.left).toBe(0);
+        expect(b.top).toBe(0);
+        expect(b.right).toBe(250);   // 300 - 50
+        expect(b.bottom).toBe(150);  // 200 - 50
+    });
+
+    it('backs the current transform out of the element rect', () => {
+        // The element already shows a +40/+30 transform, so its untransformed origin is (10,20).
+        const c = rect(0, 0, 300, 200);
+        const e = rect(50, 50, 50, 50); // measured rect includes the +40/+30 offset
+        const b = resolveConstraintBounds(c, e, 40, 30);
+        // base = (50-40, 50-30) = (10, 20)
+        expect(b.left).toBe(-10);
+        expect(b.top).toBe(-20);
+        expect(b.right).toBe(240);   // 300 - (10 + 50)
+        expect(b.bottom).toBe(130);  // 200 - (20 + 50)
+    });
+
+    it('collapses to a centered offset when the element is larger than the container', () => {
+        const c = rect(0, 0, 100, 100);
+        const e = rect(0, 0, 160, 160); // bigger than container
+        const b = resolveConstraintBounds(c, e, 0, 0);
+        // right (100-160=-60) < left (0) → both become the midpoint -30
+        expect(b.left).toBe(-30);
+        expect(b.right).toBe(-30);
+        expect(b.top).toBe(-30);
+        expect(b.bottom).toBe(-30);
+    });
+});
+
+describe('clampToConstraints', () => {
+    const elastic = { left: 0, right: 0, top: 0, bottom: 0 };
+    const c = { left: -100, right: 100, top: -50, bottom: 50 };
+
+    it('passes through values within bounds', () => {
+        expect(clampToConstraints(20, 10, c, elastic)).toEqual({ x: 20, y: 10 });
+    });
+
+    it('rigidly clamps beyond bounds when elastic is 0', () => {
+        expect(clampToConstraints(200, 999, c, elastic)).toEqual({ x: 100, y: 50 });
+        expect(clampToConstraints(-200, -999, c, elastic)).toEqual({ x: -100, y: -50 });
+    });
+
+    it('applies elastic give past the edge', () => {
+        // 50px past the right edge with 0.5 elastic → 100 + 25 = 125
+        const soft = { left: 0.5, right: 0.5, top: 0.5, bottom: 0.5 };
+        expect(clampToConstraints(150, 0, c, soft).x).toBe(125);
+        // 50px past the left edge → -100 - 25 = -125
+        expect(clampToConstraints(-150, 0, c, soft).x).toBe(-125);
+    });
+
+    it('returns the input unchanged when there are no constraints', () => {
+        expect(clampToConstraints(9999, -9999, null, elastic)).toEqual({ x: 9999, y: -9999 });
+    });
+
+    it('ignores an unconstrained (null) edge', () => {
+        const partial = { left: null, right: 100, top: null, bottom: null };
+        // left is null → large negative x passes through; right still clamps.
+        expect(clampToConstraints(-5000, 0, partial, elastic).x).toBe(-5000);
+        expect(clampToConstraints(5000, 0, partial, elastic).x).toBe(100);
+    });
+});
+
+describe('scrollFraction', () => {
+    it('is 0 when the content does not overflow', () => {
+        expect(scrollFraction(0, 500, 500)).toBe(0);
+        expect(scrollFraction(0, 400, 500)).toBe(0);
+    });
+    it('is the normalised progress across the scrollable range', () => {
+        expect(scrollFraction(0, 1000, 500)).toBe(0);
+        expect(scrollFraction(250, 1000, 500)).toBe(0.5);
+        expect(scrollFraction(500, 1000, 500)).toBe(1);
+    });
+});

--- a/src/Bmotion/Tests/bit-bmotion-js/flip-correction.test.js
+++ b/src/Bmotion/Tests/bit-bmotion-js/flip-correction.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { flipChildCorrection, correctedRadius } from '../../Bit.Bmotion/wwwroot/bit-bmotion.js';
+
+const rect = (left, top, width, height) => ({
+    left, top, width, height, right: left + width, bottom: top + height, x: left, y: top,
+});
+
+describe('flipChildCorrection', () => {
+    it('inverts the parent scale and origins at the parent top-left', () => {
+        const parent = rect(0, 0, 200, 100);
+        const child = rect(20, 10, 40, 40); // 20px right, 10px down from parent
+        const c = flipChildCorrection(parent, child, 2, 0.5);
+
+        expect(c.fromScaleX).toBe(0.5);   // 1 / 2
+        expect(c.fromScaleY).toBe(2);     // 1 / 0.5
+        // Origin is the parent's top-left expressed in the child's box coords → negated offset.
+        expect(c.originX).toBe(-20);
+        expect(c.originY).toBe(-10);
+    });
+
+    it('a child flush with the parent origin scales about its own top-left', () => {
+        const parent = rect(50, 50, 300, 300);
+        const child = rect(50, 50, 100, 100);
+        const c = flipChildCorrection(parent, child, 3, 3);
+        expect(c.originX).toBeCloseTo(0); // -0 renders identically to 0
+        expect(c.originY).toBeCloseTo(0);
+        expect(c.fromScaleX).toBeCloseTo(1 / 3);
+        expect(c.fromScaleY).toBeCloseTo(1 / 3);
+    });
+});
+
+describe('correctedRadius', () => {
+    it('divides the radius by the scale so corners render constant', () => {
+        const r = correctedRadius(12, 2, 4);
+        expect(r.fromX).toBe(6);  // 12 / 2
+        expect(r.fromY).toBe(3);  // 12 / 4
+    });
+    it('is identity at scale 1', () => {
+        const r = correctedRadius(10, 1, 1);
+        expect(r.fromX).toBe(10);
+        expect(r.fromY).toBe(10);
+    });
+});

--- a/src/Bmotion/Tests/bit-bmotion-js/flip-correction.test.js
+++ b/src/Bmotion/Tests/bit-bmotion-js/flip-correction.test.js
@@ -27,6 +27,23 @@ describe('flipChildCorrection', () => {
         expect(c.fromScaleX).toBeCloseTo(1 / 3);
         expect(c.fromScaleY).toBeCloseTo(1 / 3);
     });
+
+    it('defaults to no translate correction when the FLIP delta is omitted', () => {
+        const parent = rect(0, 0, 200, 100);
+        const child = rect(20, 10, 40, 40);
+        const c = flipChildCorrection(parent, child, 2, 0.5);
+        expect(c.fromTranslateX).toBeCloseTo(0); // -0 renders identically to 0
+        expect(c.fromTranslateY).toBeCloseTo(0);
+    });
+
+    it('cancels the parent translate as -d/s so the child does not jump', () => {
+        const parent = rect(0, 0, 200, 100);
+        const child = rect(20, 10, 40, 40);
+        // Parent FLIP: translate(30,-12) scale(2, 0.5) about its top-left.
+        const c = flipChildCorrection(parent, child, 2, 0.5, 30, -12);
+        expect(c.fromTranslateX).toBe(-15); // -30 / 2
+        expect(c.fromTranslateY).toBe(24);  // -(-12) / 0.5
+    });
 });
 
 describe('correctedRadius', () => {

--- a/src/Bmotion/Tests/bit-bmotion-js/flip-correction.test.js
+++ b/src/Bmotion/Tests/bit-bmotion-js/flip-correction.test.js
@@ -44,6 +44,17 @@ describe('flipChildCorrection', () => {
         expect(c.fromTranslateX).toBe(-15); // -30 / 2
         expect(c.fromTranslateY).toBe(24);  // -(-12) / 0.5
     });
+
+    it('clamps a zero scale so the inverse stays finite', () => {
+        const parent = rect(0, 0, 200, 100);
+        const child = rect(20, 10, 40, 40);
+        // A 0-sized start rect yields sx = sy = 0 - must not produce Infinity/NaN.
+        const c = flipChildCorrection(parent, child, 0, 0, 30, -12);
+        expect(Number.isFinite(c.fromScaleX)).toBe(true);
+        expect(Number.isFinite(c.fromScaleY)).toBe(true);
+        expect(Number.isFinite(c.fromTranslateX)).toBe(true);
+        expect(Number.isFinite(c.fromTranslateY)).toBe(true);
+    });
 });
 
 describe('correctedRadius', () => {
@@ -56,5 +67,10 @@ describe('correctedRadius', () => {
         const r = correctedRadius(10, 1, 1);
         expect(r.fromX).toBe(10);
         expect(r.fromY).toBe(10);
+    });
+    it('clamps a zero scale so the radius stays finite', () => {
+        const r = correctedRadius(12, 0, 0);
+        expect(Number.isFinite(r.fromX)).toBe(true);
+        expect(Number.isFinite(r.fromY)).toBe(true);
     });
 });

--- a/src/Bmotion/Tests/bit-bmotion-js/package-lock.json
+++ b/src/Bmotion/Tests/bit-bmotion-js/package-lock.json
@@ -1,0 +1,1624 @@
+{
+  "name": "bit-bmotion-js-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bit-bmotion-js-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/src/Bmotion/Tests/bit-bmotion-js/package.json
+++ b/src/Bmotion/Tests/bit-bmotion-js/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bit-bmotion-js-tests",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Unit tests for the pure drag/scroll math in bit-bmotion.js",
+  "scripts": {
+    "test": "vitest run",
+    "watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}


### PR DESCRIPTION
closes #12605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Blazor demo pages (Easing, Color spaces, Motion Path, CSS props, View transitions) plus expanded Drag/variant/layout sections.
  * Added a live animation diagnostics overlay.
  * Added native View Transitions support, OKLab color interpolation, stepped easing, grid-based stagger, and opt-in nested drag propagation.
* **API Updates**
  * Added library-wide configuration options for reduced motion and CSS safe mode, plus per-transition color-space and step-jump support.
  * Extended `Bm.To(...)` for more animatable CSS properties and added cancellation-token support to imperative animation APIs.
* **Bug Fixes**
  * Improved reduced-motion behavior and tightened inline CSS safety validation.
* **Documentation / Tests / CI**
  * Expanded .NET and JS test coverage and updated CI to run the new suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->