### PR TITLE
Add missing features to Brouter (#12640)

### DIFF
--- a/src/Brouter/Bit.Brouter/Bit.Brouter.csproj
+++ b/src/Brouter/Bit.Brouter/Bit.Brouter.csproj
@@ -19,6 +19,9 @@
         <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.AspNetCore.Components.Web" Version="[8.0.0,9.0.0)" />
         <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.AspNetCore.Components.Web" Version="[9.0.0,10.0.0)" />
         <PackageReference Condition="'$(TargetFramework)' == 'net10.0'" Include="Microsoft.AspNetCore.Components.Web" Version="[10.0.0,11.0.0)" />
+        <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.AspNetCore.Components.Authorization" Version="[8.0.0,9.0.0)" />
+        <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.AspNetCore.Components.Authorization" Version="[9.0.0,10.0.0)" />
+        <PackageReference Condition="'$(TargetFramework)' == 'net10.0'" Include="Microsoft.AspNetCore.Components.Authorization" Version="[10.0.0,11.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Brouter/Bit.Brouter/Broute.cs
+++ b/src/Brouter/Bit.Brouter/Broute.cs
@@ -141,6 +141,14 @@ public class Broute : ComponentBase, IDisposable
     /// <summary>Child routes (used for nesting).</summary>
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Alias for <see cref="ChildContent"/>. When another template (<see cref="Content"/>,
+    /// <see cref="ErrorContent"/>, ...) forces the child fragments to be spelled out explicitly,
+    /// <c>&lt;Routes&gt;</c> states the intent better than <c>&lt;ChildContent&gt;</c>.
+    /// Set one or the other, not both.
+    /// </summary>
+    [Parameter] public RenderFragment? Routes { get; set; }
+
 
     [CascadingParameter(Name = "Brouter")] internal Brouter? Brouter { get; set; }
     [CascadingParameter(Name = "ParentRoute")] internal Broute? Parent { get; set; }
@@ -240,6 +248,15 @@ public class Broute : ComponentBase, IDisposable
     internal BrouterErrorContext? CurrentError { get; set; }
 
     private BrouterRouteRenderer? _renderer;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        if (ChildContent is not null && Routes is not null)
+            throw new InvalidOperationException(
+                $"{nameof(Broute)} accepts either {nameof(ChildContent)} or {nameof(Routes)} ({nameof(Routes)} is an alias for {nameof(ChildContent)}), not both.");
+    }
 
     protected override void OnInitialized()
     {

--- a/src/Brouter/Bit.Brouter/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Brouter.cs
@@ -199,8 +199,9 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// parameter always wins; otherwise setting any of <see cref="NotAuthorized"/> /
     /// <see cref="Authorizing"/> / <see cref="Resource"/> composes the framework's
     /// <c>AuthorizeRouteView</c>, a lone <see cref="DefaultLayout"/> composes the framework's
-    /// <c>RouteView</c> (which itself fails closed on <c>[Authorize]</c> pages), and with nothing
-    /// set Brouter renders components natively (null).
+    /// <c>RouteView</c> (behind Brouter's own fail-closed <c>[Authorize]</c> guard - see
+    /// <see cref="RenderPageWithLayout"/>), and with nothing set Brouter renders components
+    /// natively (null).
     /// </summary>
     internal RenderFragment<RouteData>? EffectiveFound
     {
@@ -242,10 +243,14 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     };
 
     // The layout-only composition: the framework RouteView, which resolves per-page @layout chains
-    // with DefaultLayout as the fallback - and throws for [Authorize] pages, so a layout-only
-    // configuration can never silently skip authorization.
+    // with DefaultLayout as the fallback. RouteView performs no authorization check whatsoever
+    // (the Components assembly doesn't even reference the authorization package), so Brouter
+    // applies its own fail-closed guard first - a layout-only configuration must never silently
+    // render an [Authorize] page.
     private RenderFragment RenderPageWithLayout(RouteData routeData) => builder =>
     {
+        BrouterRouteRenderer.EnsureNoAuthorizationRequirements(routeData.PageType);
+
         builder.OpenComponent<RouteView>(0);
         builder.AddAttribute(1, nameof(RouteView.RouteData), routeData);
         builder.AddAttribute(2, nameof(RouteView.DefaultLayout), DefaultLayout);
@@ -1212,6 +1217,9 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 // the URL deliberately stays put (the resource at this URL is what's missing).
                 foreach (var r in GetRoutesSnapshot()) r.Matched = false;
                 _noRouteMatched = true;
+                // The fallback replaces the routed content, so nothing routed is on screen anymore -
+                // a later navigation must not run leave guards for the replaced chain.
+                _committedChain = [];
                 _currentRouteData = null;
 
                 if (OnNotFound is not null) await OnNotFound(location);
@@ -2053,8 +2061,11 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
 
             // Publish the committed navigation's framework RouteData on the observer cascade (see
             // _currentRouteData). Content-fragment routes have no page type, so they publish null.
+            // Route values carry explicit nulls for unfilled optional parameters, matching the
+            // framework router's RouteData contract (see NormalizeRouteValues).
             _currentRouteData = winner.Component is not null
-                ? new RouteData(winner.Component, winner.Parameters)
+                ? new RouteData(winner.Component,
+                    BrouterRouteRenderer.NormalizeRouteValues(winner.Parameters, winner.TemplateParameterNames))
                 : null;
 
             if (OnMatch is not null) await OnMatch(winner);
@@ -2331,6 +2342,12 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 for (var n = node; n is not null; n = n.Parent) chain.Add(n);
                 chain.Reverse();
                 _committedChain = chain.ToArray();
+
+                // The failed target's page never rendered - the boundary is on screen in its place -
+                // so the observer cascade must stop publishing the previous page's RouteData.
+                // StateHasChanged re-emits the cascade (SetMatched only re-renders the routes).
+                _currentRouteData = null;
+                StateHasChanged();
                 return;
             }
         }
@@ -2339,6 +2356,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         {
             _navError = errorContext;
             _committedChain = [];
+            _currentRouteData = null;
             StateHasChanged();
         }
     }

--- a/src/Brouter/Bit.Brouter/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Brouter.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
@@ -23,13 +24,86 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// URL to navigate to when no route matches. If null, no redirect happens and
-    /// <see cref="NotFoundContent"/> (if any) is rendered in place.
+    /// Alias for <see cref="ChildContent"/>. When another template (<see cref="Found"/>,
+    /// <see cref="NotFound"/>, <see cref="Navigating"/>, ...) forces the child fragments to be
+    /// spelled out explicitly, <c>&lt;Routes&gt;</c> states the intent better than
+    /// <c>&lt;ChildContent&gt;</c>. Set one or the other, not both.
     /// </summary>
-    [Parameter] public string? NotFound { get; set; }
+    [Parameter] public RenderFragment? Routes { get; set; }
 
-    /// <summary>Inline content to render when no route matches and <see cref="NotFound"/> is null.</summary>
-    [Parameter] public RenderFragment<BrouterLocation>? NotFoundContent { get; set; }
+    /// <summary>
+    /// When set, every matched route that renders a <see cref="Broute.Component"/> (attribute-discovered
+    /// <c>@page</c> routes and hand-declared <c>Component=</c> routes alike) renders through this template
+    /// instead of Brouter instantiating the component itself. The fragment receives a real framework
+    /// <see cref="RouteData"/> - the matched page type plus the route parameter values - which is exactly
+    /// what the built-in <c>RouteView</c>, <c>AuthorizeRouteView</c> and <c>FocusOnNavigate</c> consume.
+    /// This makes the built-in Router's <c>&lt;Found Context="routeData"&gt;</c> block port over unchanged:
+    /// <c>[Authorize]</c> handling, <c>Authorizing</c>/<c>NotAuthorized</c> UI, per-page <c>@layout</c>
+    /// resolution and focus-on-navigate all keep working through those framework components, with no
+    /// Brouter-specific reimplementation. The template is responsible for rendering the page (typically by
+    /// ending in a <c>RouteView</c>/<c>AuthorizeRouteView</c> bound to the supplied route data); guards,
+    /// loaders, keep-alive and error boundaries still run around it as usual. Routes that render a
+    /// <see cref="Broute.Content"/> fragment ignore this template - they have no page type to expose -
+    /// and so do child routes rendered into a <see cref="BrouterOutlet"/>: nested-outlet layouts are
+    /// Brouter's own layout model, and a Found template that resolves per-page <c>@layout</c>s inside
+    /// an outlet-hosted layout would apply two layout systems at once. Mirrors <c>Router.Found</c>.
+    /// For the common case you don't need this template at all: set <see cref="NotAuthorized"/> /
+    /// <see cref="Authorizing"/> / <see cref="DefaultLayout"/> instead and Brouter composes the
+    /// standard <c>AuthorizeRouteView</c>/<c>RouteView</c> rendering itself; an explicitly set Found
+    /// always wins over that composition.
+    /// </summary>
+    [Parameter] public RenderFragment<RouteData>? Found { get; set; }
+
+    /// <summary>
+    /// Displayed when the user is not authorized for the matched <c>[Authorize]</c> page, receiving
+    /// the current <c>AuthenticationState</c>. Setting this (or <see cref="Authorizing"/> /
+    /// <see cref="Resource"/>) routes every Component-rendering route through the framework's own
+    /// <c>AuthorizeRouteView</c> - so policy/role evaluation, per-page <c>@layout</c> +
+    /// <see cref="DefaultLayout"/> resolution and reaction to live authentication-state changes are
+    /// all the framework's implementation, with no routing template in the app. Pages without
+    /// <c>[Authorize]</c> render normally through the same path. Like <c>AuthorizeRouteView</c>
+    /// itself, this requires the cascading <c>Task&lt;AuthenticationState&gt;</c>
+    /// (<c>CascadingAuthenticationState</c> / <c>AddCascadingAuthenticationState()</c>) and
+    /// <c>AddAuthorizationCore()</c>. When null, the framework's default "Not authorized" content
+    /// is shown. Ignored when <see cref="Found"/> is set.
+    /// </summary>
+    [Parameter] public RenderFragment<AuthenticationState>? NotAuthorized { get; set; }
+
+    /// <summary>
+    /// Displayed while the framework determines whether the user is authorized for an
+    /// <c>[Authorize]</c> page (e.g. an async <c>AuthenticationStateProvider</c> is still
+    /// resolving). Enables the same <c>AuthorizeRouteView</c> composition as
+    /// <see cref="NotAuthorized"/>. When null, the framework's default "Authorizing..." content is
+    /// shown. Ignored when <see cref="Found"/> is set.
+    /// </summary>
+    [Parameter] public RenderFragment? Authorizing { get; set; }
+
+    /// <summary>
+    /// The layout for matched pages that don't declare their own <c>@layout</c> - a page-level
+    /// <c>@layout</c> (and its nested layout chain) always wins, exactly like the built-in
+    /// <c>RouteView.DefaultLayout</c>. On its own it routes Component-rendering routes through the
+    /// framework's <c>RouteView</c>; combined with <see cref="NotAuthorized"/> /
+    /// <see cref="Authorizing"/> / <see cref="Resource"/> it flows to their
+    /// <c>AuthorizeRouteView</c> composition instead. Ignored when <see cref="Found"/> is set.
+    /// </summary>
+    [Parameter, DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public Type? DefaultLayout { get; set; }
+
+    /// <summary>
+    /// Optional resource passed to the authorization service for resource-based policy evaluation,
+    /// forwarded to <c>AuthorizeRouteView.Resource</c>. Enables the same <c>AuthorizeRouteView</c>
+    /// composition as <see cref="NotAuthorized"/>. Ignored when <see cref="Found"/> is set.
+    /// </summary>
+    [Parameter] public object? Resource { get; set; }
+
+    /// <summary>
+    /// URL to navigate to when no route matches. If null, no redirect happens and
+    /// <see cref="NotFound"/> (if any) is rendered in place.
+    /// </summary>
+    [Parameter] public string? NotFoundUrl { get; set; }
+
+    /// <summary>Inline content to render when no route matches and <see cref="NotFoundUrl"/> is null.</summary>
+    [Parameter] public RenderFragment<BrouterLocation>? NotFound { get; set; }
 
     /// <summary>
     /// Router-level error UI: the fallback boundary for commit-phase navigation failures (typically
@@ -110,6 +184,82 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
 
     internal BrouterLocation CurrentLocation { get; private set; } = BrouterLocation.Empty;
     internal BrouterOptions Options => _brouterService.Options;
+
+
+    // Cached delegates for the built-in Found compositions below. Method-group conversion allocates
+    // a fresh delegate per use, and EffectiveFound is read on every render of every matched route,
+    // so the delegate is minted once and reused. The composing methods read the live parameter
+    // values (NotAuthorized, DefaultLayout, ...) at render time, so caching the delegate never
+    // captures stale configuration.
+    private RenderFragment<RouteData>? _authorizeRouteViewFound;
+    private RenderFragment<RouteData>? _routeViewFound;
+
+    /// <summary>
+    /// The Found template in effect for Component-rendering routes. An explicit <see cref="Found"/>
+    /// parameter always wins; otherwise setting any of <see cref="NotAuthorized"/> /
+    /// <see cref="Authorizing"/> / <see cref="Resource"/> composes the framework's
+    /// <c>AuthorizeRouteView</c>, a lone <see cref="DefaultLayout"/> composes the framework's
+    /// <c>RouteView</c> (which itself fails closed on <c>[Authorize]</c> pages), and with nothing
+    /// set Brouter renders components natively (null).
+    /// </summary>
+    internal RenderFragment<RouteData>? EffectiveFound
+    {
+        get
+        {
+            if (Found is not null) return Found;
+
+            // AuthorizeRouteView only when an auth-related parameter opted in: it unconditionally
+            // requires the cascading Task<AuthenticationState>, so composing it for every app would
+            // break auth-less hosts.
+            if (NotAuthorized is not null || Authorizing is not null || Resource is not null)
+            {
+                return _authorizeRouteViewFound ??= RenderPageWithAuthorization;
+            }
+
+            if (DefaultLayout is not null)
+            {
+                return _routeViewFound ??= RenderPageWithLayout;
+            }
+
+            return null;
+        }
+    }
+
+    // The built-in authorization composition: the framework AuthorizeRouteView bound to the
+    // RouteData the router built for the matched page. Authorization correctness (policy/role
+    // evaluation, Authorizing/NotAuthorized states, layout resolution, live auth-state changes)
+    // deliberately stays the framework's implementation - Brouter only composes it. Null fragments
+    // are passed through; AuthorizeRouteView substitutes its own defaults.
+    private RenderFragment RenderPageWithAuthorization(RouteData routeData) => builder =>
+    {
+        builder.OpenComponent<AuthorizeRouteView>(0);
+        builder.AddAttribute(1, nameof(AuthorizeRouteView.RouteData), routeData);
+        builder.AddAttribute(2, nameof(AuthorizeRouteView.DefaultLayout), DefaultLayout);
+        builder.AddAttribute(3, nameof(AuthorizeRouteView.NotAuthorized), NotAuthorized);
+        builder.AddAttribute(4, nameof(AuthorizeRouteView.Authorizing), Authorizing);
+        builder.AddAttribute(5, nameof(AuthorizeRouteView.Resource), Resource);
+        builder.CloseComponent();
+    };
+
+    // The layout-only composition: the framework RouteView, which resolves per-page @layout chains
+    // with DefaultLayout as the fallback - and throws for [Authorize] pages, so a layout-only
+    // configuration can never silently skip authorization.
+    private RenderFragment RenderPageWithLayout(RouteData routeData) => builder =>
+    {
+        builder.OpenComponent<RouteView>(0);
+        builder.AddAttribute(1, nameof(RouteView.RouteData), routeData);
+        builder.AddAttribute(2, nameof(RouteView.DefaultLayout), DefaultLayout);
+        builder.CloseComponent();
+    };
+
+
+    // The framework RouteData of the currently committed navigation: the matched page type plus its
+    // route parameter values, or null when nothing (or a Content-fragment route, which has no page
+    // type) is committed. Cascaded unnamed-by-type from BuildRenderTree as an observer channel, so
+    // components anywhere under the Brouter (route-data publishers, breadcrumbs, telemetry) can take
+    // a [CascadingParameter] RouteData? without threading it through a Found template. Written only
+    // by the navigation pipeline on the renderer's dispatcher, like the rest of the nav-state fields.
+    private RouteData? _currentRouteData;
 
 
     // Routes discovered by scanning AppAssembly / AdditionalAssemblies for [Route]/@page components.
@@ -547,6 +697,11 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     {
         base.OnInitialized();
 
+        // Validate here as well as in OnParametersSet: the first OnParametersSet only runs after the
+        // async initialization below completes, and a misconfiguration should fail the first render
+        // synchronously instead of surfacing as an unhandled async exception.
+        ValidateChildContentAlias();
+
         // Compute discovered routes here (not only in OnParametersSet): the initial route match runs in
         // OnInitializedAsync, before OnParametersSet, and the synthetic <Broute> children must already be
         // present in the first render so they register in time to be matched on the initial navigation.
@@ -592,10 +747,19 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     {
         base.OnParametersSet();
 
+        ValidateChildContentAlias();
+
         // Refresh discovered routes whenever the assembly set changes (including the first parameter set,
         // and when AdditionalAssemblies grows because a lazy-loaded assembly was added). Kept out of the
         // navigation pipeline so scanning cost is paid on parameter changes, not per navigation.
         RefreshDiscoveredRoutesIfNeeded();
+    }
+
+    private void ValidateChildContentAlias()
+    {
+        if (ChildContent is not null && Routes is not null)
+            throw new InvalidOperationException(
+                $"{nameof(Brouter)} accepts either {nameof(ChildContent)} or {nameof(Routes)} ({nameof(Routes)} is an alias for {nameof(ChildContent)}), not both.");
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026",
@@ -834,9 +998,18 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         builder.OpenComponent<CascadingValue<Brouter>>(0);
         builder.AddAttribute(1, "Name", "Brouter");
         builder.AddAttribute(2, "Value", this);
-        builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
+        builder.AddAttribute(3, "ChildContent", (RenderFragment)(bo =>
         {
-            b.AddContent(0, ChildContent);
+            // Observer channel: the committed navigation's framework RouteData (or null when nothing
+            // routed is committed), cascaded unnamed-by-type so any descendant can take a
+            // [CascadingParameter] RouteData? - publishers, breadcrumbs, telemetry - without a Found
+            // template. Not fixed: the value is replaced on every commit and subscribers must see it.
+            bo.OpenComponent<CascadingValue<RouteData?>>(0);
+            bo.AddAttribute(1, "Value", _currentRouteData);
+            bo.AddAttribute(2, "IsFixed", false);
+            bo.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
+            {
+            b.AddContent(0, ChildContent ?? Routes);
 
             // Emit a synthetic <Broute> for each attribute-discovered route. They register themselves
             // exactly like hand-declared children (via Broute.OnInitialized) and so participate in the
@@ -881,12 +1054,12 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 b.CloseRegion();
             }
 
-            // Render the inline fallback when no route matched and either NotFound is unset, or
-            // NotFound resolves to the current URL (no redirect happened, so we'd otherwise show nothing).
-            if (_noRouteMatched && NotFoundContent is not null &&
-                (string.IsNullOrEmpty(NotFound) || IsSamePath(CurrentLocation.Path, NotFound)))
+            // Render the inline fallback when no route matched and either NotFoundUrl is unset, or
+            // NotFoundUrl resolves to the current URL (no redirect happened, so we'd otherwise show nothing).
+            if (_noRouteMatched && NotFound is not null &&
+                (string.IsNullOrEmpty(NotFoundUrl) || IsSamePath(CurrentLocation.Path, NotFoundUrl)))
             {
-                b.AddContent(2, NotFoundContent(CurrentLocation));
+                b.AddContent(2, NotFound(CurrentLocation));
             }
 
             // Pending-navigation UI. Shown while the current navigation awaits its loaders (see the
@@ -906,6 +1079,8 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             {
                 b.AddContent(4, ErrorContent(_navError));
             }
+            }));
+            bo.CloseComponent();
         }));
         builder.CloseComponent();
     }
@@ -997,7 +1172,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// Handles <c>NavigationManager.OnNotFound</c> (.NET 10): application code called
     /// <c>NavigationManager.NotFound()</c> to report a missing resource (e.g. a page whose entity
     /// lookup failed). Brouter takes over rendering: it fires its own <see cref="OnNotFound"/> hook,
-    /// then either redirects to <see cref="NotFound"/> or renders <see cref="NotFoundContent"/> in
+    /// then either redirects to <see cref="NotFoundUrl"/> or renders <see cref="NotFound"/> in
     /// place, and signals the framework via <c>NotFoundEventArgs.Path</c> that the rendering is
     /// handled (mirroring the built-in Router's contract).
     /// </summary>
@@ -1008,11 +1183,11 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         // Signal "handled" synchronously (the framework reads args after the event returns). Only
         // claim it when this Brouter actually has a fallback to show; otherwise leave the args
         // untouched so the framework's own not-found handling (status codes / re-execution) runs.
-        if (string.IsNullOrEmpty(NotFound) is false)
+        if (string.IsNullOrEmpty(NotFoundUrl) is false)
         {
-            args.Path = NotFound;
+            args.Path = NotFoundUrl;
         }
-        else if (NotFoundContent is not null)
+        else if (NotFound is not null)
         {
             args.Path = CurrentLocation.Path;
         }
@@ -1037,12 +1212,13 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 // the URL deliberately stays put (the resource at this URL is what's missing).
                 foreach (var r in GetRoutesSnapshot()) r.Matched = false;
                 _noRouteMatched = true;
+                _currentRouteData = null;
 
                 if (OnNotFound is not null) await OnNotFound(location);
 
-                if (string.IsNullOrEmpty(NotFound) is false && IsSamePath(location.Path, NotFound) is false)
+                if (string.IsNullOrEmpty(NotFoundUrl) is false && IsSamePath(location.Path, NotFoundUrl) is false)
                 {
-                    NavigateInternal(NotFound);
+                    NavigateInternal(NotFoundUrl);
                     return;
                 }
 
@@ -1131,17 +1307,17 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
 
             if (winnerMatch is null)
             {
-                // No route matched. Fire OnNotFound, then either redirect to the NotFound target
+                // No route matched. Fire OnNotFound, then either redirect to the NotFoundUrl target
                 // (preventively, so the unmatched URL never appears in the address bar) or allow
-                // the commit phase to render NotFoundContent in place.
+                // the commit phase to render NotFound in place.
                 if (OnNotFound is not null) await OnNotFound(to);
                 if (token.IsCancellationRequested) return;
 
-                if (string.IsNullOrEmpty(NotFound) is false && IsSamePath(to.Path, NotFound) is false)
+                if (string.IsNullOrEmpty(NotFoundUrl) is false && IsSamePath(to.Path, NotFoundUrl) is false)
                 {
                     context.PreventNavigation();
                     ResolveNavigationOutcome(to.FullUri, BrouterNavigationOutcome.NotFound());
-                    NavigateInternal(NotFound);
+                    NavigateInternal(NotFoundUrl);
                     return;
                 }
 
@@ -1235,7 +1411,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// <summary>
     /// Marks the next navigation this Brouter is about to trigger programmatically as a push or a
     /// replace, then delegates to <c>NavigationManager.NavigateTo</c>. Used for all of Brouter's own
-    /// internal navigations (redirects, NotFound redirect, cancelled-navigation address-bar restore) so
+    /// internal navigations (redirects, NotFoundUrl redirect, cancelled-navigation address-bar restore) so
     /// the phase that observes the resulting navigation classifies it correctly instead of guessing.
     /// </summary>
     private void NavigateInternal(string url, bool replace = false)
@@ -1341,9 +1517,9 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         return new BrouterLocation(uri, path, rawSegments, query, hash, hasTrailingSlash, historyState);
     }
 
-    // Cache the most recently-computed normalization. NotFound is typically a constant per
-    // Brouter instance, and BuildRenderTree calls IsSamePath on every render (NotFoundContent
-    // fallback check). One-slot cache is enough; on a NotFound parameter change the cached
+    // Cache the most recently-computed normalization. NotFoundUrl is typically a constant per
+    // Brouter instance, and BuildRenderTree calls IsSamePath on every render (NotFound
+    // fallback check). One-slot cache is enough; on a NotFoundUrl parameter change the cached
     // entry is replaced.
     private string? _isSamePathCacheTarget;
     private string? _isSamePathCacheNormalized;
@@ -1354,7 +1530,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// when their normalized path components are equal.
     /// </summary>
     /// <remarks>
-    /// Used by the NotFound logic to detect the "we're already at the NotFound target"
+    /// Used by the not-found logic to detect the "we're already at the NotFoundUrl target"
     /// case without triggering a redirect loop. The target may be absolute, base-relative,
     /// trailing-slash, query-bearing, or fragment-bearing; we strip query/fragment, drop
     /// the trailing slash under <see cref="BrouterOptions.IgnoreTrailingSlash"/>, and apply
@@ -1534,11 +1710,12 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 _noRouteMatched = true;
                 // Nothing routed is on screen once the fallback renders below; leave guards of the
                 // previous chain already ran for this navigation. Either way this navigation's
-                // awaited outcome is NotFound (resolved before any NotFound redirect fires).
+                // awaited outcome is NotFound (resolved before any NotFoundUrl redirect fires).
                 _committedChain = [];
+                _currentRouteData = null;
                 ResolveNavigationOutcome(to.FullUri, BrouterNavigationOutcome.NotFound());
 
-                // OnNotFound + the preventive NotFound redirect already ran in the changing phase
+                // OnNotFound + the preventive NotFoundUrl redirect already ran in the changing phase
                 // when decisionAlreadyMade is true; only run them here for the full-pipeline path.
                 if (decisionAlreadyMade is false)
                 {
@@ -1549,17 +1726,17 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                     // redirect/render on behalf of a superseded navigation.
                     if (token.IsCancellationRequested || version != _navVersion) return;
 
-                    if (string.IsNullOrEmpty(NotFound) is false)
+                    if (string.IsNullOrEmpty(NotFoundUrl) is false)
                     {
-                        // Avoid a self-redirect loop when the current URL is already the NotFound target
+                        // Avoid a self-redirect loop when the current URL is already the NotFoundUrl target
                         // (and still doesn't match any route). Render the fallback UI instead.
                         // Compare normalized base-relative paths rather than raw absolute URIs:
                         // "http://host/x" vs "http://host/x/" or vs "http://host/x?foo=1" would
                         // otherwise miss the equality check and trigger an infinite redirect loop
-                        // (the NotFound URL keeps not matching, we keep navigating to it).
-                        if (IsSamePath(to.Path, NotFound) is false)
+                        // (the NotFoundUrl keeps not matching, we keep navigating to it).
+                        if (IsSamePath(to.Path, NotFoundUrl) is false)
                         {
-                            NavigateInternal(NotFound);
+                            NavigateInternal(NotFoundUrl);
                             return;
                         }
                     }
@@ -1873,6 +2050,12 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             // Record what is now on screen so the next navigation's leave guards know which routes
             // they would deactivate.
             _committedChain = matchedChain.ToArray();
+
+            // Publish the committed navigation's framework RouteData on the observer cascade (see
+            // _currentRouteData). Content-fragment routes have no page type, so they publish null.
+            _currentRouteData = winner.Component is not null
+                ? new RouteData(winner.Component, winner.Parameters)
+                : null;
 
             if (OnMatch is not null) await OnMatch(winner);
             // Each await below can yield long enough for a newer navigation to start. If that

--- a/src/Brouter/Bit.Brouter/BrouterOutlet.cs
+++ b/src/Brouter/Bit.Brouter/BrouterOutlet.cs
@@ -227,6 +227,9 @@ public class BrouterOutlet : ComponentBase, IDisposable
         }
         else if (child.Component is not null)
         {
+            // Outlet-hosted routes always render natively (Found deliberately doesn't apply here -
+            // see Brouter.Found), so the same fail-closed [Authorize] guard as the inline path applies.
+            BrouterRouteRenderer.EnsureNoAuthorizationRequirements(child.Component);
             b2.OpenComponent(0, child.Component);
             BrouterRouteRenderer.ApplyTypedParameters(b2, child.Component, entry.Parameters, child.Brouter?.CurrentLocation,
                 child.BindComponentParametersByName ? child.TemplateParameterNames : null);

--- a/src/Brouter/Bit.Brouter/BrouterRouteRenderer.cs
+++ b/src/Brouter/Bit.Brouter/BrouterRouteRenderer.cs
@@ -112,7 +112,7 @@ internal class BrouterRouteRenderer
         builder.AddAttribute(2, "Value", _route);
         builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
         {
-            b.AddContent(0, _route.ChildContent);
+            b.AddContent(0, _route.ChildContent ?? _route.Routes);
             // A KeepAlive route that has been shown at least once keeps rendering while unmatched -
             // hidden - so its component state survives until it matches again (unless ClearKeepAlive
             // dropped it, in which case it re-renders only once it matches again).
@@ -362,11 +362,84 @@ internal class BrouterRouteRenderer
         }
         else if (_route.Component is not null)
         {
-            b3.OpenComponent(0, _route.Component);
-            ApplyTypedParameters(b3, _route.Component, routeParams, _route.Brouter?.CurrentLocation,
-                _route.BindComponentParametersByName ? _route.TemplateParameterNames : null);
-            b3.CloseComponent();
+            // Brouter's effective Found template (the built-in Router.Found counterpart) - the Found
+            // parameter, or the built-in AuthorizeRouteView/RouteView composition that Brouter's
+            // NotAuthorized/Authorizing/DefaultLayout/Resource parameters enable (see EffectiveFound). The
+            // template renders the page itself - typically via RouteView/AuthorizeRouteView bound to
+            // the framework RouteData built here - so Brouter must not also instantiate the component.
+            // Which branch runs is fixed for the app's lifetime (both sources are wired up before the
+            // initial match), so sharing sequence 0 with the direct-instantiation branch diffs cleanly.
+            var found = _route.Brouter?.EffectiveFound;
+            if (found is not null)
+            {
+                b3.AddContent(0, found(GetFrameworkRouteData(routeParams)));
+            }
+            else
+            {
+                EnsureNoAuthorizationRequirements(_route.Component);
+                b3.OpenComponent(0, _route.Component);
+                ApplyTypedParameters(b3, _route.Component, routeParams, _route.Brouter?.CurrentLocation,
+                    _route.BindComponentParametersByName ? _route.TemplateParameterNames : null);
+                b3.CloseComponent();
+            }
         }
+    }
+
+    // Whether a component type declares authorization requirements ([Authorize] / any IAuthorizeData),
+    // cached per type: the check runs on every native render of a Component route.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, bool> _requiresAuthorizationCache = new();
+
+    /// <summary>
+    /// Fail-closed guard for the native rendering path, mirroring the built-in <c>RouteView</c>:
+    /// a component carrying <c>[Authorize]</c> must never be instantiated by a code path that
+    /// cannot enforce it. Rendering through <c>Brouter.Found</c> or the built-in
+    /// <c>NotAuthorized</c>/<c>Authorizing</c> composition never reaches this (the framework's
+    /// <c>AuthorizeRouteView</c>/<c>RouteView</c> handle or reject it there); this covers direct
+    /// instantiation by Brouter itself, inline or inside a <see cref="BrouterOutlet"/>.
+    /// </summary>
+    internal static void EnsureNoAuthorizationRequirements(Type componentType)
+    {
+        var requiresAuthorization = _requiresAuthorizationCache.GetOrAdd(
+            componentType,
+            static t => t.GetCustomAttributes(inherit: true).OfType<Microsoft.AspNetCore.Authorization.IAuthorizeData>().Any());
+
+        if (requiresAuthorization)
+        {
+            throw new InvalidOperationException(
+                $"The component '{componentType.FullName}' declares authorization requirements ([Authorize]), " +
+                "but it is being rendered without authorization support, which would silently skip the check. " +
+                "Set Brouter's NotAuthorized/Authorizing parameters (or a Found template ending in AuthorizeRouteView) " +
+                "so pages render through the framework's authorization pipeline, or enforce access with a route " +
+                "Guard and remove the [Authorize] attribute from the component.");
+        }
+    }
+
+    // Cached framework RouteData handed to Brouter.Found, rebuilt only when the matched parameters
+    // instance or the component type actually changes (same reuse rationale as the wrapper caches
+    // above: a stable instance keeps the Found fragment's consumers - RouteView/AuthorizeRouteView -
+    // quiet on renders where nothing routing-related changed). Keyed on the BrouterRouteParameters
+    // reference: RenderRoute reissues it exactly when a navigation commits new routing state, and
+    // per-parameter keep-alive entries each carry their own frozen instance, so a hidden kept page
+    // keeps seeing the route values it was deactivated with.
+    private RouteData? _cachedPageRouteData;
+    private BrouterRouteParameters? _cachedPageRouteDataParamsRef;
+    private Type? _cachedPageRouteDataComponentRef;
+
+    private RouteData GetFrameworkRouteData(BrouterRouteParameters routeParams)
+    {
+        if (_cachedPageRouteData is null
+            || ReferenceEquals(_cachedPageRouteDataParamsRef, routeParams) is false
+            || ReferenceEquals(_cachedPageRouteDataComponentRef, _route.Component) is false)
+        {
+            // The merged parameter values (ancestor + own template parameters) mirror what the
+            // built-in router's RouteData.RouteValues carries for the matched page: for a flat
+            // discovered @page route they are exactly the template's matched values, constraint-
+            // converted (e.g. {id:int} -> boxed int) the same way RouteView expects to bind them.
+            _cachedPageRouteData = new RouteData(_route.Component!, routeParams.Values);
+            _cachedPageRouteDataParamsRef = routeParams;
+            _cachedPageRouteDataComponentRef = _route.Component;
+        }
+        return _cachedPageRouteData;
     }
 
     internal static void ApplyTypedParameters(RenderTreeBuilder builder, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] Type componentType, BrouterRouteParameters parameters, BrouterLocation? location, IReadOnlySet<string>? conventionalTemplateParameters = null)

--- a/src/Brouter/Bit.Brouter/BrouterRouteRenderer.cs
+++ b/src/Brouter/Bit.Brouter/BrouterRouteRenderer.cs
@@ -390,12 +390,14 @@ internal class BrouterRouteRenderer
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, bool> _requiresAuthorizationCache = new();
 
     /// <summary>
-    /// Fail-closed guard for the native rendering path, mirroring the built-in <c>RouteView</c>:
-    /// a component carrying <c>[Authorize]</c> must never be instantiated by a code path that
-    /// cannot enforce it. Rendering through <c>Brouter.Found</c> or the built-in
+    /// Fail-closed guard for code paths that cannot enforce authorization: a component carrying
+    /// <c>[Authorize]</c> must never be instantiated by one. The built-in
     /// <c>NotAuthorized</c>/<c>Authorizing</c> composition never reaches this (the framework's
-    /// <c>AuthorizeRouteView</c>/<c>RouteView</c> handle or reject it there); this covers direct
-    /// instantiation by Brouter itself, inline or inside a <see cref="BrouterOutlet"/>.
+    /// <c>AuthorizeRouteView</c> enforces the attribute there); a user-supplied <c>Brouter.Found</c>
+    /// template owns its own auth stack, like the built-in Router. This covers direct instantiation
+    /// by Brouter itself - inline or inside a <see cref="BrouterOutlet"/> - and the layout-only
+    /// <c>DefaultLayout</c> composition, because the framework's plain <c>RouteView</c> performs
+    /// no authorization check at all.
     /// </summary>
     internal static void EnsureNoAuthorizationRequirements(Type componentType)
     {
@@ -434,12 +436,34 @@ internal class BrouterRouteRenderer
             // The merged parameter values (ancestor + own template parameters) mirror what the
             // built-in router's RouteData.RouteValues carries for the matched page: for a flat
             // discovered @page route they are exactly the template's matched values, constraint-
-            // converted (e.g. {id:int} -> boxed int) the same way RouteView expects to bind them.
-            _cachedPageRouteData = new RouteData(_route.Component!, routeParams.Values);
+            // converted (e.g. {id:int} -> boxed int) the same way RouteView expects to bind them,
+            // normalized with explicit nulls for optional parameters the URL left unfilled.
+            _cachedPageRouteData = new RouteData(_route.Component!,
+                NormalizeRouteValues(routeParams.Values, _route.TemplateParameterNames));
             _cachedPageRouteDataParamsRef = routeParams;
             _cachedPageRouteDataComponentRef = _route.Component;
         }
         return _cachedPageRouteData;
+    }
+
+    // Framework-router parity for RouteData.RouteValues: the built-in router adds an explicit null
+    // entry for every route parameter the URL left unfilled (trailing optionals), so RouteView still
+    // emits a parameter frame for it and a page instance reused across navigations (e.g.
+    // /profile/saleh -> /profile) has the stale value reset instead of silently kept. Returns the
+    // original dictionary unchanged when every template parameter is present.
+    internal static IReadOnlyDictionary<string, object?> NormalizeRouteValues(
+        IReadOnlyDictionary<string, object?> values, IReadOnlySet<string>? templateParameterNames)
+    {
+        if (templateParameterNames is null || templateParameterNames.Count == 0) return values;
+
+        Dictionary<string, object?>? augmented = null;
+        foreach (var name in templateParameterNames)
+        {
+            if (values.ContainsKey(name)) continue;
+            augmented ??= new Dictionary<string, object?>(values, StringComparer.OrdinalIgnoreCase);
+            augmented[name] = null;
+        }
+        return augmented ?? values;
     }
 
     internal static void ApplyTypedParameters(RenderTreeBuilder builder, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] Type componentType, BrouterRouteParameters parameters, BrouterLocation? location, IReadOnlySet<string>? conventionalTemplateParameters = null)

--- a/src/Brouter/InteralDemos/Core/AppRouter.razor
+++ b/src/Brouter/InteralDemos/Core/AppRouter.razor
@@ -118,327 +118,391 @@
 @* AppAssembly enables attribute-route discovery: components with @page / [Route] (e.g. DiscoveredPage)
    are matched alongside the hand-declared routes below, without being listed here.
    OnNavigateAsync is the lazy route-loading hook (see OnNavigate above). *@
-<Brouter NotFound="404" AppAssembly="@GetType().Assembly" OnNavigateAsync="OnNavigate">
-    <ChildContent>
-    <Broute Path="/" RedirectTo="/home" />
+<Brouter NotFoundUrl="404" AppAssembly="@GetType().Assembly" OnNavigateAsync="OnNavigate">
+    <Routes>
+        <Broute Path="/" RedirectTo="/home" />
 
-    <Broute Name="home" Path="/home">
-        <Content><HomePage CountValue="@_currentCount" /></Content>
-    </Broute>
+        <Broute Name="home" Path="/home">
+            <Content>
+                <HomePage CountValue="@_currentCount" />
+            </Content>
+        </Broute>
 
-    <Broute Path="/counter">
-        <Content><CounterPage @bind-CurrentCount="_currentCount" ChangeCount="@ChangeCountValue" /></Content>
-    </Broute>
+        <Broute Path="/counter">
+            <Content>
+                <CounterPage @bind-CurrentCount="_currentCount" ChangeCount="@ChangeCountValue" />
+            </Content>
+        </Broute>
 
-    <Broute Name="counter" Path="/counter/{init:int}">
-        <Content><CounterPage @bind-CurrentCount="_currentCount" ChangeCount="@ChangeCountValue" /></Content>
-    </Broute>
+        <Broute Name="counter" Path="/counter/{init:int}">
+            <Content>
+                <CounterPage @bind-CurrentCount="_currentCount" ChangeCount="@ChangeCountValue" />
+            </Content>
+        </Broute>
 
-    <Broute Path="/counter/multi/{id:int:long}/{age:long:decimal:double}/{name}">
-        <Content><CounterPage @bind-CurrentCount="_currentCount" ChangeCount="@ChangeCountValue" /></Content>
-    </Broute>
+        <Broute Path="/counter/multi/{id:int:long}/{age:long:decimal:double}/{name}">
+            <Content>
+                <CounterPage @bind-CurrentCount="_currentCount" ChangeCount="@ChangeCountValue" />
+            </Content>
+        </Broute>
 
-    <Broute Path="/fetchdata" Component="@typeof(FetchDataPage)" />
+        <Broute Path="/fetchdata" Component="@typeof(FetchDataPage)" />
 
-    @* Optional parameter: /profile or /profile/saleh both match. *@
-    <Broute Path="/profile/{username?}" Component="@typeof(ProfilePage)" />
+        @* Optional parameter: /profile or /profile/saleh both match. *@
+        <Broute Path="/profile/{username?}" Component="@typeof(ProfilePage)" />
 
-    @* Catch-all parameter: /posts/2024/12/hello-world binds the whole tail. *@
-    <Broute Path="/posts/{**slug}" Component="@typeof(PostPage)" />
+        @* Catch-all parameter: /posts/2024/12/hello-world binds the whole tail. *@
+        <Broute Path="/posts/{**slug}" Component="@typeof(PostPage)" />
 
-    <Broute Path="/{prefix}/test2/{postfix}">
-        <Content Context="p">
-            <div class="bb-intro">
-                <h1>Test2 pattern</h1>
-                <p class="bb-subtitle">Matched <code>{prefix}/test2/{postfix}</code>.</p>
-            </div>
-            <dl class="bb-params">
-                <dt>prefix</dt><dd>@p["prefix"]</dd>
-                <dt>postfix</dt><dd>@p["postfix"]</dd>
-            </dl>
-        </Content>
-    </Broute>
-
-    @* Wildcard route - only wins if nothing more specific matches. *@
-    <Broute Path="/*/test">
-        <Content>
-            <div class="bb-intro">
-                <h1>Wildcard test</h1>
-                <p class="bb-subtitle">Matched the wildcard pattern <code>/*/test</code>.</p>
-            </div>
-        </Content>
-    </Broute>
-
-    @*============================================================================*@
-
-    <Broute Path="/nested-route">
-        <Broute Path="/{id:int}" Component="@typeof(FetchDataPage)" />
-        <Broute Path="/{id:int}/hello">
+        <Broute Path="/{prefix}/test2/{postfix}">
             <Content Context="p">
                 <div class="bb-intro">
-                    <h1>Nested route <code>/{id:int}/hello</code></h1>
+                    <h1>Test2 pattern</h1>
+                    <p class="bb-subtitle">Matched <code>{prefix}/test2/{postfix}</code>.</p>
                 </div>
                 <dl class="bb-params">
-                    <dt>id</dt><dd>@p["id"]</dd>
+                    <dt>prefix</dt>
+                    <dd>@p["prefix"]</dd>
+                    <dt>postfix</dt>
+                    <dd>@p["postfix"]</dd>
                 </dl>
-                <hr />
-                <FetchDataPage Value="2" />
             </Content>
         </Broute>
-        <Broute Path="/{id:int}/world">
-            <Content Context="p">
+
+        @* Wildcard route - only wins if nothing more specific matches. *@
+        <Broute Path="/*/test">
+            <Content>
                 <div class="bb-intro">
-                    <h1>Nested route <code>/{id:int}/world</code></h1>
+                    <h1>Wildcard test</h1>
+                    <p class="bb-subtitle">Matched the wildcard pattern <code>/*/test</code>.</p>
                 </div>
-                <dl class="bb-params">
-                    <dt>id</dt><dd>@p["id"]</dd>
-                </dl>
-                <hr />
-                <FetchDataPage Value="3" />
             </Content>
         </Broute>
-    </Broute>
 
-    @*============================================================================*@
+        @*============================================================================*@
 
-    <Broute Path="g1" Guard="@GuardEvenSecond">
-        <Content>
-            <div class="bb-intro">
-                <h1>Guarded route <code>/g1</code></h1>
-                <p class="bb-subtitle">Allowed only when the current second is even - otherwise redirects to <code>/403</code>.</p>
-            </div>
-            <div class="bb-card">
-                <span class="bb-badge bb-badge-success">access granted</span>
-                <p style="margin-top: .5rem;">You made it through the guard.</p>
-            </div>
-        </Content>
-    </Broute>
+        <Broute Path="/nested-route">
+            <Broute Path="/{id:int}" Component="@typeof(FetchDataPage)" />
+            <Broute Path="/{id:int}/hello">
+                <Content Context="p">
+                    <div class="bb-intro">
+                        <h1>Nested route <code>/{id:int}/hello</code></h1>
+                    </div>
+                    <dl class="bb-params">
+                        <dt>id</dt>
+                        <dd>@p["id"]</dd>
+                    </dl>
+                    <hr />
+                    <FetchDataPage Value="2" />
+                </Content>
+            </Broute>
+            <Broute Path="/{id:int}/world">
+                <Content Context="p">
+                    <div class="bb-intro">
+                        <h1>Nested route <code>/{id:int}/world</code></h1>
+                    </div>
+                    <dl class="bb-params">
+                        <dt>id</dt>
+                        <dd>@p["id"]</dd>
+                    </dl>
+                    <hr />
+                    <FetchDataPage Value="3" />
+                </Content>
+            </Broute>
+        </Broute>
 
-    <Broute Path="g2" Guard="@CheckEvenMinute">
-        <Content>
-            <div class="bb-intro">
-                <h1>Guarded route <code>/g2</code></h1>
-                <p class="bb-subtitle">Allowed only when the current minute is even - otherwise redirects to <code>/403</code>.</p>
-            </div>
-            <div class="bb-card">
-                <span class="bb-badge bb-badge-success">access granted</span>
-                <p style="margin-top: .5rem;">You made it through the async guard.</p>
-            </div>
-        </Content>
-    </Broute>
+        @*============================================================================*@
 
-    @*============================================================================*@
-
-    <Broute Path="nested" Component="@typeof(Nested)">
-        <Broute Path="n1/{count:int}">
-            <Content Context="p">
-                <h3>Child: <code>/nested/n1</code></h3>
-                <dl class="bb-params"><dt>count</dt><dd>@p["count"]</dd></dl>
+        <Broute Path="g1" Guard="@GuardEvenSecond">
+            <Content>
+                <div class="bb-intro">
+                    <h1>Guarded route <code>/g1</code></h1>
+                    <p class="bb-subtitle">Allowed only when the current second is even - otherwise redirects to
+                        <code>/403</code>.
+                    </p>
+                </div>
+                <div class="bb-card">
+                    <span class="bb-badge bb-badge-success">access granted</span>
+                    <p style="margin-top: .5rem;">You made it through the guard.</p>
+                </div>
             </Content>
         </Broute>
-    </Broute>
 
-    <Broute Path="nested2" Component="@typeof(Nested2)">
-        <Broute Path="n1/{count:int}">
-            <Content Context="p">
-                <h3>Child: <code>/nested2/n1</code></h3>
-                <dl class="bb-params"><dt>count</dt><dd>@p["count"]</dd></dl>
+        <Broute Path="g2" Guard="@CheckEvenMinute">
+            <Content>
+                <div class="bb-intro">
+                    <h1>Guarded route <code>/g2</code></h1>
+                    <p class="bb-subtitle">Allowed only when the current minute is even - otherwise redirects to
+                        <code>/403</code>.
+                    </p>
+                </div>
+                <div class="bb-card">
+                    <span class="bb-badge bb-badge-success">access granted</span>
+                    <p style="margin-top: .5rem;">You made it through the async guard.</p>
+                </div>
             </Content>
         </Broute>
-        <Broute Path="n2/{count:int}">
-            <Content Context="p">
-                <h3>Child: <code>/nested2/n2</code></h3>
-                <dl class="bb-params"><dt>count</dt><dd><strong>@p["count"]</strong></dd></dl>
-            </Content>
-        </Broute>
-    </Broute>
 
-    <Broute Path="nested3">
-        <Content>
-            <div class="bb-intro">
-                <h1>Nested route <code>/nested3</code></h1>
-                <p class="bb-subtitle">An inline parent route that also defines its own outlet.</p>
-            </div>
-            <div class="bb-card">
-                <h3 class="bb-card-title">Children</h3>
-                <ul class="bb-link-list">
-                    <li><BrouterLink Href="/nested3/n1/1">/nested3/n1/1</BrouterLink></li>
-                    <li><BrouterLink Href="/nested3/n2/2">/nested3/n2/2</BrouterLink></li>
-                </ul>
-            </div>
-            <div class="bb-card">
-                <h3 class="bb-card-title">
-                    <span class="bb-dot bb-dot-success"></span>
-                    Outlet
-                </h3>
-                <BrouterOutlet />
-            </div>
-        </Content>
-        <ChildContent>
+        @*============================================================================*@
+
+        <Broute Path="nested" Component="@typeof(Nested)">
             <Broute Path="n1/{count:int}">
                 <Content Context="p">
-                    <h3>Child: <code>/nested3/n1</code></h3>
-                    <dl class="bb-params"><dt>count</dt><dd><em>@p["count"]</em></dd></dl>
+                    <h3>Child: <code>/nested/n1</code></h3>
+                    <dl class="bb-params">
+                        <dt>count</dt>
+                        <dd>@p["count"]</dd>
+                    </dl>
+                </Content>
+            </Broute>
+        </Broute>
+
+        <Broute Path="nested2" Component="@typeof(Nested2)">
+            <Broute Path="n1/{count:int}">
+                <Content Context="p">
+                    <h3>Child: <code>/nested2/n1</code></h3>
+                    <dl class="bb-params">
+                        <dt>count</dt>
+                        <dd>@p["count"]</dd>
+                    </dl>
                 </Content>
             </Broute>
             <Broute Path="n2/{count:int}">
                 <Content Context="p">
-                    <h3>Child: <code>/nested3/n2</code></h3>
-                    <dl class="bb-params"><dt>count</dt><dd><strong>@p["count"]</strong></dd></dl>
+                    <h3>Child: <code>/nested2/n2</code></h3>
+                    <dl class="bb-params">
+                        <dt>count</dt>
+                        <dd><strong>@p["count"]</strong></dd>
+                    </dl>
                 </Content>
             </Broute>
-        </ChildContent>
-    </Broute>
+        </Broute>
 
-    @*============================================================================*@
+        <Broute Path="nested3">
+            <Content>
+                <div class="bb-intro">
+                    <h1>Nested route <code>/nested3</code></h1>
+                    <p class="bb-subtitle">An inline parent route that also defines its own outlet.</p>
+                </div>
+                <div class="bb-card">
+                    <h3 class="bb-card-title">Children</h3>
+                    <ul class="bb-link-list">
+                        <li>
+                            <BrouterLink Href="/nested3/n1/1">/nested3/n1/1</BrouterLink>
+                        </li>
+                        <li>
+                            <BrouterLink Href="/nested3/n2/2">/nested3/n2/2</BrouterLink>
+                        </li>
+                    </ul>
+                </div>
+                <div class="bb-card">
+                    <h3 class="bb-card-title">
+                        <span class="bb-dot bb-dot-success"></span>
+                        Outlet
+                    </h3>
+                    <BrouterOutlet />
+                </div>
+            </Content>
+            <Routes>
+                <Broute Path="n1/{count:int}">
+                    <Content Context="p">
+                        <h3>Child: <code>/nested3/n1</code></h3>
+                        <dl class="bb-params">
+                            <dt>count</dt>
+                            <dd><em>@p["count"]</em></dd>
+                        </dl>
+                    </Content>
+                </Broute>
+                <Broute Path="n2/{count:int}">
+                    <Content Context="p">
+                        <h3>Child: <code>/nested3/n2</code></h3>
+                        <dl class="bb-params">
+                            <dt>count</dt>
+                            <dd><strong>@p["count"]</strong></dd>
+                        </dl>
+                    </Content>
+                </Broute>
+            </Routes>
+        </Broute>
 
-    <Broute Path="404">
-        <Content>
-            <div class="bb-error bb-error-404">
-                <h1>404</h1>
-                <p>Sorry, there's nothing at this address.</p>
-                <BrouterLink Href="/" class="btn btn-primary">Back to home</BrouterLink>
-            </div>
-        </Content>
-    </Broute>
+        @*============================================================================*@
 
-    <Broute Path="/403">
-        <Content>
-            <div class="bb-error bb-error-403">
-                <h1>403</h1>
-                <p>Oops! You can't go there yet.</p>
-                <BrouterLink Href="/" class="btn btn-primary">Back to home</BrouterLink>
-            </div>
-        </Content>
-    </Broute>
+        <Broute Path="404">
+            <Content>
+                <div class="bb-error bb-error-404">
+                    <h1>404</h1>
+                    <p>Sorry, there's nothing at this address.</p>
+                    <BrouterLink Href="/" class="btn btn-primary">Back to home</BrouterLink>
+                </div>
+            </Content>
+        </Broute>
 
-    @*============================================================================*@
-    @* Data layer: loader + StaleTime cache + revalidation + query updates (DataPage),
+        <Broute Path="/403">
+            <Content>
+                <div class="bb-error bb-error-403">
+                    <h1>403</h1>
+                    <p>Oops! You can't go there yet.</p>
+                    <BrouterLink Href="/" class="btn btn-primary">Back to home</BrouterLink>
+                </div>
+            </Content>
+        </Broute>
+
+        @*============================================================================*@
+        @* Data layer: loader + StaleTime cache + revalidation + query updates (DataPage),
        deferred/streamed data (DeferredPage), error boundary with retry (UnstablePage). *@
 
-    <Broute Name="data" Path="/data" Loader="LoadData" StaleTime="TimeSpan.FromSeconds(30)" Meta="@("Data & caching demo")">
-        <Content><DataPage /></Content>
-    </Broute>
+        <Broute Name="data" Path="/data" Loader="LoadData" StaleTime="TimeSpan.FromSeconds(30)"
+                Meta="@("Data & caching demo")">
+            <Content>
+                <DataPage />
+            </Content>
+        </Broute>
 
-    <Broute Path="/deferred" Loader="LoadDeferred">
-        <Content><DeferredPage /></Content>
-    </Broute>
+        <Broute Path="/deferred" Loader="LoadDeferred">
+            <Content>
+                <DeferredPage />
+            </Content>
+        </Broute>
 
-    <Broute Path="/unstable" Loader="LoadUnstable">
-        <Content><UnstablePage /></Content>
-        <ErrorContent Context="err">
-            <div class="bb-error bb-error-403">
-                <h1>Route failed to load</h1>
-                <p>@err.Exception.Message</p>
-                <button class="btn btn-primary" @onclick="@(async () => { demoState.UnstableShouldFail = false; await err.RetryAsync(); })">
-                    Fix the service &amp; retry
-                </button>
-            </div>
-        </ErrorContent>
-    </Broute>
+        <Broute Path="/unstable" Loader="LoadUnstable">
+            <Content>
+                <UnstablePage />
+            </Content>
+            <ErrorContent Context="err">
+                <div class="bb-error bb-error-403">
+                    <h1>Route failed to load</h1>
+                    <p>@err.Exception.Message</p>
+                    <button class="btn btn-primary"
+                            @onclick="@(async () => { demoState.UnstableShouldFail = false; await err.RetryAsync(); })">
+                        Fix the service &amp; retry
+                    </button>
+                </div>
+            </ErrorContent>
+        </Broute>
 
-    @*============================================================================*@
-    @* Navigation control: leave guard (unsaved changes), history entry state,
+        @*============================================================================*@
+        @* Navigation control: leave guard (unsaved changes), history entry state,
        awaited navigation outcomes, and the always-cancelling /blocked target. *@
 
-    <Broute Path="/editor" LeaveGuard="GuardEditorLeave">
-        <Content><EditorPage /></Content>
-    </Broute>
+        <Broute Path="/editor" LeaveGuard="GuardEditorLeave">
+            <Content>
+                <EditorPage />
+            </Content>
+        </Broute>
 
-    <Broute Path="/history-state">
-        <Content><HistoryStatePage /></Content>
-    </Broute>
+        <Broute Path="/history-state">
+            <Content>
+                <HistoryStatePage />
+            </Content>
+        </Broute>
 
-    <Broute Path="/outcomes">
-        <Content><OutcomesPage /></Content>
-    </Broute>
+        <Broute Path="/outcomes">
+            <Content>
+                <OutcomesPage />
+            </Content>
+        </Broute>
 
-    <Broute Path="/blocked" Guard="BlockAlways">
-        <Content><div>This never renders - the guard always cancels.</div></Content>
-    </Broute>
+        <Broute Path="/blocked" Guard="BlockAlways">
+            <Content>
+                <div>This never renders - the guard always cancels.</div>
+            </Content>
+        </Broute>
 
-    @*============================================================================*@
-    @* Keep-alive: /sticky vs the /fleeting control shows singleton retention plus the
+        @*============================================================================*@
+        @* Keep-alive: /sticky vs the /fleeting control shows singleton retention plus the
        activate/deactivate lifecycle (BrouterKeepAliveContext pauses the page's timer while
        hidden); /notes/{id} shows per-parameter caching (KeepAliveMax) with LRU eviction and
        IBrouter.ClearKeepAlive(). *@
 
-    <Broute Path="/sticky" KeepAlive="true">
-        <Content><StickyNotePage KeepAliveDemo="true" /></Content>
-    </Broute>
+        <Broute Path="/sticky" KeepAlive="true">
+            <Content>
+                <StickyNotePage KeepAliveDemo="true" />
+            </Content>
+        </Broute>
 
-    <Broute Path="/fleeting">
-        <Content><StickyNotePage KeepAliveDemo="false" /></Content>
-    </Broute>
+        <Broute Path="/fleeting">
+            <Content>
+                <StickyNotePage KeepAliveDemo="false" />
+            </Content>
+        </Broute>
 
-    <Broute Name="notes" Path="/notes/{id:int}" KeepAlive="true" KeepAliveMax="2" Component="@typeof(NotebookPage)" />
+        <Broute Name="notes" Path="/notes/{id:int}" KeepAlive="true" KeepAliveMax="2"
+                Component="@typeof(NotebookPage)" />
 
-    @*============================================================================*@
-    @* View Transitions showcase: shared-element morphs between the gallery grid and the item
+        @*============================================================================*@
+        @* View Transitions showcase: shared-element morphs between the gallery grid and the item
        detail hero via matching view-transition-name declarations (pure CSS wiring). *@
 
-    <Broute Name="gallery" Path="/gallery" Component="@typeof(GalleryPage)" />
-    <Broute Path="/gallery/{id:int}" Component="@typeof(GalleryItemPage)" />
+        <Broute Name="gallery" Path="/gallery" Component="@typeof(GalleryPage)" />
+        <Broute Path="/gallery/{id:int}" Component="@typeof(GalleryItemPage)" />
 
-    @*============================================================================*@
-    @* Named outlets + pathless group: one child route fills two layout regions; the group
+        @*============================================================================*@
+        @* Named outlets + pathless group: one child route fills two layout regions; the group
        attaches a shared guard to every dashboard child without adding a URL segment. *@
 
-    <Broute Path="/dashboard">
-        <Content>
-            <div class="bb-intro">
-                <h1>Dashboard (named outlets)</h1>
-                <p class="bb-subtitle">
-                    One child route drives two regions. Entries into this section, counted by the
-                    pathless group's shared guard: <strong>@_dashboardVisits</strong>
-                </p>
-            </div>
-            <nav style="margin-bottom: 1rem; display: flex; gap: .5rem;">
-                <BrouterLink Href="/dashboard/stats" class="btn btn-primary">Stats</BrouterLink>
-                <BrouterLink Href="/dashboard/activity" class="btn btn-primary">Activity</BrouterLink>
-            </nav>
-            <div class="bb-grid">
-                <section class="bb-card">
-                    <h3 class="bb-card-title"><span class="bb-dot bb-dot-primary"></span> Main (primary outlet)</h3>
-                    <BrouterOutlet />
-                </section>
-                <section class="bb-card">
-                    <h3 class="bb-card-title"><span class="bb-dot bb-dot-success"></span> Sidebar (named outlet)</h3>
-                    <BrouterOutlet Name="sidebar" />
-                </section>
-            </div>
-        </Content>
-        <ChildContent>
-            <Broute Group Path="" Guard="CountDashboardVisit">
-                <ChildContent>
-                    <Broute Path="/stats">
-                        <Content><p>Stats main content, rendered by the primary outlet.</p></Content>
-                        <ChildContent>
-                            <BrouterView Name="sidebar" Context="p">
-                                <p>Stats filters - a <code>&lt;BrouterView Name="sidebar"&gt;</code> rendered by the same-named outlet.</p>
-                            </BrouterView>
-                        </ChildContent>
+        <Broute Path="/dashboard">
+            <Content>
+                <div class="bb-intro">
+                    <h1>Dashboard (named outlets)</h1>
+                    <p class="bb-subtitle">
+                        One child route drives two regions. Entries into this section, counted by the
+                        pathless group's shared guard: <strong>@_dashboardVisits</strong>
+                    </p>
+                </div>
+                <nav style="margin-bottom: 1rem; display: flex; gap: .5rem;">
+                    <BrouterLink Href="/dashboard/stats" class="btn btn-primary">Stats</BrouterLink>
+                    <BrouterLink Href="/dashboard/activity" class="btn btn-primary">Activity</BrouterLink>
+                </nav>
+                <div class="bb-grid">
+                    <section class="bb-card">
+                        <h3 class="bb-card-title"><span class="bb-dot bb-dot-primary"></span> Main (primary outlet)</h3>
+                        <BrouterOutlet />
+                    </section>
+                    <section class="bb-card">
+                        <h3 class="bb-card-title"><span class="bb-dot bb-dot-success"></span> Sidebar (named outlet)
+                        </h3>
+                        <BrouterOutlet Name="sidebar" />
+                    </section>
+                </div>
+            </Content>
+            <Routes>
+                <Broute Group Path="" Guard="CountDashboardVisit">
+                    <Routes>
+                        <Broute Path="/stats">
+                            <Content>
+                                <p>Stats main content, rendered by the primary outlet.</p>
+                            </Content>
+                            <Routes>
+                                <BrouterView Name="sidebar" Context="p">
+                                    <p>Stats filters - a <code>&lt;BrouterView Name="sidebar"&gt;</code> rendered by the
+                                        same-named outlet.
+                                    </p>
+                                </BrouterView>
+                            </Routes>
+                        </Broute>
+                        <Broute Path="/activity">
+                            <Content>
+                                <p>Activity main content. This route declares no sidebar view, so the named outlet stays
+                                    empty.</p>
+                                </Content>
+                            </Broute>
+                        </Routes>
                     </Broute>
-                    <Broute Path="/activity">
-                        <Content><p>Activity main content. This route declares no sidebar view, so the named outlet stays empty.</p></Content>
-                    </Broute>
-                </ChildContent>
+                </Routes>
             </Broute>
-        </ChildContent>
-    </Broute>
-    </ChildContent>
+        </Routes>
 
-    @* Shown while a navigation awaits slow loaders (visible on the first, uncached visit to /data). *@
-    <Navigating>
-        <div class="bb-card"><em>Loading route data…</em></div>
-    </Navigating>
+        @* Shown while a navigation awaits slow loaders (visible on the first, uncached visit to /data). *@
+        <Navigating>
+            <div class="bb-card"><em>Loading route data…</em></div>
+        </Navigating>
 
-    @* Router-level error boundary: failures on routes without their own ErrorContent land here. *@
-    <ErrorContent Context="err">
-        <div class="bb-error bb-error-403">
-            <h1>Navigation failed</h1>
-            <p>@err.Exception.Message</p>
-            <button class="btn btn-primary" @onclick="@(() => err.RetryAsync())">Retry</button>
-        </div>
-    </ErrorContent>
-</Brouter>
+        @* Router-level error boundary: failures on routes without their own ErrorContent land here. *@
+        <ErrorContent Context="err">
+            <div class="bb-error bb-error-403">
+                <h1>Navigation failed</h1>
+                <p>@err.Exception.Message</p>
+                <button class="btn btn-primary" @onclick="@(() => err.RetryAsync())">Retry</button>
+            </div>
+        </ErrorContent>
+    </Brouter>

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -34,7 +34,7 @@ render modes.
 ## Quick start
 
 ```razor
-<Brouter NotFound="404">
+<Brouter NotFoundUrl="404">
     <Broute Path="/" RedirectTo="/home" />
 
     <Broute Name="home" Path="/home">
@@ -92,7 +92,7 @@ render modes.
 - Component or `Content` (typed render fragment) rendering
 - **Pending navigation UI**: a `Navigating` fragment shown while a navigation awaits slow loaders - revealed lazily so loader-less (or cache-hit) navigations never flash it (mirrors the built-in `Router.Navigating`)
 - Router-level hooks: `OnMatch` (a route matched) and `OnNotFound` (nothing matched), alongside the global `IBrouter` events
-- `NotFound` URL or inline `NotFoundContent`
+- `NotFoundUrl` redirect or inline `NotFound` content
 - **Type-safe `BrouterRouteParameters`** with `TryGet<T>` / `Get<T>` / `GetOrDefault<T>`
 - **Auto-binding** to component properties via `[Parameter, BrouterParameter]`
 - **`<BrouterLink>`** component with active-class and `aria-current` (NavLink-style)
@@ -103,6 +103,9 @@ render modes.
 - **Preventive guards** (via `RegisterLocationChangingHandler`): a cancel/redirect stops the URL from ever changing - no address-bar flicker, no corrupted history/back button, and real "unsaved changes" prompts are possible
 - In-flight loader cancellation when navigation is superseded
 - **Attribute-route / `@page` discovery**: scan `AppAssembly` / `AdditionalAssemblies` for `[Route]`-annotated components so routes live colocated with their pages (Razor class libraries and lazy-loaded assemblies included)
+- **Drop-in built-in-Router migration via `Found`**: a `RenderFragment<RouteData>` that receives a real framework `RouteData` for every matched page, so the built-in `RouteView`, `AuthorizeRouteView` (`[Authorize]`, `Authorizing`/`NotAuthorized` UI), per-page `@layout` resolution and `FocusOnNavigate` all keep working unchanged - the built-in Router's `<Found Context="routeData">` block ports over as-is
+- **Zero-template authorization**: set `NotAuthorized` / `Authorizing` / `DefaultLayout` / `Resource` directly on `<Brouter>` and `[Authorize]` pages just work - Brouter composes the framework's own `AuthorizeRouteView`/`RouteView` internally, so authorization correctness stays Microsoft's code; native rendering fails closed on `[Authorize]` components it can't enforce
+- **Cascaded `RouteData` observer channel**: the committed navigation's framework `RouteData` (or null on not-found) is cascaded unnamed-by-type, so publishers/breadcrumbs/telemetry anywhere under the router can take `[CascadingParameter] RouteData?` with no template plumbing
 - **Prerender state bridging**: loader results captured during prerender are restored on the interactive pass via `PersistentComponentState`, so loaders don't double-fetch (opt-in)
 - Query string and hash exposed via `BrouterLocation`
 - Configurable case sensitivity and trailing-slash handling
@@ -205,7 +208,7 @@ still fires either way.
 
 ```razor
 <Brouter>
-    <ChildContent>
+    <Routes>
         <Broute Path="/users/{id:int}" Loader="@LoadUser">
             <Content Context="p"><UserDetails /></Content>
             <ErrorContent Context="err">
@@ -213,7 +216,7 @@ still fires either way.
                 <button @onclick="@(() => err.RetryAsync())">Try again</button>
             </ErrorContent>
         </Broute>
-    </ChildContent>
+    </Routes>
     <ErrorContent Context="err">
         <h1>Something went wrong</h1>
         <button @onclick="@(() => err.RetryAsync())">Retry</button>
@@ -285,9 +288,9 @@ instead of all of them combined.
 
 ```razor
 <Brouter>
-    <ChildContent>
+    <Routes>
         <Broute Path="/reports" Loader="@LoadReports">...</Broute>
-    </ChildContent>
+    </Routes>
     <Navigating>
         <div class="spinner">Loading…</div>
     </Navigating>
@@ -575,8 +578,8 @@ is inert - navigation behaves exactly as with the option off.
 On net10.0, Brouter participates in the framework's not-found contract:
 
 - Application code calling `NavigationManager.NotFound()` (e.g. a page whose entity lookup failed)
-  flows through Brouter: the `OnNotFound` hook fires, then the `NotFound` URL redirect or inline
-  `NotFoundContent` renders - the URL stays put, mirroring the built-in router.
+  flows through Brouter: the `OnNotFound` hook fires, then the `NotFoundUrl` redirect or inline
+  `NotFound` content renders - the URL stays put, mirroring the built-in router.
 - When Brouter itself matches nothing during **static SSR**, it calls `NavigationManager.NotFound()`
   so the response carries a real **HTTP 404** (and drives `UseStatusCodePagesWithReExecute` when
   configured) instead of a 200 with fallback HTML.
@@ -619,7 +622,7 @@ On net10.0, Brouter participates in the framework's not-found contract:
 
 Besides the `IBrouter` events, the `Brouter` component itself takes two async hooks:
 `OnMatch` (fired with the winning `Broute` whenever a route matches) and `OnNotFound` (fired with
-the `BrouterLocation` when nothing matches, before the `NotFound` redirect/fallback applies).
+the `BrouterLocation` when nothing matches, before the `NotFoundUrl` redirect / `NotFound` fallback applies).
 
 ## Nested routes
 
@@ -638,11 +641,16 @@ the `BrouterLocation` when nothing matches, before the `NotFound` redirect/fallb
         <h1>Dashboard</h1>
         <BrouterOutlet />
     </Content>
-    <ChildContent>
+    <Routes>
         <Broute Path="/stats" Component="@typeof(StatsPage)" />
-    </ChildContent>
+    </Routes>
 </Broute>
 ```
+
+When another template (`Content`, `Found`, `NotFound`, `ErrorContent`, ...) is present, Razor
+requires the child routes to be wrapped in an explicit fragment. `Routes` is an alias for
+`ChildContent` on both `Brouter` and `Broute` so that wrapper can carry a self-describing name -
+either spelling works (setting both throws).
 
 ### Pathless group routes
 
@@ -653,10 +661,10 @@ Share behavior across routes without inventing a URL segment:
     <Content>
         <AdminShell><BrouterOutlet /></AdminShell>
     </Content>
-    <ChildContent>
+    <Routes>
         <Broute Path="/dashboard" Component="@typeof(DashboardPage)" />
         <Broute Path="/audit" Component="@typeof(AuditPage)" />
-    </ChildContent>
+    </Routes>
 </Broute>
 ```
 
@@ -741,15 +749,15 @@ route provides its main content plus optional named `BrouterView` fragments:
         <main><BrouterOutlet /></main>                @* primary: the child's Content/Component *@
         <aside><BrouterOutlet Name="sidebar" /></aside> @* named: the child's matching BrouterView *@
     </Content>
-    <ChildContent>
+    <Routes>
         <Broute Path="/stats">
             <Content><StatsPage /></Content>
-            <ChildContent>
+            <Routes>
                 <BrouterView Name="sidebar" Context="p"><StatsFilters /></BrouterView>
-            </ChildContent>
+            </Routes>
         </Broute>
         <Broute Path="/settings" Component="@typeof(SettingsPage)" />  @* no view -> sidebar renders empty *@
-    </ChildContent>
+    </Routes>
 </Broute>
 ```
 
@@ -888,6 +896,112 @@ same by-name binding on a hand-declared route, set `BindComponentParametersByNam
 
 > Discovery reflects over the given assemblies, so - like the built-in Blazor `Router` - keep your routable
 > components preserved when trimming.
+
+## Migrating from the built-in Router
+
+The built-in Router's companion components - `RouteView`, `AuthorizeRouteView`, `FocusOnNavigate` - are
+router-independent: they consume a `RouteData` (the matched page type plus its route values), not the
+`Router` itself. Brouter builds that `RouteData` for every matched page and hands it to those framework
+components for you - so for the common case the whole `Found`/`AuthorizeRouteView` template disappears
+into a few flat parameters, and for full control the built-in `<Found>` block still ports over verbatim.
+
+### Zero-template authorization
+
+For the common case - `[Authorize]` on pages, a layout, fallback UI - you don't need any routing
+template at all. Set the fallback fragments (and optionally a `DefaultLayout`) directly on the router:
+
+```razor
+<Brouter AppAssembly="@typeof(App).Assembly" AdditionalAssemblies="_additional"
+         DefaultLayout="@typeof(MainLayout)">
+    <Authorizing>Checking credentials…</Authorizing>
+    <NotAuthorized><RedirectToLogin /></NotAuthorized>
+    <NotFound>Sorry, there's nothing here.</NotFound>
+    <Navigating>Loading…</Navigating>
+</Brouter>
+```
+
+Setting any of `NotAuthorized` / `Authorizing` / `Resource` routes every Component-rendering route
+through the framework's own `AuthorizeRouteView`. That's deliberate: policy/role evaluation, the
+`Authorizing`/`NotAuthorized` states, `DefaultLayout` plus per-page `@layout` resolution, and reaction
+to live authentication-state changes are all Microsoft's implementation - Brouter never owns
+authorization correctness. Pages without `[Authorize]` render normally through the same path, and
+`Resource` is forwarded for resource-based policies. As with the built-in Router stack, the app still
+provides `CascadingAuthenticationState` (or `AddCascadingAuthenticationState()`) and
+`AddAuthorizationCore()`.
+
+A lone `DefaultLayout` (no auth fragments) composes the framework's plain `RouteView` instead - which,
+per its own contract, throws for `[Authorize]` pages rather than skipping the check. And when nothing
+is configured at all, Brouter's native rendering **fails closed** too: instantiating a component that
+declares `[Authorize]` throws with guidance, so a missing configuration can never silently bypass
+authorization (use a route `Guard` and drop the attribute if you want guard-based auth instead). An
+explicit `Found` parameter (below) always wins over these built-in compositions.
+
+### Full control: the `Found` template
+
+When you need arbitrary per-navigation markup around the page - telemetry publishers, custom
+`AuthorizeRouteView` subclasses, `FocusOnNavigate` - the built-in Router's `<Found Context="routeData">`
+block ports over verbatim:
+
+```razor
+<Brouter AppAssembly="@typeof(App).Assembly" AdditionalAssemblies="_additional">
+    <Found Context="routeData">
+        <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+            <Authorizing>Checking credentials…</Authorizing>
+            <NotAuthorized><RedirectToLogin /></NotAuthorized>
+        </AuthorizeRouteView>
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+    <NotFound>Sorry, there's nothing here.</NotFound>
+    <Navigating>Loading…</Navigating>
+</Brouter>
+```
+
+Everything the framework components already do keeps working with zero Brouter-specific code:
+
+- **Authorization** - `[Authorize]` (policies/roles) on pages, the `Authorizing` and `NotAuthorized`
+  fragments, and `CascadingAuthenticationState` integration, all via the built-in `AuthorizeRouteView`.
+- **Layouts** - `DefaultLayout` plus per-page `@layout` directives (nested layout chains included), via
+  the built-in `RouteView`/`AuthorizeRouteView`.
+- **Focus** - `FocusOnNavigate` re-focuses its selector whenever the supplied `RouteData` changes.
+
+### Observing the current `RouteData` from anywhere
+
+Brouter also cascades the committed navigation's `RouteData` (unnamed, by type) to every descendant -
+null when nothing matched or the matched route renders a `Content` fragment. Route-data publishers,
+breadcrumbs and telemetry components can observe it without touching the routing template:
+
+```razor
+@* Works anywhere under the Brouter - no Found template required. *@
+@code {
+    [CascadingParameter] public RouteData? RouteData { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        // Fires on every committed navigation with the new RouteData (or null on not-found).
+    }
+}
+```
+
+The mapping from the built-in `Router`:
+
+| Built-in `Router` stack | Brouter |
+|---|---|
+| `<Found>` + `<AuthorizeRouteView>` + `Authorizing`/`NotAuthorized` | flat `Authorizing`/`NotAuthorized` fragments on `<Brouter>` (no template), or an unchanged `<Found Context="routeData">` for full control |
+| `RouteView`/`AuthorizeRouteView` `DefaultLayout` | `DefaultLayout` on `<Brouter>` |
+| `AuthorizeRouteView` `Resource` | `Resource` on `<Brouter>` |
+| `<NotFound>` | `<NotFound>` (unchanged; or a `NotFoundUrl` redirect URL) |
+| `<Navigating>` | `<Navigating>` (unchanged) |
+| `AppAssembly` / `AdditionalAssemblies` / `OnNavigateAsync` | same-named parameters |
+
+`Found` applies to every matched route that renders a `Component` - attribute-discovered `@page` routes
+and hand-declared `<Broute Component=...>` routes alike. When set, Brouter builds the `RouteData` and the
+template renders the page; Brouter does not instantiate the component itself, so parameter binding is the
+built-in `RouteView` binding (which is the point: identical behavior to the built-in stack). Guards,
+loaders, keep-alive and error boundaries still run around the template as usual. Two kinds of routes
+deliberately ignore `Found`: `Content`-fragment routes (no page type to expose) and child routes rendered
+into a `BrouterOutlet` - nested-outlet layouts are Brouter's own layout model, and resolving per-page
+`@layout`s inside an outlet-hosted layout would apply two layout systems at once. Migrate first, then
+adopt guards/loaders/outlets incrementally where they earn their keep.
 
 ## Performance & scalability
 

--- a/src/Brouter/Tests/Bit.Brouter.Tests/AutoAuthHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/AutoAuthHost.razor
@@ -1,0 +1,7 @@
+@* The flat, zero-template authorization setup: NotAuthorized/Authorizing directly on the Brouter
+   make [Authorize] pages work through the framework's AuthorizeRouteView - no Found template, no
+   RouteView/AuthorizeRouteView in the app's routing markup. *@
+<Brouter AppAssembly="@typeof(AutoAuthHost).Assembly">
+    <NotAuthorized><div data-testid="auto-denied">denied</div></NotAuthorized>
+    <Authorizing><div data-testid="auto-authorizing">authorizing</div></Authorizing>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/AutoAuthLayoutHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/AutoAuthLayoutHost.razor
@@ -1,3 +1,4 @@
 @* DefaultLayout alone composes the framework RouteView, wrapping pages that declare no @layout of
-   their own (and failing closed on [Authorize] pages, per RouteView's own contract). *@
+   their own (failing closed on [Authorize] pages via Brouter's own guard - plain RouteView
+   performs no authorization check). *@
 <Brouter AppAssembly="@typeof(AutoAuthLayoutHost).Assembly" DefaultLayout="@typeof(FoundTestLayout)" />

--- a/src/Brouter/Tests/Bit.Brouter.Tests/AutoAuthLayoutHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/AutoAuthLayoutHost.razor
@@ -1,0 +1,3 @@
+@* DefaultLayout alone composes the framework RouteView, wrapping pages that declare no @layout of
+   their own (and failing closed on [Authorize] pages, per RouteView's own contract). *@
+<Brouter AppAssembly="@typeof(AutoAuthLayoutHost).Assembly" DefaultLayout="@typeof(FoundTestLayout)" />

--- a/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
@@ -1,0 +1,109 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+[TestClass]
+public class BrouterAuthorizationTests : BunitTestContext
+{
+    [TestMethod]
+    public void Authorize_page_renders_when_authorized_with_no_Found_template()
+    {
+        var auth = Context!.AddTestAuthorization();
+        auth.SetAuthorized("alice");
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        var cut = RenderComponent<AutoAuthHost>();
+
+        cut.WaitForAssertion(() => Assert.AreEqual("secure", cut.Find("[data-testid=secure]").TextContent));
+    }
+
+    [TestMethod]
+    public void Authorize_page_renders_NotAuthorized_when_denied()
+    {
+        var auth = Context!.AddTestAuthorization();
+        auth.SetNotAuthorized();
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        var cut = RenderComponent<AutoAuthHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("denied", cut.Find("[data-testid=auto-denied]").TextContent);
+            Assert.AreEqual(0, cut.FindAll("[data-testid=secure]").Count);
+        });
+    }
+
+    [TestMethod]
+    public void Unprotected_page_renders_even_when_not_authorized()
+    {
+        var auth = Context!.AddTestAuthorization();
+        auth.SetNotAuthorized();
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/5");
+
+        var cut = RenderComponent<AutoAuthHost>();
+
+        // No [Authorize] on DiscoveredPage: AuthorizeRouteView renders it without an auth check,
+        // exactly like the built-in Router stack.
+        cut.WaitForAssertion(() =>
+            StringAssert.StartsWith(cut.Find("[data-testid=discovered]").TextContent, "id:5"));
+    }
+
+    [TestMethod]
+    public void DefaultLayout_wraps_pages_without_their_own_layout()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/1");
+
+        var cut = RenderComponent<AutoAuthLayoutHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var layout = cut.Find("[data-testid=layout-marker]");
+            Assert.IsNotNull(layout.QuerySelector("[data-testid=discovered]"));
+        });
+    }
+
+    [TestMethod]
+    public void Explicit_Found_parameter_wins_over_the_builtin_composition()
+    {
+        var auth = Context!.AddTestAuthorization();
+        auth.SetAuthorized("alice");
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/1");
+
+        var cut = RenderComponent<FoundOverrideHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            // The explicit Found rendered (its marker is present) and the built-in composition
+            // did not (the host's DefaultLayout never wrapped the page).
+            Assert.AreEqual(nameof(DiscoveredPage), cut.Find("[data-testid=explicit-found]").TextContent);
+            Assert.AreEqual(0, cut.FindAll("[data-testid=layout-marker]").Count);
+        });
+    }
+
+    [TestMethod]
+    public async Task Authorize_page_rendered_natively_fails_closed()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        // DiscoveryHost sets no Found and no auth parameters, so SecurePage would render natively -
+        // which must throw rather than silently skip the [Authorize] check (mirroring RouteView).
+        _ = RenderComponent<DiscoveryHost>();
+
+        var exception = await Context!.Renderer.UnhandledException.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.IsInstanceOfType<InvalidOperationException>(exception);
+        StringAssert.Contains(exception.Message, "authorization");
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
@@ -93,6 +93,22 @@ public class BrouterAuthorizationTests : BunitTestContext
     }
 
     [TestMethod]
+    public async Task Authorize_page_fails_closed_under_the_DefaultLayout_only_composition()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        // AutoAuthLayoutHost sets only DefaultLayout, composing the framework RouteView - which
+        // performs no authorization check at all - so Brouter's own guard must throw rather than
+        // silently render the [Authorize] page.
+        _ = RenderComponent<AutoAuthLayoutHost>();
+
+        var exception = await Context!.Renderer.UnhandledException.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.IsInstanceOfType<InvalidOperationException>(exception);
+        StringAssert.Contains(exception.Message, "authorization");
+    }
+
+    [TestMethod]
     public async Task Authorize_page_rendered_natively_fails_closed()
     {
         var nav = Services.GetRequiredService<FakeNavigationManager>();

--- a/src/Brouter/Tests/Bit.Brouter.Tests/CascadedRouteDataProbe.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/CascadedRouteDataProbe.razor
@@ -1,0 +1,7 @@
+@* An observer of Brouter's cascaded framework RouteData - the pattern for route-data publishers,
+   breadcrumbs and telemetry components that need the matched page type without a Found template. *@
+<div data-testid="probe">@(RouteData?.PageType.Name ?? "null")</div>
+
+@code {
+    [CascadingParameter] public RouteData? RouteData { get; set; }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/FoundAuthHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/FoundAuthHost.razor
@@ -1,0 +1,12 @@
+@using Microsoft.AspNetCore.Components.Authorization
+
+@* The Boilerplate-style Found block: the built-in AuthorizeRouteView consumes the RouteData
+   Brouter supplies, providing [Authorize] handling and the NotAuthorized/Authorizing UI slots. *@
+<Brouter AppAssembly="@typeof(FoundAuthHost).Assembly">
+    <Found Context="routeData">
+        <AuthorizeRouteView RouteData="@routeData">
+            <NotAuthorized><div data-testid="not-authorized">denied</div></NotAuthorized>
+            <Authorizing><div data-testid="authorizing">authorizing</div></Authorizing>
+        </AuthorizeRouteView>
+    </Found>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/FoundHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/FoundHost.razor
@@ -1,0 +1,19 @@
+@* Exercises Brouter.Found: attribute-discovered @page routes and hand-declared Component routes
+   render through the template - which delegates the actual page rendering to the built-in
+   RouteView, exactly like the built-in Router's <Found Context="routeData"> block - while
+   Content-based routes and the NotFound fallback are unaffected. *@
+<Brouter AppAssembly="@typeof(FoundHost).Assembly">
+    <ChildContent>
+        <Broute Path="/hand" Component="@typeof(HandComponentPage)" />
+        <Broute Path="/content-route">
+            <Content><div data-testid="content-route">content</div></Content>
+        </Broute>
+    </ChildContent>
+    <Found Context="routeData">
+        <div data-testid="found-page-type">@routeData.PageType.Name</div>
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound Context="location">
+        <div data-testid="not-found">nf:@location.Path</div>
+    </NotFound>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/FoundOverrideHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/FoundOverrideHost.razor
@@ -1,0 +1,9 @@
+@* An explicitly set Found parameter must win over the built-in NotAuthorized/DefaultLayout
+   composition. *@
+<Brouter AppAssembly="@typeof(FoundOverrideHost).Assembly" DefaultLayout="@typeof(FoundTestLayout)">
+    <Found Context="routeData">
+        <div data-testid="explicit-found">@routeData.PageType.Name</div>
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotAuthorized><div data-testid="override-denied">denied</div></NotAuthorized>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/FoundTemplateTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/FoundTemplateTests.cs
@@ -124,6 +124,23 @@ public class FoundTemplateTests : BunitTestContext
     }
 
     [TestMethod]
+    public void RouteView_clears_an_optional_route_value_left_unfilled_by_the_next_navigation()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/opt/saleh");
+
+        var cut = RenderComponent<OptionalRouteViewHost>();
+        cut.WaitForAssertion(() => Assert.AreEqual("saleh", cut.Find("[data-testid=opt-name]").TextContent));
+
+        // Same Broute and page type: the component instance is reused, so the unfilled optional
+        // must arrive as an explicit null route value (framework RouteData parity) - omitting the
+        // entry would leave the previous navigation's value on the parameter.
+        nav.NavigateTo("http://localhost/opt");
+
+        cut.WaitForAssertion(() => Assert.AreEqual("(none)", cut.Find("[data-testid=opt-name]").TextContent));
+    }
+
+    [TestMethod]
     public void AuthorizeRouteView_inside_Found_renders_the_page_when_authorized()
     {
         var auth = Context!.AddTestAuthorization();

--- a/src/Brouter/Tests/Bit.Brouter.Tests/FoundTemplateTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/FoundTemplateTests.cs
@@ -1,0 +1,157 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+[TestClass]
+public class FoundTemplateTests : BunitTestContext
+{
+    [TestMethod]
+    public void Found_receives_a_framework_RouteData_for_a_discovered_page()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/42");
+
+        var cut = RenderComponent<FoundHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            // The Found template observed the matched page type via RouteData.PageType.
+            Assert.AreEqual(nameof(DiscoveredPage), cut.Find("[data-testid=found-page-type]").TextContent);
+            // The page itself was rendered by the built-in RouteView from the supplied RouteData,
+            // binding the {id:int} route value to the [Parameter] property - Brouter did not
+            // instantiate the component itself.
+            StringAssert.StartsWith(cut.Find("[data-testid=discovered]").TextContent, "id:42");
+        });
+    }
+
+    [TestMethod]
+    public void Found_wraps_hand_declared_Component_routes_too()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/hand");
+
+        var cut = RenderComponent<FoundHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(nameof(HandComponentPage), cut.Find("[data-testid=found-page-type]").TextContent);
+            Assert.AreEqual("hand", cut.Find("[data-testid=hand]").TextContent);
+        });
+    }
+
+    [TestMethod]
+    public void Content_routes_render_natively_and_ignore_Found()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/content-route");
+
+        var cut = RenderComponent<FoundHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("content", cut.Find("[data-testid=content-route]").TextContent);
+            // No page type exists for a Content route, so the Found template must not have run.
+            Assert.AreEqual(0, cut.FindAll("[data-testid=found-page-type]").Count);
+        });
+    }
+
+    [TestMethod]
+    public void NotFound_fallback_still_renders_when_Found_is_set()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/definitely-missing");
+
+        var cut = RenderComponent<FoundHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("nf:/definitely-missing", cut.Find("[data-testid=not-found]").TextContent);
+            Assert.AreEqual(0, cut.FindAll("[data-testid=found-page-type]").Count);
+        });
+    }
+
+    [TestMethod]
+    public void Found_updates_across_navigations_between_pages()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/1");
+
+        var cut = RenderComponent<FoundHost>();
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual(nameof(DiscoveredPage), cut.Find("[data-testid=found-page-type]").TextContent));
+
+        nav.NavigateTo("http://localhost/hand");
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(nameof(HandComponentPage), cut.Find("[data-testid=found-page-type]").TextContent);
+            // The previous page was unrendered along with its Found wrapper.
+            Assert.AreEqual(0, cut.FindAll("[data-testid=discovered]").Count);
+        });
+    }
+
+    [TestMethod]
+    public void Page_layout_attribute_is_honored_by_RouteView_inside_Found()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/layouted");
+
+        var cut = RenderComponent<FoundHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            // @layout FoundTestLayout on the page is resolved by the built-in RouteView, so the
+            // page body renders inside the layout's marker element.
+            var layout = cut.Find("[data-testid=layout-marker]");
+            Assert.IsNotNull(layout.QuerySelector("[data-testid=layouted]"));
+        });
+    }
+
+    [TestMethod]
+    public void Component_with_multiple_page_directives_contributes_one_route_each()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/multi-a");
+
+        var cut = RenderComponent<FoundHost>();
+        cut.WaitForAssertion(() => Assert.AreEqual("multi", cut.Find("[data-testid=multi]").TextContent));
+
+        nav.NavigateTo("http://localhost/multi-b");
+        cut.WaitForAssertion(() => Assert.AreEqual("multi", cut.Find("[data-testid=multi]").TextContent));
+    }
+
+    [TestMethod]
+    public void AuthorizeRouteView_inside_Found_renders_the_page_when_authorized()
+    {
+        var auth = Context!.AddTestAuthorization();
+        auth.SetAuthorized("alice");
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        var cut = RenderComponent<FoundAuthHost>();
+
+        cut.WaitForAssertion(() => Assert.AreEqual("secure", cut.Find("[data-testid=secure]").TextContent));
+    }
+
+    [TestMethod]
+    public void AuthorizeRouteView_inside_Found_renders_NotAuthorized_when_denied()
+    {
+        var auth = Context!.AddTestAuthorization();
+        auth.SetNotAuthorized();
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        var cut = RenderComponent<FoundAuthHost>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("denied", cut.Find("[data-testid=not-authorized]").TextContent);
+            Assert.AreEqual(0, cut.FindAll("[data-testid=secure]").Count);
+        });
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/FoundTestLayout.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/FoundTestLayout.razor
@@ -1,0 +1,5 @@
+@inherits LayoutComponentBase
+
+<div data-testid="layout-marker">
+    @Body
+</div>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/GuardHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/GuardHost.razor
@@ -1,6 +1,6 @@
 @using Bit.Brouter
 
-<Brouter NotFound="/404">
+<Brouter NotFoundUrl="/404">
     <Broute Path="/secret" Guard="@Deny">
         <Content><div data-testid="ok">should not render</div></Content>
     </Broute>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/HandComponentPage.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/HandComponentPage.razor
@@ -1,0 +1,3 @@
+@* A component with no @page directive, rendered by a hand-declared <Broute Component=...> in
+   FoundHost - Found must wrap these exactly like attribute-discovered pages. *@
+<div data-testid="hand">hand</div>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/LayoutedPage.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/LayoutedPage.razor
@@ -1,0 +1,6 @@
+@page "/layouted"
+@layout FoundTestLayout
+
+@* Per-page @layout: not interpreted by Brouter itself, but honored by the built-in RouteView
+   rendered from the Found template - the same division of labor as the built-in Router. *@
+<div data-testid="layouted">layouted</div>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/MultiRoutePage.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/MultiRoutePage.razor
@@ -1,0 +1,6 @@
+@page "/multi-a"
+@page "/multi-b"
+
+@* A component with several @page directives must contribute one discovered route per directive,
+   mirroring the built-in Router. *@
+<div data-testid="multi">multi</div>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/NotFoundInteropHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/NotFoundInteropHost.razor
@@ -1,13 +1,13 @@
-@* Host for NotFoundInteropTests: a page route, a 404 page route, and inline NotFoundContent, so
+@* Host for NotFoundInteropTests: a page route, a 404 page route, and inline NotFound content, so
    tests can exercise NavigationManager.NotFound() flowing through Brouter's OnNotFound event
    handling in both the redirect (NotFoundUrl set) and render-in-place (inline) shapes. Brouter
-   only renders the inline fragment when no NotFound URL redirect applies, so both shapes can
+   only renders the inline fragment when no NotFoundUrl redirect applies, so both shapes can
    coexist here. *@
 
 @using Bit.Brouter
 @inject IBrouter Brouter
 
-<Brouter NotFound="@NotFoundUrl" OnNotFound="@RecordNotFound">
+<Brouter NotFoundUrl="@NotFoundUrl" OnNotFound="@RecordNotFound">
     <ChildContent>
         <Broute Path="/a">
             <Content><div data-testid="a">a</div></Content>
@@ -16,9 +16,9 @@
             <Content><div data-testid="nf-page">404 page</div></Content>
         </Broute>
     </ChildContent>
-    <NotFoundContent Context="loc">
+    <NotFound Context="loc">
         <div data-testid="nf-inline">inline 404 for @loc.Path</div>
-    </NotFoundContent>
+    </NotFound>
 </Brouter>
 
 @code {

--- a/src/Brouter/Tests/Bit.Brouter.Tests/OptionalRouteViewHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/OptionalRouteViewHost.razor
@@ -1,0 +1,8 @@
+@* A lone DefaultLayout routes Component pages through the framework RouteView; an optional route
+   value the URL leaves unfilled must reach RouteView as an explicit null entry so a page instance
+   reused across /opt/x -> /opt has the parameter reset (framework-router RouteData parity). *@
+@using Bit.Brouter
+
+<Brouter DefaultLayout="@typeof(FoundTestLayout)">
+    <Broute Path="/opt/{name?}" Component="@typeof(OptionalRouteViewPage)" />
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/OptionalRouteViewPage.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/OptionalRouteViewPage.razor
@@ -1,0 +1,7 @@
+@* Hand-declared (no @page) page with an optional route parameter, rendered through the framework
+   RouteView by the DefaultLayout-only composition. *@
+<div data-testid="opt-name">@(Name ?? "(none)")</div>
+
+@code {
+    [Parameter] public string? Name { get; set; }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataErrorObserverHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataErrorObserverHost.razor
@@ -1,0 +1,23 @@
+@* Observer + a failing navigation: when a commit-phase failure renders an error boundary, the
+   cascaded RouteData must reset to null - the failed target's page never rendered, and the
+   previous page's RouteData must not keep being published. *@
+@using Bit.Brouter
+
+<Brouter>
+    <ChildContent>
+        <Broute Path="/ok-observed" Component="@typeof(MultiRoutePage)" />
+
+        <Broute Path="/fail-observed" Component="@typeof(HandComponentPage)" Loader="FailLoader">
+            <ErrorContent Context="err">
+                <div data-testid="observer-boundary">@err.Exception.Message</div>
+            </ErrorContent>
+        </Broute>
+
+        <CascadedRouteDataProbe />
+    </ChildContent>
+</Brouter>
+
+@code {
+    private ValueTask<object?> FailLoader(BrouterNavigationContext ctx)
+        => throw new InvalidOperationException("observed loader failed");
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataObserverHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataObserverHost.razor
@@ -1,0 +1,5 @@
+@* The probe lives in plain ChildContent - no Found template anywhere - and still observes the
+   committed navigation's RouteData via the unnamed-by-type cascade. *@
+<Brouter AppAssembly="@typeof(RouteDataObserverHost).Assembly">
+    <CascadedRouteDataProbe />
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataObserverTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataObserverTests.cs
@@ -1,0 +1,50 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+[TestClass]
+public class RouteDataObserverTests : BunitTestContext
+{
+    [TestMethod]
+    public void Cascaded_RouteData_carries_the_matched_page_type()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/7");
+
+        var cut = RenderComponent<RouteDataObserverHost>();
+
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual(nameof(DiscoveredPage), cut.Find("[data-testid=probe]").TextContent));
+    }
+
+    [TestMethod]
+    public void Cascaded_RouteData_updates_across_navigations()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/discovered/7");
+
+        var cut = RenderComponent<RouteDataObserverHost>();
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual(nameof(DiscoveredPage), cut.Find("[data-testid=probe]").TextContent));
+
+        nav.NavigateTo("http://localhost/multi-a");
+
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual(nameof(MultiRoutePage), cut.Find("[data-testid=probe]").TextContent));
+    }
+
+    [TestMethod]
+    public void Cascaded_RouteData_is_null_when_nothing_matches()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/definitely-missing");
+
+        var cut = RenderComponent<RouteDataObserverHost>();
+
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual("null", cut.Find("[data-testid=probe]").TextContent));
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataObserverTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RouteDataObserverTests.cs
@@ -47,4 +47,25 @@ public class RouteDataObserverTests : BunitTestContext
         cut.WaitForAssertion(() =>
             Assert.AreEqual("null", cut.Find("[data-testid=probe]").TextContent));
     }
+
+    [TestMethod]
+    public void Cascaded_RouteData_resets_to_null_when_a_navigation_fails_into_an_error_boundary()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/ok-observed");
+
+        var cut = RenderComponent<RouteDataErrorObserverHost>();
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual(nameof(MultiRoutePage), cut.Find("[data-testid=probe]").TextContent));
+
+        nav.NavigateTo("http://localhost/fail-observed");
+
+        // The failed target's page never rendered - the error boundary is on screen instead -
+        // so observers must not keep seeing the previous page's RouteData.
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsNotNull(cut.Find("[data-testid=observer-boundary]"));
+            Assert.AreEqual("null", cut.Find("[data-testid=probe]").TextContent);
+        });
+    }
 }

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RoutesAliasHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RoutesAliasHost.razor
@@ -1,0 +1,19 @@
+@* Exercises the Routes alias for ChildContent on both Brouter and Broute: routes declared inside
+   an explicit <Routes> fragment register and render exactly like ChildContent-declared ones,
+   nesting included. *@
+@using Bit.Brouter
+
+<Brouter>
+    <Routes>
+        <Broute Path="/top">
+            <Content><div data-testid="top">top</div></Content>
+        </Broute>
+        <Broute Path="/parent">
+            <Routes>
+                <Broute Path="/child">
+                    <Content><div data-testid="child">child</div></Content>
+                </Broute>
+            </Routes>
+        </Broute>
+    </Routes>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RoutesAliasTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RoutesAliasTests.cs
@@ -1,0 +1,52 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// The <c>Routes</c> parameter is an alias for <c>ChildContent</c> on both <see cref="Brouter"/>
+/// and <see cref="Broute"/>, so hosts that must spell fragments out explicitly (because another
+/// template like Found/NotFound/Content is present) can declare their routes under a
+/// self-describing name. Setting both on the same component is a misconfiguration and throws.
+/// </summary>
+[TestClass]
+public class RoutesAliasTests : BunitTestContext
+{
+    [TestMethod]
+    public void Routes_declared_via_the_alias_register_and_render()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/top");
+
+        var cut = RenderComponent<RoutesAliasHost>();
+
+        cut.WaitForAssertion(() => Assert.AreEqual("top", cut.Find("[data-testid=top]").TextContent));
+    }
+
+    [TestMethod]
+    public void Nested_routes_declared_via_the_alias_on_a_Broute_match_too()
+    {
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        nav.NavigateTo("http://localhost/parent/child");
+
+        var cut = RenderComponent<RoutesAliasHost>();
+
+        cut.WaitForAssertion(() => Assert.AreEqual("child", cut.Find("[data-testid=child]").TextContent));
+    }
+
+    [TestMethod]
+    public void Setting_both_ChildContent_and_Routes_on_Brouter_throws()
+    {
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => RenderComponent<RoutesConflictBrouterHost>());
+        StringAssert.Contains(ex.Message, "Routes is an alias");
+    }
+
+    [TestMethod]
+    public void Setting_both_ChildContent_and_Routes_on_Broute_throws()
+    {
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => RenderComponent<RoutesConflictBrouteHost>());
+        StringAssert.Contains(ex.Message, "Routes is an alias");
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RoutesConflictBrouteHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RoutesConflictBrouteHost.razor
@@ -1,0 +1,18 @@
+@* Misconfiguration host for RoutesAliasTests: a Broute with BOTH ChildContent and its Routes
+   alias set, which must throw instead of silently picking one. *@
+@using Bit.Brouter
+
+<Brouter>
+    <Broute Path="/parent">
+        <ChildContent>
+            <Broute Path="/a">
+                <Content><div data-testid="a">a</div></Content>
+            </Broute>
+        </ChildContent>
+        <Routes>
+            <Broute Path="/b">
+                <Content><div data-testid="b">b</div></Content>
+            </Broute>
+        </Routes>
+    </Broute>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RoutesConflictBrouterHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RoutesConflictBrouterHost.razor
@@ -1,0 +1,16 @@
+@* Misconfiguration host for RoutesAliasTests: a Brouter with BOTH ChildContent and its Routes
+   alias set, which must throw instead of silently picking one. *@
+@using Bit.Brouter
+
+<Brouter>
+    <ChildContent>
+        <Broute Path="/a">
+            <Content><div data-testid="a">a</div></Content>
+        </Broute>
+    </ChildContent>
+    <Routes>
+        <Broute Path="/b">
+            <Content><div data-testid="b">b</div></Content>
+        </Broute>
+    </Routes>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SecurePage.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SecurePage.razor
@@ -1,0 +1,6 @@
+@page "/secure"
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+
+@* An [Authorize]-protected page: with Brouter.Found handing a real framework RouteData to the
+   built-in AuthorizeRouteView, the attribute is honored with zero Brouter-specific auth code. *@
+<div data-testid="secure">secure</div>


### PR DESCRIPTION
closes #12640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `<Routes>` as an alias for route declarations, including conflict validation.
  * Enhanced `Found` rendering with support for layouts, authorization-aware composition, and framework-style `RouteData`.
  * Cascades matched `RouteData` to descendants and resets it when navigation fails.
  * Added fail-closed checks for protected components when rendered through outlets.

* **Bug Fixes**
  * Improved not-found handling, redirect-loop prevention, and consistent `OnNotFound`/fallback behavior.

* **Documentation**
  * Updated not-found configuration and migration guidance to use `NotFoundUrl`.

* **Tests**
  * Added/extended authorization, `Found`, route alias, and cascaded `RouteData` coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->