### PR TITLE
Add GetText APIs to BitRichTextEditor (#12608)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.razor.cs
@@ -126,6 +126,22 @@ public partial class BitRichTextEditor : BitComponentBase
     }
 
     /// <summary>
+    /// Returns the current content of the editor as plain text: visible text only, with block
+    /// boundaries and line breaks rendered as newlines and all markup removed.
+    /// </summary>
+    public async ValueTask<string> GetTextAsync()
+    {
+        // Before the JS bridge is set up there is no editor DOM to read and interop may not be
+        // available (prerendering); the cached content is empty at that point, so return empty.
+        if (_initialized is false) return "";
+        // While source view is active the WYSIWYG element is detached/hidden and the raw-HTML
+        // textarea (_sourceText) drives the live content, so extract the text from the source
+        // buffer instead of the stale editor DOM in that mode.
+        if (_inSourceView) return await _js.BitRichTextEditorHtmlToText(_editorRef, _sourceText);
+        return await _js.BitRichTextEditorGetText(_editorRef);
+    }
+
+    /// <summary>
     /// Runs a raw editing command against the editor.
     /// </summary>
     public Task ExecuteCommandAsync(string command, string? value = null) => ExecAsync(command, value);

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditor.ts
@@ -157,6 +157,38 @@ namespace BitBlazorUI {
             return editor ? RichTextEditor.snapshot(editor) : '';
         }
 
+        // Returns the editor content as plain text: visible text only, with block/br boundaries
+        // rendered as line breaks (innerText) and non-breaking spaces normalized to regular
+        // spaces, matching how the content facts treat text. The transient find-highlight marks
+        // only wrap existing text, so they need no special handling here.
+        public static getText(editor: any): string {
+            if (!editor) return '';
+            return (editor.innerText || '').replace(/\u00a0/g, ' ');
+        }
+
+        // Extracts the plain text of an arbitrary HTML string (used while source view is active,
+        // where the raw-HTML textarea - not the editor DOM - holds the live content).
+        public static htmlToText(editor: any, html: string): string {
+            if (!html) return '';
+            const d = document.createElement('div');
+            d.setAttribute('aria-hidden', 'true');
+            // Sanitize against the active policy first so markup the editor would never render
+            // (e.g. disallowed element bodies) cannot leak into the extracted text.
+            d.innerHTML = RichTextEditor.sanitize(editor, html);
+            // innerText only honors block/br line breaks on a rendered element; display:none or
+            // visibility:hidden would degrade it to textContent and lose the breaks, so park the
+            // scratch node offscreen instead.
+            d.style.position = 'fixed';
+            d.style.top = '0';
+            d.style.left = '-99999px';
+            document.body.appendChild(d);
+            try {
+                return (d.innerText || '').replace(/\u00a0/g, ' ');
+            } finally {
+                d.remove();
+            }
+        }
+
         // Returns the editor's HTML with transient find-highlight markup stripped, so the
         // temporary <mark class="bit-rte-find"> nodes never leak into persisted Value.
         private static cleanHtml(editor: any): string {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/RichTextEditor/BitRichTextEditorJsRuntimeExtensions.cs
@@ -46,6 +46,16 @@ internal static class BitRichTextEditorJsRuntimeExtensions
         return jsRuntime.Invoke<string>("BitBlazorUI.RichTextEditor.getHtml", editor);
     }
 
+    public static ValueTask<string> BitRichTextEditorGetText(this IJSRuntime jsRuntime, ElementReference editor)
+    {
+        return jsRuntime.Invoke<string>("BitBlazorUI.RichTextEditor.getText", editor);
+    }
+
+    public static ValueTask<string> BitRichTextEditorHtmlToText(this IJSRuntime jsRuntime, ElementReference editor, string? html)
+    {
+        return jsRuntime.Invoke<string>("BitBlazorUI.RichTextEditor.htmlToText", editor, html);
+    }
+
     public static ValueTask BitRichTextEditorSetHtml(this IJSRuntime jsRuntime, ElementReference editor, string? html)
     {
         return jsRuntime.InvokeVoid("BitBlazorUI.RichTextEditor.setHtml", editor, html);

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/RichTextEditor/BitRichTextEditorDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/RichTextEditor/BitRichTextEditorDemo.razor
@@ -384,7 +384,8 @@
             <DemoExample Title="Imperative API" RazorCode="@example29RazorCode" CsharpCode="@example29CsharpCode" Id="example29">
                 <div>
                     Capture the component with <b>@@ref</b> to drive it from code: <b>FocusAsync</b> moves keyboard focus,
-                    <b>ExecuteCommandAsync</b> runs a raw editing command, and <b>GetHtmlAsync</b> reads the current HTML.
+                    <b>ExecuteCommandAsync</b> runs a raw editing command, <b>GetHtmlAsync</b> reads the current HTML,
+                    and <b>GetTextAsync</b> reads the current content as plain text.
                 </div>
                 <br />
                 <BitRichTextEditor @ref="apiEditor" @bind-Value="apiHtml"
@@ -394,6 +395,7 @@
                     <BitButton OnClick="FocusEditor">FocusAsync</BitButton>
                     <BitButton OnClick="@(() => apiEditor.ExecuteCommandAsync("bold"))">ExecuteCommand("bold")</BitButton>
                     <BitButton OnClick="GetEditorHtml">GetHtmlAsync</BitButton>
+                    <BitButton OnClick="GetEditorText">GetTextAsync</BitButton>
                 </div>
                 <br />
                 <div>result:</div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/RichTextEditor/BitRichTextEditorDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/RichTextEditor/BitRichTextEditorDemo.razor.cs
@@ -197,6 +197,12 @@ public partial class BitRichTextEditorDemo
         },
         new()
         {
+            Name = "GetTextAsync",
+            Type = "ValueTask<string>",
+            Description = "Returns the current content of the editor as plain text, with block boundaries rendered as newlines and all markup removed."
+        },
+        new()
+        {
             Name = "ExecuteCommandAsync",
             Type = "Task",
             Description = "Runs a raw editing command against the editor."
@@ -454,6 +460,10 @@ public partial class BitRichTextEditorDemo
     {
         apiResult = await apiEditor.GetHtmlAsync();
     }
+    private async Task GetEditorText()
+    {
+        apiResult = await apiEditor.GetTextAsync();
+    }
 
 
 
@@ -672,6 +682,7 @@ private readonly BitRichTextEditorToolbarConfig reorderConfig = new()
 <BitButton OnClick=""FocusEditor"">FocusAsync</BitButton>
 <BitButton OnClick='@(() => apiEditor.ExecuteCommandAsync(""bold""))'>ExecuteCommand(""bold"")</BitButton>
 <BitButton OnClick=""GetEditorHtml"">GetHtmlAsync</BitButton>
+<BitButton OnClick=""GetEditorText"">GetTextAsync</BitButton>
 
 <pre>@apiResult</pre>";
     private readonly string example29CsharpCode = @"
@@ -684,6 +695,10 @@ private async Task FocusEditor()
 private async Task GetEditorHtml()
 {
     apiResult = await apiEditor.GetHtmlAsync();
+}
+private async Task GetEditorText()
+{
+    apiResult = await apiEditor.GetTextAsync();
 }";
 
     private readonly string example30RazorCode = @"

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/RichTextEditor/BitRichTextEditorTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/RichTextEditor/BitRichTextEditorTests.cs
@@ -19,6 +19,7 @@ public class BitRichTextEditorTests : BunitTestContext
         Context.JSInterop.SetupVoid("BitBlazorUI.RichTextEditor.focus");
         Context.JSInterop.SetupVoid("BitBlazorUI.RichTextEditor.dispose");
         Context.JSInterop.Setup<string>("BitBlazorUI.RichTextEditor.getHtml", _ => true).SetResult("<p>html</p>");
+        Context.JSInterop.Setup<string>("BitBlazorUI.RichTextEditor.getText", _ => true).SetResult("text");
     }
 
     [TestMethod]
@@ -131,6 +132,18 @@ public class BitRichTextEditorTests : BunitTestContext
         var html = await component.Instance.GetHtmlAsync();
 
         Assert.AreEqual("<p>html</p>", html);
+    }
+
+    [TestMethod]
+    public async Task BitRichTextEditorShouldGetText()
+    {
+        SetupJsInterop();
+
+        var component = RenderComponent<BitRichTextEditor>();
+
+        var text = await component.Instance.GetTextAsync();
+
+        Assert.AreEqual("text", text);
     }
 
     [TestMethod]


### PR DESCRIPTION
closes #12608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plain-text retrieval option for the rich text editor, letting users copy or inspect the visible content without formatting.
  * Updated the demo to include a button and example showing how to fetch editor text.

* **Bug Fixes**
  * Improved text extraction so source-view content returns the latest visible text instead of stale formatted content.
  * Normalizes spacing for more consistent plain-text output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->