### PR TITLE
Fix style issue of disabled toggled BitToggle (#12726)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Toggle/BitToggle.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Toggle/BitToggle.scss
@@ -40,7 +40,7 @@
             }
 
             .bit-tgl-sta {
-                background-color: $clr-bg-dis;
+                background-color: $clr-fg-dis;
             }
         }
     }


### PR DESCRIPTION
closes #12726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance of disabled, checked toggle buttons by applying the correct disabled text and icon color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->