### PR TITLE
Fix duplicate exposure of Basic pipeline in BitMarkdownEditor (#12630)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -42,7 +42,7 @@ public partial class BitMarkdownViewer : BitComponentBase
     [Parameter] public string? Markdown { get; set; }
 
     /// <summary>
-    /// The processing pipeline (flavor set). Defaults to <see cref="BitMarkdownPipeline.Basic"/>,
+    /// The processing pipeline (flavor set). Defaults to <see cref="BitMarkdownPipelines.Basic"/>,
     /// i.e. the basic CommonMark core with no extensions.
     /// </summary>
     [Parameter] public BitMarkdownPipeline? Pipeline { get; set; }
@@ -90,7 +90,7 @@ public partial class BitMarkdownViewer : BitComponentBase
 
     protected override string RootElementClass => "bit-mdv";
 
-    private BitMarkdownPipeline EffectivePipeline => Pipeline ?? BitMarkdownPipeline.Basic;
+    private BitMarkdownPipeline EffectivePipeline => Pipeline ?? BitMarkdownPipelines.Basic;
 
     protected override void OnParametersSet()
     {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelines.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelines.cs
@@ -3,13 +3,15 @@ namespace Bit.BlazorUI;
 /// <summary>Ready-made, cached pipelines for common configurations.</summary>
 public static class BitMarkdownPipelines
 {
+    private static readonly Lazy<BitMarkdownPipeline> _basic
+        = new(() => new BitMarkdownPipelineBuilder().Build());
     private static readonly Lazy<BitMarkdownPipeline> _gitHub
         = new(() => new BitMarkdownPipelineBuilder().UseGitHubFlavored().Build());
     private static readonly Lazy<BitMarkdownPipeline> _advanced
         = new(() => new BitMarkdownPipelineBuilder().UseAdvanced().Build());
 
     /// <summary>Basic CommonMark core only (no flavors).</summary>
-    public static BitMarkdownPipeline Basic => BitMarkdownPipeline.Basic;
+    public static BitMarkdownPipeline Basic => _basic.Value;
 
     /// <summary>GitHub Flavored Markdown (tables, strikethrough, task lists, autolinks).</summary>
     public static BitMarkdownPipeline GitHub => _gitHub.Value;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownParser.cs
@@ -4,9 +4,9 @@ namespace Bit.BlazorUI;
 public static class BitMarkdownParser
 {
     /// <summary>
-    /// Parses Markdown using the supplied pipeline, or <see cref="BitMarkdownPipeline.Basic"/>
+    /// Parses Markdown using the supplied pipeline, or <see cref="BitMarkdownPipelines.Basic"/>
     /// (basic CommonMark core only) when none is given.
     /// </summary>
     public static BitMarkdownDocumentNode Parse(string? markdown, BitMarkdownPipeline? pipeline = null)
-        => (pipeline ?? BitMarkdownPipeline.Basic).Parse(markdown);
+        => (pipeline ?? BitMarkdownPipelines.Basic).Parse(markdown);
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
@@ -7,12 +7,6 @@ namespace Bit.BlazorUI;
 /// </summary>
 public sealed class BitMarkdownPipeline
 {
-    private static readonly Lazy<BitMarkdownPipeline> _basic =
-        new(() => new BitMarkdownPipelineBuilder().Build());
-
-    /// <summary>A pipeline with only the basic CommonMark core (no flavors).</summary>
-    public static BitMarkdownPipeline Basic => _basic.Value;
-
     internal BitMarkdownPipeline(BitMarkdownPipelineBuilder builder)
     {
         BlockParsers = builder.BlockParsers.OrderBy(p => p.Order).ToArray();


### PR DESCRIPTION
closes #12630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the default Markdown processing pipeline selection for Markdown viewers.
  * Improved reuse of the basic Markdown pipeline, helping maintain consistent parsing behavior.

* **Refactor**
  * Streamlined Markdown pipeline management while preserving existing parsing and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->