### PR TITLE
Add missing installation guide to Brouter demo (#12731)

### DIFF
--- a/src/Brouter/Demos/Core/Pages/GeneratorPage.razor
+++ b/src/Brouter/Demos/Core/Pages/GeneratorPage.razor
@@ -27,9 +27,20 @@
         (<code>Path="@@expr"</code>) can't be known at compile time, so that tag and everything
         beneath it is skipped.
     </p>
-    <pre class="bb-code"><span class="c">&lt;!-- Bit.Brouter.Demos.Core.csproj - referenced as an analyzer: --&gt;</span>
-&lt;<span class="k">ProjectReference</span> Include=<span class="s">"..\Bit.Brouter.Generators\Bit.Brouter.Generators.csproj"</span>
-                  OutputItemType=<span class="s">"Analyzer"</span> ReferenceOutputAssembly=<span class="s">"false"</span> /&gt;</pre>
+    <pre class="bb-code"><span class="c"># Add the router and the generator to your Blazor project:</span>
+dotnet add package Bit.Brouter
+dotnet add package Bit.Brouter.Generators
+
+<span class="c">&lt;!-- ...or declare them in your .csproj. Bit.Brouter.Generators is an analyzer-only
+     package (it ships no runtime assembly), so PrivateAssets="all" keeps it out of
+     your own package's dependencies: --&gt;</span>
+&lt;<span class="k">PackageReference</span> Include=<span class="s">"Bit.Brouter"</span> Version=<span class="s">"10.5.0"</span> /&gt;
+&lt;<span class="k">PackageReference</span> Include=<span class="s">"Bit.Brouter.Generators"</span> Version=<span class="s">"10.5.0"</span> PrivateAssets=<span class="s">"all"</span> /&gt;</pre>
+    <p class="bb-card-desc">
+        Nothing else is wired up by hand: the package drops the generator into the compiler, and
+        the very next build emits <code>BrouterRoutes</code> from the routes already declared in
+        your project. No tool to run, no file to check in.
+    </p>
     <p class="bb-card-desc">
         The output is a single <code>static partial class BrouterRoutes</code> in your project's
         root namespace (<code>BrouterRoutes.g.cs</code>). Duplicate templates across files are

--- a/src/Brouter/Demos/Core/Pages/HomePage.razor
+++ b/src/Brouter/Demos/Core/Pages/HomePage.razor
@@ -14,8 +14,25 @@
 <div class="bb-card">
     <h3 class="bb-card-title"><span class="bb-dot bb-dot-primary"></span> Getting started</h3>
     <p class="bb-card-desc">
-        Register the services, then declare routes in markup with <code>&lt;Brouter&gt;</code> and
-        <code>&lt;Broute&gt;</code>. Templates are a superset-compatible match of the built-in
+        Install the package into your Blazor app. <code>Bit.Brouter</code> targets net8.0, net9.0
+        and net10.0, and brings its own JavaScript along as a static web asset - there is no script
+        tag to add. The optional <code>Bit.Brouter.Generators</code> package is an analyzer-only
+        companion that generates the typed <code>BrouterRoutes</code> URL builders.
+    </p>
+    <pre class="bb-code"><span class="c"># The router itself:</span>
+dotnet add package Bit.Brouter
+
+<span class="c"># Optional - typed, compile-time-safe URL builders:</span>
+dotnet add package Bit.Brouter.Generators
+
+<span class="c">&lt;!-- ...or declare them in your .csproj. PrivateAssets="all" on the generator keeps
+     the analyzer out of your own package's dependencies: --&gt;</span>
+&lt;<span class="k">PackageReference</span> Include=<span class="s">"Bit.Brouter"</span> Version=<span class="s">"10.5.0"</span> /&gt;
+&lt;<span class="k">PackageReference</span> Include=<span class="s">"Bit.Brouter.Generators"</span> Version=<span class="s">"10.5.0"</span> PrivateAssets=<span class="s">"all"</span> /&gt;</pre>
+    <p class="bb-card-desc">
+        Then register the services, add <code>@@using Bit.Brouter</code> to your
+        <code>_Imports.razor</code>, and declare routes in markup with <code>&lt;Brouter&gt;</code>
+        and <code>&lt;Broute&gt;</code>. Templates are a superset-compatible match of the built-in
         router's, so <code>@@page</code> components keep working - <code>AppAssembly</code>
         discovers them alongside the hand-declared tree.
     </p>


### PR DESCRIPTION
closes #12731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started instructions with explicit NuGet commands for installing `Bit.Brouter`.
  * Added optional setup instructions for `Bit.Brouter.Generators`.
  * Included package reference examples with version `10.5.0` and generator asset configuration.
  * Refined project setup guidance for adding routing and code generation to Blazor applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->