### PR TITLE
Add Junie and Gemini agent instruction files #12710

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.junie/guidelines.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.junie/guidelines.md
@@ -1,0 +1,5 @@
+# Junie Guidelines
+
+This project uses @AGENTS.md (at the repository root) as the single source of truth for all coding conventions, project structure, technology stack, and behavioral directives.
+
+**Before performing any task, read the full content of `/AGENTS.md`.**

--- a/src/Templates/Boilerplate/Bit.Boilerplate/GEMINI.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/GEMINI.md
@@ -1,0 +1,5 @@
+# Gemini Instructions
+
+This project uses @AGENTS.md (at the repository root) as the single source of truth for all coding conventions, project structure, technology stack, and behavioral directives.
+
+**Before performing any task, read the full content of `/AGENTS.md`.**


### PR DESCRIPTION
## Summary
Adds the well-known agent instruction files for JetBrains Junie (Rider / IntelliJ) and Gemini CLI to the bit Boilerplate project template, so those assistants pick up the project conventions that already live in `AGENTS.md`.

## Changes
- Add `.junie/guidelines.md`, redirecting Junie to `AGENTS.md`.
- Add `GEMINI.md`, redirecting Gemini CLI to `AGENTS.md`.

Both files are intentionally thin pointers, so `AGENTS.md` remains the single source of truth alongside the existing `CLAUDE.md` and `.github/copilot-instructions.md`. `.vscode/settings.json` already nests `GEMINI.md` under `AGENTS.md`, so no explorer-nesting change is needed.

## Related Issue
This closes #12710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added initial guidance to the boilerplate’s AI instruction documentation.
  - Established the repository-level `AGENTS.md` as the central source for coding conventions and directives.
  - Added instructions to review these conventions before beginning work, improving consistency across AI-assisted tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->