### PR TITLE
Warn about sign-out after security-stamp changes #12647

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -151,7 +151,7 @@
             ]
         },
         "multitenant": {
-            "displayName": "Multi-tenancy",
+            "displayName": "Multi-Tenant",
             "type": "parameter",
             "datatype": "bool",
             "defaultValue": "true",
@@ -520,7 +520,12 @@
                 {
                     "condition": "(advancedTests != true)",
                     "exclude": [
-                        "src/Tests/Features/Todo/OfflineTodoTests.cs"
+                        "src/Tests/Features/Todo/OfflineTodoTests.cs",
+                        "src/Tests/Features/Identity/TrustedOriginsTests.cs",
+                        "src/Tests/Features/Identity/MagicLinkSignInTests.cs",
+                        "src/Tests/Features/Identity/MagicLinkSignInUtils.cs",
+                        "src/Tests/Features/Seo/**",
+                        "src/Tests/Features/Tenants/TenantInvitationUITests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppShell.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppShell.razor
@@ -36,6 +36,20 @@
                             </AuthorizeView>
                             @if (isNavPanelToggled is false)
                             {
+                                @*#if (multitenant == true)*@
+                                @if (CurrentTenant is not null)
+                                {
+                                    <BitActionButton Class="current-tenant"
+                                                     IconName="@BitIconName.Org"
+                                                     Href="@PageUrls.ManageMyTenants"
+                                                     Title="@Localizer[nameof(AppStrings.CurrentTenant)]"
+                                                     Styles="@(new() { Content = "overflow:hidden;white-space:nowrap;text-overflow:ellipsis" })">
+                                        <BitText Typography="BitTypography.Caption2">
+                                            @(string.IsNullOrEmpty(CurrentTenant.Title) ? CurrentTenant.Name : CurrentTenant.Title)
+                                        </BitText>
+                                    </BitActionButton>
+                                }
+                                @*#endif*@
                                 <BitActionButton Class="app-version" OnClick="WrapHandled(UpdateApp)">
                                     <BitText Typography="BitTypography.Caption2">@TelemetryContext.AppVersion</BitText>
                                 </BitActionButton>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppShell.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppShell.razor.cs
@@ -1,5 +1,8 @@
 ﻿//+:cnd:noEmit
 using Microsoft.AspNetCore.Components.Routing;
+//#if (multitenant == true)
+using Boilerplate.Shared.Features.Tenants.Dtos;
+//#endif
 
 namespace Boilerplate.Client.Core.Components.Layout;
 
@@ -8,6 +11,13 @@ public partial class AppShell
     [Parameter] public bool? IsIdentityPage { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public List<BitNavItem> NavPanelItems { get; set; } = [];
+
+    //#if (multitenant == true)
+    /// <summary>
+    /// The tenant the user is currently signed into, or null when none is selected. Shown next to the app version.
+    /// </summary>
+    [CascadingParameter] public TenantDto? CurrentTenant { get; set; }
+    //#endif
 
 
     [AutoInject] private IAppUpdateService appUpdateService = default!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppShell.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppShell.razor.scss
@@ -1,3 +1,4 @@
+//+:cnd:noEmit
 @import '../../Styles/abstracts/_media-queries.scss';
 @import '../../Styles/abstracts/_bit-css-variables.scss';
 
@@ -125,4 +126,13 @@ main {
         inset-block-end: 0;
         inset-inline-end: 0;
     }
+
+    //#if (multitenant == true)
+    .current-tenant {
+        max-width: 60%;
+        position: absolute;
+        inset-block-end: 0;
+        inset-inline-start: 0;
+    }
+    //#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor.cs
@@ -95,7 +95,8 @@ public partial class AppMenu
         if (await AuthManager.SwitchTenant(newTenantId, CurrentCancellationToken))
         {
             NavigationManager.RefreshCurrentPage(); // Re-renders the current page so it reflects the new tenant's data.
-            // If you've changed the layout to show tenant information somewwhere, you may need to use PubSub to notify the layout to re-render.
+            // The layout's tenant display (next to the app version) updates on its own: switching changes the tenant claim, which
+            // triggers the authentication-state change that MainLayout re-resolves the current tenant from (See MainLayout.SetCurrentTenantIfNeeded).
         }
     }
     //#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor
@@ -1,6 +1,9 @@
 @*+:cnd:noEmit*@
 @inherits LayoutComponentBase
 
+@*#if (multitenant == true)*@
+<CascadingValue Value="currentTenant">
+@*#endif*@
 <CascadingValue Value="currentDir">
     <CascadingValue Value="currentUser">
         <CascadingValue Value="currentTheme">
@@ -28,3 +31,6 @@
         </CascadingValue>
     </CascadingValue>
 </CascadingValue>
+@*#if (multitenant == true)*@
+</CascadingValue>
+@*#endif*@

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor.cs
@@ -2,6 +2,10 @@
 using System.Reflection;
 using Boilerplate.Shared.Features.Identity;
 using Boilerplate.Shared.Features.Identity.Dtos;
+//#if (multitenant == true)
+using Boilerplate.Shared.Features.Tenants;
+using Boilerplate.Shared.Features.Tenants.Dtos;
+//#endif
 
 namespace Boilerplate.Client.Core.Components.Layout;
 
@@ -18,6 +22,9 @@ public partial class MainLayout : IAsyncDisposable
     [AutoInject] private ThemeService themeService = default!;
     [AutoInject] private PubSubService pubSubService = default!;
     [AutoInject] private IUserController userController = default!;
+    //#if (multitenant == true)
+    [AutoInject] private ITenantController tenantController = default!;
+    //#endif
     [AutoInject] private BitExtraServices bitExtraServices = default!;
     [AutoInject] private ClientExceptionHandlerBase exceptionHandler = default!;
     [AutoInject] private ITelemetryContext telemetryContext = default!;
@@ -32,6 +39,9 @@ public partial class MainLayout : IAsyncDisposable
     private BitDir? currentDir;
     private bool? isIdentityPage;
     private UserDto? currentUser;
+    //#if (multitenant == true)
+    private TenantDto? currentTenant;
+    //#endif
     private AppThemeType? currentTheme;
     private RouteData? currentRouteData;
     private List<Action> unsubscribers = [];
@@ -95,6 +105,17 @@ public partial class MainLayout : IAsyncDisposable
                 await InvokeAsync(StateHasChanged);
             }));
 
+            //#if (multitenant == true)
+            unsubscribers.Add(pubSubService.Subscribe(ClientAppMessages.CURRENT_TENANT_CHANGED, async payload =>
+            {
+                // Published by the pages/menus that change the current tenant (See ManageMyTenantsPage). Switching, signing in/out and
+                // leaving a tenant already update this through the authentication-state change, so this mainly covers renaming the current tenant.
+                currentTenant = (TenantDto?)payload;
+
+                await InvokeAsync(StateHasChanged);
+            }));
+            //#endif
+
             await SetCurrentUser(AuthenticationStateTask);
 
             SetCurrentDir();
@@ -148,12 +169,41 @@ public partial class MainLayout : IAsyncDisposable
         if (authUser.IsAuthenticated() is false)
         {
             currentUser = null;
+            //#if (multitenant == true)
+            currentTenant = null;
+            //#endif
         }
-        else if (authUser.GetUserId() != currentUser?.Id)
+        else
         {
-            currentUser = await userController.GetCurrentUser(getCurrentUserCts.Token);
+            if (authUser.GetUserId() != currentUser?.Id)
+            {
+                currentUser = await userController.GetCurrentUser(getCurrentUserCts.Token);
+            }
+
+            //#if (multitenant == true)
+            await SetCurrentTenantIfNeeded(authUser.GetTenantId(), getCurrentUserCts.Token);
+            //#endif
         }
     }
+
+    //#if (multitenant == true)
+    /// <summary>
+    /// Resolves the tenant the user is currently signed into (shown next to the app version in AppShell).
+    /// Switching, signing in/out and leaving a tenant all change the tenant claim, so re-resolving here keeps the display in sync.
+    /// </summary>
+    private async Task SetCurrentTenantIfNeeded(Guid? tenantId, CancellationToken cancellationToken)
+    {
+        if (tenantId is null)
+        {
+            currentTenant = null;
+            return;
+        }
+
+        if (currentTenant?.Id == tenantId) return; // Already showing this tenant (e.g. a page already published it).
+
+        currentTenant = await tenantController.GetCurrentTenant(cancellationToken);
+    }
+    //#endif
 
     private void SetCurrentDir()
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/AccountSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/AccountSection.razor
@@ -1,19 +1,10 @@
 @inherits AppComponentBase
 
 <section>
-    <BitPivot Alignment="BitAlignment.Center">
-        <BitPivotItem Key="@nameof(AppStrings.Email)" HeaderText="@Localizer[nameof(AppStrings.Email)]">
-            <ChangeEmailTab Email="@CurrentUser?.Email" />
+    <BitPivot Alignment="BitAlignment.Center" OverflowBehavior="BitPivotOverflowBehavior.Menu">
+        <BitPivotItem Key="@nameof(AppStrings.Passwordless)" HeaderText="@Localizer[nameof(AppStrings.Passwordless)]">
+            <PasswordlessTab User="CurrentUser" />
         </BitPivotItem>
-        <BitPivotItem Key="@nameof(AppStrings.Phone)" HeaderText="@Localizer[nameof(AppStrings.Phone)]">
-            <ChangePhoneNumberTab PhoneNumber="@CurrentUser?.PhoneNumber" />
-        </BitPivotItem>
-        @if (showPasswordless)
-        {
-            <BitPivotItem Key="@nameof(AppStrings.Passwordless)" HeaderText="@Localizer[nameof(AppStrings.Passwordless)]">
-                <PasswordlessTab User="CurrentUser" />
-            </BitPivotItem>
-        }
         <BitPivotItem Key="@nameof(AppStrings.Delete)">
             <Header>
                 <BitText Color="BitColor.Error">@Localizer[nameof(AppStrings.Delete)]</BitText>
@@ -21,6 +12,15 @@
             <Body>
                 <DeleteAccountTab />
             </Body>
+        </BitPivotItem>
+        <BitPivotItem Key="@nameof(AppStrings.Email)" HeaderText="@Localizer[nameof(AppStrings.Email)]">
+            <ChangeEmailTab Email="@CurrentUser?.Email" />
+        </BitPivotItem>
+        <BitPivotItem Key="@nameof(AppStrings.Phone)" HeaderText="@Localizer[nameof(AppStrings.Phone)]">
+            <ChangePhoneNumberTab PhoneNumber="@CurrentUser?.PhoneNumber" />
+        </BitPivotItem>
+        <BitPivotItem Key="@nameof(AppStrings.Password)" HeaderText="@Localizer[nameof(AppStrings.Password)]">
+            <ChangePasswordTab />
         </BitPivotItem>
     </BitPivot>
 </section>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/AccountSection.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/AccountSection.razor.cs
@@ -5,21 +5,4 @@ namespace Boilerplate.Client.Core.Components.Pages.Settings.Account;
 public partial class AccountSection
 {
     [CascadingParameter] public UserDto? CurrentUser { get; set; }
-
-
-    [AutoInject] private IWebAuthnService webAuthnService = default!;
-
-
-    private bool showPasswordless;
-
-
-    protected override async Task OnInitAsync()
-    {
-        await base.OnInitAsync();
-
-        if (InPrerenderSession is false)
-        {
-            showPasswordless = await webAuthnService.IsWebAuthnAvailable();
-        }
-    }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangeEmailTab.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangeEmailTab.razor.cs
@@ -13,6 +13,8 @@ public partial class ChangeEmailTab
     [Parameter, SupplyParameterFromQuery(Name = "emailToken")]
     public string? EmailTokenQueryString { get; set; }
 
+    [CascadingParameter] public UserDto? CurrentUser { get; set; }
+
 
     [AutoInject] private IUserController userController = default!;
 
@@ -83,7 +85,12 @@ public partial class ChangeEmailTab
         {
             await userController.ChangeEmail(changeModel, CurrentCancellationToken);
 
-            NavigationManager.NavigateTo($"{PageUrls.Settings}/{PageUrls.SettingsSections.Account}", forceLoad: true);
+            CurrentUser!.Email = changeModel.Email;
+            PubSubService.Publish(ClientAppMessages.PROFILE_UPDATED, CurrentUser);
+
+            showConfirmation = false;
+            isEmailUnavailable = true;
+            sendModel.Email = changeModel.Email = changeModel.Token = null;
         }
         catch (KnownException e)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePasswordTab.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePasswordTab.razor
@@ -1,0 +1,40 @@
+@inherits AppComponentBase
+
+<section>
+    <BitStack HorizontalAlign="BitAlignment.Center">
+        <EditForm Model="model" OnValidSubmit="WrapHandled(ChangePassword)" novalidate class="max-width">
+            <AppDataAnnotationsValidator @ref="validatorRef" />
+
+            <BitStack FillContent>
+                <BitTextField @bind-Value="model.OldPassword"
+                              AutoFocus TabIndex="1"
+                              CanRevealPassword
+                              AutoComplete="current-password"
+                              Type="BitInputType.Password"
+                              Label="@Localizer[nameof(AppStrings.OldPassword)]" />
+                <ValidationMessage For="@(() => model.OldPassword)" />
+
+                <BitTextField @bind-Value="model.NewPassword"
+                              TabIndex="2"
+                              CanRevealPassword
+                              AutoComplete="new-password"
+                              Type="BitInputType.Password"
+                              Label="@Localizer[nameof(AppStrings.NewPassword)]" />
+                <ValidationMessage For="@(() => model.NewPassword)" />
+
+                <BitTextField @bind-Value="model.ConfirmPassword"
+                              TabIndex="3"
+                              CanRevealPassword
+                              AutoComplete="new-password"
+                              Type="BitInputType.Password"
+                              Label="@Localizer[nameof(AppStrings.ConfirmNewPassword)]" />
+                <ValidationMessage For="@(() => model.ConfirmPassword)" />
+
+                <BitButton IsLoading="isWaiting" ButtonType="BitButtonType.Submit">
+                    @Localizer[nameof(AppStrings.ChangePasswordButtonText)]
+                </BitButton>
+            </BitStack>
+        </EditForm>
+        <br />
+    </BitStack>
+</section>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePasswordTab.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePasswordTab.razor.cs
@@ -1,0 +1,45 @@
+﻿using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Shared.Features.Identity.Dtos;
+
+namespace Boilerplate.Client.Core.Components.Pages.Settings.Account;
+
+public partial class ChangePasswordTab
+{
+    [AutoInject] private IUserController userController = default!;
+
+
+    private bool isWaiting;
+    private readonly ChangePasswordRequestDto model = new();
+    private AppDataAnnotationsValidator validatorRef = default!;
+
+
+    private async Task ChangePassword()
+    {
+        if (isWaiting) return;
+
+        isWaiting = true;
+
+        try
+        {
+            await userController.ChangePassword(model, CurrentCancellationToken);
+
+            model.OldPassword = model.NewPassword = model.ConfirmPassword = null;
+
+            SnackBarService.Success(Localizer[nameof(AppStrings.PasswordChangedSuccessfullyMessage)]);
+            // Changing the password regenerates the security stamp on the server, so every active session gets signed out on its next token refresh.
+            SnackBarService.Warning(Localizer[nameof(AppStrings.SignOutOfAllDevicesWarningMessage)]);
+        }
+        catch(ResourceValidationException exp)
+        {
+            validatorRef.DisplayErrors(exp);
+        }
+        catch (KnownException exp)
+        {
+            SnackBarService.Error(exp.Message);
+        }
+        finally
+        {
+            isWaiting = false;
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePhoneNumberTab.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/ChangePhoneNumberTab.razor.cs
@@ -13,6 +13,8 @@ public partial class ChangePhoneNumberTab
     [Parameter, SupplyParameterFromQuery(Name = "phoneToken")]
     public string? PhoneNumberTokenQueryString { get; set; }
 
+    [CascadingParameter] public UserDto? CurrentUser { get; set; }
+
 
     [AutoInject] private IUserController userController = default!;
 
@@ -83,7 +85,18 @@ public partial class ChangePhoneNumberTab
         {
             await userController.ChangePhoneNumber(changeModel, CurrentCancellationToken);
 
-            NavigationManager.NavigateTo($"{PageUrls.Settings}/{PageUrls.SettingsSections.Account}", forceLoad: true);
+            // Changing the phone number regenerates the security stamp on the server, which signs the user out of every
+            // device (including this one) on the next token refresh. Refresh the cached user so the UI reflects the new
+            // number, then warn about the imminent sign-out. A soft navigation (instead of a forced reload) is used here
+            // so the warning snackbar survives to be seen by the user.
+            SnackBarService.Warning(Localizer[nameof(AppStrings.SignOutOfAllDevicesWarningMessage)]);
+
+            CurrentUser!.PhoneNumber = changeModel.PhoneNumber;
+            PubSubService.Publish(ClientAppMessages.PROFILE_UPDATED, CurrentUser);
+
+            showConfirmation = false;
+            isPhoneNumberUnavailable = true;
+            sendModel.PhoneNumber = changeModel.PhoneNumber = changeModel.Token = null;
         }
         catch (KnownException e)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor
@@ -16,7 +16,7 @@
         }
         else
         {
-            <BitButton AutoLoading OnClick="WrapHandled(EnablePasswordless)">
+            <BitButton AutoLoading OnClick="WrapHandled(EnablePasswordless)" IconName="@BitIconName.Fingerprint" IsEnabled="isAvailable">
                 @Localizer[nameof(AppStrings.EnablePasswordless)]
             </BitButton>
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs
@@ -6,6 +6,7 @@ namespace Boilerplate.Client.Core.Components.Pages.Settings.Account;
 public partial class PasswordlessTab
 {
     private bool isConfigured;
+    private bool isAvailable = false;
 
 
     [AutoInject] IUserController userController = default!;
@@ -22,6 +23,7 @@ public partial class PasswordlessTab
 
         if (User?.UserName is null) return;
 
+        isAvailable = await webAuthnService.IsWebAuthnAvailable();
         isConfigured = await webAuthnService.IsWebAuthnConfigured(User.Id);
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/TwoFactorSection.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/TwoFactorSection.razor.cs
@@ -38,15 +38,26 @@ public partial class TwoFactorSection
         var request = new TwoFactorAuthRequestDto { Enable = true, TwoFactorCode = twoFactorCode };
         var response = await SendTwoFactorAuthRequest(request);
 
-        recoveryCodes = response?.RecoveryCodes;
+        if (response is null) return; // The request failed and the error was already reported to the user.
+
+        recoveryCodes = response.RecoveryCodes;
         SnackBarService.Success(Localizer[nameof(AppStrings.TwoFactorAuthenticationEnabled)]);
+        // Enabling 2fa regenerates the security stamp on the server, so every active session gets signed out on its next token refresh.
+        SnackBarService.Warning(Localizer[nameof(AppStrings.SignOutOfAllDevicesWarningMessage)]);
     }
 
     private async Task DisableTwoFactorAuth()
     {
         var request = new TwoFactorAuthRequestDto { Enable = false };
-        await SendTwoFactorAuthRequest(request);
+        var response = await SendTwoFactorAuthRequest(request);
+
+        if (response is null) return; // The request failed and the error was already reported to the user.
+
         SnackBarService.Success(Localizer[nameof(AppStrings.TwoFactorAuthenticationDisabled)]);
+        // Disabling 2fa regenerates the security stamp on the server, so every active session gets signed out on its next token refresh.
+        SnackBarService.Warning(Localizer[nameof(AppStrings.SignOutOfAllDevicesWarningMessage)]);
+
+        recoveryCodes = [];
     }
 
     private async Task GenerateRecoveryCode()
@@ -60,7 +71,13 @@ public partial class TwoFactorSection
     private async Task ResetAuthenticatorKey()
     {
         var request = new TwoFactorAuthRequestDto { ResetSharedKey = true };
-        await SendTwoFactorAuthRequest(request);
+        var response = await SendTwoFactorAuthRequest(request);
+
+        if (response is null) return; // The request failed and the error was already reported to the user.
+
+        // Resetting the authenticator key (and disabling 2fa) regenerates the security stamp on the server,
+        // so every active session gets signed out on its next token refresh.
+        SnackBarService.Warning(Localizer[nameof(AppStrings.SignOutOfAllDevicesWarningMessage)]);
     }
 
     //private async Task ForgetMachine()

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Tenants/ManageMyTenantsPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Tenants/ManageMyTenantsPage.razor.cs
@@ -89,7 +89,7 @@ public partial class ManageMyTenantsPage
 
         if (await AuthManager.SwitchTenant(tenant.Id, CurrentCancellationToken))
         {
-            NavigationManager.RefreshCurrentPage(); // Re-renders the current page so it reflects the new tenant's data.
+            await Refresh();
         }
     }
 
@@ -109,7 +109,7 @@ public partial class ManageMyTenantsPage
 
             if (await AuthManager.SwitchTenant(createdTenant.Id, CurrentCancellationToken))
             {
-                NavigationManager.RefreshCurrentPage();
+                await Refresh();
                 return;
             }
 
@@ -180,7 +180,7 @@ public partial class ManageMyTenantsPage
 
             SnackBarService.Success(Localizer[nameof(AppStrings.LeftTenantSuccessfullyMessage)]);
 
-            NavigationManager.RefreshCurrentPage();
+            await Refresh();
         }
         catch (KnownException e)
         {
@@ -220,5 +220,11 @@ public partial class ManageMyTenantsPage
         {
             isInviting = false;
         }
+    }
+
+    private async Task Refresh()
+    {
+        await LoadTenants();
+        PubSubService.Publish(ClientAppMessages.CURRENT_TENANT_CHANGED, currentTenant);
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs
@@ -114,4 +114,12 @@ public partial class ClientAppMessages
     /// When a user completes external sign-in in a separate window, this message is published to notify the app.
     /// </summary>
     public const string EXTERNAL_SIGN_IN_CALLBACK = nameof(EXTERNAL_SIGN_IN_CALLBACK);
+
+//#if (multitenant == true)
+    /// <summary>
+    /// A publisher that publishes this message notifies that the user's current tenant has changed (switched, renamed, created or left).
+    /// The payload is the new current tenant (a <c>TenantDto</c>) or null when the user no longer has a tenant selected.
+    /// </summary>
+    public const string CURRENT_TENANT_CHANGED = nameof(CURRENT_TENANT_CHANGED);
+//#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/SnackBarService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/SnackBarService.cs
@@ -12,4 +12,5 @@ public partial class SnackBarService
 
     public void Error(string title, string body = "") => Show(title, body, BitColor.Error);
     public void Success(string title, string body = "") => Show(title, body, BitColor.Success);
+    public void Warning(string title, string body = "") => Show(title, body, BitColor.Warning);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/package-lock.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/package-lock.json
@@ -1246,9 +1246,9 @@
             "optional": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "optional": true,

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Identity/Dtos/IdentityJsonContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Identity/Dtos/IdentityJsonContext.cs
@@ -25,6 +25,7 @@ namespace Boilerplate.Shared.Features.Identity;
 [JsonSerializable(typeof(SendPhoneTokenRequestDto))]
 [JsonSerializable(typeof(ConfirmEmailRequestDto))]
 [JsonSerializable(typeof(ChangeEmailRequestDto))]
+[JsonSerializable(typeof(ChangePasswordRequestDto))]
 [JsonSerializable(typeof(ConfirmPhoneRequestDto))]
 [JsonSerializable(typeof(ChangePhoneNumberRequestDto))]
 [JsonSerializable(typeof(SendResetPasswordTokenRequestDto))]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
@@ -774,6 +774,15 @@
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>بعد مسح رمز QR أو إدخال المفتاح أعلاه، سيوفر تطبيق المصادقة عاملين كودًا فريدًا. أدخل الكود في مربع التأكيد أدناه</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>لأسباب أمنية، سيتم تسجيل خروجك من جميع أجهزتك، بما في ذلك هذا الجهاز، خلال بضع دقائق. يُرجى تسجيل الدخول مرة أخرى.</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>تغيير كلمة المرور</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>تم تغيير كلمة المرور الخاصة بك بنجاح.</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>تم تفعيل المصادقة عاملين</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
@@ -774,6 +774,15 @@ Nach Erreichen von {0} haben zusätzliche Anmeldungen reduzierte Funktionen.</va
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>Sobald Sie den QR-Code gescannt oder den obigen Schlüssel eingegeben haben, stellt Ihre Zwei-Faktor-Authentifizierungs-App Ihnen einen eindeutigen Code zur Verfügung. Geben Sie den Code in das Bestätigungsfeld unten ein.</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>Aus Sicherheitsgründen werden Sie innerhalb weniger Minuten auf allen Ihren Geräten, einschließlich diesem, abgemeldet. Bitte melden Sie sich erneut an.</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>Passwort ändern</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>Ihr Passwort wurde erfolgreich geändert.</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>Zwei-Faktor-Authentifizierung wurde aktiviert.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
@@ -774,6 +774,15 @@ Después de alcanzar {0}, los inicios de sesión adicionales tendrán funciones 
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>Una vez que hayas escaneado el código QR o ingresado la clave anterior, tu app de autenticación de dos factores te proporcionará un código único. Ingresa el código en el cuadro de confirmación a continuación.</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>Por tu seguridad, se cerrará tu sesión en todos tus dispositivos, incluido este, en unos minutos. Vuelve a iniciar sesión.</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>Cambiar contraseña</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>Tu contraseña se ha cambiado correctamente.</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>La autenticación de dos factores ha sido habilitada.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
@@ -774,6 +774,15 @@
     <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>هنگامی که کد QR را اسکن کردید یا کلید بالا را وارد کردید، برنامه احراز هویت دو عاملی شما یک کد منحصر به فرد را در اختیار شما قرار می دهد. کد را در کادر تایید زیر وارد کنید.</value>
   </data>
+    <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>به‌دلیل مسائل امنیتی، طی چند دقیقه‌ی آینده از همه‌ی دستگاه‌های شما، از جمله همین دستگاه، خارج خواهید شد. لطفاً دوباره وارد شوید.</value>
+  </data>
+    <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>تغییر گذرواژه</value>
+  </data>
+    <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>گذرواژه‌ی شما با موفقیت تغییر کرد.</value>
+  </data>
     <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>احراز هویت دو مرحله‌ای فعال شد.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
@@ -774,6 +774,15 @@ Après avoir atteint {0}, les connexions supplémentaires auront des fonctions r
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>Une fois le code QR scanné ou la clé saisie ci-dessus, votre application d’authentification à deux facteurs vous fournira un code unique. Saisissez-le dans la boîte de confirmation ci-dessous.</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>Pour votre sécurité, vous serez déconnecté de tous vos appareils, y compris celui-ci, dans quelques minutes. Veuillez vous reconnecter.</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>Changer le mot de passe</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>Votre mot de passe a été modifié avec succès.</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>L’authentification à deux facteurs a été activée.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
@@ -774,6 +774,15 @@
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>एक बार QR कोड स्कैन या ऊपर कुंजी इनपुट करने के बाद, आपका दो-कारक प्रमाणीकरण ऐप आपको अद्वितीय कोड प्रदान करेगा। नीचे पुष्टि बॉक्स में कोड दर्ज करें।</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>आपकी सुरक्षा के लिए, कुछ ही मिनटों में इस डिवाइस सहित आपके सभी डिवाइसों से आपको साइन आउट कर दिया जाएगा। कृपया फिर से साइन इन करें।</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>पासवर्ड बदलें</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>आपका पासवर्ड सफलतापूर्वक बदल दिया गया है।</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>दो-कारक प्रमाणीकरण सक्षम हो गया है।</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
@@ -774,6 +774,15 @@ Na het bereiken van {0} zullen extra aanmeldingen verminderde functies hebben.</
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>Zodra u de QR-code hebt gescand of de sleutel hierboven hebt ingevoerd, zal uw twee-factor-authenticatie-app u een unieke code geven. Voer de code in het bevestigingsvak hieronder in.</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>Om veiligheidsredenen wordt u binnen enkele minuten op al uw apparaten, inclusief dit apparaat, afgemeld. Meld u opnieuw aan.</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>Wachtwoord wijzigen</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>Uw wachtwoord is succesvol gewijzigd.</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>Twee-factor-authenticatie is ingeschakeld.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -774,6 +774,15 @@ After reaching {0}, extra sign-ins will have reduced functions.</value>
     <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>Once you have scanned the QR code or input the key above, your two factor authentication app will provide you with a unique code. Enter the code in the confirmation box below.</value>
   </data>
+    <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>For your security, you'll be signed out of all your devices, including this one, within a few minutes. Please sign in again.</value>
+  </data>
+    <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>Change password</value>
+  </data>
+    <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>Your password has been changed successfully.</value>
+  </data>
     <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>Two-factor authentication has been enabled.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
@@ -774,6 +774,15 @@ Efter att ha nått {0} kommer extra inloggningar att ha reducerade funktioner.</
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>När du har skannat QR-koden eller angett nyckeln ovan kommer din tvåfaktorsautentiseringsapp att ge dig en unik kod. Ange koden i bekräftelsefältet nedan.</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>Av säkerhetsskäl loggas du ut från alla dina enheter, inklusive den här, inom några minuter. Logga in igen.</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>Ändra lösenord</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>Ditt lösenord har ändrats.</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>Tvåfaktorsautentisering har aktiverats.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
@@ -774,6 +774,15 @@
   <data name="TfaConfigureAutAppStep3" xml:space="preserve">
     <value>扫描二维码或输入上述密钥后，您的两因素认证应用将为您提供唯一代码。请在下面的确认框中输入代码。</value>
   </data>
+  <data name="SignOutOfAllDevicesWarningMessage" xml:space="preserve">
+    <value>出于安全考虑，几分钟后您将从包括本设备在内的所有设备上退出登录。请重新登录。</value>
+  </data>
+  <data name="ChangePasswordButtonText" xml:space="preserve">
+    <value>修改密码</value>
+  </data>
+  <data name="PasswordChangedSuccessfullyMessage" xml:space="preserve">
+    <value>您的密码已成功修改。</value>
+  </data>
   <data name="TwoFactorAuthenticationEnabled" xml:space="preserve">
     <value>两因素认证已启用。</value>
   </data>


### PR DESCRIPTION
## Summary

Changing a security-sensitive setting regenerates the user's ASP.NET Core Identity security stamp, which the server re-validates on every token refresh (`IdentityController.Refresh` → `ValidateSecurityStampAsync`). As a result, all of the user's sessions — including the current device — get signed out on the next refresh. This previously happened silently. This PR warns the user with a localized snackbar right after such an operation succeeds, adds a Change Password tab, and stops forcing a full app reload after account edits.

## Changes

**Warn about the imminent sign-out (security-stamp-changing operations):**
- Add `SnackBarService.Warning` (uses `BitColor.Warning`).
- Add `SignOutOfAllDevicesWarningMessage` resource string to all 10 locale `.resx` files.
- Show the warning after:
  - `TwoFactorSection`: enabling 2FA, disabling 2FA, and resetting the authenticator key (also guards the success/warning snackbars so they no longer show when the request failed).
  - `ChangePhoneNumberTab`: changing the phone number.
  - `ChangePasswordTab` (new): changing the password.

**New Change Password tab:**
- Add `ChangePasswordTab` (backed by the existing `ChangePassword` endpoint) to the account settings, placed before the Passwordless tab. It shows a success snackbar plus the sign-out warning.
- Add `ChangePasswordButtonText` and `PasswordChangedSuccessfullyMessage` resources across all 10 locales.

**No more full app reload on account edits:**
- `ChangePhoneNumberTab` and `ChangeEmailTab` previously did a forced reload (`NavigateTo(..., forceLoad: true)`), which also wiped any snackbar. They now refresh the cached user via `PROFILE_UPDATED` and re-render the current page with `NavigationManager.RefreshCurrentPage()`. Changing the email does not regenerate the security stamp, so no sign-out warning is shown there.

## Notes

- `ChangeUserName` also regenerates the stamp but currently has no UI; `ResetPassword` is the unauthenticated forgot-password flow — so no snackbar location applies to them here.
- The current `ChangeEmail` implementation sets the email through the store directly and does not regenerate the security stamp, so it does not sign the user out (arguably a separate inconsistency, left out of scope).

## Related Issue

closes #12647


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Password tab for changing account passwords with validation.
  * Added “sign out of all devices” security warnings for password, phone, and two-factor changes.
  * Updated two-factor flows to refresh recovery codes when applicable.
  * In multitenant setups, added a “Current Tenant” action in the footer.
* **Improvements**
  * Account/profile updates now refresh the UI without disruptive navigation.
  * Two-factor actions now handle responses more safely and show clearer messaging.
  * Tenant switching now refreshes tenant state reliably.
* **Configuration**
  * Updated template labeling to “Multi-Tenant” and expanded advanced test filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->