### PR TITLE
Add CD pipelines for Bmotion and Brouter WASM demos #12691

### DIFF
--- a/.github/workflows/bmotion.demo.cd.yml
+++ b/.github/workflows/bmotion.demo.cd.yml
@@ -1,0 +1,40 @@
+name: Bmotion Demo CD
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  deploy_blazor_wasm_standalone:
+    name: build blazor wasm standalone
+    runs-on: ubuntu-24.04
+
+    steps:
+
+    - name: Checkout source code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+          persist-credentials: false
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+      with:
+        global-json-file: src/global.json
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+
+    - name: Install wasm
+      run:  cd src && dotnet workload install wasm-tools
+
+    - name: Publish
+      run: dotnet publish src/Bmotion/Bit.Bmotion.Demos/Bit.Bmotion.Demos.csproj -c Release -o client -p:Version="${{ vars.APP_VERSION}}" -p:InvariantGlobalization=true
+
+    - name: Upload to asw
+      run: |
+          npm install -g @azure/static-web-apps-cli
+          swa deploy --deployment-token ${{ secrets.BMOTION_ASW_TOKEN }} --env production --app-location client/wwwroot

--- a/.github/workflows/brouter.demo.cd.yml
+++ b/.github/workflows/brouter.demo.cd.yml
@@ -1,0 +1,42 @@
+name: Brouter Demo CD
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  build_blazor_wasm:
+    name: build blazor wasm
+    runs-on: ubuntu-24.04
+
+    steps:
+
+    - name: Checkout source code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+          persist-credentials: false
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+      with:
+        global-json-file: src/global.json
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+
+    - name: Install wasm
+      run:  cd src && dotnet workload install wasm-tools
+
+    - name: Publish
+      run: dotnet publish src/Brouter/InteralDemos/Wasm/Bit.Brouter.Demos.Wasm/Bit.Brouter.Demos.Wasm.csproj -c Release -o server -p:Version="${{ vars.APP_VERSION}}" -p:InvariantGlobalization=true
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: BrouterDemo
+        path: server
+        include-hidden-files: true


### PR DESCRIPTION
## Summary
Adds two manually triggered (`workflow_dispatch`) CD pipelines so the Bmotion demo and the Brouter WASM demo can be built from CI instead of a developer machine.

## Changes
- `.github/workflows/bmotion.demo.cd.yml`: publishes `Bit.Bmotion.Demos` (Blazor WASM standalone) and deploys `client/wwwroot` to Azure Static Web Apps via the SWA CLI using the `BMOTION_ASW_TOKEN` secret. Node is installed because the `Bit.Bmotion` build runs `npm ci` + tsc/esbuild to produce `bit-bmotion.js`.
- `.github/workflows/brouter.demo.cd.yml`: publishes `Bit.Brouter.Demos.Wasm` and uploads the result as the `BrouterDemo` GitHub artifact for manual download and deployment.
- Both publish with `-p:InvariantGlobalization=true` to reduce the payload size, and reuse the same pinned action SHAs as the existing CD workflows.

Note: the `BMOTION_ASW_TOKEN` repository secret needs to be added before the Bmotion workflow can run successfully.

## Related Issue
This closes #12691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manually triggered deployment automation for the Bmotion Demo to Azure Static Web Apps.
  * Added a build workflow for the Brouter Demo that publishes and stores a deployable artifact.
  * Demo builds now include the configured application version and optimized WebAssembly output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->