### PR TITLE
fix(pipeline): wiki workflow stops commenting due to stateless MCP server #12714

### DIFF
--- a/.github/workflows/wiki.sh
+++ b/.github/workflows/wiki.sh
@@ -2,32 +2,17 @@
 
 # This script performs the full MCP query and prints the final URL as its output.
 
+set -euo pipefail
+
 # Combine issue title and body from environment variables provided by the workflow.
 QUESTION="Title: $ISSUE_TITLE. Body: $ISSUE_BODY"
 
 # The URL of the MCP tool endpoint.
 url="https://mcp.deepwiki.com/mcp"
 
-# Step 1: Initialize session and capture the session ID from server headers.
-session_id=$(curl -s --dump-header - -X POST \
--H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
--d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"GitHubActionClient","version":"1.0.2"},"capabilities":{}}}' \
-"$url" -o /dev/null | grep -i '^mcp-session-id:' | cut -d ':' -f 2 | tr -d '[:space:]')
-
-# Exit if the session ID could not be retrieved.
-if [ -z "$session_id" ]; then
-  exit 1
-fi
-
-# Step 2: Send the 'initialized' notification to the server.
-curl -s -X POST \
--H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
--H "Mcp-Session-Id: $session_id" \
--d '{"jsonrpc":"2.0","method":"initialized","params":{}}' \
-"$url" > /dev/null
-
-# Step 3: Use jq to safely construct the JSON payload.
-# We pass the question as an argument to jq to avoid shell interpretation issues.
+# The server runs in stateless mode, so no initialize/initialized handshake is needed.
+# Use jq to safely construct the JSON payload, passing the question as an argument
+# to avoid shell interpretation issues.
 JSON_PAYLOAD=$(jq -n \
   --arg question "$QUESTION" \
   '{
@@ -43,9 +28,18 @@ JSON_PAYLOAD=$(jq -n \
     }
   }')
 
-# Step 4: Send the final query, extract the URL, and replace the domain.
-curl -s -X POST \
--H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
--H "Mcp-Session-Id: $session_id" \
--d "$JSON_PAYLOAD" \
-"$url" | grep -o 'https://deepwiki.com/search/[^"]*' | sed 's|https://deepwiki.com|https://wiki.bitplatform.dev|'
+# Send the query. A transport level failure here fails the whole step.
+RESPONSE=$(curl -s --fail-with-body -X POST \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d "$JSON_PAYLOAD" \
+  "$url")
+
+# Extract the first URL and replace the domain.
+# The URL is embedded in a JSON string, so stop at the first quote or backslash
+# (the response terminates the URL with an escaped newline).
+# An empty result is not an error, it just means no comment gets posted.
+# The trailing `|| true` keeps a no-match grep from tripping `pipefail`.
+echo "$RESPONSE" \
+  | { grep -o 'https://deepwiki\.com/search/[^"\\]*' || true; } \
+  | head -n 1 \
+  | sed 's|https://deepwiki.com|https://wiki.bitplatform.dev|'

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -26,7 +26,10 @@ jobs:
         id: run-mcp-query
         run: |
           chmod +x ./.github/workflows/wiki.sh
-          echo "wiki_url=$(./.github/workflows/wiki.sh)" >> $GITHUB_OUTPUT
+          # Assign first so a failing script fails this step instead of silently
+          # producing an empty output and skipping the comment.
+          wiki_url=$(./.github/workflows/wiki.sh)
+          echo "wiki_url=$wiki_url" >> $GITHUB_OUTPUT
         env:
           ISSUE_TITLE: ${{ github.event.issue.title || github.event.discussion.title }}
           ISSUE_BODY: ${{ github.event.issue.body || github.event.discussion.body }}


### PR DESCRIPTION
## Summary
The `bitplatform wiki` workflow stopped commenting on new issues and discussions because DeepWiki's MCP server moved to stateless mode. This restores it and makes the failure mode loud instead of silent.

## Changes
- Removed the MCP `initialize` / `initialized` handshake from `wiki.sh`. The server (`DeepWiki 2.14.3`) no longer returns an `mcp-session-id` response header, so the session-ID guard aborted the script on every run. A plain `tools/call` with no session header works.
- `wiki.yml` now assigns the script output to a variable before writing `$GITHUB_OUTPUT`, so a failing script fails the step. Previously the exit code came from `echo` and the job stayed green while the `Write comment` step was silently skipped.
- Tightened the URL pattern to `[^"\\]*` plus `head -n 1`, so the escaped newline the server now appends no longer ends up inside the link.
- Added `set -euo pipefail` and `curl --fail-with-body` so transport-level errors surface. A no-match `grep` is still tolerated, since "no wiki page found" should skip the comment rather than fail the job.

## Verification
Local Git Bash on the authoring machine could not fork processes, so the script was not executed end to end. The underlying HTTP call and extraction pipeline were verified against the live endpoint:

- `initialize` returns `200 OK` with no `mcp-session-id` header, confirming the root cause.
- A stateless `tools/call` returns the answer, and the new pattern yields a clean `https://wiki.bitplatform.dev/search/...` with no trailing `\n`.

End-to-end confirmation will come from the next issue opened after merge.

## Related Issue
This closes #12714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated documentation link generation to handle request failures more reliably.
  - Updated search result processing to select and convert the relevant documentation link consistently.
  - Workflow steps now stop when link retrieval fails instead of continuing with an empty result, improving the accuracy of published documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->