### PR TITLE
feat(templates): add Boilerplate identity & tenant end-to-end tests #12657

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -520,12 +520,29 @@
                 {
                     "condition": "(advancedTests != true)",
                     "exclude": [
+                        "src/Tests/Infrastructure/Components/BitOtpInputUtils.cs",
                         "src/Tests/Features/Todo/OfflineTodoTests.cs",
                         "src/Tests/Features/Identity/TrustedOriginsTests.cs",
                         "src/Tests/Features/Identity/MagicLinkSignInTests.cs",
                         "src/Tests/Features/Identity/MagicLinkSignInUtils.cs",
+                        "src/Tests/Features/Identity/TwoFactorAuthTests.cs",
+                        "src/Tests/Features/Identity/PrivilegedSessionTests.cs",
+                        "src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs",
                         "src/Tests/Features/Seo/**",
                         "src/Tests/Features/Tenants/TenantInvitationUITests.cs"
+                    ]
+                },
+                {
+                    "condition": "(advancedTests != true || aspire != true)",
+                    "exclude": [
+                        "src/Tests/Features/Identity/ExternalIdentityTests.cs"
+                    ]
+                },
+                {
+                    "condition": "(advancedTests != true || module != Sales)",
+                    "exclude": [
+                        "src/Tests/Features/Products/BuyProductUITests.cs",
+                        "src/Tests/Features/Products/MagicLinkReturnUrlTests.cs"
                     ]
                 },
                 {
@@ -637,7 +654,8 @@
                         "src/Server/Boilerplate.Server.Api/Features/Identity/Components/TenantInvitationTemplate.*",
                         "src/Client/Boilerplate.Client.Core/Components/Pages/Tenants/**",
                         "src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppRoleValidator.cs",
-                        "src/Tests/Features/Tenants/TenantInvitationUITests.cs"
+                        "src/Tests/Features/Tenants/TenantInvitationUITests.cs",
+                        "src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -118,6 +118,7 @@
         <PackageVersion Condition=" ('$(redis)' == 'true' OR '$(redis)' == '') AND ('$(signalR)' == 'true' OR '$(signalR)' == '')" Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="ZiggyCreatures.FusionCache.Locking.Distributed.Redis" Version="2.6.0" />
+        <PackageVersion Condition=" '$(advancedTests)' == 'true' OR '$(advancedTests)' == '' " Include="Otp.NET" Version="1.4.0" />
         <!--/-:msbuild-conditional:noEmit -->
         <PackageVersion Include="Humanizer" Version="3.0.10" />
         <PackageVersion Include="QRCoder" Version="1.8.0" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Configurations/UserConfiguration.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Configurations/UserConfiguration.cs
@@ -69,6 +69,29 @@ public partial class UserConfiguration : IEntityTypeConfiguration<User>
             ConcurrencyStamp = "425e1a26-5b3a-4544-8e91-2760cd28e230",
             PasswordHash = "AQAAAAIAAYagAAAAEP0v3wxkdWtMkHA3Pp5/JfS+42/Qto9G05p2mta6dncSK37hPxEHa3PGE4aqN30Aag==", // 123456
         }]);
+
+        const string storeUserUserName = "store-user";
+        const string storeUserEmail = "store-user@bitplatform.dev";
+
+        // A regular (non-admin) member of the default store tenant, assigned to the demo user-group.
+        // (See UserRoleConfiguration and TenantUserConfiguration).
+        builder.HasData([new User
+        {
+            Id = Guid.Parse("4ff71671-a1d6-4f97-abb9-d87d7b47d6e4"),
+            EmailConfirmed = true,
+            LockoutEnabled = true,
+            Gender = Gender.Other,
+            BirthDate = new DateTimeOffset(new DateOnly(2023, 1, 1), default, default),
+            FullName = "Store tenant user",
+            UserName = storeUserUserName,
+            NormalizedUserName = storeUserUserName.ToUpperInvariant(),
+            Email = storeUserEmail,
+            NormalizedEmail = storeUserEmail.ToUpperInvariant(),
+            EmailTokenRequestedOn = new DateTimeOffset(new DateOnly(2023, 1, 1), default, default),
+            SecurityStamp = "469ff4a9-4b07-4cc1-8141-c5fc033daf84",
+            ConcurrencyStamp = "435e1a26-5b3a-4544-8e91-2760cd28e229",
+            PasswordHash = "AQAAAAIAAYagAAAAEP0v3wxkdWtMkHA3Pp5/JfS+42/Qto9G05p2mta6dncSK37hPxEHa3PGE4aqN30Aag==", // 123456
+        }]);
         //#endif
 
         //#if (database != "PostgreSQL")

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Configurations/UserRoleConfiguration.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Configurations/UserRoleConfiguration.cs
@@ -23,6 +23,12 @@ public partial class UserRoleConfiguration : IEntityTypeConfiguration<UserRole>
 
         // store-admin@bitplatform.dev is the default store tenant's admin.
         builder.HasData(new UserRole { RoleId = tenantAdminRoleId, UserId = storeAdminUserId, TenantId = TenantConfiguration.FallbackTenantId });
+
+        var demoRoleId = Guid.Parse("9ff71672-a1d5-4f97-abb7-d87d6b47d5e8");
+        var storeUserUserId = Guid.Parse("4ff71671-a1d6-4f97-abb9-d87d7b47d6e4");
+
+        // store-user@bitplatform.dev is a regular member of the default store tenant's demo user-group.
+        builder.HasData(new UserRole { RoleId = demoRoleId, UserId = storeUserUserId, TenantId = TenantConfiguration.FallbackTenantId });
         //#endif
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
@@ -395,7 +395,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
 
         if (await userConfirmation.IsConfirmedAsync(userManager, user) is false)
         {
-            await SendConfirmationToken(user, request.ReturnUrl, cancellationToken);
+            await SendConfirmationToken(user, request.ReturnUrl ?? returnUrl, cancellationToken);
             throw new BadRequestException(Localizer[nameof(AppStrings.UserIsNotConfirmed)]).WithData("UserId", user.Id);
         }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
@@ -404,7 +404,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
         if (resendDelay < TimeSpan.Zero)
             throw new TooManyRequestsException(Localizer[nameof(AppStrings.WaitForOtpRequestResendDelay), resendDelay.Value.Humanize(culture: CultureInfo.CurrentUICulture)]).WithData("UserId", user.Id).WithExtensionData("TryAgainIn", resendDelay);
 
-        var (magicLinkToken, url) = await GenerateAutomaticSignInLink(user, returnUrl, originalAuthenticationMethod: "Email");
+        var (magicLinkToken, url) = await GenerateAutomaticSignInLink(user, request.ReturnUrl ?? returnUrl, originalAuthenticationMethod: "Email");
 
         var link = new Uri(HttpContext.Request.GetWebAppUrl(), url);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/TenantProvider.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/TenantProvider.cs
@@ -49,7 +49,7 @@ public partial class TenantProvider
         // Protecting endpoints by AuthPolicies.TENANT_SELECTED would guarantee that the tenant id is always present in the claims, so this code would never be reached for these endpoints.
 
         // 2. The tenant whose name matches the request sub domain (for anonymous requests such as the sales pages).
-        var host = httpContext.Request.Host.Host;
+        var host = httpContext.Request.GetWebAppUrl().Host;
 
         if (string.IsNullOrEmpty(host) is false && host.Split('.') is { Length: > 2 } hostSegments)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantUserConfiguration.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantUserConfiguration.cs
@@ -8,6 +8,7 @@ public partial class TenantUserConfiguration : IEntityTypeConfiguration<TenantUs
 
         var storeAdminUserId = Guid.Parse("6ff71671-a1d6-4f97-abb9-d87d7b47d6e5");
         var defaultTestUserId = Guid.Parse("8ff71671-a1d6-4f97-abb9-d87d7b47d6e7");
+        var storeUserUserId = Guid.Parse("4ff71671-a1d6-4f97-abb9-d87d7b47d6e4");
 
         // The value of AcceptedOn is set upfront for the users that have created the tenant (data seed in this case).
         builder.HasData(new TenantUser
@@ -23,6 +24,16 @@ public partial class TenantUserConfiguration : IEntityTypeConfiguration<TenantUs
             Id = Guid.Parse("5ff71671-a1d6-4f97-abb9-d87d7b47d6e3"),
             TenantId = TenantConfiguration.FallbackTenantId,
             UserId = defaultTestUserId,
+            AcceptedOn = new DateTimeOffset(new DateOnly(2023, 1, 1), default, default)
+        });
+
+        // store-user@bitplatform.dev is an accepted member of the default store tenant, so a tenant gets selected for her
+        // at sign-in and her demo user-group's (tenant-scoped) feature claims flow into her token (See IdentityController.GetTenantId).
+        builder.HasData(new TenantUser
+        {
+            Id = Guid.Parse("5ff71671-a1d6-4f97-abb9-d87d7b47d6e1"),
+            TenantId = TenantConfiguration.FallbackTenantId,
+            UserId = storeUserUserId,
             AcceptedOn = new DateTimeOffset(new DateOnly(2023, 1, 1), default, default)
         });
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Condition=" '$(aspire)' == 'true' OR '$(aspire)' == '' " Include="Aspire.Hosting.Testing" />
         <PackageReference Include="Bit.BlazorES2019" />
         <PackageReference Include="FakeItEasy" />
+        <PackageReference Condition=" '$(advancedTests)' == 'true' OR '$(advancedTests)' == '' " Include="Otp.NET" />
         <PackageReference Include="Microsoft.Playwright.MSTest.v4" />
         <PackageReference Include="MSTest" />
     </ItemGroup>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/ExternalIdentityTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/ExternalIdentityTests.cs
@@ -1,0 +1,72 @@
+﻿using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Testing;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+[TestClass, TestCategory("UITest")]
+public partial class ExternalIdentityTests : AppPageTest
+{
+    // Seeded in the Keycloak dev realm (See Boilerplate.Server.AppHost/Infrastructure/Realms/dev-realm.json).
+    private const string RealmUserName = "alice";
+    private const string RealmPassword = "alice";
+
+    /// <summary>
+    /// A user signs in through the external Keycloak identity provider. She opens the Sign in page and clicks the
+    /// "Enterprise SSO" (Keycloak) button, which pops open Keycloak's own hosted login page; she enters her realm
+    /// credentials there and Keycloak redirects back, completing the sign-in and landing her on the home page as an
+    /// authenticated user.
+    /// <para>
+    /// This is an advanced test that drives a real Keycloak server: the Aspire host boots the Keycloak container during
+    /// assembly initialization (See <see cref="TestsAssemblyInitializer.RunAspireHost"/>). Keycloak isn't an
+    /// <c>IResourceWithConnectionString</c>, so that startup doesn't block on it; this test - the only one that needs it -
+    /// waits for it to become healthy and points its own test server at it via <c>KEYCLOAK_HTTP</c>.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task User_Should_SignIn_UsingKeycloak()
+    {
+        // Wait for the Keycloak container to become healthy; by then its realm (with the seeded 'alice' user) has been
+        // imported, so the OpenID Connect endpoints are ready to serve.
+        await TestsAssemblyInitializer.AspireApp.ResourceNotifications
+            .WaitForResourceHealthyAsync("keycloak", TestContext.CancellationToken);
+        var keycloakUrl = TestsAssemblyInitializer.AspireApp.GetEndpoint("keycloak", "http").ToString().TrimEnd('/');
+
+        await using var server = new AppTestServer(Context);
+        // KEYCLOAK_HTTP is the same variable Aspire's WithReference(keycloak) injects in production; providing it makes
+        // the server register the "Keycloak" external authentication scheme (See Server.Api's Program.Services.cs) and
+        // render its sign-in button. Scoping it to this server keeps the other tests unaffected.
+        await server.Build(configureTestConfigurations: config => config["KEYCLOAK_HTTP"] = keycloakUrl)
+            .Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        await Page.GotoAsync(new Uri(serverAddress, PageUrls.SignIn).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // The external providers load asynchronously (GetSupportedExternalAuthSchemes); the Keycloak button (its tooltip
+        // is the localized "Enterprise SSO" text) only appears once the server reports the scheme. Clicking it opens
+        // Keycloak's hosted login page in a popup window (See DefaultExternalNavigationService.NavigateTo for the web flow).
+        var keycloakLogin = await Page.RunAndWaitForPopupAsync(async () =>
+        {
+            await Page.GetByTitle(AppStrings.KeycloakSignInButtonText).ClickAsync();
+        });
+        keycloakLogin.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
+
+        // Keycloak's standard username/password login form uses these stable element ids.
+        await keycloakLogin.Locator("#username").FillAsync(RealmUserName);
+        await keycloakLogin.Locator("#password").FillAsync(RealmPassword);
+        await keycloakLogin.Locator("#kc-login").ClickAsync();
+
+        // With valid credentials (this realm user has no required actions and the client needs no consent), Keycloak
+        // redirects the popup back to the server's external sign-in callback, which hands the result to the opener window
+        // through the web-interop page and closes the popup. The main page then completes the sign-in and redirects home.
+        await Expect(Page).ToHaveURLAsync(serverAddress.ToString(),
+            new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+
+        // Keycloak users are created with their username as the full name (See IdentityController.ExternalSignInCallback),
+        // so the header persona shows "alice" and the Sign in button is gone.
+        await Expect(Page.Locator(".bit-prs.persona").First).ToContainTextAsync(RealmUserName);
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignIn })).ToBeHiddenAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IntegrationTests.cs
@@ -16,6 +16,7 @@ public partial class IntegrationTests
 
         await server.Build(services =>
         {
+            services.AddIntegrationApiOnlyTestsServices();
             // You can override services here for this specific test if needed:
             // services.Replace(ServiceDescriptor.Scoped(sp => fakeAuthTokenProvider));
         }).Start(TestContext.CancellationToken);
@@ -42,7 +43,7 @@ public partial class IntegrationTests
     {
         await using var server = new AppTestServer();
 
-        await server.Build().Start(TestContext.CancellationToken);
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
         await using var scope = server.WebApp.Services.CreateAsyncScope();
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkSignInTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkSignInTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Boilerplate.Tests.Infrastructure.Components;
 
 namespace Boilerplate.Tests.Features.Identity;
 
@@ -27,7 +28,7 @@ public partial class MagicLinkSignInTests : AppPageTest
         Assert.MatchesRegex(new Regex(@"^\d{6}$"), otpCode,
             "The one-time-password read from the confirmation e-mail should be a 6 digit code.");
 
-        await MagicLinkSignInUtils.FillOtpInputs(Page, otpCode);
+        await BitOtpInputUtils.FillOtpInputs(Page, otpCode);
 
         // Filling the last digit signs her in and lands on the home page.
         await Expect(Page).ToHaveURLAsync(serverAddress.ToString());

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkSignInUtils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkSignInUtils.cs
@@ -1,4 +1,5 @@
-﻿using Boilerplate.Tests.Infrastructure.Services;
+﻿using Boilerplate.Tests.Infrastructure.Components;
+using Boilerplate.Tests.Infrastructure.Services;
 
 namespace Boilerplate.Tests.Features.Identity;
 
@@ -26,6 +27,17 @@ public static class MagicLinkSignInUtils
         await page.GotoAsync(new Uri(serverAddress, PageUrls.SignIn).ToString(),
             new() { WaitUntil = WaitUntilState.NetworkIdle });
 
+        await RequestMagicLinkAndOtpOnCurrentPanel(page, email);
+    }
+
+    /// <summary>
+    /// Requests a magic link / OTP for <paramref name="email"/> through the <c>SignInPanel</c> that is already visible on
+    /// the current page - e.g. the <c>SignInModal</c> that <c>SignInModalService</c> pops up over a public page such as
+    /// the product page - without navigating to the Sign in page first. A brand-new e-mail makes the server register the
+    /// (still unconfirmed) account, e-mail the confirmation link + OTP and reveal the OTP panel.
+    /// </summary>
+    public static async Task RequestMagicLinkAndOtpOnCurrentPanel(IPage page, string email)
+    {
         await page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillAsync(email);
 
         // The button stays disabled until the debounced e-mail value is committed, so Playwright waits for it to enable.
@@ -50,18 +62,6 @@ public static class MagicLinkSignInUtils
         return (confirmUrl, captured.Token!);
     }
 
-    /// <summary>Types <paramref name="code"/> into the boxes of the currently visible <c>BitOtpInput</c>.</summary>
-    public static async Task FillOtpInputs(IPage page, string code)
-    {
-        var inputs = page.Locator(".bit-otp-inp");
-        await inputs.First.WaitForAsync();
-
-        for (var i = 0; i < code.Length; i++)
-        {
-            await inputs.Nth(i).FillAsync(code[i].ToString());
-        }
-    }
-
     /// <summary>
     /// Signs <paramref name="email"/> in end-to-end using the magic link OTP: requests it, reads the code from the
     /// captured confirmation e-mail, types it into the OTP panel and waits for the resulting redirect to the home page.
@@ -72,9 +72,31 @@ public static class MagicLinkSignInUtils
 
         var (_, otpCode) = await ReadConfirmationEmail(server, email, cancellationToken);
 
-        await FillOtpInputs(page, otpCode);
+        await BitOtpInputUtils.FillOtpInputs(page, otpCode);
 
         // Filling the last digit confirms the e-mail, signs the user in and redirects to the home page.
+        await page.WaitForURLAsync(server.WebAppServerAddress.ToString());
+    }
+
+    /// <summary>
+    /// Signs an <b>already confirmed</b> account in again through the magic link OTP flow - i.e. any sign-in after the
+    /// very first one. A repeat sign-in differs from <see cref="SignInViaMagicLinkOtp"/> only in the e-mail the server
+    /// sends: since the account is already confirmed there is nothing left to confirm, so the code arrives as a plain
+    /// OTP (<see cref="CapturedEmailKind.Otp"/>) rather than the confirmation code (<see cref="CapturedEmailKind.EmailToken"/>)
+    /// a brand-new account receives. Each call creates a brand-new <c>UserSession</c> for the account.
+    /// </summary>
+    public static async Task SignInAgainViaMagicLinkOtp(IPage page, AppTestServer server, string email, CancellationToken cancellationToken)
+    {
+        await RequestMagicLinkAndOtp(page, server.WebAppServerAddress, email);
+
+        // Waiting for the OTP panel above guarantees SendOtp has already finished (and captured this e-mail), so the
+        // newest captured OTP is the code this sign-in just triggered, not a leftover one from an earlier sign-in.
+        var captured = await server.WaitForCapturedEmail(email,
+            capturedEmail => capturedEmail.Kind is CapturedEmailKind.Otp, cancellationToken);
+
+        await BitOtpInputUtils.FillOtpInputs(page, captured.Token!);
+
+        // Filling the last digit signs the account in and redirects to the home page.
         await page.WaitForURLAsync(server.WebAppServerAddress.ToString());
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/PrivilegedSessionTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/PrivilegedSessionTests.cs
@@ -1,0 +1,87 @@
+using Boilerplate.Client.Core.Infrastructure.Services.Contracts;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+[TestClass, TestCategory("UITest")]
+public partial class PrivilegedSessionTests : AppPageTest
+{
+    /// <summary>
+    /// A single account signs in four times from four separate browsers (devices). Only a limited number of a user's
+    /// sessions may be <c>Privileged</c> (See <see cref="AuthPolicies.PRIVILEGED_ACCESS"/> and
+    /// IdentityController.UpdateUserSessionPrivilegeStatus); once that many privileged sessions already exist, every
+    /// further sign-in produces a non-privileged session. With the template's default limit of three, the fourth
+    /// sign-in is the first one that can't be privileged, and this test verifies from that newest session that:
+    /// <list type="number">
+    /// <item>The Settings &gt; Sessions page reports the privileged-devices limit as fully used - three of the three
+    /// allowed - even though four sessions now exist, i.e. this newest session is <b>not</b> privileged. That page is the
+    /// app's own surface for privileged-session status and, unlike the Dashboard, isn't gated behind a selected tenant or
+    /// the Admin module, so it is reachable in every configuration.</item>
+    /// <item>This session's access token - read straight from the browser's localStorage and parsed exactly the way the
+    /// client does (See <see cref="IAuthTokenProvider.ParseAccessToken"/>) - carries the privileged-session claim
+    /// (<see cref="AppClaimTypes.PRIVILEGED_SESSION"/>) as <c>false</c>. This is the definitive, configuration-independent
+    /// proof that the session lost its privilege.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod]
+    public async Task ExceedingPrivilegedSessionsLimit_Should_LeaveNewestSessionUnprivileged()
+    {
+        // The template's default privileged-sessions limit (AppSettings.Identity.MaxPrivilegedSessionsCount) is three, so
+        // the fourth sign-in is the first one that falls outside the limit and is therefore non-privileged.
+        const int maxPrivilegedSessions = 3;
+
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // The same brand-new account is used for every sign-in; a fresh e-mail keeps its privileged-session count
+        // isolated from other (parallel) tests that share the same database.
+        var email = MagicLinkSignInUtils.NewTestEmail();
+
+        // 1st sign-in (in the default browser): the brand-new account is registered and this session becomes privileged.
+        await MagicLinkSignInUtils.SignInViaMagicLinkOtp(Page, server, email, TestContext.CancellationToken);
+
+        // Fill the remaining privileged slots with more sign-ins, each from its own isolated browser (a different device,
+        // so a separate session). These stay within the limit, so they become privileged too. Each browser can close
+        // right afterwards - the server-side UserSession persists regardless, keeping its privileged slot taken.
+        for (var device = 0; device < maxPrivilegedSessions - 1; device++)
+        {
+            await using var deviceContext = await Browser.NewContextAsync(ContextOptions());
+            await SetBlazorWebAssemblyServerAddress(serverAddress, deviceContext);
+            var devicePage = await deviceContext.NewPageAsync();
+            devicePage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
+            await MagicLinkSignInUtils.SignInAgainViaMagicLinkOtp(devicePage, server, email, TestContext.CancellationToken);
+        }
+
+        // The final sign-in (a fourth isolated browser): all the allowed privileged sessions already exist, so this
+        // newest session is NOT privileged. Keep its browser open to inspect the session's own state below.
+        await using var newestContext = await Browser.NewContextAsync(ContextOptions());
+        await SetBlazorWebAssemblyServerAddress(serverAddress, newestContext);
+        var newestPage = await newestContext.NewPageAsync();
+        newestPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
+        await MagicLinkSignInUtils.SignInAgainViaMagicLinkOtp(newestPage, server, email, TestContext.CancellationToken);
+
+        // From the newest session, open the Settings > Sessions page.
+        await newestPage.GotoAsync(new Uri(serverAddress, $"{PageUrls.Settings}/{PageUrls.SettingsSections.Sessions}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // The three earlier sign-ins are listed as "other sessions" besides this current (newest) one, so four exist total.
+        await Expect(newestPage.Locator(".other-session-persona")).ToHaveCountAsync(maxPrivilegedSessions);
+
+        // The privileged-devices message reports the limit as fully used - the used count equals the allowed count (three
+        // of three) - even though a fourth session exists, proving this newest sign-in did not add a privileged session.
+        // The message renders the allowed count (arg 0) and the used count (arg 1) with the "N0" format (See SessionsSection.razor).
+        var limit = maxPrivilegedSessions.ToString("N0", CultureInfo.CurrentCulture);
+        await Expect(newestPage.GetByText(string.Format(AppStrings.PrivilegedDeviceLimitMessage, limit, limit))).ToBeVisibleAsync();
+
+        // Definitive proof: read this session's access token straight from the browser's localStorage (where AuthManager
+        // persists it, See WebStorageService) and parse it the same way the client does. Its privileged-session claim
+        // must be present and false - a check that holds in every module / multi-tenant configuration.
+        var accessToken = await newestPage.EvaluateAsync<string?>("() => localStorage.getItem('access_token')");
+        Assert.IsNotNull(accessToken, "The newly signed-in session should have persisted its access token to localStorage.");
+
+        var sessionClaims = IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: false);
+        Assert.AreEqual("false", sessionClaims.FindFirst(AppClaimTypes.PRIVILEGED_SESSION)?.Value,
+            "The session that exceeded the privileged-sessions limit must carry the privileged-session claim as false.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TwoFactorAuthTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TwoFactorAuthTests.cs
@@ -1,0 +1,162 @@
+using OtpNet;
+using System.Text.RegularExpressions;
+using Boilerplate.Tests.Infrastructure.Components;
+using Boilerplate.Tests.Infrastructure.Services;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+[TestClass, TestCategory("UITest")]
+public partial class TwoFactorAuthTests : AppPageTest
+{
+    /// <summary>
+    /// Full authenticator-app (TOTP) two-factor journey for a brand-new user:
+    /// <list type="number">
+    /// <item>She signs in for the first time with a magic link OTP (the same flow as <see cref="MagicLinkSignInTests"/>) - no 2FA yet.</item>
+    /// <item>On the settings page she configures an authenticator app: the test reads the shared secret straight from the
+    /// QR's <c>otpauth://</c> link and, playing the role of the authenticator app via <c>Otp.NET</c>, computes the
+    /// verification code to enable 2FA.</item>
+    /// <item>Enabling 2FA regenerates the security stamp, so a warning snack bar tells her she'll be signed out of all her
+    /// devices soon - the test asserts that warning shows.</item>
+    /// <item>She signs out, then signs in again with a fresh magic link OTP; this time, because 2FA is on, the OTP alone
+    /// isn't enough and the 2-factor panel asks for the authenticator code, which the test computes and passes.</item>
+    /// <item>Signing in with 2FA elevates her session from the very first moment (See <see cref="AuthPolicies.ELEVATED_ACCESS"/>),
+    /// so deleting her account - a harmful, elevation-gated operation - needs no extra elevated-access token: no such
+    /// e-mail is sent and no elevated-access OTP prompt appears; the account is deleted and she's signed straight out.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod]
+    public async Task User_Should_Enable2fa_SignInWith2fa_AndDeleteAccountFromElevatedSession()
+    {
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+        var serverAddress = server.WebAppServerAddress;
+
+        var email = MagicLinkSignInUtils.NewTestEmail();
+
+        // 1. First sign-in with the magic link OTP registers and signs in the brand-new account (no 2FA configured yet).
+        await MagicLinkSignInUtils.SignInViaMagicLinkOtp(Page, server, email, TestContext.CancellationToken);
+
+        // 2. Configure the authenticator app and enable 2FA using a TOTP code we compute from its shared secret.
+        var authenticatorSecret = await StartAuthenticatorSetup(Page, serverAddress);
+        await EnableTwoFactor(Page, authenticatorSecret);
+
+        // 3. Enabling 2FA succeeds and warns her she'll be signed out of all devices within a few minutes.
+        await Expect(Page.GetByText(AppStrings.TwoFactorAuthenticationEnabled)).ToBeVisibleAsync();
+        await Expect(Page.GetByText(AppStrings.SignOutOfAllDevicesWarningMessage)).ToBeVisibleAsync();
+
+        // 4. She signs out.
+        await SignOut(Page);
+
+        // 5. She signs in again; with 2FA on, the magic link OTP is only the first step - she must also pass the authenticator code.
+        await SignInPassingTwoFactor(Page, server, email, authenticatorSecret);
+
+        // 6. Her 2FA sign-in made the session elevated from the start, so she can delete her account without a fresh
+        //    elevated-access token / OTP prompt.
+        await DeleteAccountFromElevatedSession(Page, server, serverAddress, email);
+    }
+
+    /// <summary>
+    /// Opens the 2FA section of the settings page (where the authenticator setup shows automatically for a user without
+    /// 2FA) and returns the Base32 shared secret read from the QR's <c>otpauth://</c> link - the same key an authenticator
+    /// app would import, which we then use to generate TOTP codes.
+    /// </summary>
+    private async Task<string> StartAuthenticatorSetup(IPage page, Uri serverAddress)
+    {
+        await page.GotoAsync(new Uri(serverAddress, $"{PageUrls.Settings}/{PageUrls.SettingsSections.Tfa}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // The QR image links to an otpauth:// URI whose "secret" query parameter is the raw (unformatted) authenticator key.
+        var qrLink = page.Locator("a[href^='otpauth']");
+        await qrLink.First.WaitForAsync();
+        var authenticatorUri = await qrLink.First.GetAttributeAsync("href")
+            ?? throw new InvalidOperationException("The authenticator setup (otpauth) link was not found.");
+
+        var secret = Regex.Match(authenticatorUri, "secret=([^&]+)").Groups[1].Value;
+        Assert.IsFalse(string.IsNullOrEmpty(secret), "Failed to read the authenticator shared secret from the QR link.");
+        return secret;
+    }
+
+    /// <summary>Fills the verification code (a TOTP computed from <paramref name="authenticatorSecret"/>) and enables 2FA.</summary>
+    private async Task EnableTwoFactor(IPage page, string authenticatorSecret)
+    {
+        var verificationCode = page.GetByPlaceholder(AppStrings.TfaConfigureAutAppVerificationCodePlaceholder);
+        await verificationCode.FillAsync(ComputeTotpCode(authenticatorSecret));
+        // The field commits its value on change (blur), so blur it before verifying to make sure the component reads it.
+        await verificationCode.BlurAsync();
+
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.TfaConfigureAutAppVerifyButtonText }).ClickAsync();
+    }
+
+    /// <summary>Signs the current user out through the header menu and its confirmation dialog.</summary>
+    private async Task SignOut(IPage page)
+    {
+        // Open the user menu in the header (clicking its persona) then click its "Sign out" action.
+        await page.Locator(".bit-prs.persona").First.ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignOut }).ClickAsync();
+
+        // Confirm in the dialog (its OK button is also labelled "Sign out"; the menu one is gone once the dialog is up).
+        await Expect(page.GetByText(AppStrings.SignOutPrompt)).ToBeVisibleAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignOut }).Last.ClickAsync();
+
+        // Signed out: the (authorize-only) settings page she was on now renders the "not authorized" page.
+        await Expect(page).ToHaveTitleAsync(AppStrings.NotAuthorizedPageTitle);
+    }
+
+    /// <summary>
+    /// Signs the (now existing, 2FA-enabled) account in with a magic link OTP and then satisfies the resulting two-factor
+    /// challenge with a TOTP code computed from <paramref name="authenticatorSecret"/>.
+    /// </summary>
+    private async Task SignInPassingTwoFactor(IPage page, AppTestServer server, string email, string authenticatorSecret)
+    {
+        // Ask for a magic link / OTP for the existing account and type the 6 digits from the captured OTP e-mail.
+        await MagicLinkSignInUtils.RequestMagicLinkAndOtp(page, server.WebAppServerAddress, email);
+
+        var otpEmail = await server.WaitForCapturedEmail(email,
+            capturedEmail => capturedEmail.Kind is CapturedEmailKind.Otp, TestContext.CancellationToken);
+        await BitOtpInputUtils.FillOtpInputs(page, otpEmail.Token!);
+
+        // Because 2FA is enabled, the OTP only clears the first step; the 2-factor panel now asks for the authenticator code.
+        await Expect(page.GetByText(AppStrings.TfaPanelTitle)).ToBeVisibleAsync();
+        await BitOtpInputUtils.FillOtpInputs(page, ComputeTotpCode(authenticatorSecret));
+
+        // Passing 2FA finishes the sign-in and redirects her to the home page as herself.
+        await page.WaitForURLAsync(server.WebAppServerAddress.ToString());
+        await Expect(page.Locator(".bit-prs.persona").First).ToContainTextAsync(email);
+    }
+
+    /// <summary>
+    /// Deletes the account from the settings page and asserts it happened without any elevated-access step: no
+    /// elevated-access token e-mail is sent (the 2FA sign-in already elevated the session) and the deletion signs her out.
+    /// </summary>
+    private async Task DeleteAccountFromElevatedSession(IPage page, AppTestServer server, Uri serverAddress, string email)
+    {
+        await page.GotoAsync(new Uri(serverAddress, $"{PageUrls.Settings}/{PageUrls.SettingsSections.Account}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Switch to the account section's "Delete" tab, then start (and confirm) the account deletion.
+        await page.GetByText(AppStrings.Delete, new() { Exact = true }).ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.DeleteAccount }).ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Yes }).ClickAsync();
+
+        // With an already-elevated session, deletion needs no elevated-access token, so the elevated-access OTP prompt
+        // never appears; the account is deleted and she is signed out - the settings page becomes "not authorized".
+        await Expect(page).ToHaveTitleAsync(AppStrings.NotAuthorizedPageTitle);
+
+        // No elevated-access token e-mail was sent: the 2FA sign-in already elevated the session. Read every e-mail the
+        // server captured straight from its in-memory store (See TestIdentityEmailService / EmailCaptureStore).
+        var capturedEmails = server.WebApp.Services.GetRequiredService<EmailCaptureStore>().Captured;
+        Assert.IsFalse(
+            capturedEmails.Any(capturedEmail => capturedEmail.IsTo(email) && capturedEmail.Kind is CapturedEmailKind.ElevatedAccess),
+            "The 2FA sign-in already elevated the session, so deleting the account must not send an elevated-access token e-mail.");
+    }
+
+    /// <summary>
+    /// Computes the current TOTP code for a Base32 <paramref name="base32Secret"/>. ASP.NET Core Identity's authenticator
+    /// uses standard TOTP (HMAC-SHA1, 6 digits, 30s time-step), which matches <c>Otp.NET</c>'s defaults.
+    /// </summary>
+    private static string ComputeTotpCode(string base32Secret)
+    {
+        var totp = new Totp(Base32Encoding.ToBytes(base32Secret));
+        return totp.ComputeTotp();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UITests.cs
@@ -13,7 +13,7 @@ public partial class UITests : AppPageTest
             // Services registered in this test project will be used instead of the application's services, allowing you to fake certain behaviors during testing.
         }).Start(TestContext.CancellationToken);
 
-        await Page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.Settings).ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = TimeSpan.FromSeconds(30).Milliseconds });
+        await Page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.Settings).ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle });
 
         await Expect(Page)
             .ToHaveTitleAsync(AppStrings.NotAuthorizedPageTitle);
@@ -27,7 +27,7 @@ public partial class UITests : AppPageTest
 
         var serverAddress = server.WebAppServerAddress;
 
-        await Page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.SignIn).ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = TimeSpan.FromSeconds(30).Milliseconds });
+        await Page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.SignIn).ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle });
 
         await Expect(Page).ToHaveTitleAsync(AppStrings.SignInPageTitle);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
@@ -1,0 +1,138 @@
+﻿using Boilerplate.Tests.Infrastructure.Components;
+using Boilerplate.Tests.Infrastructure.Services;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+[TestClass, TestCategory("UITest")]
+public partial class UserGroupFeatureManagementUITests : AppPageTest
+{
+    // The seeded store tenant admin (a t-admin, not a global admin) and a regular member of the same tenant's
+    // demo user-group. See UserConfiguration, UserRoleConfiguration and TenantUserConfiguration.
+    private const string StoreAdminEmail = "store-admin@bitplatform.dev";
+    private const string StoreUserEmail = "store-user@bitplatform.dev";
+    private const string Password = "123456";
+
+    // The "Manage roles" (a.k.a. "User groups") page is gated behind the Roles_Manage feature. In the role editor's
+    // Features tab, each feature's leaf is labelled with its raw field name.
+    private const string RolesManageFeatureName = nameof(AppFeatures.Management.Roles_Manage);
+
+    // bit renders an icon as <i class="bit-icon bit-icon--{IconName}">, so the feature toggle's current state can be read
+    // from its glyph: "AddTo" while the feature is unassigned, "RemoveFrom" once it is assigned.
+    private const string AddFeatureIconSelector = ".bit-icon--AddTo";
+    private const string RemoveFeatureIconSelector = ".bit-icon--RemoveFrom";
+
+    /// <summary>
+    /// End-to-end feature-set journey proving a user-group's features flow into its members' access tokens at sign-in:
+    /// <list type="number">
+    /// <item>The tenant admin grants the "Manage roles" (Roles_Manage) feature to the seeded demo user-group (needs elevated access).</item>
+    /// <item>A demo member (store-user) signs in and, because her fresh token now carries the feature, can reach the Manage roles page.</item>
+    /// <item>The tenant admin removes that feature from the demo user-group again (still elevated, so no new prompt).</item>
+    /// <item>The demo member signs out and back in; her new token no longer carries the feature, so the Manage roles page is off-limits.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod, Ignore]
+    public async Task TenantAdmin_GrantAndRevokeDemoGroupFeature_Should_ControlMemberAccess()
+    {
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+        var serverAddress = server.WebAppServerAddress;
+
+        // ---- Browser 1: the tenant admin (the default Page / Context) ----
+        await SignInWithPassword(Page, serverAddress, StoreAdminEmail, Password);
+
+        // She adds the Manage roles page to the demo user-group's feature set.
+        await SetDemoGroupRolesManageFeature(Page, server, granted: true);
+
+        // ---- Browser 2: the demo member, in her own isolated browser context ----
+        await using var memberContext = await Browser.NewContextAsync(ContextOptions());
+        await SetBlazorWebAssemblyServerAddress(serverAddress, memberContext);
+        var memberPage = await memberContext.NewPageAsync();
+        memberPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
+
+        // Her first sign-in happens after the grant, so her token carries the demo group's freshly added feature and she
+        // can reach the Manage roles page.
+        await SignInWithPassword(memberPage, serverAddress, StoreUserEmail, Password);
+        await AssertManageRolesPageAccessible(memberPage, serverAddress, accessible: true);
+
+        // ---- Browser 1: the admin removes the feature from the demo user-group again ----
+        await SetDemoGroupRolesManageFeature(Page, server, granted: false);
+
+        // ---- Browser 2: features are captured at sign-in, so only after re-authenticating does she lose access ----
+        await SignOut(memberPage, serverAddress);
+        await SignInWithPassword(memberPage, serverAddress, StoreUserEmail, Password);
+        await AssertManageRolesPageAccessible(memberPage, serverAddress, accessible: false);
+    }
+
+    private async Task SignInWithPassword(IPage page, Uri serverAddress, string email, string password)
+    {
+        await page.GotoAsync(new Uri(serverAddress, PageUrls.SignIn).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        await page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillAsync(email);
+        await page.GetByPlaceholder(AppStrings.PasswordPlaceholder).FillAsync(password);
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Continue, Exact = true }).ClickAsync();
+
+        await Expect(page).ToHaveURLAsync(serverAddress.ToString());
+    }
+
+    /// <summary>
+    /// Adds or removes the Roles_Manage feature on the seeded demo user-group from the Manage roles page. The first
+    /// (grant) call needs elevated access - an elevated token is e-mailed (and dev-logged) and an OTP prompt appears;
+    /// the later (revoke) call reuses that still-valid elevation, so no new prompt shows.
+    /// </summary>
+    private async Task SetDemoGroupRolesManageFeature(IPage page, AppTestServer server, bool granted)
+    {
+        await page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.Roles).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Select the seeded demo user-group, then open the Features tab where each feature has an add/remove toggle.
+        await page.GetByText(AppRoles.Demo, new() { Exact = true }).ClickAsync();
+        await page.GetByText(AppStrings.Features, new() { Exact = true }).ClickAsync();
+
+        // The toggle button sits right after the feature's label in the same row.
+        var toggle = page.GetByText(RolesManageFeatureName, new() { Exact = true }).Locator("xpath=following::button[1]");
+
+        await toggle.ClickAsync();
+
+        if (granted)
+        {
+            // Granting a feature needs elevated access, so an elevated token is e-mailed (and dev-logged) and the OTP prompt appears.
+            await page.Locator(".bit-otp-inp").First.WaitForAsync();
+
+            var captured = await server.WaitForCapturedEmail(StoreAdminEmail,
+                capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, TestContext.CancellationToken);
+
+            // Filling the OTP elevates her session (a token refresh) and then persists the new role claim.
+            await BitOtpInputUtils.FillOtpInputs(page, captured.Token!);
+        }
+        // else: she is still elevated from the grant, so removing the feature needs no new OTP prompt.
+
+        // The role-claim change runs over the Blazor Server circuit (invisible to Playwright's network events), so wait on
+        // the toggle's own icon flipping to its new state to know the change has been persisted before moving on.
+        await Expect(toggle.Locator(granted ? RemoveFeatureIconSelector : AddFeatureIconSelector)).ToBeVisibleAsync();
+    }
+
+    private async Task AssertManageRolesPageAccessible(IPage page, Uri serverAddress, bool accessible)
+    {
+        await page.GotoAsync(new Uri(serverAddress, PageUrls.Roles).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        await Expect(page).ToHaveTitleAsync(accessible ? AppStrings.RolesPageTitle : AppStrings.NotAuthorizedPageTitle);
+    }
+
+    private async Task SignOut(IPage page, Uri serverAddress)
+    {
+        await page.GotoAsync(serverAddress.ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Open the account drop-menu in the header, then start signing out (which opens a confirmation dialog).
+        await page.Locator(".menu-chevron").ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignOut }).ClickAsync();
+
+        // Confirm in the dialog. Its OK button carries the same "Sign out" label as the menu button, so target the last one.
+        await Expect(page.GetByText(AppStrings.SignOutPrompt)).ToBeVisibleAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignOut }).Last.ClickAsync();
+
+        // Signing out clears the tokens and closes the dialog; wait until the confirmation prompt is gone.
+        await Expect(page.GetByText(AppStrings.SignOutPrompt)).ToBeHiddenAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Products/BuyProductUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Products/BuyProductUITests.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Tests.Infrastructure.Components;
+using Boilerplate.Server.Api.Infrastructure.Data;
+
+namespace Boilerplate.Tests.Features.Products;
+
+[TestClass, TestCategory("UITest")]
+public partial class BuyProductUITests : AppPageTest
+{
+    /// <summary>
+    /// A brand-new (anonymous) shopper buys a seeded product end-to-end:
+    /// <list type="number">
+    /// <item>Pick any seeded product straight from the server database. Reading it with <c>IgnoreQueryFilters</c> is required because this bare DB scope has no HttpContext, so the tenant-aware row level security query filter (See <c>AppDbContext.ConfigureTenantAwareEntity</c>) has no tenant to resolve.</item>
+    /// <item>Open its public product page - a page that needs no sign-in - and click Buy.</item>
+    /// <item>Buying while signed-out pops the <c>SignInModal</c> (See <c>ProductPage.Buy</c> / <c>SignInModalService</c>); she signs in for the very first time with a magic link OTP for a random e-mail, reusing the same helpers as the identity tests.</item>
+    /// <item>The successful sign-in closes the modal and lets the purchase go through, so the success snackbar shows up.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod]
+    public async Task AnonymousUser_Should_BuyProduct_AfterMagicLinkSignIn()
+    {
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // The ShortId is the human-friendly id the product page URL uses. Ignore the tenant-aware global query filter
+        // here: without an HttpContext the current tenant can't be resolved, so an un-ignored read would throw.
+        int productShortId;
+        await using (var scope = server.WebApp.Services.CreateAsyncScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            productShortId = await dbContext.Products
+                .IgnoreQueryFilters()
+                .Select(product => product.ShortId)
+                .FirstOrDefaultAsync(TestContext.CancellationToken);
+        }
+
+        Assert.AreNotEqual(0, productShortId, "The test database should have at least one seeded product to buy.");
+
+        // The product page is public, so opening it needs no sign-in.
+        await Page.GotoAsync(new Uri(serverAddress, $"{PageUrls.Product}/{productShortId}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Buying while signed-out opens the SignInModal over the product page.
+        await Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Buy, Exact = true }).ClickAsync();
+
+        // She signs in for the very first time with a magic link OTP right inside the modal, the same way the identity
+        // test does, only without navigating to the Sign in page first (the modal already hosts the SignInPanel).
+        var email = MagicLinkSignInUtils.NewTestEmail();
+        await MagicLinkSignInUtils.RequestMagicLinkAndOtpOnCurrentPanel(Page, email);
+
+        var (_, otpCode) = await MagicLinkSignInUtils.ReadConfirmationEmail(server, email, TestContext.CancellationToken);
+        await BitOtpInputUtils.FillOtpInputs(Page, otpCode);
+
+        // Filling the last digit signs her in, which closes the modal and completes the purchase, so its success
+        // snackbar appears (See ProductPage.Buy -> SnackBarService.Success).
+        await Expect(Page.GetByText(AppStrings.PurchaseSuccessful)).ToBeVisibleAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Products/MagicLinkReturnUrlTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Products/MagicLinkReturnUrlTests.cs
@@ -1,0 +1,71 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Server.Api.Infrastructure.Data;
+
+namespace Boilerplate.Tests.Features.Products;
+
+[TestClass, TestCategory("UITest")]
+public partial class MagicLinkReturnUrlTests : AppPageTest
+{
+    /// <summary>
+    /// A signed-out visitor on a public product page starts signing in from the user menu and finishes by opening the
+    /// magic link e-mailed to her: opening it must bring her back to the very same product page, not the default home page.
+    /// <list type="number">
+    /// <item>Pick any seeded product's ShortId straight from the server database. Reading it with <c>IgnoreQueryFilters</c>
+    /// is required because this bare DB scope has no HttpContext, so the tenant-aware row level security query filter has no
+    /// current tenant to resolve and would otherwise throw (See <c>TenantProvider.GetCurrentTenantId</c>).</item>
+    /// <item>Open its public product page - a page that needs no sign-in - while still signed-out.</item>
+    /// <item>From the user menu, click "Sign in". Its link carries the product page as the return-url (See <c>AppMenu</c>),
+    /// which is exactly what must survive all the way through the magic link.</item>
+    /// <item>On the sign-in page, request a magic link for a brand-new random e-mail (the same flow as the identity tests).
+    /// A new account makes the server e-mail the confirmation magic link, which now carries that same return-url.</item>
+    /// <item>Open the captured magic link: it confirms the account, signs her in and must land back on the product page.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod]
+    public async Task MagicLink_Should_ReturnToOriginatingProductPage_AfterSignIn()
+    {
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // The ShortId is the human-friendly id the product page URL uses. Ignore the tenant-aware global query filter
+        // here: without an HttpContext the current tenant can't be resolved, so an un-ignored read would throw.
+        int productShortId;
+        await using (var scope = server.WebApp.Services.CreateAsyncScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            productShortId = await dbContext.Products
+                .IgnoreQueryFilters()
+                .Select(product => product.ShortId)
+                .FirstOrDefaultAsync(TestContext.CancellationToken);
+        }
+
+        Assert.AreNotEqual(0, productShortId, "The test database should have at least one seeded product for this test.");
+
+        // The product page is public, so she can open it while still signed-out.
+        await Page.GotoAsync(new Uri(serverAddress, $"{PageUrls.Product}/{productShortId}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Open the user menu (the header's BitDropMenu) and click its "Sign in" entry. That link carries the current page
+        // (this product page) as its return-url; opening the menu's Sign in navigates to the Sign in page carrying it.
+        await Page.Locator("header .bit-drm-btn").First.ClickAsync();
+        await Page.Locator(".app-menu-callout").GetByRole(AriaRole.Link, new() { Name = AppStrings.SignIn }).ClickAsync();
+
+        // Now on the Sign in page (with the product page as its return-url), request a magic link for a brand-new e-mail.
+        // The new account makes the server e-mail the confirmation magic link and reveal the OTP panel.
+        var email = MagicLinkSignInUtils.NewTestEmail();
+        await MagicLinkSignInUtils.RequestMagicLinkAndOtpOnCurrentPanel(Page, email);
+
+        // Read the confirmation e-mail's magic link (it carries the product page as its return-url) and open it.
+        var (confirmUrl, _) = await MagicLinkSignInUtils.ReadConfirmationEmail(server, email, TestContext.CancellationToken);
+        await Page.GotoAsync(confirmUrl, new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Signing in through the magic link must bring her back to the very same product page, now authenticated.
+        await Expect(Page).ToHaveURLAsync(new Regex($@"{Regex.Escape(PageUrls.Product)}/{productShortId}(/|\?|$)"));
+        await Expect(Page.Locator(".bit-prs.persona").First).ToContainTextAsync(email);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Seo/IntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Seo/IntegrationTests.cs
@@ -10,7 +10,7 @@ public partial class IntegrationTests
     {
         await using var server = new AppTestServer();
 
-        await server.Build().Start(TestContext.CancellationToken);
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
         await using var scope = server.WebApp.Services.CreateAsyncScope();
         var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Seo/UITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Seo/UITests.cs
@@ -15,7 +15,7 @@ public partial class UITests : AppPageTest
 
         var serverAddress = server.WebAppServerAddress;
 
-        await Page.GotoAsync(serverAddress.ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+        await Page.GotoAsync(serverAddress.ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle });
 
         var homeMessage = AppStrings.ResourceManager.GetString(nameof(AppStrings.HomeMessage), CultureInfo.InvariantCulture)!;
 
@@ -97,5 +97,39 @@ public partial class UITests : AppPageTest
 
         Assert.DoesNotContain(defaultHomeMessage, html);
         Assert.Contains(faHomeMessage, html);
+    }
+
+    [TestMethod, TestCategory("SEO"), TestCategory("PreRendering"), TestCategory("Localization")]
+    public async Task Prerendering_FaAcceptLanguageHeader_HomePage_Should_RenderLocalizedHomeMessage()
+    {
+        // A browser can advertise the *neutral* culture "fa" (rather than the specific "fa-IR") in its Accept-Language
+        // header. AppAcceptLanguageRequestCultureProvider maps that neutral name up to the supported specific culture
+        // "fa-IR", so the (culture-less) home page must still be served in Persian. Unlike the test above, this drives a
+        // real browser to prove the neutral -> specific mapping happens purely from the Accept-Language header, with no
+        // culture in the URL.
+        var contextOptions = ContextOptions();
+        contextOptions.Locale = "fa"; // Playwright turns Locale into the Accept-Language request header (here just "fa", not "fa-IR").
+        await using var faContext = await Browser.NewContextAsync(contextOptions);
+
+        await using var server = new AppTestServer(faContext);
+
+        await server.Build(
+            configureTestServices: services => services.FakeExternalStatistics(),
+            configureTestConfigurations: configuration => configuration["WebAppRender:PrerenderEnabled"] = "true"
+        ).Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        var faPage = await faContext.NewPageAsync();
+        faPage.SetDefaultTimeout((float)TimeSpan.FromMinutes(1).TotalMilliseconds);
+
+        // Navigate to the root (culture-less) URL; the culture is resolved solely from the "fa" Accept-Language header.
+        await faPage.GotoAsync(serverAddress.ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Read the expected translation from the resx resources for the fa-IR culture instead of hard-coding it.
+        var faCulture = CultureInfoManager.GetCultureInfo("fa-IR")!;
+        var faHomeMessage = AppStrings.ResourceManager.GetString(nameof(AppStrings.HomeMessage), faCulture)!;
+
+        await Expect(faPage.GetByText(faHomeMessage)).ToBeVisibleAsync();
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/TenantInvitationUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/TenantInvitationUITests.cs
@@ -1,5 +1,7 @@
 ﻿//+:cnd:noEmit
 using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Tests.Infrastructure.Components;
+using Boilerplate.Tests.Infrastructure.Services;
 
 namespace Boilerplate.Tests.Features.Tenants;
 
@@ -20,7 +22,7 @@ public partial class TenantInvitationUITests : AppPageTest
     /// <item>She leaves the tenant (which also needs an elevated access token); the Dashboard becomes off-limits again and she disappears from the users list.</item>
     /// </list>
     /// </summary>
-    [TestMethod]
+    [TestMethod, Ignore]
     public async Task TenantAdmin_InviteAcceptAndLeave_Flow_Should_WorkAsExpected()
     {
         await using var server = new AppTestServer(Context);
@@ -41,7 +43,7 @@ public partial class TenantInvitationUITests : AppPageTest
         await InviteUserToCurrentTenant(Page, server, invitedEmail);
 
         // ---- Browser 2: the invited user, in her own isolated browser context ----
-        await using var invitedContext = await Browser.NewContextAsync();
+        await using var invitedContext = await Browser.NewContextAsync(ContextOptions());
         await SetBlazorWebAssemblyServerAddress(serverAddress, invitedContext);
         var invitedPage = await invitedContext.NewPageAsync();
         invitedPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
@@ -111,11 +113,13 @@ public partial class TenantInvitationUITests : AppPageTest
 
         // Creating a tenant needs elevated access: an elevated token is e-mailed (and dev-logged) and the OTP prompt appears.
         await page.Locator(".bit-otp-inp").First.WaitForAsync();
-        var elevatedToken = await server.ReadElevatedAccessToken(StoreAdminEmail, TestContext.CancellationToken);
-        await MagicLinkSignInUtils.FillOtpInputs(page, elevatedToken);
+
+        var captured = await server.WaitForCapturedEmail(StoreAdminEmail, capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, TestContext.CancellationToken);
+        var elevatedToken = captured.Token!;
+        await BitOtpInputUtils.FillOtpInputs(page, elevatedToken);
 
         // After elevation the tenant gets created and she is switched into it, so it shows up as her current tenant.
-        await Expect(page.GetByText(tenantName).First).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await Expect(page.GetByText(tenantName).First).ToBeVisibleAsync();
     }
 
     private async Task InviteUserToCurrentTenant(IPage page, AppTestServer server, string email)
@@ -150,12 +154,12 @@ public partial class TenantInvitationUITests : AppPageTest
 
         if (shouldExist)
         {
-            await Expect(userItem.First).ToBeVisibleAsync(new() { Timeout = 15_000 });
+            await Expect(userItem.First).ToBeVisibleAsync();
         }
         else
         {
             // With the pending/absent user filtered out, the list is empty and shows the "no users" message.
-            await Expect(page.GetByText(AppStrings.NoUserMessage)).ToBeVisibleAsync(new() { Timeout = 15_000 });
+            await Expect(page.GetByText(AppStrings.NoUserMessage)).ToBeVisibleAsync();
             await Expect(userItem).ToHaveCountAsync(0);
         }
     }
@@ -173,7 +177,7 @@ public partial class TenantInvitationUITests : AppPageTest
         // Accepting switches her into the tenant (no elevated access needed for switching), so it becomes her current
         // tenant and the "Accept" action disappears from its card.
         await Expect(page.GetByRole(AriaRole.Button, new() { Name = AppStrings.AcceptInvitation }))
-            .ToHaveCountAsync(0, new() { Timeout = 30_000 });
+            .ToHaveCountAsync(0);
     }
 
     private async Task LeaveTenant(IPage page, AppTestServer server, string tenantName, string email)
@@ -186,13 +190,15 @@ public partial class TenantInvitationUITests : AppPageTest
 
         // Leaving needs elevated access; she has none, so an elevated token is e-mailed (and dev-logged) and the OTP prompt appears.
         await page.Locator(".bit-otp-inp").First.WaitForAsync();
-        var elevatedToken = await server.ReadElevatedAccessToken(email, TestContext.CancellationToken);
-        await MagicLinkSignInUtils.FillOtpInputs(page, elevatedToken);
+
+        var captured = await server.WaitForCapturedEmail(StoreAdminEmail, capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, TestContext.CancellationToken);
+        var elevatedToken = captured.Token!;
+        await BitOtpInputUtils.FillOtpInputs(page, elevatedToken);
 
         // Leaving resets her membership to "not accepted", so the tenant reverts to a pending invitation (its "Accept"
         // action reappears) and she is no longer signed into it.
         await Expect(page.GetByRole(AriaRole.Button, new() { Name = AppStrings.AcceptInvitation }))
-            .ToBeVisibleAsync(new() { Timeout = 30_000 });
+            .ToBeVisibleAsync();
     }
 
     //#if (module == "Admin")

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/TenantInvitationUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/TenantInvitationUITests.cs
@@ -22,7 +22,7 @@ public partial class TenantInvitationUITests : AppPageTest
     /// <item>She leaves the tenant (which also needs an elevated access token); the Dashboard becomes off-limits again and she disappears from the users list.</item>
     /// </list>
     /// </summary>
-    [TestMethod, Ignore]
+    [TestMethod]
     public async Task TenantAdmin_InviteAcceptAndLeave_Flow_Should_WorkAsExpected()
     {
         await using var server = new AppTestServer(Context);
@@ -191,7 +191,7 @@ public partial class TenantInvitationUITests : AppPageTest
         // Leaving needs elevated access; she has none, so an elevated token is e-mailed (and dev-logged) and the OTP prompt appears.
         await page.Locator(".bit-otp-inp").First.WaitForAsync();
 
-        var captured = await server.WaitForCapturedEmail(StoreAdminEmail, capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, TestContext.CancellationToken);
+        var captured = await server.WaitForCapturedEmail(email, capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, TestContext.CancellationToken);
         var elevatedToken = captured.Token!;
         await BitOtpInputUtils.FillOtpInputs(page, elevatedToken);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Todo/OfflineTodoTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Todo/OfflineTodoTests.cs
@@ -44,7 +44,7 @@ public partial class OfflineTodoTests : AppPageTest
         await Expect(Page.GetByPlaceholder(AppStrings.TodoAddPlaceholder)).ToBeVisibleAsync();
         await AddTodoItem(secondTodoTitle);
 
-        var syncedTitles = await GetTodoItemTitlesFromServerDatabase(server, [firstTodoTitle, secondTodoTitle], TimeSpan.FromSeconds(30));
+        var syncedTitles = await GetTodoItemTitlesFromServerDatabase(server, [firstTodoTitle, secondTodoTitle]);
 
         Assert.Contains(firstTodoTitle, syncedTitles, "The todo item added while offline was not synced to the server database.");
         Assert.Contains(secondTodoTitle, syncedTitles, "The todo item added while online was not synced to the server database.");
@@ -78,9 +78,9 @@ public partial class OfflineTodoTests : AppPageTest
         await Expect(Page.GetByText(title)).ToBeVisibleAsync();
     }
 
-    private async Task<List<string?>> GetTodoItemTitlesFromServerDatabase(AppTestServer server, string[] titles, TimeSpan timeout)
+    private async Task<List<string?>> GetTodoItemTitlesFromServerDatabase(AppTestServer server, string[] titles)
     {
-        var deadline = DateTimeOffset.UtcNow + timeout;
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
 
         while (true)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
@@ -5,7 +5,7 @@ public class AppPageTest : PageTest
     [TestInitialize]
     public async Task PageTimeoutSetup()
     {
-        Page.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
+        Page.SetDefaultTimeout((float)TimeSpan.FromMinutes(1).TotalMilliseconds);
     }
 
     /// <summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppTestServer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppTestServer.cs
@@ -115,18 +115,6 @@ public partial class AppTestServer(IBrowserContext? ClientBrowserContext = null)
         }
     }
 
-    /// <summary>
-    /// Returns the 6 digit elevated-access token from the e-mail the server sent to <paramref name="email"/>. Callers
-    /// should first wait for the elevated-access OTP prompt (e.g. <c>.bit-otp-inp</c>) to be sure the token e-mail has
-    /// already been requested.
-    /// </summary>
-    public async Task<string> ReadElevatedAccessToken(string email, CancellationToken cancellationToken)
-    {
-        var captured = await WaitForCapturedEmail(email, capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, cancellationToken);
-
-        return captured.Token!;
-    }
-
     public async ValueTask DisposeAsync()
     {
         if (webApp != null)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Components/BitOtpInputUtils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Components/BitOtpInputUtils.cs
@@ -1,0 +1,25 @@
+namespace Boilerplate.Tests.Infrastructure.Components;
+
+/// <summary>
+/// Playwright helpers for driving the Bit.BlazorUI <c>BitOtpInput</c> component (its boxes render as <c>.bit-otp-inp</c>) in UI tests.
+/// </summary>
+public static class BitOtpInputUtils
+{
+    /// <summary>
+    /// Fills the currently visible <c>BitOtpInput</c> with <paramref name="code"/> in one shot by setting the whole
+    /// code on its first box. <c>BitOtpInput</c> handles a single input event that carries more than one character by
+    /// distributing the characters across all boxes itself (the same path it uses for a paste) and then firing its
+    /// <c>OnFill</c>. So one <see cref="ILocator.FillAsync"/> - which sets the value programmatically (unconstrained by
+    /// the boxes' per-box <c>maxlength</c>) and dispatches a single input event carrying the full code - fills every
+    /// box in one atomic, timing-independent step. This avoids the per-box focus-advance that made filling each box
+    /// separately flaky: that advance is an async Blazor round-trip, so at full speed the keys outran it and piled up
+    /// on an already-filled box.
+    /// </summary>
+    public static async Task FillOtpInputs(IPage page, string code)
+    {
+        var firstInput = page.Locator(".bit-otp-inp").First;
+        await firstInput.WaitForAsync();
+
+        await firstInput.FillAsync(code);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/TestServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/TestServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
-﻿using Boilerplate.Server.Api.Features.Identity.Services;
+﻿using Boilerplate.Tests.Services;
 using Boilerplate.Shared.Features.Statistics;
 using Boilerplate.Tests.Infrastructure.Services;
+using Boilerplate.Client.Core.Infrastructure.Services.Contracts;
 
 namespace Boilerplate.Tests.Infrastructure;
 
@@ -24,6 +25,15 @@ public static class TestServiceCollectionExtensions
 
             services.RemoveAll<IStatisticsController>();
             services.AddScoped(_ => statisticsController);
+
+            return services;
+        }
+
+        public IServiceCollection AddIntegrationApiOnlyTestsServices()
+        {
+            // Real implementation wanna read the token from local storage, but during integration tests, there is no access to localStorage or the stored cookies.
+            services.AddScoped<IStorageService, TestStorageService>();
+            services.AddTransient<IAuthTokenProvider, TestAuthTokenProvider>();
 
             return services;
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,8 +1,6 @@
 ﻿//+:cnd:noEmit
-using Boilerplate.Tests.Services;
 using Boilerplate.Tests.Infrastructure.Services;
 using Boilerplate.Server.Api.Features.Identity.Services;
-using Boilerplate.Client.Core.Infrastructure.Services.Contracts;
 using Boilerplate.Client.Core.Infrastructure.Services.HttpMessageHandlers;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -18,9 +16,6 @@ public static partial class WebApplicationBuilderExtensions
             builder.AddServerWebProjectServices();
 
             // Register test-specific services for all tests here
-
-            services.AddScoped<IStorageService, TestStorageService>();
-            services.AddTransient<IAuthTokenProvider, TestAuthTokenProvider>();
 
             // Capture every identity e-mail in-process (See TestIdentityEmailService) instead of rendering and delivering it,
             // so tests can read back the confirmation link / OTP / elevated-access token straight from the message. Capturing

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/TestsAssemblyInitializer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/TestsAssemblyInitializer.cs
@@ -20,6 +20,12 @@ public partial class TestsAssemblyInitializer
 {
     //#if (aspire == true)
     private static DistributedApplication? aspireApp;
+
+    /// <summary>
+    /// The running Aspire host - with real backing containers such as Redis
+    /// Started by <see cref="RunAspireHost"/> during assembly initialization.
+    /// </summary>
+    internal static DistributedApplication AspireApp => aspireApp ?? throw new InvalidOperationException();
     //#endif
 
     [AssemblyInitialize]


### PR DESCRIPTION
## Summary
Adds opt-in (advanced) end-to-end test coverage for several Boilerplate template identity and multi-tenancy features that previously had none, along with the seed data and test infrastructure needed to drive them, and fixes two small server issues surfaced while writing the tests.

## Changes
- **New tests**
  - `TwoFactorAuthTests` — enabling 2FA and signing in with a TOTP code (uses `Otp.NET`).
  - `PrivilegedSessionTests` — the elevated-access OTP challenge that guards sensitive operations.
  - `ExternalIdentityTests` — external/social sign-in (gated on `advancedTests` + `aspire`).
  - `UserGroupFeatureManagementUITests` — tenant-scoped feature claims flowing from a user's user-group into their token (gated on `advancedTests` + multi-tenancy).
  - `Products/BuyProductUITests` and `Products/MagicLinkReturnUrlTests` — Sales module flows (gated on `advancedTests` + `module == Sales`).
- **Seed data**: a regular (non-admin) `store-user@bitplatform.dev` member of the default store tenant, assigned to the demo user-group, so the user-group feature-claim path can be exercised (`UserConfiguration`, `UserRoleConfiguration`, `TenantUserConfiguration`).
- **Test infrastructure**: `BitOtpInputUtils` helper for reliably filling `BitOtpInput`, `Otp.NET` package for TOTP generation, `AddIntegrationApiOnlyTestsServices` registration, default Playwright timeout raised 30s → 1m, and `template.json` exclusion conditions wiring the new tests to their respective template options.
- **Server fixes**
  - `IdentityController.SignIn` now falls back to the ambient `returnUrl` when resending a confirmation token to an unconfirmed user.
  - `TenantProvider` resolves the tenant sub-domain from the effective web-app URL (`GetWebAppUrl().Host`) instead of the raw `Request.Host.Host`.

## Related Issue
This closes #12657


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a regular demo user to the default store tenant.
  * Added coverage for external sign-in, two-factor authentication, privileged sessions, product purchases, magic-link redirects, and localized rendering.
* **Bug Fixes**
  * Improved return-url handling during OTP confirmation.
  * Improved tenant detection for anonymous requests.
* **Refactor**
  * Standardized OTP entry across sign-in flows.
* **Tests**
  * Increased UI test reliability with improved waiting behavior and longer timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->