### PR TITLE
Fix parent item toggle issue in nav (#12694)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/_BitNavChild.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/_BitNavChild.razor
@@ -124,7 +124,7 @@
             {
                 <_BitNavItemContainer Href="@href"
                                       Target="@target"
-                                      OnClick="() => HandleOnClick(renderLink)"
+                                      OnClick="HandleOnClick"
                                       RenderLink="renderLink"
                                       Disabled="@(isEnabled is false)"
                                       AriaLabel="@Nav.GetAriaLabel(Item)"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/_BitNavChild.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Navs/Nav/_BitNavChild.razor.cs
@@ -20,7 +20,11 @@ public partial class _BitNavChild<TItem> where TItem : class
 
 
 
-    private async Task HandleOnClick(bool renderLink)
+    // Method group (not a closure) so the EventCallback stays delegate-equal across renders and the DOM
+    // click handler id survives re-renders; a per-render lambda gets disposed/recreated on each render,
+    // making clicks that race a re-render (e.g. the swipe-trap pointerup re-render in BitNavPanel)
+    // dispatch a stale handler id and silently fail on WebAssembly.
+    private async Task HandleOnClick()
     {
         if (Nav is null) return;
         if (Nav.GetIsEnabled(Item) is false) return;
@@ -36,7 +40,7 @@ public partial class _BitNavChild<TItem> where TItem : class
 
         if (Nav.SelectedItem != Item || Nav.Reselectable)
         {
-            if (renderLink)
+            if (Nav.GetUrl(Item).HasValue() || Nav.GetForceAnchor(Item))
             {
                 await Task.Yield(); // wait for the link to navigate first
             }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
@@ -181,6 +181,37 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitNavPanelParentItemBodyClickShouldToggleExpansion()
+    {
+        IList<BitNavItem> items =
+        [
+            new() { Text = "Home", Url = "/home" },
+            new()
+            {
+                Text = "AdminPanel",
+                ChildItems =
+                [
+                    new() { Text = "Dashboard", Url = "/dashboard" },
+                    new() { Text = "Categories", Url = "/categories" },
+                ]
+            }
+        ];
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+        });
+
+        var parentButton = component.FindAll(".bit-nav-ict")[1];
+
+        parentButton.Click();
+        component.WaitForAssertion(() => Assert.AreEqual(4, component.FindAll(".bit-nav-ict").Count));
+
+        component.FindAll(".bit-nav-ict")[1].Click();
+        component.WaitForAssertion(() => Assert.AreEqual(2, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
     public void BitNavPanelShouldRenderSearchBoxByDefault()
     {
         var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/Nav/BitNavTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Navs/Nav/BitNavTests.cs
@@ -213,6 +213,36 @@ public class BitNavTests : BunitTestContext
         }
     }
 
+    [TestMethod]
+    public void BitNavParentItemBodyClickShouldToggleExpansion()
+    {
+        var items = new List<BitNavItem>
+        {
+            new()
+            {
+                Text = "AdminPanel",
+                ChildItems = new List<BitNavItem>
+                {
+                    new() { Text = "Dashboard", Url = "/dashboard" },
+                    new() { Text = "Categories", Url = "/categories" },
+                }
+            }
+        };
+
+        var component = RenderComponent<BitNav<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+        });
+
+        var parentButton = component.Find(".bit-nav-ict");
+
+        parentButton.Click();
+        Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count);
+
+        parentButton.Click();
+        Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count);
+    }
+
     private List<BitNavItem> BasicNavLinks = new List<BitNavItem>()
     {
         new BitNavItem { Text = "Activity", Url = "http://msn.com", Target = "_blank" },


### PR DESCRIPTION
closes #12694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parent navigation item body clicks so child items expand and collapse consistently.
  * Improved click handling for navigation items with links and forced anchors.

* **Tests**
  * Added coverage confirming expansion and collapse behavior in navigation panels and navigation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->