### PR TITLE
test(templates): add Boilerplate feature tests #12660

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -538,7 +538,8 @@
                         "src/Tests/Features/Theme/ThemeTogglePersistenceUITests.cs",
                         "src/Tests/Features/Culture/CultureSelectionUITests.cs",
                         "src/Tests/Features/Identity/PhoneNumberNormalizationUITests.cs",
-                        "src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs"
+                        "src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs",
+                        "src/Tests/Features/OpenApi/OpenApiScalarIntegrationTests.cs"
                     ]
                 },
                 {
@@ -557,7 +558,8 @@
                 {
                     "condition": "(advancedTests != true || signalR != true)",
                     "exclude": [
-                        "src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs"
+                        "src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs",
+                        "src/Tests/Features/Mcp/GetCurrentDateTimeMcpIntegrationTests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -529,7 +529,16 @@
                         "src/Tests/Features/Identity/PrivilegedSessionTests.cs",
                         "src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs",
                         "src/Tests/Features/Seo/**",
-                        "src/Tests/Features/Tenants/TenantInvitationUITests.cs"
+                        "src/Tests/Features/Tenants/TenantInvitationUITests.cs",
+                        "src/Tests/Features/MinimalApiSample/IntegrationTests.cs",
+                        "src/Tests/Infrastructure/Configuration/AppConfigurationBuilderTests.cs",
+                        "src/Tests/Features/Diagnostics/HealthCheckIntegrationTests.cs",
+                        "src/Tests/Features/Attachments/UserProfilePictureWebPTests.cs",
+                        "src/Tests/Features/WellKnown/AppleAppSiteAssociationTests.cs",
+                        "src/Tests/Features/Theme/ThemeTogglePersistenceUITests.cs",
+                        "src/Tests/Features/Culture/CultureSelectionUITests.cs",
+                        "src/Tests/Features/Identity/PhoneNumberNormalizationUITests.cs",
+                        "src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs"
                     ]
                 },
                 {
@@ -541,8 +550,20 @@
                 {
                     "condition": "(advancedTests != true || module != Sales)",
                     "exclude": [
-                        "src/Tests/Features/Products/BuyProductUITests.cs",
-                        "src/Tests/Features/Products/MagicLinkReturnUrlTests.cs"
+                        "src/Tests/Features/Identity/QuickSignInUITests.cs",
+                        "src/Tests/Features/Identity/MagicLinkReturnUrlTests.cs"
+                    ]
+                },
+                {
+                    "condition": "(advancedTests != true || signalR != true)",
+                    "exclude": [
+                        "src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs"
+                    ]
+                },
+                {
+                    "condition": "(advancedTests != true || notification != true || signalR != true)",
+                    "exclude": [
+                        "src/Tests/Features/PushNotification/PushNotificationUITests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs
@@ -1,6 +1,7 @@
 ﻿//+:cnd:noEmit
 using Boilerplate.Shared.Features.Identity;
 using Boilerplate.Shared.Features.Identity.Dtos;
+using Boilerplate.Client.Core.Infrastructure.Services.HttpMessageHandlers;
 
 namespace Boilerplate.Client.Core.Infrastructure.Services;
 
@@ -18,7 +19,6 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
     [AutoInject] private IStringLocalizer<AppStrings> localizer = default!;
     [AutoInject] private IIdentityController identityController = default!;
     [AutoInject] private IAuthorizationService authorizationService = default!;
-    [AutoInject] private AbsoluteServerAddressProvider absoluteServerAddress = default!;
 
     public void OnInit()
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/service-worker.published.js
@@ -48,10 +48,6 @@ self.assetsExclude = [
     /bit\.blazorui\.fluent-dark\.css$/,
     /bit\.blazorui\.fluent-light\.css$/,
 
-    // If a PDF reader (https://blazorui.bitplatform.dev/components/pdfreader) is needed in the PWA, remove these two lines:
-    /pdfjs-4\.7\.76\.js$/,
-    /pdfjs-4\.7\.76-worker\.js$/,
-
     // country flags
     /_content\/Bit\.BlazorUI\.Extras\/flags/
 ];

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -149,6 +149,7 @@
         <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
         <PackageVersion Include="System.Text.Json" Version="10.0.0" />
         <PackageVersion Include="FakeItEasy" Version="9.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
         <PackageVersion Include="Microsoft.Playwright.MSTest.v4" Version="1.61.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache.AspNetCore.OutputCaching" Version="2.6.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.6.0" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -576,9 +576,12 @@ public static partial class Program
             }
             else
             {
+                var isRunningInsideDocker = Directory.Exists("/container_volume"); // It's supposed to be a mounted volume named /container_volume
+                var appDataDirPath = Path.Combine(isRunningInsideDocker ? "/container_volume" : Directory.GetCurrentDirectory(), "App_Data");
+                Directory.CreateDirectory(appDataDirPath);
                 hangfireConfiguration.UseEFCoreStorage(optionsBuilder =>
                 {
-                    optionsBuilder.UseSqlite($"Data Source=App_Data/BoilerplateJobDb.db;");
+                    optionsBuilder.UseSqlite($"Data Source={Path.Combine(appDataDirPath, "BoilerplateJobDb.db")};");
                 }, new()
                 {
                     Schema = "jobs",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -578,27 +578,13 @@ public static partial class Program
             {
                 hangfireConfiguration.UseEFCoreStorage(optionsBuilder =>
                 {
-                    var keepAliveConnection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source=BoilerplateJobs-{Guid.NewGuid():N};Mode=Memory;Cache=Shared;");
-                    keepAliveConnection.Open();
-                    sp.GetRequiredService<IHostApplicationLifetime>().ApplicationStopped.Register(keepAliveConnection.Dispose);
-
-                    optionsBuilder.UseSqlite(keepAliveConnection.ConnectionString);
+                    optionsBuilder.UseSqlite($"Data Source=App_Data/BoilerplateJobDb.db;");
                 }, new()
                 {
                     Schema = "jobs",
                     QueuePollInterval = new TimeSpan(0, 0, 1)
                 })
                 .UseDatabaseCreator();
-
-                if (env.IsDevelopment())
-                {
-                    // Hangfire keeps its log provider in a process-wide static (Hangfire.Logging.LogProvider.CurrentLogProvider).
-                    // With several hosts per process, each AddHangfire binds that static to its own (disposable) ILoggerFactory,
-                    // so disposing one host makes every still-running host throw ObjectDisposedException the next time Hangfire
-                    // logs (e.g. while constructing a background job client during a request). Bind logging to the never-disposed
-                    // NullLoggerFactory so the shared static stays valid for the whole lifetime of the process.
-                    hangfireConfiguration.UseLogProvider(new Hangfire.AspNetCore.AspNetCoreLogProvider(Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance));
-                }
             }
 
             hangfireConfiguration.UseRecommendedSerializerSettings();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Runtime.Loader;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Components.Endpoints;
 //#if (api == "Integrated")
@@ -74,17 +73,16 @@ public static partial class Program
             }
         });
 
-        if (string.IsNullOrEmpty(env.WebRootPath) is false && Path.Exists(Path.Combine(env.WebRootPath, @".well-known")))
+        // https://yurl.chayev.com/
+        app.UseWhen(context => context.Request.Path.StartsWithSegments("/.well-known"), wellKnownApp =>
         {
-            // https://yurl.chayev.com/
-            app.UseStaticFiles(new StaticFileOptions()
+            wellKnownApp.UseStaticFiles(new StaticFileOptions()
             {
-                FileProvider = new PhysicalFileProvider(Path.Combine(env.WebRootPath, @".well-known")),
-                RequestPath = new PathString("/.well-known"),
+                FileProvider = env.WebRootFileProvider,
                 DefaultContentType = "application/json",
                 ServeUnknownFileTypes = true
             });
-        }
+        });
 
         //#if (api == "Integrated")
         app.UseCors();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/.runsettings
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/.runsettings
@@ -12,9 +12,7 @@
             <!--<BROWSER>firefox</BROWSER>-->
 
             <!-- You can override the configuration from appsettings.json for tests here. -->
-            <Hangfire__UseIsolatedStorage>true</Hangfire__UseIsolatedStorage>
             <DOTNET_SYSTEM_GLOBALIZATION_INVARIANT>false</DOTNET_SYSTEM_GLOBALIZATION_INVARIANT>
-            <ConnectionStrings__sqlite>Data Source=BoilerplateDb.db;Mode=Memory;Cache=Shared;</ConnectionStrings__sqlite>
         </EnvironmentVariables>
     </RunConfiguration>
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Boilerplate.Tests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Condition=" '$(aspire)' == 'true' OR '$(aspire)' == '' " Include="Aspire.Hosting.Testing" />
         <PackageReference Include="Bit.BlazorES2019" />
         <PackageReference Include="FakeItEasy" />
+        <PackageReference Condition=" '$(advancedTests)' == 'true' OR '$(advancedTests)' == '' " Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Condition=" '$(advancedTests)' == 'true' OR '$(advancedTests)' == '' " Include="Otp.NET" />
         <PackageReference Include="Microsoft.Playwright.MSTest.v4" />
         <PackageReference Include="MSTest" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Attachments/UserProfilePictureWebPTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Attachments/UserProfilePictureWebPTests.cs
@@ -1,0 +1,77 @@
+using ImageMagick;
+using System.Net.Http.Headers;
+using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Shared.Features.Attachments;
+using Boilerplate.Client.Core.Infrastructure.Services;
+
+namespace Boilerplate.Tests.Features.Attachments;
+
+[TestClass, TestCategory("IntegrationTest")]
+public partial class UserProfilePictureWebPTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Verifies the server-side image pipeline of <c>AttachmentController.UploadUserProfilePicture</c>: uploading a
+    /// NON-webp source image (the repo's 512x512 <c>images/icons/bit-icon-512.png</c>) must produce a
+    /// <see cref="AttachmentKind.UserProfileImageSmall"/> attachment that is resized to 256x256 and re-encoded to WebP
+    /// via ImageMagick (<c>sourceImage.ToByteArray(MagickFormat.WebP)</c>). After signing in with the seeded default
+    /// account, the test POSTs the PNG as multipart/form-data through the authenticated DI <see cref="HttpClient"/>
+    /// (the <c>AuthDelegatingHandler</c> attaches the bearer token automatically), then GETs the small attachment back
+    /// (<c>GetAttachment/{userId}/UserProfileImageSmall</c>, an anonymous endpoint) and asserts the downloaded bytes
+    /// really decode as WebP - and are 256x256 - proving the format conversion actually happened rather than the
+    /// original PNG being served back.
+    /// </summary>
+    [TestMethod]
+    public async Task UploadUserProfilePicture_Should_StoreAndServeSmallImageAsWebP()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        // Sign in with the seeded default account (id 8ff71671-a1d6-4f97-abb9-d87d7b47d6e7). A raw HttpClient resolved
+        // from the same scope shares the token store, so requests it sends are authenticated by AuthDelegatingHandler.
+        var authManager = scope.ServiceProvider.GetRequiredService<AuthManager>();
+        await authManager.SignIn(new()
+        {
+            Email = TestData.DefaultTestEmail,
+            Password = TestData.DefaultTestPassword
+        }, TestContext.CancellationToken);
+
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        var currentUser = await scope.ServiceProvider.GetRequiredService<IUserController>()
+            .GetCurrentUser(TestContext.CancellationToken);
+
+        // Real, non-webp repo image served at the web root (512x512 PNG >= the 256x256 minimum, so it is not rejected
+        // with ImageTooSmall). Downloading it through the running server avoids brittle on-disk asset paths.
+        var sourceImageBytes = await httpClient.GetByteArrayAsync("images/icons/bit-icon-512.png", TestContext.CancellationToken);
+
+        // Sanity: the source really is NOT WebP, otherwise the assertion below would be meaningless.
+        Assert.AreNotEqual(MagickFormat.WebP, new MagickImageInfo(sourceImageBytes).Format);
+
+        using var form = new MultipartFormDataContent();
+        using var fileContent = new ByteArrayContent(sourceImageBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        // The endpoint binds an IFormFile parameter named "file".
+        form.Add(fileContent, "file", "bit-icon-512.png");
+
+        using var uploadResponse = await httpClient.PostAsync("api/v1/Attachment/UploadUserProfilePicture", form, TestContext.CancellationToken);
+        uploadResponse.EnsureSuccessStatusCode();
+
+        // Download the generated small (256x256) attachment. attachmentId for a profile picture is the user id.
+        var downloadedBytes = await httpClient.GetByteArrayAsync(
+            $"api/v1/Attachment/GetAttachment/{currentUser.Id}/{AttachmentKind.UserProfileImageSmall}",
+            TestContext.CancellationToken);
+
+        var downloadedInfo = new MagickImageInfo(downloadedBytes);
+
+        // The core assertion: the stored/served small profile image is genuinely WebP, regardless of the PNG we uploaded.
+        Assert.AreEqual(MagickFormat.WebP, downloadedInfo.Format);
+        Assert.AreEqual(256u, downloadedInfo.Width);
+        Assert.AreEqual(256u, downloadedInfo.Height);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Configuration/AppConfigurationBuilderTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Configuration/AppConfigurationBuilderTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Reflection;
+
+namespace Boilerplate.Tests.Features.Configuration;
+
+/// <summary>
+/// Unit tests for <c>IConfigurationBuilderExtensions.AddClientConfigurations</c>. They run against the non-browser,
+/// non-Blazor-Hybrid ("server/test host") branch of the method - the one that merges the embedded client appsettings
+/// beneath whatever sources the builder already carries.
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class AppConfigurationBuilderTests
+{
+    /// <summary>
+    /// <c>AddClientConfigurations</c> reflects over the already-loaded <c>Boilerplate.Client.Core</c> assembly via
+    /// <c>AppDomain.CurrentDomain.GetAssemblies().Single(...)</c>. In a bare unit test nothing may have forced those
+    /// client assemblies to load yet, so eagerly load them here to keep that <c>Single(...)</c> lookup deterministic.
+    /// </summary>
+    [ClassInitialize]
+    public static void EnsureClientAssembliesLoaded(TestContext _)
+    {
+        Assembly.Load("Boilerplate.Client.Core");
+        Assembly.Load("Boilerplate.Client.Web");
+    }
+
+    [TestMethod]
+    public void AddClientConfigurations_Should_MergeSharedAndClientCoreAppSettings()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddClientConfigurations(clientEntryAssemblyName: "Boilerplate.Client.Web")
+            .Build();
+
+        // Provided by Boilerplate.Client.Core/appsettings.json.
+        Assert.AreEqual("http://localhost:5030/", configuration["ServerAddress"]);
+        // Provided by Boilerplate.Shared/appsettings.json - the lowest-priority layer - proving it is merged in too.
+        Assert.AreEqual("100000", configuration["MemoryCache:SizeLimit"]);
+    }
+
+    [TestMethod]
+    public void AddClientConfigurations_Should_ReturnTheSameBuilderForChaining()
+    {
+        var builder = new ConfigurationBuilder();
+
+        var returned = builder.AddClientConfigurations(clientEntryAssemblyName: "Boilerplate.Client.Web");
+
+        Assert.AreSame(builder, returned);
+    }
+
+    [TestMethod]
+    public void AddClientConfigurations_Should_KeepPreExistingSourcesAsHighestPriority()
+    {
+        // A source already present on the builder (e.g. the host's own configuration or environment variables the
+        // caller added) must keep winning over the embedded client appsettings the extension appends beneath it.
+        var builder = new ConfigurationBuilder();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ServerAddress"] = "https://overridden.example/"
+        });
+
+        var configuration = builder
+            .AddClientConfigurations(clientEntryAssemblyName: "Boilerplate.Client.Web")
+            .Build();
+
+        Assert.AreEqual("https://overridden.example/", configuration["ServerAddress"]);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Culture/CultureSelectionUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Culture/CultureSelectionUITests.cs
@@ -1,0 +1,72 @@
+namespace Boilerplate.Tests.Features.Culture;
+
+[TestClass, TestCategory("UITest")]
+public partial class CultureSelectionUITests : AppPageTest
+{
+    /// <summary>
+    /// An anonymous visitor changes the app language from the header app-menu and the UI re-renders in the chosen language:
+    /// <list type="number">
+    /// <item>Open the home page (no sign-in required) and confirm the default English home message is shown.</item>
+    /// <item>Open the header app-menu (the persona drop-menu), tap Language, and pick Persian (fa-IR) from the culture list. Selecting a culture writes the .AspNetCore.Culture cookie and force-reloads the culture-less URL (See <c>CultureService.ChangeCulture</c>).</item>
+    /// <item>After the reload the home message now shows its Persian (fa-IR) translation, read from the resx for the fa-IR culture (never hard-coded), and the English message is gone.</item>
+    /// <item>Switch back to English from the same menu and confirm the English home message returns, proving the switch is reversible.</item>
+    /// </list>
+    /// The culture selector only exists when invariant globalization is disabled (See <c>AppMenu.razor</c> / <c>CultureInfoManager.InvariantGlobalization</c>), so the test is inconclusive on an invariant build.
+    /// </summary>
+    [TestMethod, TestCategory("Localization")]
+    public async Task ChangingCulture_Should_SwitchUiLanguage()
+    {
+        if (CultureInfoManager.InvariantGlobalization)
+        {
+            Assert.Inconclusive("The culture selector is only available when invariant globalization is disabled.");
+            return;
+        }
+
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // Read the expected home messages straight from the resx for each culture instead of hard-coding them.
+        var faCulture = CultureInfoManager.GetCultureInfo("fa-IR")!;
+        var defaultHomeMessage = AppStrings.ResourceManager.GetString(nameof(AppStrings.HomeMessage), CultureInfo.InvariantCulture)!;
+        var faHomeMessage = AppStrings.ResourceManager.GetString(nameof(AppStrings.HomeMessage), faCulture)!;
+
+        // The culture list labels are the hard-coded DisplayName values from CultureInfoManager.SupportedCultures
+        // (e.g. "فارسی" for fa-IR, "English US" for en-US); they are not resx strings, so read them from there.
+        var faDisplayName = CultureInfoManager.SupportedCultures.First(sc => sc.Culture.Name == "fa-IR").DisplayName;
+        var enDisplayName = CultureInfoManager.SupportedCultures.First(sc => sc.Culture.Name == "en-US").DisplayName;
+        var faLanguageLabel = AppStrings.ResourceManager.GetString(nameof(AppStrings.Language), faCulture)!;
+
+        // The home page is public, so opening it needs no sign-in. It renders in the default (English) culture.
+        await Page.GotoAsync(serverAddress.ToString(), new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await Expect(Page.GetByText(defaultHomeMessage)).ToBeVisibleAsync();
+
+        // ---- Switch to Persian (fa-IR) ----
+
+        // Open the header app-menu (the persona drop-menu) via its chevron icon.
+        await Page.Locator(".menu-chevron").ClickAsync();
+
+        // Open the culture sub-menu, then confirm the "Select language" list is showing.
+        await Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Language }).ClickAsync();
+        await Expect(Page.GetByText(AppStrings.SelectLanguage)).ToBeVisibleAsync();
+
+        // Pick Persian. This writes the culture cookie and force-reloads the page (See CultureService.ChangeCulture).
+        await Page.GetByText(faDisplayName, new() { Exact = true }).ClickAsync();
+
+        // After the reload the home message is now in Persian and the English one is gone.
+        await Expect(Page.GetByText(faHomeMessage)).ToBeVisibleAsync();
+        await Expect(Page.GetByText(defaultHomeMessage)).ToBeHiddenAsync();
+
+        // ---- Switch back to English ----
+
+        // The menu chrome class stays the same across cultures, but the Language button now carries its Persian label.
+        await Page.Locator(".menu-chevron").ClickAsync();
+        await Page.GetByRole(AriaRole.Button, new() { Name = faLanguageLabel }).ClickAsync();
+        await Page.GetByText(enDisplayName, new() { Exact = true }).ClickAsync();
+
+        // The English home message returns, proving the language switch is reversible.
+        await Expect(Page.GetByText(defaultHomeMessage)).ToBeVisibleAsync();
+        await Expect(Page.GetByText(faHomeMessage)).ToBeHiddenAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Diagnostics/HealthCheckIntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Diagnostics/HealthCheckIntegrationTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+
+namespace Boilerplate.Tests.Features.Diagnostics;
+
+[TestClass, TestCategory("IntegrationTest")]
+public partial class HealthCheckIntegrationTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Verifies the application exposes a working liveness health-check endpoint. <c>MapAppHealthChecks</c>
+    /// (See <c>WebApplicationExtensions.MapAppHealthChecks</c>) maps <c>GET /alive</c> with a predicate that runs
+    /// only the checks tagged <c>"live"</c> - which, per <c>AddDefaultHealthChecks</c>, is exactly the single
+    /// <c>binStorage</c> disk-storage check. That check is deterministically healthy in any test/CI environment
+    /// (it only requires free disk space), so the endpoint returns HTTP 200 with the default plain-text body
+    /// <c>"Healthy"</c>. <c>/alive</c> is deliberately preferred over <c>/health</c> here: <c>/health</c> also runs
+    /// the Hangfire check (which is racy right after the host starts, before the Hangfire server has written its
+    /// first heartbeat) plus the DbContext and blob-storage checks, none of which are deterministic at this instant.
+    /// The endpoint is anonymous, so no sign-in is required; the request is issued through the DI <see cref="HttpClient"/>
+    /// resolved from a request scope (BaseAddress is the test server address).
+    /// </summary>
+    [TestMethod]
+    public async Task Health_Should_ReportHealthy()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        using var response = await httpClient.GetAsync("alive", TestContext.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        // The default MapHealthChecks response writer emits the overall HealthStatus name as plain text.
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Unexpected status. Body: '{body}'.");
+        Assert.AreEqual("Healthy", body.Trim());
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs
@@ -1,0 +1,48 @@
+using Boilerplate.Tests.Features.Identity;
+
+namespace Boilerplate.Tests.Features.ForceUpdate;
+
+[TestClass, TestCategory("UITest")]
+public partial class ForceUpdateUITests : AppPageTest
+{
+    /// <summary>
+    /// Proves the Force Update system end-to-end for the Web platform: this test raises the server's
+    /// <c>SupportedAppVersions:MinimumSupportedWebAppVersion</c> to 2.0.0 - a version higher than the app's own
+    /// (1.0.0, See Directory.Build.props). Every internal API call carries an <c>X-App-Version</c> / <c>X-App-Platform</c>
+    /// header (See <c>RequestHeadersDelegatingHandler</c>), so the very next call the browser makes is rejected by
+    /// <c>ForceUpdateMiddleware</c> with a <c>ClientNotSupportedException</c>. The client turns that into a persistent
+    /// <c>FORCE_UPDATE</c> message (See <c>ExceptionDelegatingHandler</c>), which <c>ForceUpdateSnackBar</c> shows.
+    /// <para>
+    /// SignalR is off by default, so an anonymous home-page load makes no internal API call on its own. We therefore
+    /// trigger one the same way a real user would: requesting a magic link on the Sign in page fires an internal POST,
+    /// which the middleware rejects - so instead of the OTP panel, the force update panel appears.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task WhenClientBelowMinimumSupportedVersion_Should_ShowForceUpdatePanel()
+    {
+        await using var server = new AppTestServer(Context);
+
+        // The app reports version 1.0.0, so requiring 2.0.0 makes every internal request from this browser unsupported.
+        await server.Build(
+            configureTestConfigurations: configuration => configuration["SupportedAppVersions:MinimumSupportedWebAppVersion"] = "2.0.0"
+        ).Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // Open the Sign in page and ask for a magic link. This is the first internal API call the browser makes; the
+        // server rejects it because the client version is below the (now 2.0.0) minimum supported web app version.
+        await Page.GotoAsync(new Uri(serverAddress, PageUrls.SignIn).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        await Page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillAsync(MagicLinkSignInUtils.NewTestEmail());
+
+        // The button stays disabled until the debounced e-mail value is committed, so Playwright waits for it to enable.
+        await Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SendMagicLinkButtonText }).ClickAsync();
+
+        // The rejected request publishes the persistent FORCE_UPDATE message, so the force update panel shows up with its
+        // title and body (See ForceUpdateSnackBar.razor) instead of the OTP panel the request would otherwise reveal.
+        await Expect(Page.GetByText(AppStrings.ForceUpdateTitle)).ToBeVisibleAsync();
+        await Expect(Page.GetByText(AppStrings.ForceUpdateBody)).ToBeVisibleAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkReturnUrlTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkReturnUrlTests.cs
@@ -1,9 +1,8 @@
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
-using Boilerplate.Tests.Features.Identity;
 using Boilerplate.Server.Api.Infrastructure.Data;
 
-namespace Boilerplate.Tests.Features.Products;
+namespace Boilerplate.Tests.Features.Identity;
 
 [TestClass, TestCategory("UITest")]
 public partial class MagicLinkReturnUrlTests : AppPageTest

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/PhoneNumberNormalizationUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/PhoneNumberNormalizationUITests.cs
@@ -1,0 +1,163 @@
+﻿using Hangfire;
+using PhoneNumbers;
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Boilerplate.Server.Api;
+using Boilerplate.Server.Api.Infrastructure.Services;
+using Boilerplate.Tests.Infrastructure.Components;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+[TestClass, TestCategory("UITest")]
+public partial class PhoneNumberNormalizationUITests : AppPageTest
+{
+    /// <summary>
+    /// The Sign in page accepts a phone number in any human format, but the server must always text the one-time code to
+    /// the canonical E.164 number: whatever the visitor types, <c>PhoneService.NormalizePhoneNumber</c> (libphonenumber,
+    /// See <c>IdentityController.SendOtp</c>) runs before <c>PhoneService.SendSms</c> is ever called.
+    /// <list type="number">
+    /// <item>Replace the real <c>PhoneService</c> with a subclass that overrides only <c>SendSms</c> to record every
+    /// (message, phone-number) pair into a static collector and deliver nothing - no Hangfire job, no Twilio - while
+    /// still using the real <c>NormalizePhoneNumber</c>, which is exactly the behavior under test.</item>
+    /// <item>For three brand-new random US numbers, each typed in a different de-normalized format (parentheses + dash,
+    /// dots, spaces), switch to the Phone tab and request the code. A brand-new number makes the server register the
+    /// (still unconfirmed) account, text the confirmation code and reveal the OTP panel.</item>
+    /// <item>Assert every number handed to <c>SendSms</c> arrived already normalized to E.164 - a leading "+", digits
+    /// only, none of the punctuation that was typed.</item>
+    /// <item>For the last number, finish signing in: read the 6 digit code straight from the captured SMS body (the SMS
+    /// is the only place a phone code is delivered), type it into the OTP panel and land on the home page, signed in.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod]
+    public async Task SignIn_Should_NormalizePhoneNumber_BeforeSendingSms()
+    {
+        // A shared static collector can never mix in another test's calls because every assertion below filters by this
+        // run's own unique random numbers; clearing it up-front just keeps the failure messages readable.
+        CapturingPhoneService.SentMessages.Clear();
+
+        await using var server = new AppTestServer(Context);
+        await server.Build(services =>
+        {
+            // Swap the real PhoneService (registered as AddScoped<PhoneService> in Program.Services) for the capturing
+            // subclass, only for this test's server. IdentityController injects the concrete PhoneService, so the service
+            // type stays PhoneService and only the implementation becomes the fake.
+            services.RemoveAll<PhoneService>();
+            services.AddScoped<PhoneService, CapturingPhoneService>();
+        }).Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // Three brand-new, unique US numbers (random area code + exchange, three consecutive subscriber numbers), each
+        // written in a different de-normalized format. All three must normalize to "+1" + the ten digits. Random keeps
+        // them unique per run so a process-wide collector can never confuse them with another run's calls.
+        var random = Random.Shared;
+        var areaCode = random.Next(200, 1000);    // 3 digits, first digit 2-9
+        var exchange = random.Next(200, 1000);    // 3 digits, first digit 2-9
+        var subscriber = random.Next(1000, 9000); // 4 digit base; +0/+1/+2 keeps all three distinct and still 4 digits
+
+        var attempts = new[]
+        {
+            (Typed: $"({areaCode}) {exchange}-{subscriber + 0:D4}", Normalized: $"+1{areaCode}{exchange}{subscriber + 0:D4}"),
+            (Typed: $"{areaCode}.{exchange}.{subscriber + 1:D4}",   Normalized: $"+1{areaCode}{exchange}{subscriber + 1:D4}"),
+            (Typed: $"{areaCode} {exchange} {subscriber + 2:D4}",   Normalized: $"+1{areaCode}{exchange}{subscriber + 2:D4}"),
+        };
+
+        // Canonical E.164: a leading '+' and digits only. Fails on any space, parenthesis, dash or dot, so matching it
+        // proves the number was normalized (not merely passed through).
+        var e164 = new Regex(@"^\+[1-9]\d{6,14}$");
+
+        foreach (var attempt in attempts)
+        {
+            // Each request starts from a fresh Sign in page. A hard reload is the simplest way back to the phone form:
+            // the OTP panel is treated as a modal, but its NavigationLock only intercepts internal Blazor navigation
+            // (SignInPanel.razor), so a full page navigation resets the panel cleanly.
+            await Page.GotoAsync(new Uri(serverAddress, PageUrls.SignIn).ToString(),
+                new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+            // Switch from the default Email tab to the Phone tab (BitPivot HeaderOnly renders each header as role="tab").
+            await Page.GetByRole(AriaRole.Tab, new() { Name = AppStrings.Phone, Exact = true }).ClickAsync();
+
+            // Type the de-normalized number into the BitPhoneInput's number box (its <input type="tel"> carries the
+            // placeholder) and ask for the code. Send OTP stays disabled until the debounced value commits, so
+            // Playwright's actionability wait covers the 500ms debounce.
+            await Page.GetByPlaceholder(AppStrings.PhoneNumberPlaceholder).FillAsync(attempt.Typed);
+            await Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SendOtpButtonText }).ClickAsync();
+
+            // The server registers the new account, texts the confirmation code (captured synchronously by the fake) and
+            // answers "not confirmed", which reveals the OTP panel - a reliable signal that SendSms has already run.
+            await Page.Locator(".bit-otp-inp").First.WaitForAsync();
+
+            var sms = await WaitForSmsTo(attempt.Normalized, TestContext.CancellationToken);
+
+            Assert.AreEqual(attempt.Normalized, sms.PhoneNumber,
+                $"The server should have normalized '{attempt.Typed}' to E.164 before calling SendSms.");
+            Assert.MatchesRegex(e164, sms.PhoneNumber,
+                "SendSms must receive a canonical E.164 number (leading '+', digits only, no formatting).");
+        }
+
+        // The OTP panel for the last number is still on screen. Complete the sign-in using the code from its SMS body.
+        var lastSms = await WaitForSmsTo(attempts[^1].Normalized, TestContext.CancellationToken);
+
+        // The confirmation SMS reads "{code} is your code in Boilerplate.\n@host #code" (See ConfirmPhoneTokenShortText),
+        // so the code is the first 6 digit run in the body.
+        var otpCode = Regex.Match(lastSms.MessageText, @"\d{6}").Value;
+        Assert.MatchesRegex(new Regex(@"^\d{6}$"), otpCode,
+            "The confirmation SMS should start with a 6 digit code.");
+
+        await BitOtpInputUtils.FillOtpInputs(Page, otpCode);
+
+        // Filling the last digit confirms the phone number, signs the account in and redirects to the home page.
+        await Expect(Page).ToHaveURLAsync(serverAddress.ToString());
+        await Expect(Page.Locator(".bit-prs.persona").First).ToBeVisibleAsync();
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignIn })).ToBeHiddenAsync();
+    }
+
+    /// <summary>
+    /// Polls the static collector for the newest <c>SendSms</c> call addressed to <paramref name="phoneNumber"/>. The
+    /// call is normally already recorded (SendSms runs synchronously inside the request that then reveals the OTP panel);
+    /// the short poll only guards against reading a hair too early.
+    /// </summary>
+    private static async Task<(string MessageText, string PhoneNumber)> WaitForSmsTo(string phoneNumber, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+
+        while (true)
+        {
+            // Newest-first so a freshly requested code wins over any earlier one for the same number.
+            var match = CapturingPhoneService.SentMessages.LastOrDefault(sms => sms.PhoneNumber == phoneNumber);
+            if (match.PhoneNumber is not null)
+                return match;
+
+            if (DateTimeOffset.UtcNow >= deadline)
+                throw new InvalidOperationException(
+                    $"No SMS was captured for '{phoneNumber}'. Captured numbers: " +
+                    $"[{string.Join(", ", CapturingPhoneService.SentMessages.Select(sms => sms.PhoneNumber))}].");
+
+            await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+        }
+    }
+}
+
+/// <summary>
+/// Test double for <see cref="PhoneService"/> that records every <see cref="SendSms"/> call and delivers nothing.
+/// Only delivery is faked: <c>NormalizePhoneNumber</c> is left to the real base, so the number reaching <c>SendSms</c>
+/// is exactly what the server normalized - which is the behavior under test. Registered per-test via
+/// <c>configureTestServices</c> (RemoveAll&lt;PhoneService&gt; then AddScoped&lt;PhoneService, CapturingPhoneService&gt;).
+/// </summary>
+public partial class CapturingPhoneService(ServerApiSettings appSettings, IBackgroundJobClient backgroundJobClient, IHostEnvironment hostEnvironment, IHttpContextAccessor httpContextAccessor, ILogger<PhoneService> phoneLogger, PhoneNumberUtil phoneNumberUtil) :
+    PhoneService(appSettings, backgroundJobClient, hostEnvironment, httpContextAccessor, phoneLogger, phoneNumberUtil)
+{
+    /// <summary>
+    /// Every SendSms call as (message body, phone number). Static because DI owns the resolved instance's lifetime, so a
+    /// test cannot hold a reference to the fake; entries are filtered by each test's unique numbers to stay isolated.
+    /// </summary>
+    public static readonly ConcurrentQueue<(string MessageText, string PhoneNumber)> SentMessages = new();
+
+    public override Task SendSms(string messageText, string phoneNumber)
+    {
+        SentMessages.Enqueue((messageText, phoneNumber));
+        return Task.CompletedTask; // Do not call base: no Hangfire delivery job and no Twilio in tests.
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/QuickSignInUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/QuickSignInUITests.cs
@@ -1,12 +1,11 @@
-using Microsoft.EntityFrameworkCore;
-using Boilerplate.Tests.Features.Identity;
+﻿using Microsoft.EntityFrameworkCore;
 using Boilerplate.Tests.Infrastructure.Components;
 using Boilerplate.Server.Api.Infrastructure.Data;
 
-namespace Boilerplate.Tests.Features.Products;
+namespace Boilerplate.Tests.Features.Identity;
 
 [TestClass, TestCategory("UITest")]
-public partial class BuyProductUITests : AppPageTest
+public partial class QuickSignInUITests : AppPageTest
 {
     /// <summary>
     /// A brand-new (anonymous) shopper buys a seeded product end-to-end:

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
@@ -89,27 +89,46 @@ public partial class UserGroupFeatureManagementUITests : AppPageTest
         await page.GetByText(AppRoles.Demo, new() { Exact = true }).ClickAsync();
         await page.GetByText(AppStrings.Features, new() { Exact = true }).ClickAsync();
 
-        // The toggle button sits right after the feature's label in the same row.
+        // The toggle button sits right after the feature's label in the same row. Its glyph reflects the current state:
+        // "AddTo" while unassigned, "RemoveFrom" once assigned.
         var toggle = page.GetByText(RolesManageFeatureName, new() { Exact = true }).Locator("xpath=following::button[1]");
+        var targetStateIcon = granted ? RemoveFeatureIconSelector : AddFeatureIconSelector;
+
+        // The toggle stays disabled (and its glyph reads as unassigned) until the selected role's claims finish loading, so
+        // wait for it to become enabled before trusting its glyph.
+        await Expect(toggle).ToBeEnabledAsync();
+
+        // Be tolerant of the demo user-group already being in the wanted state (e.g. a feature the seed already granted):
+        // if the toggle is already showing the target glyph there is nothing to do and no elevation is needed.
+        if (await toggle.Locator(targetStateIcon).IsVisibleAsync())
+            return;
 
         await toggle.ClickAsync();
 
-        if (granted)
+        // Mutating a role's features needs elevated access. The first such mutation in the session pops the OTP prompt (and
+        // an elevated token is e-mailed / dev-logged); later mutations reuse that still-valid elevation, so no prompt shows.
+        // Wait briefly for the prompt and only fill it when it actually appears, rather than assuming which call elevates.
+        try
         {
-            // Granting a feature needs elevated access, so an elevated token is e-mailed (and dev-logged) and the OTP prompt appears.
-            await page.Locator(".bit-otp-inp").First.WaitForAsync();
+            await page.Locator(".bit-otp-inp").First.WaitForAsync(new()
+            {
+                Timeout = (float)TimeSpan.FromSeconds(10).TotalMilliseconds
+            });
 
             var captured = await server.WaitForCapturedEmail(StoreAdminEmail,
                 capturedEmail => capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, TestContext.CancellationToken);
 
-            // Filling the OTP elevates her session (a token refresh) and then persists the new role claim.
+            // Filling the OTP elevates her session (a token refresh) and then persists the role-claim change.
             await BitOtpInputUtils.FillOtpInputs(page, captured.Token!);
         }
-        // else: she is still elevated from the grant, so removing the feature needs no new OTP prompt.
+        catch (TimeoutException)
+        {
+            // No prompt appeared: the session is still elevated from an earlier mutation, so the change was persisted directly.
+        }
 
         // The role-claim change runs over the Blazor Server circuit (invisible to Playwright's network events), so wait on
         // the toggle's own icon flipping to its new state to know the change has been persisted before moving on.
-        await Expect(toggle.Locator(granted ? RemoveFeatureIconSelector : AddFeatureIconSelector)).ToBeVisibleAsync();
+        await Expect(toggle.Locator(targetStateIcon)).ToBeVisibleAsync();
     }
 
     private async Task AssertManageRolesPageAccessible(IPage page, Uri serverAddress, bool accessible)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs
@@ -1,0 +1,159 @@
+using Boilerplate.Tests.Infrastructure.Components;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+[TestClass, TestCategory("UITest")]
+public partial class WebAuthnPasswordlessUITests : AppPageTest
+{
+    /// <summary>
+    /// End-to-end WebAuthn / passwordless (passkey) journey for a brand-new user, driven through a Chrome DevTools
+    /// virtual authenticator (Playwright can't touch a real fingerprint sensor):
+    /// <list type="number">
+    /// <item>A CDP virtual <b>platform</b> authenticator is attached to the page (auto-approving user presence and user
+    /// verification), so <c>navigator.credentials.create()</c> / <c>get()</c> succeed headlessly - no device, no gesture.</item>
+    /// <item>She signs in for the first time with a magic link OTP (the same flow as <see cref="MagicLinkSignInTests"/>).</item>
+    /// <item>On Settings &gt; Account &gt; Passwordless she clicks "Enable passwordless sign-in", which registers a
+    /// credential (<c>credentials.create()</c>) against the virtual authenticator and stores it on the server and in local
+    /// storage; the success snackbar shows and the button flips to its "disable" state.</item>
+    /// <item>She signs out - which clears only the auth tokens; the <c>bit-webauthn</c> local-storage marker survives, so
+    /// the sign-in page will still offer the passkey button.</item>
+    /// <item>On the sign-in page she clicks the fingerprint (passkey) button, which runs <c>credentials.get()</c> against
+    /// the virtual authenticator and signs her straight back in - the home page shows her persona.</item>
+    /// </list>
+    /// The whole test runs on the <c>http://localhost:&lt;port&gt;</c> alias of the loopback test server (not its
+    /// <c>127.0.0.1</c> address): Chrome refuses an IP literal as a WebAuthn RP ID, and the server derives its RP ID and
+    /// allowed origin per-request from the Host header (See <c>HttpRequestExtensions.GetWebAppUrl</c>), so a "localhost"
+    /// Host makes the RP ID "localhost" - matching the browser's origin - with no server-side configuration override.
+    /// </summary>
+    [TestMethod]
+    public async Task User_Should_EnablePasswordless_AndSignInWithPasskey()
+    {
+        // The CDP virtual authenticator (WebAuthn.addVirtualAuthenticator) is a Chromium-only capability.
+        if (Browser.BrowserType.Name is not "chromium")
+        {
+            Assert.Inconclusive("The WebAuthn virtual authenticator is only available through a Chromium CDP session.");
+            return;
+        }
+
+        // A bare server (no ClientBrowserContext) so that we - not AppTestServer.Start - own the WebAssembly
+        // ServerAddress init script and can point it at the localhost alias below (a single, consistent origin).
+        await using var server = new AppTestServer();
+
+        // Same loopback server, reached through its "localhost" host so the WebAuthn RP ID resolves to "localhost"
+        // (Chrome rejects the raw 127.0.0.1 IP literal as an RP ID). Computed before Build so the ServerAddress override
+        // below can point every internal API call at the same localhost origin.
+        var appBaseUrl = new UriBuilder(server.WebAppServerAddress) { Host = "localhost" }.Uri;
+
+        // The test host runs Blazor Server, so the WebAuthn options (and their RP ID) are produced by a SERVER-SIDE call
+        // to the identity API through the app's internal HttpClient, whose base address is the ServerAddress config
+        // (127.0.0.1 by default). Point that at the localhost origin so the RP ID the server derives from the request
+        // Host (See HttpRequestExtensions.GetWebAppUrl -> Fido2Configuration.ServerDomain) matches the browser's
+        // localhost origin - otherwise credentials.create() fails with "relying party ID is not ... the current domain".
+        await server.Build(configureTestConfigurations: configuration => configuration["ServerAddress"] = appBaseUrl.ToString())
+            .Start(TestContext.CancellationToken);
+
+        // Also feed the localhost origin to the Blazor WebAssembly startup params, so the same holds if the host ever
+        // runs the app in WebAssembly mode (where the API call - and thus the RP ID - comes from the browser instead).
+        await SetBlazorWebAssemblyServerAddress(appBaseUrl, Context);
+
+        // Attach the virtual authenticator before any credential ceremony runs.
+        await AddVirtualAuthenticator(Page);
+
+        var email = MagicLinkSignInUtils.NewTestEmail();
+
+        // 1. First sign-in with the magic link OTP registers and signs in the brand-new account (no passkey yet).
+        await SignInWithMagicLinkOtp(Page, server, appBaseUrl, email);
+
+        // 2. Enable passwordless sign-in on the account settings page. Navigating to /settings/account expands the
+        //    account accordion, whose first (default) pivot tab is Passwordless, so the "Enable" button is already shown.
+        await Page.GotoAsync(new Uri(appBaseUrl, $"{PageUrls.Settings}/{PageUrls.SettingsSections.Account}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        await Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.EnablePasswordless }).ClickAsync();
+
+        // credentials.create() against the virtual authenticator succeeds: the success snackbar shows and the button
+        // flips to its "disable" state (isConfigured == true).
+        await Expect(Page.GetByText(AppStrings.EnablePasswordlessSucsessMessage)).ToBeVisibleAsync();
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.DisablePasswordless })).ToBeVisibleAsync();
+
+        // 3. She signs out. Sign-out clears only the auth tokens; the bit-webauthn marker survives, so the passkey option
+        //    will still be offered at the next sign-in.
+        await SignOut(Page);
+
+        // 4. Sign back in with the passkey.
+        await Page.GotoAsync(new Uri(appBaseUrl, PageUrls.SignIn).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // The passwordless button is icon-only (BitIconName.Fingerprint); Bit renders the icon as
+        // <i class="bit-icon bit-icon--Fingerprint">. It appears once SignInPanel's first render has confirmed a
+        // configured credential exists (See SignInPanel.OnAfterFirstRenderAsync -> showWebAuthn). It is the only
+        // Fingerprint icon on the sign-in page, so this selector is unambiguous.
+        await Page.Locator("button:has(.bit-icon--Fingerprint)").ClickAsync();
+
+        // credentials.get() against the virtual authenticator completes the sign-in and redirects home as her.
+        // The account has no 2FA, so no two-factor panel appears.
+        await Page.WaitForURLAsync(appBaseUrl.ToString());
+        await Expect(Page.Locator(".bit-prs.persona").First).ToContainTextAsync(email);
+    }
+
+    /// <summary>
+    /// Enables the CDP WebAuthn domain on the page's session and attaches a virtual <b>platform</b> ("internal")
+    /// authenticator that auto-confirms user presence and user verification, so both the registration
+    /// (<c>navigator.credentials.create()</c>) and the assertion (<c>navigator.credentials.get()</c>) ceremonies
+    /// complete without a real authenticator or any user gesture. The "internal" transport matches the server's
+    /// <c>AuthenticatorAttachment.Platform</c> requirement, and <c>isUserVerified</c> satisfies its
+    /// <c>UserVerification.Required</c>. The authenticator (and the credential registered into it) lives on the page's
+    /// target for the rest of the test, surviving the sign-out navigation.
+    /// </summary>
+    private static async Task AddVirtualAuthenticator(IPage page)
+    {
+        var cdp = await page.Context.NewCDPSessionAsync(page);
+
+        await cdp.SendAsync("WebAuthn.enable");
+
+        await cdp.SendAsync("WebAuthn.addVirtualAuthenticator", new Dictionary<string, object>
+        {
+            ["options"] = new Dictionary<string, object>
+            {
+                ["protocol"] = "ctap2",
+                ["transport"] = "internal",             // platform authenticator - matches AuthenticatorAttachment.Platform
+                ["hasResidentKey"] = true,
+                ["hasUserVerification"] = true,
+                ["isUserVerified"] = true,              // user verification always satisfied (options require it)
+                ["automaticPresenceSimulation"] = true, // user presence auto-confirmed - no touch needed
+            }
+        });
+    }
+
+    /// <summary>
+    /// Signs a brand-new account in through the magic link OTP flow against the given (localhost) origin - the same
+    /// steps as <see cref="MagicLinkSignInUtils.SignInViaMagicLinkOtp"/>, but navigating the localhost alias so the
+    /// whole test stays on one origin (and one local-storage partition).
+    /// </summary>
+    private async Task SignInWithMagicLinkOtp(IPage page, AppTestServer server, Uri appBaseUrl, string email)
+    {
+        await MagicLinkSignInUtils.RequestMagicLinkAndOtp(page, appBaseUrl, email);
+
+        // A brand-new account's confirmation e-mail carries the OTP; we only need the code, not the (127.0.0.1-based) link.
+        var (_, otpCode) = await MagicLinkSignInUtils.ReadConfirmationEmail(server, email, TestContext.CancellationToken);
+        await BitOtpInputUtils.FillOtpInputs(page, otpCode);
+
+        // Filling the last digit confirms the e-mail, signs her in and redirects to the home page.
+        await page.WaitForURLAsync(appBaseUrl.ToString());
+    }
+
+    /// <summary>Signs the current user out through the header persona menu and its confirmation dialog.</summary>
+    private async Task SignOut(IPage page)
+    {
+        // Open the user menu in the header (clicking its persona) then click its "Sign out" action.
+        await page.Locator(".bit-prs.persona").First.ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignOut }).ClickAsync();
+
+        // Confirm in the dialog (its OK button is also labelled "Sign out"; the menu one is gone once the dialog is up).
+        await Expect(page.GetByText(AppStrings.SignOutPrompt)).ToBeVisibleAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SignOut }).Last.ClickAsync();
+
+        // Signing out clears the tokens and closes the dialog; wait until the confirmation prompt is gone.
+        await Expect(page.GetByText(AppStrings.SignOutPrompt)).ToBeHiddenAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Mcp/GetCurrentDateTimeMcpIntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Mcp/GetCurrentDateTimeMcpIntegrationTests.cs
@@ -1,0 +1,92 @@
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Microsoft.Extensions.Time.Testing;
+using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Client.Core.Infrastructure.Services;
+using Boilerplate.Client.Core.Infrastructure.Services.Contracts;
+
+namespace Boilerplate.Tests.Features.Mcp;
+
+[TestClass, TestCategory("IntegrationTest")]
+public partial class GetCurrentDateTimeMcpIntegrationTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Proves the server's Model Context Protocol endpoint is working by driving it with a real MCP client. The server
+    /// maps it via <c>app.MapMcp("/mcp").RequireAuthorization()</c> (See <c>Program.Middlewares</c>) and advertises the
+    /// chatbot tools registered by <c>AddMcpServer().WithHttpTransport().WithToolsFromAssembly()</c>. The test connects an
+    /// <see cref="McpClient"/> over the Streamable HTTP transport, authenticating with a bearer token, then lists the
+    /// tools and invokes <c>GetCurrentDateTime</c> (See <c>AppChatbot.Tools.cs</c>) for the UTC timezone.
+    /// <para>
+    /// <c>GetCurrentDateTime</c> reads the DI <see cref="TimeProvider"/>, so this test replaces it with a
+    /// <see cref="FakeTimeProvider"/> to make the tool's output deterministic - the fake time is not strictly needed for
+    /// the endpoint to work, but it lets the test assert on an exact, controlled instant rather than the wall clock. The
+    /// fake is seeded from the real current time so every other time-dependent component (e.g. bearer-token lifetime
+    /// validation) stays free of clock skew while still returning a frozen, assertable value.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task McpEndpoint_Should_InvokeGetCurrentDateTimeTool()
+    {
+        // Freeze time at a fixed, known instant (seeded from now, so it does not skew token validation).
+        var fakeTimeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
+        await using var server = new AppTestServer();
+
+        await server.Build(services =>
+        {
+            services.AddIntegrationApiOnlyTestsServices();
+
+            // Even though GetCurrentDateTime works fine with the real clock, fake the TimeProvider so the tool returns
+            // an instant we control and can assert on exactly.
+            services.Replace(ServiceDescriptor.Singleton<TimeProvider>(fakeTimeProvider));
+        }).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        // The /mcp endpoint is behind RequireAuthorization(), so sign in with the seeded default account first and reuse
+        // the resulting bearer token to authenticate the MCP transport.
+        await scope.ServiceProvider.GetRequiredService<AuthManager>().SignIn(new()
+        {
+            Email = TestData.DefaultTestEmail,
+            Password = TestData.DefaultTestPassword
+        }, TestContext.CancellationToken);
+
+        var accessToken = await scope.ServiceProvider.GetRequiredService<IStorageService>().GetItem("access_token");
+        Assert.IsNotNull(accessToken, "Sign-in should have stored an access token to authenticate the MCP request.");
+
+        // Connect a real MCP client to the server's Streamable HTTP endpoint, carrying the bearer token.
+        var transport = new HttpClientTransport(new HttpClientTransportOptions
+        {
+            Endpoint = new Uri(server.WebAppServerAddress, "mcp"),
+            TransportMode = HttpTransportMode.StreamableHttp,
+            AdditionalHeaders = new Dictionary<string, string>
+            {
+                ["Authorization"] = $"Bearer {accessToken}"
+            }
+        });
+
+        await using var mcpClient = await McpClient.CreateAsync(transport, cancellationToken: TestContext.CancellationToken);
+
+        // The GetCurrentDateTime tool must be advertised by the server (See [McpServerTool] in AppChatbot.Tools.cs).
+        var tools = await mcpClient.ListToolsAsync(cancellationToken: TestContext.CancellationToken);
+        Assert.IsTrue(tools.Any(t => t.Name == "GetCurrentDateTime"), "The MCP server must expose the GetCurrentDateTime tool.");
+
+        // Invoke it for the UTC timezone; the tool converts the (faked) UtcNow into that timezone and echoes it back as text.
+        var result = await mcpClient.CallToolAsync("GetCurrentDateTime",
+            new Dictionary<string, object?> { ["timeZoneId"] = "UTC" },
+            cancellationToken: TestContext.CancellationToken);
+
+        var text = result.Content.OfType<TextContentBlock>().First().Text;
+
+        Assert.IsTrue(result.IsError is not true, $"The GetCurrentDateTime tool call returned an error. Result: '{text}'.");
+
+        // The tool formats the instant with the round-trip ("o") format. Assert on a second-precision prefix of the faked
+        // UTC time so the check is immune to sub-second/offset formatting differences, plus that it names the timezone.
+        var expectedUtc = TimeZoneInfo.ConvertTime(fakeTimeProvider.GetUtcNow(), TimeZoneInfo.Utc);
+        Assert.IsTrue(text.Contains(expectedUtc.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)),
+            $"Tool result did not contain the faked current date/time. Result: '{text}'.");
+        Assert.IsTrue(text.Contains("UTC"), $"Tool result did not mention the requested timezone. Result: '{text}'.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/MinimalApiSample/IntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/MinimalApiSample/IntegrationTests.cs
@@ -1,0 +1,39 @@
+using Boilerplate.Shared.Features.MinimalApiSample;
+
+namespace Boilerplate.Tests.Features.MinimalApiSample;
+
+[TestClass, TestCategory("IntegrationTest")]
+public partial class IntegrationTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Exercises the sample minimal API end-to-end through its typed HttpClient proxy (See
+    /// <c>IMinimalApiSampleController</c> and its <c>app.MapGet("/api/minimal-api-sample/...")</c> registration):
+    /// the endpoint simply echoes back the route and query-string parameters it received, so a round-trip proves
+    /// both the route parameter and the (optional) query-string parameter are bound and returned correctly.
+    /// It needs no sign-in because the endpoint is anonymous.
+    /// </summary>
+    [TestMethod]
+    public async Task MinimalApiSample_Should_EchoRouteAndQueryStringParameters()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var minimalApiSampleController = scope.ServiceProvider.GetRequiredService<IMinimalApiSampleController>();
+
+        var routeParameter = "sample-route";
+        var queryStringParameter = "sample-query";
+
+        var result = await minimalApiSampleController
+            .MinimalApiSample(routeParameter, queryStringParameter, TestContext.CancellationToken);
+
+        // The endpoint returns an anonymous object { RouteParameter, QueryStringParameter } serialized with the
+        // app's camelCase policy (See AppJsonContext), so the echoed values must match what we sent.
+        Assert.AreEqual(routeParameter, result.GetProperty("routeParameter").GetString());
+        Assert.AreEqual(queryStringParameter, result.GetProperty("queryStringParameter").GetString());
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/OpenApi/OpenApiScalarIntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/OpenApi/OpenApiScalarIntegrationTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+
+namespace Boilerplate.Tests.Features.OpenApi;
+
+[TestClass, TestCategory("IntegrationTest")]
+public partial class OpenApiScalarIntegrationTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Verifies the API documentation surface is wired up end-to-end (See <c>Program.Middlewares</c>: <c>MapOpenApi</c>
+    /// and <c>MapScalarApiReference</c>, both output-cached). Two things must hold for the docs to actually work:
+    /// <list type="number">
+    /// <item>
+    /// <c>GET /openapi/v1.json</c> returns the generated OpenAPI document - an anonymous endpoint delivered as
+    /// <c>application/json</c> whose body is well-formed JSON carrying the mandatory top-level <c>openapi</c> version
+    /// string (3.x, per <c>AddOpenApi</c>'s <c>OpenApiSpecVersion.OpenApi3_1</c>) and a <c>paths</c> object.
+    /// </item>
+    /// <item>
+    /// <c>GET /scalar</c> returns the Scalar API reference UI as an HTML page. Scalar is the interactive client that
+    /// renders the document above (it is also what <c>/swagger</c> redirects to), so serving its HTML proves the
+    /// reference UI is mounted.
+    /// </item>
+    /// </list>
+    /// Both endpoints are anonymous, so no sign-in is required; requests go through the DI <see cref="HttpClient"/>
+    /// resolved from a request scope (its BaseAddress is the test server address).
+    /// </summary>
+    [TestMethod]
+    public async Task OpenApiAndScalar_Should_BeServed()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        // 1) The generated OpenAPI document must be valid JSON describing the API surface.
+        using var openApiResponse = await httpClient.GetAsync("openapi/v1.json", TestContext.CancellationToken);
+
+        var openApiBody = await openApiResponse.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.OK, openApiResponse.StatusCode, $"The OpenAPI document endpoint must be mapped. Body: '{openApiBody}'.");
+        Assert.AreEqual("application/json", openApiResponse.Content.Headers.ContentType?.MediaType);
+
+        using var openApiJson = JsonDocument.Parse(openApiBody);
+        // Every OpenAPI 3.x document has a top-level "openapi" version string and a "paths" object.
+        Assert.IsTrue(openApiJson.RootElement.TryGetProperty("openapi", out var openApiVersion), "The OpenAPI document must declare its 'openapi' version.");
+        Assert.IsTrue(openApiVersion.GetString()?.StartsWith("3.") is true, $"Unexpected OpenAPI version '{openApiVersion.GetString()}'.");
+        Assert.IsTrue(openApiJson.RootElement.TryGetProperty("paths", out _), "The OpenAPI document must contain a 'paths' section.");
+
+        // 2) The Scalar API reference UI (which renders the document above) must be served as an HTML page.
+        using var scalarResponse = await httpClient.GetAsync("scalar", TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.OK, scalarResponse.StatusCode, "The Scalar API reference UI must be mapped.");
+        Assert.AreEqual("text/html", scalarResponse.Content.Headers.ContentType?.MediaType);
+
+        var scalarBody = await scalarResponse.Content.ReadAsStringAsync(TestContext.CancellationToken);
+        // The rendered reference page bootstraps the Scalar client, so its markup references "scalar".
+        Assert.IsTrue(scalarBody.Contains("scalar", StringComparison.OrdinalIgnoreCase), "The Scalar UI HTML was not returned.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Server.Api.Infrastructure.Data;
+
+namespace Boilerplate.Tests.Features.SignalR;
+
+[TestClass, TestCategory("UITest")]
+public partial class ProfileRealtimeUpdateUITests : AppPageTest
+{
+    /// <summary>
+    /// Proves that editing a profile pushes to the user's other signed-in sessions in real time over SignalR, with no
+    /// manual refresh (See UserController.Update publishing <c>PROFILE_UPDATED</c>, AppClientCoordinator relaying the
+    /// SignalR <c>PUBLISH_MESSAGE</c> into the PubSub bus, and MainLayout's <c>PROFILE_UPDATED</c> subscription that
+    /// swaps the cascaded current user so the header persona re-renders):
+    /// <list type="number">
+    /// <item>A brand-new account signs in on browser A (the default Page) with a magic link OTP, then signs in again on a second, isolated browser B - two sessions of the very same user.</item>
+    /// <item>Both browsers' SignalR connections get registered on the server (their session rows carry a connection id), which is the precondition for the realtime push to actually reach browser B.</item>
+    /// <item>On browser A, the user opens the Profile settings, changes the full name to a new, unique value and saves it.</item>
+    /// <item>Browser B, still sitting on the home page and never reloaded, sees its header account persona update to the new full name - delivered to it over SignalR.</item>
+    /// </list>
+    /// A per-test unique (magic link) account is used rather than a shared seeded one on purpose: the tests run in parallel
+    /// (See MSTestSettings, Workers = 2) against one shared database, so mutating a seeded account's display name would race
+    /// other tests that sign into and assert on that same account. Editing only the full name also keeps the session valid -
+    /// UserController.Update patches FullName/Gender/BirthDate through userManager.UpdateAsync, which does not roll the
+    /// security stamp, so browser A is not signed out.
+    /// </summary>
+    [TestMethod]
+    public async Task ProfileEdit_Should_UpdateOtherSessionHeaderPersonaInRealtime()
+    {
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // The very same account signs into two independent browsers, so it owns two distinct sessions. A fresh e-mail
+        // keeps this account (and its sessions) isolated from other tests that share the same database.
+        var email = MagicLinkSignInUtils.NewTestEmail();
+
+        // ---- Browser A: the editor (the default Page / Context). First sign-in registers and confirms the account. ----
+        await MagicLinkSignInUtils.SignInViaMagicLinkOtp(Page, server, email, TestContext.CancellationToken);
+
+        // ---- Browser B: a second session of the same user, in its own isolated browser context. ----
+        await using var otherContext = await Browser.NewContextAsync(ContextOptions());
+        await SetBlazorWebAssemblyServerAddress(serverAddress, otherContext);
+        var otherPage = await otherContext.NewPageAsync();
+        otherPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
+
+        // The account is already confirmed now, so this repeat sign-in receives a plain OTP and opens a brand-new session.
+        await MagicLinkSignInUtils.SignInAgainViaMagicLinkOtp(otherPage, server, email, TestContext.CancellationToken);
+
+        // Browser B lands on the home page with the header account persona rendered.
+        await Expect(otherPage.Locator(".bit-prs.persona").First).ToBeVisibleAsync();
+
+        // The realtime push (UserController.Update) only targets sessions whose SignalR connection id is stored on the
+        // server, so wait until both browsers' hubs are registered before editing. SignalR traffic is invisible to
+        // Playwright's network waits, hence this explicit, deterministic gate on the server-side precondition.
+        await WaitForConnectedSignalRSessions(server, email, expectedConnectedSessions: 2, TestContext.CancellationToken);
+
+        // ---- Browser A: change the full name on the Profile settings section and save. ----
+        // Navigating straight to /settings/profile expands the Profile accordion (See SettingsPage: DefaultExpandedKey),
+        // revealing the full name field and the Save button.
+        await Page.GotoAsync(new Uri(serverAddress, $"{PageUrls.Settings}/{PageUrls.SettingsSections.Profile}").ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        var newFullName = $"Realtime Update {Guid.NewGuid():N}";
+
+        await Page.GetByPlaceholder(AppStrings.FullName).FillAsync(newFullName);
+        await Page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Save, Exact = true }).ClickAsync();
+
+        // Browser A confirms the save round-tripped (See ProfileSection.SaveProfile -> SnackBarService.Success).
+        await Expect(Page.GetByText(AppStrings.ProfileUpdatedSuccessfullyMessage)).ToBeVisibleAsync();
+
+        // ---- Browser B: without any reload, its header persona reflects the new full name, pushed to it over SignalR. ----
+        // The persona shows the user's DisplayName, which is FullName once it is set (See UserDto.DisplayName).
+        await Expect(otherPage.Locator(".bit-prs.persona").First)
+            .ToContainTextAsync(newFullName, new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+    }
+
+    /// <summary>
+    /// Polls the (shared) test database until at least <paramref name="expectedConnectedSessions"/> of the account's user
+    /// sessions have a SignalR connection id assigned (See AppHub.OnConnectedAsync / ChangeAuthenticationStateImplementation),
+    /// i.e. both browsers' hubs are connected. Scoping by the per-test unique e-mail keeps this immune to sessions created
+    /// by other parallel tests. UserSession is not tenant-aware, so it is safely readable from this bare (HttpContext-less)
+    /// scope; IgnoreQueryFilters is applied only as belt-and-suspenders.
+    /// </summary>
+    private static async Task WaitForConnectedSignalRSessions(AppTestServer server, string email, int expectedConnectedSessions, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+
+        while (true)
+        {
+            await using var scope = server.WebApp.Services.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            var connectedSessions = await dbContext.UserSessions
+                .IgnoreQueryFilters()
+                .CountAsync(us => us.User!.Email == email && us.SignalRConnectionId != null, cancellationToken);
+
+            if (connectedSessions >= expectedConnectedSessions)
+                return;
+
+            if (DateTimeOffset.UtcNow >= deadline)
+                throw new TimeoutException($"Only {connectedSessions} of {expectedConnectedSessions} SignalR sessions connected for '{email}' within the timeout.");
+
+            await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Theme/ThemeTogglePersistenceUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Theme/ThemeTogglePersistenceUITests.cs
@@ -1,0 +1,68 @@
+namespace Boilerplate.Tests.Features.Theme;
+
+[TestClass, TestCategory("UITest")]
+public partial class ThemeTogglePersistenceUITests : AppPageTest
+{
+    /// <summary>
+    /// An anonymous visitor flips the dark/light theme from the home page and the choice sticks across a refresh:
+    /// <list type="number">
+    /// <item>Open the public home page - no sign-in needed - and read the active theme from the <c>bit-theme</c> attribute that Bit.BlazorUI keeps on the <c>html</c> element (server-rendered as "dark"; See <c>App.razor</c> and Client.Web's <c>index.html</c>).</item>
+    /// <item>Open the header user menu by its chevron opener and flip the theme with the <c>BitToggle</c> switch inside the <c>.app-menu-callout</c> (See <c>AppMenu.ToggleTheme</c> -> <c>ThemeService.ToggleTheme</c> -> <c>BitThemeManager.ToggleDarkLightAsync</c>). The toggle lives outside any <c>AuthorizeView</c>, so a signed-out user can reach it. Assert the <c>html[bit-theme]</c> attribute flips to the opposite value, and that the choice is written to <c>localStorage</c> under the <c>bit-current-theme</c> key.</item>
+    /// <item>Reload the whole page and assert the flipped theme survived the refresh (persistence).</item>
+    /// <item>Toggle once more and assert the theme reverts to its original value.</item>
+    /// </list>
+    /// </summary>
+    [TestMethod]
+    public async Task AnonymousUser_Should_ToggleTheme_AndPersistAcrossRefresh()
+    {
+        await using var server = new AppTestServer(Context);
+        await server.Build().Start(TestContext.CancellationToken);
+
+        var serverAddress = server.WebAppServerAddress;
+
+        // The home page is public, so opening it needs no sign-in.
+        await Page.GotoAsync(new Uri(serverAddress, PageUrls.Home).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        var htmlElement = Page.Locator("html");
+
+        // Bit.BlazorUI tracks the active theme via the `bit-theme` attribute on <html> (server-rendered as "dark").
+        // Read it dynamically instead of assuming a literal, so the test stays robust if the default ever changes.
+        var initialTheme = await htmlElement.GetAttributeAsync("bit-theme");
+        Assert.IsFalse(string.IsNullOrEmpty(initialTheme), "The <html> element should carry a bit-theme attribute.");
+        var toggledTheme = initialTheme == "dark" ? "light" : "dark";
+
+        // Flip the theme from the anonymous user menu, then confirm the DOM signal changed.
+        await ToggleThemeFromUserMenu();
+        await Expect(htmlElement).ToHaveAttributeAsync("bit-theme", toggledTheme);
+
+        // The switch persists the choice in localStorage under the `bit-current-theme` key.
+        var persistedTheme = await Page.EvaluateAsync<string?>("() => localStorage.getItem('bit-current-theme')");
+        Assert.AreEqual(toggledTheme, persistedTheme, "The toggled theme should be persisted in localStorage.");
+
+        // A full page refresh must keep the toggled theme.
+        await Page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await Expect(htmlElement).ToHaveAttributeAsync("bit-theme", toggledTheme);
+
+        // Toggling again reverts to the original theme.
+        await ToggleThemeFromUserMenu();
+        await Expect(htmlElement).ToHaveAttributeAsync("bit-theme", initialTheme!);
+    }
+
+    /// <summary>
+    /// Opens the header user menu - available to anonymous users - by clicking its chevron opener, then flips the
+    /// dark/light theme using the BitToggle switch (role="switch") inside the app menu callout. The BitToggle is
+    /// used instead of the theme action button because that button's label reflects the current theme and therefore
+    /// is not a stable target across toggles.
+    /// </summary>
+    private async Task ToggleThemeFromUserMenu()
+    {
+        // The user menu (AppMenu) is a BitDropMenu; clicking its chevron opens the callout.
+        await Page.Locator(".menu-chevron").ClickAsync();
+
+        var callout = Page.Locator(".app-menu-callout");
+        await Expect(callout).ToBeVisibleAsync();
+
+        await callout.GetByRole(AriaRole.Switch).ClickAsync();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/WellKnown/AppleAppSiteAssociationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/WellKnown/AppleAppSiteAssociationTests.cs
@@ -1,0 +1,44 @@
+namespace Boilerplate.Tests.Features.WellKnown;
+
+[TestClass, TestCategory("IntegrationTest")]
+public partial class AppleAppSiteAssociationTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// iOS Universal Links require the host to serve the extension-less
+    /// <c>/.well-known/apple-app-site-association</c> file with a <c>Content-Type</c> of <c>application/json</c>;
+    /// Apple's CDN silently rejects the file when it is returned as any other media type. Because the file has no
+    /// extension, the default <c>UseStaticFiles</c> content-type provider cannot infer a type, so the host must serve
+    /// the <c>.well-known</c> folder with <c>ServeUnknownFileTypes = true</c> and
+    /// <c>DefaultContentType = "application/json"</c> (See <c>Boilerplate.Server.Web/Program.Middlewares.cs</c>). The
+    /// physical file ships in <c>Boilerplate.Client.Web/wwwroot/.well-known/apple-app-site-association</c> and is served
+    /// by the Server.Web host through the Blazor static-assets pipeline. This test requests the file over HTTP through
+    /// the DI <see cref="HttpClient"/> and asserts a 200 response whose body is well-formed JSON delivered as
+    /// <c>application/json</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task AppleAppSiteAssociation_Should_BeServedAsJson()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(s => s.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        var appleAppSiteAssociationUrl = new Uri(server.WebAppServerAddress, "/.well-known/apple-app-site-association");
+
+        using var response = await httpClient.GetAsync(appleAppSiteAssociationUrl, TestContext.CancellationToken);
+
+        Assert.AreEqual(200, (int)response.StatusCode, "The apple-app-site-association file must be served by the host.");
+
+        // Apple only accepts the association file when it is delivered as application/json (no other media type works).
+        Assert.AreEqual("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        // The payload must be well-formed JSON describing the app's associated domains.
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+        using var json = JsonDocument.Parse(body);
+        Assert.IsTrue(json.RootElement.TryGetProperty("applinks", out _), "The association file must contain an 'applinks' section.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -2,6 +2,10 @@
 using Boilerplate.Tests.Infrastructure.Services;
 using Boilerplate.Server.Api.Features.Identity.Services;
 using Boilerplate.Client.Core.Infrastructure.Services.HttpMessageHandlers;
+using Hangfire;
+using Hangfire.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -32,6 +36,35 @@ public static partial class WebApplicationBuilderExtensions
                 {
                     BaseAddress = new Uri(sp.GetRequiredService<IConfiguration>().GetServerAddress(), UriKind.Absolute)
                 };
+            });
+
+            services.AddHangfire((sp, hangfireConfiguration) =>
+            {
+                hangfireConfiguration.UseEFCoreStorage(optionsBuilder =>
+                {
+                    var keepAliveConnection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source=BoilerplateJobs-{Guid.NewGuid():N};Mode=Memory;Cache=Shared;");
+                    keepAliveConnection.Open();
+                    sp.GetRequiredService<IHostApplicationLifetime>().ApplicationStopped.Register(keepAliveConnection.Dispose);
+
+                    optionsBuilder.UseSqlite(keepAliveConnection.ConnectionString);
+                }, new()
+                {
+                    Schema = "jobs",
+                    QueuePollInterval = new TimeSpan(0, 0, 1)
+                })
+                .UseDatabaseCreator();
+
+                // Hangfire keeps its log provider in a process-wide static (Hangfire.Logging.LogProvider.CurrentLogProvider).
+                // With several hosts per dotnet test runner process, each AddHangfire binds that static to its own (disposable) ILoggerFactory,
+                // so disposing one host makes every still-running host throw ObjectDisposedException the next time Hangfire
+                // logs (e.g. while constructing a background job client during a request). Bind logging to the never-disposed
+                // NullLoggerFactory so the shared static stays valid for the whole lifetime of the process.
+                hangfireConfiguration.UseLogProvider(new Hangfire.AspNetCore.AspNetCoreLogProvider(Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance));
+
+                hangfireConfiguration.UseRecommendedSerializerSettings();
+                hangfireConfiguration.UseSimpleAssemblyNameTypeSerializer();
+                hangfireConfiguration.UseIgnoredAssemblyVersionTypeResolver();
+                hangfireConfiguration.SetDataCompatibilityLevel(CompatibilityLevel.Version_180);
             });
         }
     }


### PR DESCRIPTION
## Summary

Adds automated test coverage for a batch of Boilerplate template features that previously had none, moves test-only Hangfire configuration out of the template's production startup code into the test infrastructure, and simplifies `.well-known` static-file serving so it is both production-correct and testable.

## Changes

- **New tests** (wired into `.template.config/template.json` behind their template conditions):
  - `Diagnostics/HealthCheckIntegrationTests` — `/alive` liveness endpoint returns `200 Healthy`
  - `MinimalApiSample/IntegrationTests` — route + query-string parameter binding round-trip
  - `WellKnown/AppleAppSiteAssociationTests` — `apple-app-site-association` served as `application/json`
  - `Attachments/UserProfilePictureWebPTests` — WebP profile-picture handling
  - `Culture/CultureSelectionUITests` — culture selection
  - `ForceUpdate/ForceUpdateUITests` — force-update flow
  - `Identity/PhoneNumberNormalizationUITests` — phone-number normalization
  - `Identity/WebAuthnPasswordlessUITests` — WebAuthn passwordless sign-in
  - `SignalR/ProfileRealtimeUpdateUITests` — realtime profile updates over SignalR
  - `Theme/ThemeTogglePersistenceUITests` — theme-toggle persistence
  - `Configuration/AppConfigurationBuilderTests` — app configuration builder
  - `OpenApi/OpenApiScalarIntegrationTests` — `GET /openapi/v1.json` returns a valid OpenAPI 3.x document and `GET /scalar` serves the Scalar API reference UI
  - `Mcp/GetCurrentDateTimeMcpIntegrationTests` — drives the authorized `/mcp` Streamable HTTP endpoint with a real MCP client, lists tools and invokes `GetCurrentDateTime`; a `FakeTimeProvider` (new test-only `Microsoft.Extensions.TimeProvider.Testing` package, seeded from the current time to avoid token-validation clock skew) replaces the DI `TimeProvider` to make the tool output deterministic
- **Hangfire test config relocated**: removed the in-memory keep-alive SQLite connection and the dev-only log-provider workaround from `Boilerplate.Server.Api/Program.Services.cs` (the template now uses a plain file-based SQLite store), and moved that test-only setup into `Tests/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs`. Dropped the now-unneeded `.runsettings` overrides (`Hangfire__UseIsolatedStorage`, in-memory SQLite connection string).
- **`.well-known` serving simplified**: `Boilerplate.Server.Web/Program.Middlewares.cs` now serves `.well-known` via `UseWhen` + `env.WebRootFileProvider` instead of a dedicated `PhysicalFileProvider`/`RequestPath`, so files flow through the Blazor static-assets pipeline.
- **Reorganized** `MagicLinkReturnUrlTests` and `QuickSignInUITests` (formerly `BuyProductUITests`) from `Features/Products` into `Features/Identity`, and hardened `Identity/UserGroupFeatureManagementUITests` to tolerate an already-elevated session and an already-granted feature state.

## Related Issue

This closes #12660
