### PR TITLE
Redesign bit Boilerplate About page with app-info card & acknowledgements #12666

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor
@@ -1,0 +1,67 @@
+@inherits AppComponentBase
+
+@* A respectful nod to the products this app is built with, doubling as the third-party license notice. *@
+@{
+    RenderFragment<Dependency[]> cards = deps =>
+    @<BitStack Horizontal Wrap Gap="0.6rem" VerticalAlign="BitAlignment.Stretch" Class="deps-wrap">
+        @foreach (var dep in deps)
+        {
+            <div class="dep-card" @key="dep.Name">
+                <div class="dep-top">
+                    <BitLink Class="dep-name" Href="@(dep.Url ?? dep.Repo)" Target="_blank">@dep.Name</BitLink>
+                    @if (dep.Repo is not null)
+                    {
+                        <BitLink Class="dep-source" Href="@dep.Repo" Target="_blank" AriaLabel="@($"{dep.Name} source repository")">
+                            <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">
+                                <path fill="currentColor" d="M8 0c-4.42 0-8 3.58-8 8 0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                            </svg>
+                        </BitLink>
+                    }
+                </div>
+                <BitTag Class="dep-license"
+                        Text="@dep.License"
+                        Size="BitSize.Small"
+                        Variant="BitVariant.Outline" />
+            </div>
+        }
+    </BitStack>;
+
+    var sections = new[]
+    {
+        (Title: "Runtime packages",       Subtitle: "Production NuGet",               Items: RuntimeDependencies),
+        (Title: "Development & testing",  Subtitle: "Dev / test NuGet & npm",         Items: DevelopmentDependencies),
+        (Title: "IDE extensions",         Subtitle: "VS Code & Visual Studio",        Items: IdeExtensions),
+        (Title: "SDKs & tooling",         Subtitle: "Runtimes, containers & OS SDKs", Items: Tooling),
+        (Title: "CI/CD & deployment",     Subtitle: "GitHub Actions, Azure",     Items: Deployment),
+    };
+}
+
+<CascadingValue Value="BitDir.Ltr">
+    <section class="acknowledgements">
+        <BitStack Gap="1.25rem">
+            <BitStack Gap="0.25rem">
+                <BitText Typography="BitTypography.H4">Standing on the shoulders of giants</BitText>
+                <BitText Class="ack-intro" Typography="BitTypography.Body1" Color="BitColor.SecondaryForeground">
+                    Hats off to the open-source projects, tools, and services this app is built with, and to the people
+                    and communities behind them. Each links to its home and shows the license it ships under, both to honor
+                    their work and to respect their license terms.
+                </BitText>
+            </BitStack>
+
+            @foreach (var s in sections)
+            {
+                @if (s.Items.Length > 0)
+                {
+                    <div class="ack-section">
+                        <div class="ack-section-head">
+                            <BitText Class="ack-section-title" Typography="BitTypography.Subtitle1">@s.Title</BitText>
+                            <span class="ack-count">@s.Items.Length</span>
+                            <BitText Class="ack-section-sub" Typography="BitTypography.Caption2" Color="BitColor.SecondaryForeground">@s.Subtitle</BitText>
+                        </div>
+                        @cards(s.Items)
+                    </div>
+                }
+            }
+        </BitStack>
+    </section>
+</CascadingValue>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor.cs
@@ -1,0 +1,195 @@
+﻿//+:cnd:noEmit
+namespace Boilerplate.Client.Core.Components.Common;
+
+/// <summary>
+/// A tip of the hat to the open-source projects, tools, and services this app is built with.
+/// It also doubles as the third-party attribution / license notice required by many of those licenses.
+/// The lists below mirror the actual dependencies of the generated project: entries wrapped in the
+/// template's conditional markers (e.g. //#if (redis == true)) only ship when the matching option is selected.
+/// No localization on purpose: product names and license identifiers are proper nouns that stay in English.
+/// </summary>
+public partial class Acknowledgements
+{
+    /// <param name="Name">Product/library display name.</param>
+    /// <param name="Url">Official website (falls back to the repository when there is no distinct homepage).</param>
+    /// <param name="Repo">Public source repository, or null for closed-source products.</param>
+    /// <param name="License">SPDX license identifier (or a short human phrase for multi/every-non-SPDX licenses).</param>
+    private record Dependency(string Name, string? Url, string? Repo, string License);
+
+    /// <summary>
+    /// Production NuGet packages (the app's runtime dependencies), grouped by product.
+    /// </summary>
+    private static readonly Dependency[] RuntimeDependencies =
+    [
+        new("bit platform ❤️", "https://bitplatform.dev", "https://github.com/bitfoundation/bitplatform", "MIT"),
+        new(".NET", "https://dot.net", "https://github.com/dotnet/runtime", "MIT"),
+        new("ASP.NET Core - Blazor", "https://asp.net", "https://github.com/dotnet/aspnetcore", "MIT"),
+        //#if (aspire == true)
+        new(".NET Aspire", "https://aspire.dev", "https://github.com/dotnet/aspire", "MIT"),
+        //#endif
+        new("Entity Framework Core", "https://learn.microsoft.com/ef", "https://github.com/dotnet/efcore", "MIT"),
+        new(".NET MAUI", "https://dotnet.microsoft.com/apps/maui", "https://github.com/dotnet/maui", "MIT"),
+        new("OpenTelemetry .NET", "https://opentelemetry.io", "https://github.com/open-telemetry/opentelemetry-dotnet", "Apache-2.0"),
+        new("Hangfire", "https://www.hangfire.io", "https://github.com/HangfireIO/Hangfire", "LGPL-3.0 / Commercial"),
+        new("Mapperly", "https://mapperly.riok.app", "https://github.com/riok/mapperly", "Apache-2.0"),
+        new("FusionCache", "https://github.com/ZiggyCreatures/FusionCache", "https://github.com/ZiggyCreatures/FusionCache", "MIT"),
+        new("ASP.NET Core OData", "https://www.odata.org", "https://github.com/OData/AspNetCoreOData", "MIT"),
+        new("Humanizer", "https://github.com/Humanizr/Humanizer", "https://github.com/Humanizr/Humanizer", "MIT"),
+        //#if (signalR == true || database == "PostgreSQL" || database == "SqlServer")
+        new("Microsoft.Extensions.AI", "https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai", "https://github.com/dotnet/extensions", "MIT"),
+        new("Semantic Kernel", "https://learn.microsoft.com/semantic-kernel", "https://github.com/microsoft/semantic-kernel", "MIT"),
+        new("Microsoft Agent Framework", "https://learn.microsoft.com/agent-framework", "https://github.com/microsoft/agent-framework", "MIT"),
+        //#endif
+        //#if (redis == true)
+        new("Redis", "https://redis.io", "https://github.com/redis/redis", "AGPL-3.0-only"),
+        new("StackExchange.Redis", "https://stackexchange.github.io/StackExchange.Redis", "https://github.com/StackExchange/StackExchange.Redis", "MIT"),
+        //#endif
+        //#if (database == "SqlServer")
+        new("Microsoft SQL Server (EF Core provider)", "https://learn.microsoft.com/ef/core", "https://github.com/dotnet/efcore", "MIT"),
+        //#endif
+        //#if (database == "PostgreSQL")
+        new("Npgsql (PostgreSQL provider)", "https://www.npgsql.org", "https://github.com/npgsql/efcore.pg", "PostgreSQL"),
+        new("pgvector-dotnet", "https://github.com/pgvector/pgvector-dotnet", "https://github.com/pgvector/pgvector-dotnet", "MIT"),
+        //#endif
+        //#if (database == "MySql")
+        new("Pomelo (MySQL provider)", "https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql", "https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql", "MIT"),
+        //#endif
+        //#if (notification == true)
+        new("Firebase Cloud Messaging", "https://firebase.google.com/docs/cloud-messaging", "https://github.com/dotnet/android-libraries", "MIT / Apache-2.0"),
+        new("Plugin.LocalNotification", "https://github.com/thudugala/Plugin.LocalNotification", "https://github.com/thudugala/Plugin.LocalNotification", "MIT"),
+        new("AdsPush", "https://github.com/adessoTurkey-dotNET/AdsPush", "https://github.com/adessoTurkey-dotNET/AdsPush", "BSD-3-Clause"),
+        //#endif
+        //#if (filesStorage == "S3")
+        new("AWS SDK for .NET", "https://aws.amazon.com/sdk-for-net", "https://github.com/aws/aws-sdk-net", "Apache-2.0"),
+        //#endif
+        //#if (filesStorage == "AzureBlobStorage" || appInsights == true)
+        new("Azure SDK for .NET", "https://learn.microsoft.com/dotnet/azure/sdk/azure-sdk-for-dotnet", "https://github.com/Azure/azure-sdk-for-net", "MIT"),
+        //#endif
+        //#if (sentry == true)
+        new("Sentry", "https://sentry.io", "https://github.com/getsentry/sentry-dotnet", "MIT"),
+        //#endif
+        //#if (appInsights == true)
+        new("BlazorApplicationInsights", "https://github.com/IvanJosipovic/BlazorApplicationInsights", "https://github.com/IvanJosipovic/BlazorApplicationInsights", "MIT"),
+        //#endif
+        //#if (offlineDb == true)
+        new("Community Toolkit Datasync", "https://github.com/CommunityToolkit/Datasync", "https://github.com/CommunityToolkit/Datasync", "MIT"),
+        //#endif
+        new("SQLite", "https://sqlite.org", "https://github.com/sqlite/sqlite", "Public Domain"),
+        new("Microsoft.Identity.Web", "https://github.com/AzureAD/microsoft-identity-web", "https://github.com/AzureAD/microsoft-identity-web", "MIT"),
+        new("Twilio", "https://www.twilio.com", "https://github.com/twilio/twilio-csharp", "MIT"),
+        new("Magick.NET", "https://github.com/dlemstra/Magick.NET", "https://github.com/dlemstra/Magick.NET", "Apache-2.0"),
+        new("QRCoder", "https://github.com/Shane32/QRCoder", "https://github.com/Shane32/QRCoder", "MIT"),
+        new("HtmlSanitizer", "https://github.com/mganss/HtmlSanitizer", "https://github.com/mganss/HtmlSanitizer", "MIT"),
+        new("Scalar", "https://scalar.com", "https://github.com/scalar/scalar", "MIT"),
+        new("ASP.NET API Versioning", "https://github.com/dotnet/aspnet-api-versioning", "https://github.com/dotnet/aspnet-api-versioning", "MIT"),
+        new("AspNet.Security.OAuth.Providers", "https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers", "https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers", "Apache-2.0"),
+        new("Xabaril HealthChecks", "https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks", "https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks", "Apache-2.0"),
+        new("FIDO2 .NET Library", "https://github.com/passwordless-lib/fido2-net-lib", "https://github.com/passwordless-lib/fido2-net-lib", "MIT"),
+        new("libphonenumber-csharp", "https://twcclegg.github.io/libphonenumber-csharp", "https://github.com/twcclegg/libphonenumber-csharp", "Apache-2.0"),
+        new("FluentEmail", "https://github.com/lukencode/FluentEmail", "https://github.com/lukencode/FluentEmail", "MIT"),
+        new("FluentStorage", "https://github.com/robinrodricks/FluentStorage", "https://github.com/robinrodricks/FluentStorage", "MIT"),
+        new("NWebsec", "https://www.nwebsec.com", "https://github.com/NWebsec/NWebsec", "BSD-3-Clause"),
+        new("DistributedLock", "https://github.com/madelson/DistributedLock", "https://github.com/madelson/DistributedLock", "MIT"),
+        new("Velopack", "https://velopack.io", "https://github.com/velopack/velopack", "MIT"),
+        new("Meziantou.Framework", "https://github.com/meziantou/Meziantou.Framework", "https://github.com/meziantou/Meziantou.Framework", "MIT"),
+        new("EmbedIO", "https://unosquare.github.io/embedio", "https://github.com/unosquare/embedio", "MIT"),
+        new("Microsoft Edge WebView2", "https://developer.microsoft.com/microsoft-edge/webview2", null, "BSD-3-Clause"),
+        new("Oscore.Maui.AppStoreInfo", "https://github.com/oscoreio/Maui.AppStoreInfo", "https://github.com/oscoreio/Maui.AppStoreInfo", "MIT"),
+        new("Plugin.Maui.AppRating", "https://github.com/FabriBertani/Plugin.Maui.AppRating", "https://github.com/FabriBertani/Plugin.Maui.AppRating", "MIT"),
+        //#if (aspire == true)
+        new("Keycloak", "https://www.keycloak.org", "https://github.com/keycloak/keycloak", "Apache-2.0"),
+        new(".NET Aspire Community Toolkit", "https://github.com/CommunityToolkit/Aspire", "https://github.com/CommunityToolkit/Aspire", "MIT"),
+        new("Mailpit", "https://mailpit.axllent.org", "https://github.com/axllent/mailpit", "MIT"),
+        //#endif
+        //#if (aspire == true && filesStorage == "S3")
+        new("MinIO", "https://www.min.io", "https://github.com/minio/minio", "AGPL-3.0-only"),
+        //#endif
+        //#if (signalR == true)
+        new("Model Context Protocol (C# SDK)", "https://modelcontextprotocol.io", "https://github.com/modelcontextprotocol/csharp-sdk", "MIT"),
+        new("Azure SignalR Service", "https://azure.microsoft.com/products/signalr-service", "https://github.com/Azure/azure-signalr", "MIT"),
+        //#endif
+    ];
+
+    /// <summary>
+    /// NuGet packages and npm packages used only while developing and testing the app.
+    /// </summary>
+    private static readonly Dependency[] DevelopmentDependencies =
+    [
+        new("C#", "https://dotnet.microsoft.com/en-us/languages/csharp", "https://github.com/dotnet/csharplang", "MIT"),
+        new("TypeScript", "https://www.typescriptlang.org", "https://github.com/microsoft/TypeScript", "Apache-2.0"),
+        new("MSTest", "https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro", "https://github.com/microsoft/testfx", "MIT"),
+        new("Playwright for .NET", "https://playwright.dev/dotnet", "https://github.com/microsoft/playwright-dotnet", "MIT"),
+        new("esbuild", "https://esbuild.github.io", "https://github.com/evanw/esbuild", "MIT"),
+        new("Dart Sass", "https://sass-lang.com/dart-sass", "https://github.com/sass/dart-sass", "MIT"),
+        new("FakeItEasy", "https://fakeiteasy.github.io", "https://github.com/FakeItEasy/FakeItEasy", "MIT"),
+        new("EF Core Tools (dotnet-ef)", "https://learn.microsoft.com/ef/core/cli/dotnet", "https://github.com/dotnet/efcore", "MIT"),
+        new("Microsoft.Extensions.TimeProvider.Testing", "https://github.com/dotnet/extensions", "https://github.com/dotnet/extensions", "MIT"),
+        //#if (advancedTests == true)
+        new("Otp.NET", "https://github.com/kspearrin/Otp.NET", "https://github.com/kspearrin/Otp.NET", "MIT"),
+        //#endif
+    ];
+
+    /// <summary>
+    /// Recommended editor extensions (VS Code, from .devcontainer/.vscode) and Visual Studio components (from .vsconfig).
+    /// </summary>
+    private static readonly Dependency[] IdeExtensions =
+    [
+        new("GitHub Copilot Chat", "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat", "https://github.com/microsoft/vscode-copilot-chat", "MIT"),
+        new("C# (ms-dotnettools.csharp)", "https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp", "https://github.com/dotnet/vscode-csharp", "MIT"),
+        new("C# Dev Kit", "https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit", null, "Proprietary"),
+        new(".NET MAUI (VS Code)", "https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui", null, "Proprietary"),
+        new("Aspire (VS Code)", "https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode", "https://github.com/microsoft/aspire", "MIT"),
+        new(".NET Install Tool", "https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-runtime", "https://github.com/dotnet/vscode-dotnet-runtime", "MIT"),
+        new("Container Tools (Docker)", "https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker", "https://github.com/microsoft/vscode-docker", "MIT"),
+        new("Dev Containers", "https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers", null, "Proprietary"),
+        new("Blazor WASM Companion", "https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.blazorwasm-companion", "https://github.com/dotnet/razor", "MIT"),
+        new("Live Sass Compiler", "https://marketplace.visualstudio.com/items?itemName=glenn2223.live-sass", "https://github.com/glenn2223/vscode-live-sass-compiler", "MIT"),
+        new("ResX Manager", "https://marketplace.visualstudio.com/items?itemName=TomEnglert.ResXManager", "https://github.com/dotnet/ResXResourceManager", "MIT"),
+        new("VS \"ASP.NET & web development\" workload", "https://visualstudio.microsoft.com/vs/features/web", null, "Proprietary"),
+        new("VS \".NET MAUI development\" workload", "https://dotnet.microsoft.com/apps/maui", null, "Proprietary"),
+    ];
+
+    /// <summary>
+    /// SDKs, runtimes, and platform tooling used to build, containerize, and run the app
+    /// (from .devcontainer features, .vsconfig, global.json, and native Apple/Android build requirements).
+    /// </summary>
+    private static readonly Dependency[] Tooling =
+    [
+        new(".NET SDK", "https://dotnet.microsoft.com", "https://github.com/dotnet/sdk", "MIT"),
+        new("Node.js", "https://nodejs.org", "https://github.com/nodejs/node", "MIT"),
+        new("Docker", "https://www.docker.com", "https://github.com/moby/moby", "Apache-2.0"),
+        new("Kubernetes", "https://kubernetes.io", "https://github.com/kubernetes/kubernetes", "Apache-2.0"),
+        new("Python", "https://www.python.org", "https://github.com/python/cpython", "PSF-2.0"),
+        new("PowerShell", "https://learn.microsoft.com/powershell", "https://github.com/PowerShell/PowerShell", "MIT"),
+        new("Helm", "https://helm.sh", "https://github.com/helm/helm", "Apache-2.0"),
+        new("Minikube", "https://minikube.sigs.k8s.io", "https://github.com/kubernetes/minikube", "Apache-2.0"),
+        new("Apple Xcode", "https://developer.apple.com/xcode", null, "Proprietary"),
+        new("Android SDK", "https://developer.android.com/studio", null, "Proprietary"),
+    ];
+
+    /// <summary>
+    /// CI/CD and deployment tooling taken from the pipeline definitions: GitHub Actions (.github/workflows) or
+    /// Azure Pipelines (.azure-devops), plus the optional Cloudflare CDN integration. Everything here is build/deploy
+    /// time only and never ships inside the app.
+    /// </summary>
+    private static readonly Dependency[] Deployment =
+    [
+        //#if (pipeline == "GitHub")
+        new("GitHub Actions", "https://github.com/features/actions", "https://github.com/actions/runner", "MIT"),
+        new("Azure WebApps Deploy", "https://github.com/Azure/webapps-deploy", "https://github.com/Azure/webapps-deploy", "MIT"),
+        new("setup-xcode", "https://github.com/maxim-lobanov/setup-xcode", "https://github.com/maxim-lobanov/setup-xcode", "MIT"),
+        new("Apple Actions", "https://github.com/Apple-Actions", "https://github.com/Apple-Actions", "MIT"),
+        new("base64-to-file", "https://github.com/timheuer/base64-to-file", "https://github.com/timheuer/base64-to-file", "MIT"),
+        new("variable-substitution", "https://github.com/devops-actions/variable-substitution", "https://github.com/devops-actions/variable-substitution", "MIT"),
+        //#endif
+        //#if (pipeline == "Azure")
+        new("Azure Pipelines", "https://azure.microsoft.com/products/devops/pipelines", null, "Proprietary"),
+        //#endif
+        //#if (cloudflare == true)
+        new("Cloudflare", "https://www.cloudflare.com", null, "Proprietary"),
+        //#endif
+        //#if (pipeline == "GitHub" && cloudflare == true)
+        new("cloudflare-purge-action", "https://github.com/jakejarvis/cloudflare-purge-action", "https://github.com/jakejarvis/cloudflare-purge-action", "MIT"),
+        //#endif
+    ];
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor.scss
@@ -1,0 +1,108 @@
+@import '../../Styles/abstracts/_media-queries.scss';
+@import '../../Styles/abstracts/_bit-css-variables.scss';
+
+.acknowledgements {
+    width: 100%;
+    min-width: 0;
+}
+
+.ack-section {
+    gap: 0.6rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.ack-section-head {
+    gap: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+}
+
+.ack-count {
+    flex: none;
+    line-height: 1.4;
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.05rem 0.45rem;
+    border-radius: 1rem;
+    color: $bit-color-foreground-secondary;
+    background-color: $bit-color-background-tertiary;
+}
+
+.dep-card {
+    gap: 0.5rem;
+    display: flex;
+    min-width: 0;
+    // Wrap-panel item: grow to fill the row, wrap to the next line when out of room, shrink on small screens.
+    flex: 1 1 15rem;
+    flex-direction: column;
+    padding: 0.7rem 0.85rem;
+    border-radius: 0.5rem;
+    justify-content: space-between;
+    border: 1px solid $bit-color-border-secondary;
+    background-color: $bit-color-background-secondary;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+        transform: translateY(-0.0625rem);
+        box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+    }
+}
+
+.dep-top {
+    gap: 0.5rem;
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+}
+
+::deep {
+    .ack-intro {
+        max-width: 70ch;
+    }
+
+    .ack-section-title {
+        font-weight: 600;
+    }
+
+    .ack-section-sub {
+        flex: none;
+    }
+
+    .dep-name {
+        min-width: 0;
+        font-weight: 600;
+        overflow-wrap: anywhere;
+        color: $bit-color-foreground-primary;
+    }
+
+    .dep-source {
+        flex: none;
+        display: inline-flex;
+        align-items: center;
+        color: $bit-color-foreground-secondary;
+
+        &:hover {
+            color: $bit-color-primary;
+        }
+
+        svg {
+            width: 1rem;
+            height: 1rem;
+        }
+    }
+
+    // Let long license identifiers wrap instead of forcing the card wider.
+    .dep-license {
+        height: auto;
+        max-width: 100%;
+        align-self: flex-start;
+
+        span {
+            white-space: normal;
+            overflow-wrap: anywhere;
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/AppInfoCard.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/AppInfoCard.razor
@@ -1,0 +1,49 @@
+@inherits AppComponentBase
+
+@* Reusable, polished "app & device" panel shared by the About page of every client (Web, MAUI, Windows). *@
+<CascadingValue Value="BitDir.Ltr">
+    <BitCard FullSize Class="app-info-card">
+        <BitStack Gap="1rem">
+            <BitStack Horizontal VerticalAlign="BitAlignment.Center" Gap="0.85rem" Wrap>
+                <div class="app-monogram">@Monogram</div>
+                <BitStack Gap="0" Grows>
+                    <BitText Typography="BitTypography.H5">@AppName</BitText>
+                    <BitText Typography="BitTypography.Body2" Color="BitColor.SecondaryForeground">Version @AppVersion</BitText>
+                </BitStack>
+                <BitTag Text="@Environment" Size="BitSize.Small" Variant="BitVariant.Outline" Color="@EnvironmentColor" />
+            </BitStack>
+
+            <BitSeparator />
+
+            <div class="info-grid">
+                <div class="info-item">
+                    <span class="info-label">Operating system</span>
+                    <span class="info-value">@Platform</span>
+                </div>
+                @if (string.IsNullOrEmpty(WebView) is false)
+                {
+                    <div class="info-item">
+                        <span class="info-label">Web view</span>
+                        <span class="info-value">@WebView</span>
+                    </div>
+                }
+                @if (string.IsNullOrEmpty(Oem) is false)
+                {
+                    <div class="info-item">
+                        <span class="info-label">Manufacturer</span>
+                        <span class="info-value">@Oem</span>
+                    </div>
+                }
+                <div class="info-item">
+                    <span class="info-label">Process ID</span>
+                    <span class="info-value">@ProcessId</span>
+                </div>
+            </div>
+
+            @if (Note is not null)
+            {
+                <BitMessage Color="BitColor.Info" Multiline Class="app-info-note">@Note</BitMessage>
+            }
+        </BitStack>
+    </BitCard>
+</CascadingValue>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/AppInfoCard.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/AppInfoCard.razor.cs
@@ -1,0 +1,32 @@
+namespace Boilerplate.Client.Core.Components.Common;
+
+/// <summary>
+/// A polished, reusable app &amp; device info panel used on the About page of each client (Web, MAUI, Windows).
+/// Platform-specific values are gathered by the host page; the presentation lives here so every client stays consistent.
+/// </summary>
+public partial class AppInfoCard
+{
+    [Parameter, EditorRequired] public string AppName { get; set; } = default!;
+    [Parameter, EditorRequired] public string AppVersion { get; set; } = default!;
+    [Parameter, EditorRequired] public string Platform { get; set; } = default!;
+    [Parameter, EditorRequired] public string Environment { get; set; } = default!;
+    [Parameter, EditorRequired] public string ProcessId { get; set; } = default!;
+
+    /// <summary>Optional native web view (MAUI/Windows); hidden when not provided (e.g. on the web).</summary>
+    [Parameter] public string? WebView { get; set; }
+
+    /// <summary>Optional device manufacturer/OEM; hidden when not provided.</summary>
+    [Parameter] public string? Oem { get; set; }
+
+    /// <summary>Optional note/guidance rendered as an info message under the details.</summary>
+    [Parameter] public RenderFragment? Note { get; set; }
+
+    private string Monogram => string.IsNullOrWhiteSpace(AppName) ? "?" : AppName.Trim()[..1].ToUpperInvariant();
+
+    private BitColor EnvironmentColor => Environment?.ToLowerInvariant() switch
+    {
+        "production" or "prod" => BitColor.Success,
+        "development" or "dev" => BitColor.Warning,
+        _ => BitColor.Info
+    };
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/AppInfoCard.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/AppInfoCard.razor.scss
@@ -1,0 +1,44 @@
+@import '../../Styles/abstracts/_media-queries.scss';
+@import '../../Styles/abstracts/_bit-css-variables.scss';
+
+.app-monogram {
+    flex: none;
+    width: 3rem;
+    height: 3rem;
+    display: flex;
+    font-size: 1.5rem;
+    font-weight: 700;
+    user-select: none;
+    border-radius: 0.75rem;
+    align-items: center;
+    justify-content: center;
+    color: $bit-color-primary-text;
+    background: linear-gradient(135deg, $bit-color-primary, $bit-color-info);
+}
+
+.info-grid {
+    display: grid;
+    gap: 0.85rem 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+}
+
+.info-item {
+    gap: 0.15rem;
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+}
+
+.info-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: $bit-color-foreground-secondary;
+}
+
+.info-value {
+    font-weight: 500;
+    overflow-wrap: anywhere;
+    color: $bit-color-foreground-primary;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Components/Pages/AboutPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Components/Pages/AboutPage.razor
@@ -7,27 +7,23 @@
 
 <CascadingValue Value=BitDir.Ltr>
     <section>
-        <BitStack Gap="3rem">
-            <BitCard FullSize>
-                <BitText Typography="BitTypography.Body1">
-                    For Razor pages that are exclusively dependent on native Maui features for Android, iOS, Windows, and macOS functionality,
-                    consider using Client/Maui project instead of placing them in Client/Core project.
-                    <br />
-                    This approach allows direct access to native features without the need for dependency injection (DI) or publish-subscribe messaging patterns.
-                </BitText>
+        <BitStack Gap="1.5rem">
+            <AppInfoCard AppName="@appName"
+                         AppVersion="@appVersion"
+                         Platform="@platform"
+                         Environment="@AppEnvironment.Current"
+                         ProcessId="@processId"
+                         Oem="@oem"
+                         WebView="@(AppPlatform.IsIos is false && AppPlatform.IsMacOS is false ? webView : null)">
+                <Note>
+                    For Razor pages that depend exclusively on native MAUI features for Android, iOS, macOS, and Windows,
+                    consider the <b>Client.Maui</b> project instead of <b>Client.Core</b>. This gives you direct access to
+                    native features without dependency injection or publish-subscribe messaging.
+                </Note>
+            </AppInfoCard>
 
-                <BitStack AutoWidth>
-                    <BitText>App Name: <b>@appName</b></BitText>
-                    <BitText>App Version: <b>@appVersion</b></BitText>
-                    <BitText>OS: <b>@platform</b></BitText>
-                    @if (AppPlatform.IsIos is false && AppPlatform.IsMacOS is false)
-                    {
-                        <BitText>Web View: <b>@webView</b></BitText>
-                    }
-                    <BitText>OEM: <b>@oem</b></BitText>
-                    <BitText>Environment: <b>@AppEnvironment.Current</b></BitText>
-                    <BitText>Process Id: <b>@processId</b></BitText>
-                </BitStack>
+            <BitCard FullSize>
+                <Acknowledgements />
             </BitCard>
         </BitStack>
     </section>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Components/Pages/AboutPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Components/Pages/AboutPage.razor
@@ -8,24 +8,23 @@
 
 <CascadingValue Value=BitDir.Ltr>
     <section>
-        <BitStack Gap="3rem">
-            <BitCard FullSize>
-                <BitText Typography="BitTypography.Body1">
-                    You can add `.razor`, `.razor.cs`, and `.razor.scss` files to the `Client.Maui` and `Client.Windows` projects,
-                    allowing direct access to native platform features without dependency injection.
-                    <br />
-                    The `AboutPage.razor` file in `Client.Web` demonstrates that you can use the same route (e.g., `/about`) on the web,
-                    but it does not provide access to native platform features.
-                </BitText>
+        <BitStack Gap="1.5rem">
+            <AppInfoCard AppName="@appName"
+                         AppVersion="@appVersion"
+                         Platform="@platform"
+                         Environment="@AppEnvironment.Current"
+                         ProcessId="@processId"
+                         Oem="@oem">
+                <Note>
+                    You can add <code>.razor</code>, <code>.razor.cs</code>, and <code>.razor.scss</code> files to the
+                    <b>Client.Maui</b> and <b>Client.Windows</b> projects, allowing direct access to native platform
+                    features without dependency injection. This <b>AboutPage</b> in <b>Client.Web</b> reuses the same
+                    route (e.g. <code>/about</code>) on the web, though without access to native platform features.
+                </Note>
+            </AppInfoCard>
 
-                <BitStack AutoWidth>
-                    <BitText>App Name: <b>@appName</b></BitText>
-                    <BitText>App Version: <b>@appVersion</b></BitText>
-                    <BitText>OS: <b>@platform</b></BitText>
-                    <BitText>OEM: <b>@oem</b></BitText>
-                    <BitText>Environment: <b>@AppEnvironment.Current</b></BitText>
-                    <BitText>Process Id: <b>@processId</b></BitText>
-                </BitStack>
+            <BitCard FullSize>
+                <Acknowledgements />
             </BitCard>
         </BitStack>
     </section>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Components/Pages/AboutPage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Components/Pages/AboutPage.razor
@@ -7,23 +7,22 @@
 
 <CascadingValue Value=BitDir.Ltr>
     <section>
-        <BitStack Gap="3rem">
-            <BitCard FullSize>
-                <BitText Typography="BitTypography.Body1">
-                    For Razor pages that are exclusively dependent on native Windows features,
-                    consider using Client/Windows project instead of placing them in Client/Core project.
-                    <br />
-                    This approach allows direct access to native features without the need for dependency injection (DI) or publish-subscribe messaging patterns.
-                </BitText>
+        <BitStack Gap="1.5rem">
+            <AppInfoCard AppName="@appName"
+                         AppVersion="@appVersion"
+                         Platform="@platform"
+                         Environment="@AppEnvironment.Current"
+                         ProcessId="@processId"
+                         WebView="@webView">
+                <Note>
+                    For Razor pages that depend exclusively on native Windows features, consider the <b>Client.Windows</b>
+                    project instead of <b>Client.Core</b>. This gives you direct access to native features without
+                    dependency injection or publish-subscribe messaging.
+                </Note>
+            </AppInfoCard>
 
-                <BitStack AutoWidth>
-                    <BitText>App Name: <b>@appName</b></BitText>
-                    <BitText>App Version: <b>@appVersion</b></BitText>
-                    <BitText>OS: <b>@platform</b></BitText>
-                    <BitText>Web View: <b>@webView</b></BitText>
-                    <BitText>Environment: <b>@AppEnvironment.Current</b></BitText>
-                    <BitText>Process Id: <b>@processId</b></BitText>
-                </BitStack>
+            <BitCard FullSize>
+                <Acknowledgements />
             </BitCard>
         </BitStack>
     </section>


### PR DESCRIPTION
## Summary

Redesigns the Boilerplate template's About page: a shared, polished app & device info panel plus a third-party attribution / license notice, reused consistently across the Web, MAUI, and Windows clients.

## Changes

- **New `AppInfoCard` component** (`Client.Core/Components/Common`): a reusable, polished app & device info panel (monogram, app name/version, environment tag, OS, web view, manufacturer, process id, optional note). Replaces the hand-rolled `BitText` lists that each client previously duplicated.
- **New `Acknowledgements` component** (`Client.Core/Components/Common`): a third-party attribution / license notice grouping dependencies into Runtime packages, Development & testing, IDE extensions, SDKs & tooling, and CI/CD & deployment. Each entry links to its home and source repository and shows its SPDX license. Entries are wrapped in the template's conditional markers (Redis, Aspire, database provider, SignalR, etc.) so only the dependencies that actually ship are listed.
- **Web / MAUI / Windows `AboutPage.razor`**: switched to `AppInfoCard` + `Acknowledgements`, with the per-client guidance moved into the card's `Note`.

## Related Issue

Closes #12666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable app information card displaying app identity, version, platform, environment, process details, and optional device information.
  - Added an acknowledgements page section with categorized dependency listings, license details, and source repository links.
  - Added contextual informational content to About pages.

- **Improvements**
  - Refreshed About pages across supported platforms with a more consistent, structured layout.
  - Improved visual styling for app details, dependency cards, badges, and informational sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->