### PR TITLE
Make AddBitBrouterServices method idempotent (#12729)

### DIFF
--- a/src/Brouter/Bit.Brouter/BitBrouter.cs
+++ b/src/Brouter/Bit.Brouter/BitBrouter.cs
@@ -6,50 +6,39 @@ namespace Bit.Brouter;
 public static class BitBrouter
 {
     /// <summary>
-    /// Marker singleton registered exactly once by <see cref="AddBitBrouterServices"/> so the
-    /// "called more than once" check is unambiguous. Probing for <see cref="BrouterOptions"/>
-    /// is brittle: any other library that happens to register a <c>BrouterOptions</c> service
-    /// (or a future change that swaps the registration shape) would falsely trip the guard.
-    /// A dedicated marker type avoids both of those failure modes.
-    /// </summary>
-    private sealed class BitBrouterMarker { }
-
-    /// <summary>
     /// Registers the services required by Bit.Brouter, including <see cref="IBrouter"/> for
     /// programmatic navigation, named-route resolution and global navigation hooks.
     /// </summary>
+    /// <remarks>
+    /// This method is idempotent, matching the convention every <c>Add*Services</c> extension in
+    /// the .NET ecosystem follows: calling it more than once on the same
+    /// <paramref name="services"/> instance never produces duplicate registrations, so a library
+    /// and the host app can each call it without coordinating. The service registrations are made
+    /// with <c>TryAdd</c>, which also means a caller that registered its own
+    /// <see cref="IBrouter"/> / <see cref="BrouterService"/> beforehand keeps it.
+    /// <para>
+    /// The optional <paramref name="configure"/> callback follows the standard Options pattern and
+    /// is <i>additive</i>: every callback passed across all calls runs, in call order, on the same
+    /// <see cref="BrouterOptions"/> instance. Nothing is silently discarded, and later calls win on
+    /// any property they set. Note that <see cref="BrouterConstraintRegistry.Register"/> rejects a
+    /// duplicate constraint name, so if two call sites register the same custom constraint name,
+    /// prefer registering it from a single place (or guard it) rather than relying on the last one
+    /// winning.
+    /// </para>
+    /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when this method has already been called on the same <paramref name="services"/>
-    /// instance. Calling it twice is almost always a configuration bug; if you genuinely want
-    /// to add additional <see cref="BrouterOptions"/> configuration after the fact, call
-    /// <c>services.Configure&lt;BrouterOptions&gt;(...)</c> directly instead.
-    /// </exception>
     public static IServiceCollection AddBitBrouterServices(this IServiceCollection services,
                                                            Action<BrouterOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // Use a dedicated marker rather than probing for BrouterOptions so we don't
-        // misidentify foreign registrations of the same type as a duplicate call.
-        for (int i = 0; i < services.Count; i++)
-        {
-            if (services[i].ServiceType == typeof(BitBrouterMarker))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(AddBitBrouterServices)} has already been called on this service collection. " +
-                    "Bit.Brouter services must only be registered once to avoid silently discarding configuration. " +
-                    "If you need to add more configuration after the fact, call services.Configure<BrouterOptions>(...) directly.");
-            }
-        }
-
         // Use the standard Options pattern so callers can compose configuration from multiple
         // sources (e.g. appsettings binding + a Configure callback), use IOptionsMonitor for
         // change notifications in long-running processes, and integrate with PostConfigure.
+        // AddOptions itself is idempotent, and Configure is additive by design.
         var optionsBuilder = services.AddOptions<BrouterOptions>();
         if (configure is not null) optionsBuilder.Configure(configure);
 
-        services.AddSingleton(new BitBrouterMarker());
         services.TryAddScoped<BrouterService>();
         services.TryAddScoped<IBrouter>(sp => sp.GetRequiredService<BrouterService>());
         return services;

--- a/src/Brouter/Tests/Bit.Brouter.Tests/ServiceRegistrationTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+[TestClass]
+public class ServiceRegistrationTests
+{
+    [TestMethod]
+    public void AddBitBrouterServices_is_idempotent()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBitBrouterServices();
+        services.AddBitBrouterServices();
+
+        var brouter = services.Single(d => d.ServiceType == typeof(IBrouter));
+        var service = services.Single(d => d.ServiceType == typeof(BrouterService));
+
+        Assert.AreEqual(ServiceLifetime.Scoped, brouter.Lifetime);
+        Assert.AreEqual(ServiceLifetime.Scoped, service.Lifetime);
+    }
+
+    [TestMethod]
+    public void AddBitBrouterServices_applies_every_configure_callback_in_call_order()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBitBrouterServices(o => { o.CaseSensitive = true; o.MaxLoaderCacheEntries = 111; });
+        services.AddBitBrouterServices(o => o.MaxLoaderCacheEntries = 222);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<BrouterOptions>>().Value;
+
+        Assert.IsTrue(options.CaseSensitive);            // set only by the first call, not discarded
+        Assert.AreEqual(222, options.MaxLoaderCacheEntries); // the later call wins
+    }
+
+    [TestMethod]
+    public void AddBitBrouterServices_keeps_a_previously_registered_IBrouter()
+    {
+        var services = new ServiceCollection();
+        var custom = new CustomBrouterProbe();
+        services.AddScoped<IBrouter>(_ => custom);
+
+        services.AddBitBrouterServices();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.AreSame(custom, scope.ServiceProvider.GetRequiredService<IBrouter>());
+    }
+
+    private sealed class CustomBrouterProbe : IBrouter
+    {
+        public BrouterLocation Location => throw new NotSupportedException();
+        public void Navigate(string url, bool replace = false, bool forceLoad = false, string? historyState = null) => throw new NotSupportedException();
+        public void Back() => throw new NotSupportedException();
+        public void NavigateToName(string name, IReadOnlyDictionary<string, object?>? parameters = null,
+                                   string? query = null, bool replace = false, string? historyState = null) => throw new NotSupportedException();
+        public string ResolveUrl(string name, IReadOnlyDictionary<string, object?>? parameters = null, string? query = null) => throw new NotSupportedException();
+        public event Func<BrouterNavigationContext, ValueTask>? OnNavigating { add { } remove { } }
+        public event Func<BrouterNavigationContext, ValueTask>? OnNavigated { add { } remove { } }
+        public event Func<BrouterNavigationContext, Exception?, ValueTask>? OnError { add { } remove { } }
+    }
+}


### PR DESCRIPTION
closes #12729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Service registration can now be safely called multiple times without creating duplicate registrations.
  - Existing custom `IBrouter` and `BrouterService` registrations are preserved.
  - Multiple configuration callbacks are supported, applied in call order, with later settings taking precedence.
  - Service lifetimes and null-argument validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->