### PR TITLE
Correct response caching of origin-dependent and faulted responses #12733

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
@@ -150,18 +150,29 @@ Output cache still works correctly for multi-language scenarios.
 public async ValueTask CacheRequestAsync(OutputCacheContext context, CancellationToken cancellation)
 {
     var responseCacheAtt = context.HttpContext.GetResponseCacheAttribute();
-    
+
     if (responseCacheAtt is null) return;
 
-    // Default: SharedMaxAge = MaxAge if not specified
-    if (responseCacheAtt.SharedMaxAge == -1)
-    {
-        responseCacheAtt.SharedMaxAge = responseCacheAtt.MaxAge;
-    }
+    context.AllowLocking = true;
+    context.EnableOutputCaching = true;
 
-    var clientCacheTtl = responseCacheAtt.MaxAge;      // In-memory + Browser
-    var edgeCacheTtl = responseCacheAtt.SharedMaxAge;  // CDN Edge
-    var outputCacheTtl = responseCacheAtt.SharedMaxAge; // ASP.NET Core Output Cache
+    // What the output cache keys on, besides the request path:
+    context.CacheVaryByRules.QueryKeys = "*";
+    context.CacheVaryByRules.VaryByHost = true;
+    context.CacheVaryByRules.HeaderNames = new[] { HeaderNames.Origin, "X-Origin" };
+    context.CacheVaryByRules.VaryByValues.Add("Culture", CultureInfo.CurrentUICulture.Name);
+
+    // Multi-tenant: an authenticated request resolves its tenant from the user's claim rather than from the
+    // host, and tenant scoped entities are filtered by it, so two tenants on one host must not share an entry.
+    if (context.HttpContext.User.GetTenantId() is Guid currentTenantId)
+        context.CacheVaryByRules.VaryByValues.Add("Tenant", currentTenantId.ToString());
+
+    // SharedMaxAge falls back to MaxAge when it isn't set
+    var sharedMaxAge = responseCacheAtt.SharedMaxAge == -1 ? responseCacheAtt.MaxAge : responseCacheAtt.SharedMaxAge;
+
+    var clientCacheTtl = responseCacheAtt.MaxAge;  // In-memory + Browser
+    var edgeCacheTtl = sharedMaxAge;               // CDN Edge
+    var outputCacheTtl = sharedMaxAge;             // ASP.NET Core Output Cache
 
     // Disable CDN edge if configured
     if (settings.ResponseCaching?.EnableCdnEdgeCaching is false)
@@ -182,13 +193,48 @@ public async ValueTask CacheRequestAsync(OutputCacheContext context, Cancellatio
         outputCacheTtl = -1;
     }
 
+    // The entry is tagged with the request path only, without the query string: purging is done by bare path
+    // ("/product/5"), while QueryKeys = "*" gives every query string variant its own entry. Tagging those with
+    // their full PathAndQuery would leave "/product/5?utm_source=x" unpurgeable for the rest of its lifetime.
+    context.Tags.Add(new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).AbsolutePath.ToLowerInvariant());
+
     // ... set cache headers and output cache policy
 }
 ```
 
+**Responses that are never stored:** a response is kept out of every cache unless it is a `200 OK` that hands out no
+cookies (the culture cookie is exempt, since the cache varies by culture anyway). That keeps a 404 for a product created
+a minute later from surviving on the edge for days, and keeps one caller's cookies from being replayed to everybody else.
+This is enforced twice - by an `OnStarting` callback that downgrades `Cache-Control` to `no-store, private` for browsers
+and CDNs, and by clearing `AllowCacheStorage` in `ServeResponseAsync` for the output cache.
+
+**Telling shared caches what to vary on:**
+
+The output cache keys on `Origin` and `X-Origin`, so the response advertises them too:
+
+```
+Vary: Origin, X-Origin
+```
+
+- `Origin` - the CORS middleware runs before the output cache middleware and echoes the caller's origin into
+  `Access-Control-Allow-Origin`. Without the vary, the first caller's value would be replayed to every other origin and
+  their browsers would reject it.
+- `X-Origin` - the header a Blazor Hybrid / standalone WASM client sends to tell the backend which web app url it is
+  running under (See `HttpRequestExtensions.GetWebAppUrl`), which can end up embedded in the response.
+
+> **A CDN may ignore `Vary`.** Cloudflare does not consider it in caching decisions unless the header is
+> `Accept-Encoding`, or a **Cache Rules → Vary** setting naming `origin` / `x-origin` has been configured on the zone.
+> Without that rule the edge keeps a single variant per URL and hands it to callers of every origin. Configure it before
+> turning `EnableCdnEdgeCaching` on.
+
 **Important Security Note:**
 
 The `UserAgnostic` property is critical for security. If a response contains user-specific data (e.g., user's name, roles, or tenant information), it **must not** be cached in shared caches (CDN edge or output cache). Setting `UserAgnostic = true` is only safe when the response is identical for all users.
+
+> **Multi-tenant + CDN edge:** the `Tenant` discriminator above is part of the **ASP.NET Core output cache key only** -
+> `VaryByValues` never becomes a response header, so a CDN cannot see it. The output cache therefore keeps tenants apart
+> correctly, but an edge cache keyed on host + path does not. Until the tenant is part of the URL or the host, treat
+> `UserAgnostic = true` together with `EnableCdnEdgeCaching` as unsafe for any response whose body is tenant-filtered.
 
 ---
 
@@ -215,10 +261,10 @@ public partial class ResponseCacheService
     /// </summary>
     public async Task PurgeCache(params string[] relativePaths)
     {
-        // Purge from ASP.NET Core output cache
+        // Purge from ASP.NET Core output cache. Lowercased to match the tag the policy writes.
         foreach (var relativePath in relativePaths)
         {
-            await outputCacheStore.EvictByTagAsync(relativePath, default);
+            await outputCacheStore.EvictByTagAsync(relativePath.ToLowerInvariant(), default);
         }
         
         // Purge from Cloudflare CDN
@@ -231,9 +277,9 @@ public partial class ResponseCacheService
     public async Task PurgeProductCache(int shortId)
     {
         await PurgeCache(
-            "/",                                  // Home page (may list products)
-            $"/product/{shortId}",                // Product detail page
-            $"/api/ProductView/Get/{shortId}"     // Product API endpoint
+            "/",                                     // Home page (may list products)
+            $"/product/{shortId}",                   // Product detail page
+            $"/api/v1/ProductView/Get/{shortId}"     // Product API endpoint
         );
     }
 }
@@ -282,7 +328,7 @@ public string? GetPrimaryMediumImageUrl(Uri absoluteServerAddress)
     return HasPrimaryImage is false
         ? null
         : new Uri(absoluteServerAddress, 
-            $"/api/Attachment/GetAttachment/{Id}/{AttachmentKind.ProductPrimaryImageMedium}?v={Version}")
+            $"/api/v1/Attachment/GetAttachment/{Id}/{AttachmentKind.ProductPrimaryImageMedium}?v={Version}")
             .ToString();
 }
 ```
@@ -477,9 +523,43 @@ This prevents accidentally serving User A's data to User B through shared caches
       "https://sales.bitplatform.com",
       "https://sales.bitplatform.uk"
     ]
+  },
+  // Shared/appsettings.json - shared by the server AND every client (WASM, MAUI, Windows)
+  "MemoryCache": {
+    "SizeLimit": 268435456  // 256 MB, in bytes
   }
 }
 ```
+
+Both `ResponseCaching` flags default to `false`. Turn `EnableCdnEdgeCaching` on only after reading the `Vary` and
+multi-tenant notes above.
+
+---
+
+## The L1 Memory Budget
+
+Layers 1 and 4 (Client In-Memory Cache and Output Cache) both live in the app's single `IMemoryCache`, which is bounded
+by `MemoryCache:SizeLimit` in `Shared/appsettings.json` and implemented by `AppMemoryCache`.
+
+**The unit is bytes, not entries.** That matters, because the three kinds of entry are charged differently:
+
+| Entry | Charged | Set by |
+|---|---|---|
+| Output cache response body | its exact length | `FusionOutputCacheStore` (`AddFusionOutputCache`) |
+| Client in-memory cached response | its exact length | `CacheDelegatingHandler` |
+| Everything else (FusionCache data entries, 3rd party libraries) | `AppMemoryCache.EstimatedEntrySizeInBytes` (4 KB) | `WithDefaultEntryOptions` / `AppMemoryCache.CreateEntry` |
+
+The flat 4 KB estimate is deliberately generous: charging an entry too much only means fewer of them fit, while charging
+too little lets the cache outgrow the limit it exists to enforce. At 256 MB the budget holds roughly 65k estimated
+entries, minus whatever the cached response bodies take.
+
+**Why not count entries instead?** Because the output cache stores whole response bodies here. A single pre-rendered
+page or attachment would otherwise cost the same one unit as a small dictionary, letting one big response quietly
+consume a budget sized for tens of thousands of small ones - or, worse, be silently rejected once the limit was reached,
+turning output caching into a no-op with no error anywhere.
+
+If you raise `SizeLimit`, remember the same value ships to the clients: it also bounds the Blazor Hybrid / WASM app's
+in-process cache on a phone, not just the server's.
 
 ---
 
@@ -527,6 +607,7 @@ This shows the TTL (in seconds) for each cache layer. Use browser DevTools Netwo
 
 ```
 Cache-Control: public, max-age=300, s-maxage=3600
+Vary: Origin, X-Origin
 App-Cache-Response: Output:3600,Edge:3600,Client:300
 ```
 
@@ -534,6 +615,28 @@ Interpretation:
 - `max-age=300`: Browser and in-memory cache for 5 minutes
 - `s-maxage=3600`: CDN edge and output cache for 1 hour
 - `public`: Can be cached in shared caches (CDN)
+- `Vary`: the request headers a shared cache must include in its key
+- `Output:-1` (or `Edge:-1` / `Client:-1`) means that layer was disabled for this request - by configuration, by the
+  caller being authenticated on a non-`UserAgnostic` endpoint, or by the request being a pre-rendered Blazor page
+
+A response that turns out not to be cacheable (anything other than `200 OK`, or one that sets a cookie) is downgraded to
+`Cache-Control: no-store, private` on its way out, regardless of what `App-Cache-Response` announced earlier in the
+request.
+
+---
+
+### Automated Test
+
+`src/Tests/Features/Caching/ProductResponseCacheTests.cs` exercises the whole loop end to end with
+`EnableOutputCaching` and `PrerenderEnabled` both on: it fills the output cache from two directions (the tenant-user
+calling the `UserAgnostic` product API, and an anonymous visitor loading the pre-rendered product page), has the
+tenant-admin edit the product through `ProductController.Update` and asserts both readers see the change immediately,
+then deletes the row straight from the database and asserts both readers keep being served the deleted product - the
+proof that the responses are coming from the cache and not the database.
+
+Note it needs `ProductController` (Admin module) and `ProductViewController` (Sales module) at the same time, and
+`module` is a single-choice template parameter, so it is excluded from generated projects and only runs against the
+template's own source tree.
 
 ---
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -449,7 +449,11 @@
                         "**/.git/**",
                         "**/*.nuspec",
                         "src/Server/**/Data/Migrations/**",
-                        "src/**/App_Data/**"
+                        "src/**/App_Data/**",
+                        // Needs ProductController (Admin module) and ProductViewController + the product page (Sales
+                        // module) at once, and "module" is a single choice, so it can only ever run against the
+                        // template's own source tree.
+                        "src/Tests/Features/Caching/ProductResponseCacheTests.cs"
                     ]
                 },
                 {
@@ -547,7 +551,8 @@
                         "src/Tests/Features/Identity/PhoneNumberNormalizationUITests.cs",
                         "src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs",
                         "src/Tests/Features/OpenApi/OpenApiScalarIntegrationTests.cs",
-                        "src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs"
+                        "src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs",
+                        "src/Tests/Features/Caching/ProductResponseCacheTests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Routes.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Routes.razor
@@ -6,7 +6,7 @@
             <AppRouter AppAssembly="@GetType().Assembly"
                        AdditionalAssemblies="@(AssemblyLoadContext.Default.Assemblies.Where(asm => asm.GetName().Name?.Contains("Boilerplate.Client") is true))">
                 @*#if (brouter == true)*@
-                <ChildContent>
+                <Routes>
                     @*#if (module == "Admin")*@
                     @* Keep-alive: pages that host a BitDataGrid whose add/edit lives on a separate page
                        (e.g. ProductsPage -> AddOrEditProductPage) keep their grid state - current page,
@@ -16,7 +16,7 @@
                     <Broute KeepAlive Path="@PageUrls.Products" Component="@typeof(Boilerplate.Client.Core.Components.Pages.Products.ProductsPage)" />
                     <Broute KeepAlive Path="@("{culture?}" + PageUrls.Products)" Component="@typeof(Boilerplate.Client.Core.Components.Pages.Products.ProductsPage)" />
                     @*#endif*@
-                </ChildContent>
+                </Routes>
                 @*#endif*@
                 <Found Context="routeData">
                     <AppRouteDataPublisher RouteData="@routeData" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
@@ -54,7 +54,7 @@ internal class CacheDelegatingHandler(IMemoryCache memoryCache, HttpMessageHandl
                     LogScopeData = logScopeData.ToDictionary()
                 }, options: new()
                 {
-                    Size = 1,
+                    Size = responseContent.Length,
                     AbsoluteExpirationRelativeToNow = maxAge
                 });
             }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ExternalSignIn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ExternalSignIn.cs
@@ -9,8 +9,12 @@ public partial class IdentityController
     [AutoInject] private ApiServerExceptionHandler serverExceptionHandler = default!;
     [AutoInject] private IAuthenticationSchemeProvider authenticationSchemeProvider = default!;
 
+    /// <summary>
+    /// Deliberately not cached: the returned URL embeds the caller's origin, which GetWebAppUrl resolves from the X-Origin
+    /// header. That header is part of neither the output cache's vary rules nor a CDN's cache key, so a cached response would
+    /// hand one origin's sign-in URL to a caller coming from another, sending the resulting sign-in link to the wrong origin.
+    /// </summary>
     [HttpGet]
-    [AppResponseCache(SharedMaxAge = 3600 * 24 * 7, MaxAge = 60 * 5)]
     public async Task<string> GetExternalSignInUri(string provider, string? returnUrl = null, int? localHttpPort = null, CancellationToken cancellationToken = default)
     {
         var uri = Url.Action(nameof(ExternalSignIn), new { provider, returnUrl, localHttpPort, origin = Request.GetWebAppUrl() })!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.WebAuthn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.WebAuthn.cs
@@ -1,6 +1,7 @@
 //+:cnd:noEmit
 using Fido2NetLib;
 using Fido2NetLib.Objects;
+using System.Buffers.Text;
 using Boilerplate.Shared.Features.Identity.Dtos;
 using Boilerplate.Server.Api.Features.Identity.Models;
 
@@ -40,18 +41,24 @@ public partial class IdentityController
             UserVerification = UserVerificationRequirement.Required,
         });
 
-        var key = new string([.. options.Challenge.Select(b => (char)b)]);
-        await cache.SetAsync(key, options,
+        await cache.SetAsync(GetAssertionOptionsCacheKey(options.Challenge), options,
             options => options.Duration = TimeSpan.FromMinutes(3),
             cancellationToken);
 
         return options;
     }
 
+    /// <summary>
+    /// A WebAuthn challenge is raw bytes, so it's base64url encoded to keep the cache key printable.
+    /// Mapping each byte to a char instead would put NUL and control characters inside the Redis key,
+    /// making the entry unreadable in cache tooling and in logs.
+    /// </summary>
+    private static string GetAssertionOptionsCacheKey(byte[] challenge) => $"WebAuthn_AssertionOptions_{Base64Url.EncodeToString(challenge)}";
+
     [HttpPost]
     public async Task<VerifyAssertionResult> VerifyWebAuthAssertion(AuthenticatorAssertionRawResponse clientResponse, CancellationToken cancellationToken)
     {
-        var (verifyResult, _) = await Verify(clientResponse, cancellationToken);
+        var (verifyResult, _, _) = await Verify(clientResponse, cancellationToken);
 
         return verifyResult;
     }
@@ -59,14 +66,18 @@ public partial class IdentityController
     [HttpPost, Produces<SignInResponseDto>()]
     public async Task VerifyWebAuthAndSignIn(VerifyWebAuthnAndSignInRequestDto<AuthenticatorAssertionRawResponse> request, CancellationToken cancellationToken)
     {
-        var (verifyResult, credential) = await Verify(request.ClientResponse, cancellationToken);
+        var (verifyResult, credential, assertionOptionsCacheKey) = await Verify(request.ClientResponse, cancellationToken);
 
         var user = await userManager.FindByIdAsync(credential.UserId.ToString())
                     ?? throw new ResourceNotFoundException().WithData("Reason", "User not found.");
 
         var (otp, _) = await GenerateAutomaticSignInLink(user, null, "WebAuthn");
 
-        if (user.TwoFactorEnabled is false || request.TfaCode is not null)
+        // When two factor is enabled and no code has been supplied yet, SignIn below responds with RequiresTwoFactor and the
+        // client repeats this action with the code, verifying the very same client response. Only the final step is terminal.
+        var isFinalStep = user.TwoFactorEnabled is false || request.TfaCode is not null;
+
+        if (isFinalStep)
         {
             credential.SignCount = verifyResult.SignCount;
             DbContext.WebAuthnCredential.Update(credential);
@@ -74,12 +85,17 @@ public partial class IdentityController
         }
 
         await SignIn(new() { Otp = otp, TwoFactorCode = request.TfaCode }, user, cancellationToken);
+
+        if (isFinalStep)
+        {
+            await cache.RemoveAsync(assertionOptionsCacheKey, token: cancellationToken);
+        }
     }
 
     [HttpPost]
     public async Task VerifyWebAuthAndSendTwoFactorToken(AuthenticatorAssertionRawResponse clientResponse, CancellationToken cancellationToken)
     {
-        var (verifyResult, credential) = await Verify(clientResponse, cancellationToken);
+        var (verifyResult, credential, _) = await Verify(clientResponse, cancellationToken);
 
         var user = await userManager.FindByIdAsync(credential.UserId.ToString())
                     ?? throw new ResourceNotFoundException().WithData("Reason", "User not found.");
@@ -90,19 +106,15 @@ public partial class IdentityController
     }
 
 
-    private async Task<(VerifyAssertionResult, WebAuthnCredential)> Verify(AuthenticatorAssertionRawResponse clientResponse, CancellationToken cancellationToken)
+    private async Task<(VerifyAssertionResult VerifyResult, WebAuthnCredential Credential, string AssertionOptionsCacheKey)> Verify(AuthenticatorAssertionRawResponse clientResponse, CancellationToken cancellationToken)
     {
         var response = JsonSerializer.Deserialize(clientResponse.Response.ClientDataJson, jsonSerializerOptions.GetTypeInfo<AuthenticatorResponse>())
                         ?? throw new InvalidOperationException("Invalid client data.");
 
-        var key = new string([.. response.Challenge.Select(b => (char)b)]);
+        var key = GetAssertionOptionsCacheKey(response.Challenge);
         var options = await cache.GetOrSetAsync<AssertionOptions>(key,
             async _ => throw new ResourceNotFoundException().WithData("Reason", "Assertion options not found in cache."),
             token: cancellationToken);
-
-
-        // since the TFA needs this option we won't remove it from cache manually and just wait for it to expire.
-        // await cache.RemoveAsync(key, token: cancellationToken);
 
         var credential = (await DbContext.WebAuthnCredential.FirstOrDefaultAsync(c => c.Id == clientResponse.RawId, cancellationToken))
                             ?? throw new ResourceNotFoundException().WithData("Reason", "WebAuthn credential not found.");
@@ -116,7 +128,7 @@ public partial class IdentityController
             IsUserHandleOwnerOfCredentialIdCallback = IsUserHandleOwnerOfCredentialId
         }, cancellationToken);
 
-        return (verifyResult, credential);
+        return (verifyResult, credential, key);
     }
 
     private async Task<bool> IsUserHandleOwnerOfCredentialId(IsUserHandleOwnerOfCredentialIdParams args, CancellationToken cancellationToken)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
@@ -23,7 +23,7 @@ public partial class ResponseCacheService
     {
         foreach (var relativePath in relativePaths)
         {
-            await outputCacheStore.EvictByTagAsync(relativePath, default);
+            await outputCacheStore.EvictByTagAsync(relativePath.ToLowerInvariant(), default);
         }
         //#if (cloudflare == true)
         await PurgeCloudflareCache(relativePaths);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -77,9 +77,12 @@ public static class WebApplicationBuilderExtensions
                 .WithRegisteredDistributedCache()
                 .WithRegisteredDistributedLocker()
                 //#endif
-                .WithDefaultEntryOptions(options => options.Size = 1)
-                // Auto-clone cached objects to avoid further issues after scaling out and switching to distributed caching.
-                .WithOptions(options => options.DefaultEntryOptions.EnableAutoClone = true)
+                .WithDefaultEntryOptions(options => options.Size = AppMemoryCache.EstimatedEntrySizeInBytes)
+                // Auto-clone hands out a copy instead of the cached instance, so code that mutates what it reads from the cache
+                // breaks here the same way it would once you scale out and values start coming back deserialized from L2.
+                // It costs a serialize/deserialize per read though (including every output cache hit, since FusionOutputCacheStore
+                // shares these options), so it stays on in development to surface those bugs and off everywhere else.
+                .WithOptions(options => options.DefaultEntryOptions.EnableAutoClone = builder.Environment.IsDevelopment())
                 .WithSerializer(new FusionCacheSystemTextJsonSerializer())
                 .WithCacheKeyPrefix("Boilerplate:Cache:");
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
@@ -1,8 +1,9 @@
 //+:cnd:noEmit
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.OutputCaching;
-using Microsoft.Extensions.Hosting;
 
 namespace Boilerplate.Server.Shared.Infrastructure.Services;
 
@@ -26,21 +27,37 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
         context.EnableOutputCaching = true;
         context.CacheVaryByRules.QueryKeys = "*";
         context.CacheVaryByRules.VaryByHost = true;
+        // Origin is here because the CORS middleware runs before the output cache middleware and writes an
+        // Access-Control-Allow-Origin echoing the caller's Origin. The output cache stores and replays every response
+        // header (it only skips Request-Id, Content-Length and Age), so without this rule the first caller's
+        // Access-Control-Allow-Origin would be replayed to every other origin and their browsers would reject it.
+        context.CacheVaryByRules.HeaderNames = new[] { HeaderNames.Origin, "X-Origin" };
         if (CultureInfoManager.InvariantGlobalization is false)
         {
             context.CacheVaryByRules.VaryByValues.Add("Culture", CultureInfo.CurrentUICulture.Name);
         }
 
-        var requestUrl = new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).PathAndQuery;
-
-        if (responseCacheAtt.SharedMaxAge == -1)
+        //#if (multitenant == true)
+        // An authenticated request resolves its tenant from the user's claim rather than from the host (See TenantProvider),
+        // and tenant scoped entities are filtered by that tenant (See AppDbContext.ConfigureTenantAwareEntity). Without this
+        // rule two users of different tenants on the same host would share a single entry, so a UserAgnostic endpoint like
+        // ProductViewController would serve one tenant's rows to another.
+        if (context.HttpContext.User.GetTenantId() is Guid currentTenantId)
         {
-            responseCacheAtt.SharedMaxAge = responseCacheAtt.MaxAge;
+            context.CacheVaryByRules.VaryByValues.Add("Tenant", currentTenantId.ToString());
         }
+        //#endif
+
+        // Path only, without the query string: ResponseCacheService.PurgeCache is always called with bare paths ("/product/5"),
+        // while QueryKeys = "*" gives every query string variant its own entry. Tagging those with their full PathAndQuery would
+        // leave /product/5?utm_source=x unpurgeable for the rest of its lifetime.
+        var requestPath = new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).AbsolutePath.ToLowerInvariant();
+
+        var sharedMaxAge = responseCacheAtt.SharedMaxAge == -1 ? responseCacheAtt.MaxAge : responseCacheAtt.SharedMaxAge;
 
         var clientCacheTtl = responseCacheAtt.MaxAge;
-        var edgeCacheTtl = responseCacheAtt.SharedMaxAge;
-        var outputCacheTtl = responseCacheAtt.SharedMaxAge;
+        var edgeCacheTtl = sharedMaxAge;
+        var outputCacheTtl = sharedMaxAge;
 
         if (settings.ResponseCaching?.EnableCdnEdgeCaching is false)
         {
@@ -64,8 +81,8 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
 
         if (context.HttpContext.IsBlazorPageContext() && CultureInfoManager.InvariantGlobalization is false)
         {
-            // Note: Currently, we are not keeping the current culture in the URL. 
-            // The edge and client caches do not support such variations, although the output cache does. 
+            // Note: Currently, we are not keeping the current culture in the URL.
+            // The edge and client caches do not support such variations, although the output cache does.
             // As a temporary solution, client and edge caching are disabled for pre-rendered pages.
             edgeCacheTtl = -1;
             clientCacheTtl = -1;
@@ -88,12 +105,28 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
                 SharedMaxAge = edgeCacheTtl == -1 ? null : TimeSpan.FromSeconds(edgeCacheTtl)
             };
             context.HttpContext.Response.Headers.Remove("Pragma");
+            // Note: a CDN may ignore this. Cloudflare, for one, does not consider Vary in caching decisions unless the
+            // header is Accept-Encoding or a Cache Rules Vary setting naming origin/x-origin has been configured on the
+            // zone. Without that rule the edge keeps a single variant per URL and hands it to callers of every origin.
+            context.HttpContext.Response.Headers.Append(HeaderNames.Vary, "Origin, X-Origin");
+
+            context.HttpContext.Response.OnStarting(static state =>
+            {
+                var response = (HttpResponse)state;
+
+                if (IsResponseCacheable(response) is false)
+                {
+                    response.GetTypedHeaders().CacheControl = new() { NoStore = true, Private = true };
+                }
+
+                return Task.CompletedTask;
+            }, context.HttpContext.Response);
         }
 
         // ASP.NET Core Output Cache
         if (outputCacheTtl > 0)
         {
-            context.Tags.Add(requestUrl);
+            context.Tags.Add(requestPath);
             context.AllowCacheLookup = true;
             context.AllowCacheStorage = true;
             context.ResponseExpirationTimeSpan = TimeSpan.FromSeconds(outputCacheTtl);
@@ -120,12 +153,25 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
     /// </summary>
     public async ValueTask ServeResponseAsync(OutputCacheContext context, CancellationToken cancellation)
     {
-        var response = context.HttpContext.Response;
-
-        if (response.GetTypedHeaders().SetCookie.Any(sc => sc.Name != CookieRequestCultureProvider.DefaultCookieName /* The culture cookie is allowed since caching varies by culture in CacheRequestAsync. */)
-            || response.StatusCode is not StatusCodes.Status200OK)
+        // Keeps the response out of ASP.NET Core's output cache. This runs after the endpoint has produced the response,
+        // which is generally too late to touch the headers, but the middleware re-reads AllowCacheStorage when it goes to
+        // store the body, so clearing it here still prevents the entry from being written. The matching Cache-Control
+        // downgrade for browsers and CDNs is handled by the OnStarting callback registered in CacheRequestAsync.
+        if (IsResponseCacheable(context.HttpContext.Response) is false)
         {
             context.AllowCacheStorage = false;
         }
+    }
+
+    /// <summary>
+    /// A response that reports a failure or hands out cookies belongs to the caller that triggered it and may not be
+    /// stored in any cache. Otherwise a 404 of a product that gets created a minute later stays alive on the edge for
+    /// days, and one caller's cookies get replayed to everyone else.
+    /// The culture cookie is exempt because <see cref="CacheRequestAsync"/> varies the cache by culture.
+    /// </summary>
+    private static bool IsResponseCacheable(HttpResponse response)
+    {
+        return response.StatusCode is StatusCodes.Status200OK
+            && response.GetTypedHeaders().SetCookie.Any(sc => sc.Name != CookieRequestCultureProvider.DefaultCookieName) is false;
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/UriExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/UriExtensions.cs
@@ -47,14 +47,21 @@ public static partial class UriExtensions
 
             var culture = uri.GetCulture();
 
-            if (string.IsNullOrEmpty(culture) is false)
-            {
-                uri = new Uri(uri.ToString()
-                    .Replace($"{culture}/", string.Empty)
-                    .Replace(culture, string.Empty));
-            }
+            if (string.IsNullOrEmpty(culture))
+                return uri.ToString();
 
-            return uri.ToString();
+            // Only the leading path segment carries the culture. Replacing the culture everywhere in the url instead
+            // would strip its letters out of the rest of the path too, turning /en-US/product/en-US-shirt into
+            // /product/-shirt.
+            var segments = uri.AbsolutePath.Split('/'); // AbsolutePath always starts with '/', so segments[0] is empty.
+
+            if (segments.Length < 2 || string.Equals(segments[1], culture, StringComparison.OrdinalIgnoreCase) is false)
+                return uri.ToString(); // The culture came from somewhere other than the first segment.
+
+            return new UriBuilder(uri)
+            {
+                Path = string.Join('/', segments.Take(1).Concat(segments.Skip(2)))
+            }.Uri.ToString();
         }
 
         public string GetPath()

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Services/AppMemoryCache.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Services/AppMemoryCache.cs
@@ -5,21 +5,32 @@ using Microsoft.Extensions.Caching.Memory;
 namespace Boilerplate.Shared.Infrastructure.Services;
 
 /// <summary>
-/// Total capacity of the in memory cache has been set in Shared/appsettings.json in the "MemoryCacheOptions" section. The SizeLimit property is set to 100000.
-/// Unit is arbitrary; we treat it as 1 unit per average cache entry
-/// This would prevent the cache from growing indefinitely and consuming too much memory, which could lead to performance degradation or out-of-memory exceptions.
+/// Total capacity of the in memory cache has been set in Shared/appsettings.json in the "MemoryCache" section, and it
+/// prevents the cache from growing indefinitely and consuming too much memory, which could lead to performance
+/// degradation or out-of-memory exceptions.
 ///
-/// Some 3rd party libraries may not set Size when adding entries to the cache, so we set it to 1 by default in CreateEntry method to prevent potential runtime errors.
-/// https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/1190
+/// The unit is bytes. It has to be, because the ASP.NET Core output cache stores its response bodies in this very same
+/// cache and charges each one its exact length (See FusionOutputCacheStore, wired up by AddFusionOutputCache). Counting
+/// entries instead would let a single cached page or attachment consume the entire budget.
+///
+/// Entries that don't know their own size - 3rd party libraries mostly, some of which don't set Size at all
+/// (https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/1190) - are charged
+/// <see cref="EstimatedEntrySizeInBytes"/> instead. That's deliberately an over-estimate: charging an entry too much
+/// only means fewer of them fit, while charging too little lets the cache outgrow the limit it exists to enforce.
 /// </summary>
 public class AppMemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory loggerFactory) : IMemoryCache
 {
+    /// <summary>
+    /// What an entry that doesn't report a size of its own is charged against the "MemoryCache:SizeLimit" budget.
+    /// </summary>
+    public const int EstimatedEntrySizeInBytes = 4 * 1024;
+
     private readonly MemoryCache implementation = new(optionsAccessor, loggerFactory);
 
     public ICacheEntry CreateEntry(object key)
     {
         var entry = implementation.CreateEntry(key);
-        entry.Size ??= 1;
+        entry.Size ??= EstimatedEntrySizeInBytes;
         return entry;
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/appsettings.json
@@ -130,8 +130,8 @@
     "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY__Comment": "in_memory or disk temporary storage for failed OTLP requests to be retried",
 
     "MemoryCache": {
-        "SizeLimit": 100000,
-        "SizeLimit__Comment": "Total capacity of the L1 cache. Unit is arbitrary; we treat it as 1 unit per average entry."
+        "SizeLimit": 268435456,
+        "SizeLimit__Comment": "Total capacity of the L1 cache, in bytes (256 MB)."
     },
     "$schema": "https://json.schemastore.org/appsettings.json"
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ProductResponseCacheTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ProductResponseCacheTests.cs
@@ -1,0 +1,262 @@
+//+:cnd:noEmit
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Shared.Features.Products;
+using Boilerplate.Server.Api.Features.Tenants;
+using Boilerplate.Server.Api.Features.Products;
+using Boilerplate.Server.Api.Infrastructure.Data;
+using Boilerplate.Server.Api.Infrastructure.Services;
+using Boilerplate.Client.Core.Infrastructure.Services;
+
+namespace Boilerplate.Tests.Features.Caching;
+
+[TestClass, TestCategory("IntegrationTest"), TestCategory("Caching"), TestCategory("PreRendering")]
+public partial class ProductResponseCacheTests
+{
+    // Seeded members of the default (fallback) store tenant. See UserConfiguration and TenantUserConfiguration.
+    private const string TenantAdminEmail = "store-admin@bitplatform.dev";
+    private const string TenantUserEmail = "store-user@bitplatform.dev";
+    private const string Password = "123456";
+
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Proves that with <c>ResponseCaching:EnableOutputCaching</c> and <c>WebAppRender:PrerenderEnabled</c> both on, the
+    /// product's <c>UserAgnostic</c> API response and its pre-rendered public page really are stored in ASP.NET Core's
+    /// output cache, that a write through the app reaches them, and that a change made behind the app's back does not.
+    /// <list type="number">
+    /// <item>A product is inserted straight into the database for the default fallback tenant, then read twice: once as
+    /// the signed-in tenant-user through <c>ProductViewController.Get</c> (which is <c>UserAgnostic</c>, so it is cached
+    /// even for an authenticated caller, keyed by her tenant - See <c>AppResponseCachePolicy</c>), and once anonymously
+    /// as the pre-rendered <c>/product/{shortId}</c> page. Both responses are now in the output cache.</item>
+    /// <item>The tenant-admin - the member holding <c>ProductCatalog_Manage</c> for that tenant - edits the description
+    /// through the real <c>ProductController.Update</c> endpoint, which purges the product right after saving. Both
+    /// readers immediately see the new description, which proves the tags <c>AppResponseCachePolicy</c> writes match the
+    /// paths <c>ResponseCacheService.PurgeProductCache</c> evicts.</item>
+    /// <item>The product is then deleted straight from the database, bypassing the app and therefore the purge. Both
+    /// readers keep seeing the deleted product, which is the definitive proof that their responses are being served from
+    /// the output cache rather than re-read from the database.</item>
+    /// <item>Finally the cache is purged again and the very same reads now report the product as gone, which rules out
+    /// any explanation for step 3 other than the cache.</item>
+    /// </list>
+    /// Note: this test needs both <c>ProductController</c> (Admin module) and <c>ProductViewController</c> / the product
+    /// page (Sales module), and <c>module</c> is a single-choice template parameter, so no generated project can host it.
+    /// It is excluded unconditionally in template.json and only ever runs against the template's own source tree.
+    /// </summary>
+    [TestMethod]
+    public async Task OutputCache_Should_ServeProduct_UntilItsCacheIsPurged()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(
+            configureTestServices: services => services.AddIntegrationApiOnlyTestsServices().FakeExternalStatistics(),
+            configureTestConfigurations: configuration =>
+            {
+                // Pre-rendering makes the server produce the product page's HTML itself, so the page is a cacheable
+                // response rather than an empty shell filled in later by the client.
+                configuration["WebAppRender:PrerenderEnabled"] = "true";
+                configuration["ResponseCaching:EnableOutputCaching"] = "true";
+            }).Start(TestContext.CancellationToken);
+
+        // A marker keeps the assertions immune to anything else the page happens to render, and keeps this test's rows
+        // isolated from the other tests sharing the same database.
+        var marker = Guid.NewGuid().ToString("N");
+        var productName = $"cached-product-{marker}";
+        var originalDescription = $"original-description-{marker}";
+        var updatedDescription = $"updated-description-{marker}";
+
+        var (productId, productShortId) = await CreateProduct(server, productName, originalDescription);
+
+        // ---- Step 1: both readers fetch the product, filling the output cache ----
+
+        // The signed-in tenant-user reads it through the public (UserAgnostic) product view API.
+        await using var tenantUserScope = server.WebApp.Services.CreateAsyncScope();
+        await SignIn(tenantUserScope, TenantUserEmail);
+        var tenantUserProductView = tenantUserScope.ServiceProvider.GetRequiredService<IProductViewController>();
+
+        var seenByTenantUser = await tenantUserProductView.Get(productShortId, TestContext.CancellationToken);
+        Assert.AreEqual(productName, seenByTenantUser.Name);
+        Assert.AreEqual(originalDescription, seenByTenantUser.DescriptionText);
+
+        // ...and an anonymous visitor reads the pre-rendered public product page. A bare HttpClient - rather than the
+        // app's own one from DI - keeps this reader free of any access token and of the client-side message handlers
+        // (retry, client caching, exception translation) that would sit between the assertions and what the server
+        // actually returned.
+        using var visitorHttpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        var pageHtml = await GetProductPage(visitorHttpClient, productShortId, assertOutputCachingIsActive: true);
+        Assert.Contains(productName, pageHtml);
+        Assert.Contains(originalDescription, pageHtml);
+
+        // ---- Step 2: the tenant-admin edits the description through the real write endpoint ----
+
+        await using (var tenantAdminScope = server.WebApp.Services.CreateAsyncScope())
+        {
+            var tenantAdminUser = await SignIn(tenantAdminScope, TenantAdminEmail);
+
+            // ProductController demands a privileged session, a selected tenant and ProductCatalog_Manage. Her fresh
+            // password sign-in covers the first, and being a t-admin of the tenant that owns the product covers the rest.
+            Assert.AreEqual(TenantConfiguration.FallbackTenantId, tenantAdminUser.GetTenantId());
+            Assert.IsTrue(tenantAdminUser.HasFeature(AppFeatures.AdminPanel.ProductCatalog_Manage));
+
+            // A real authenticated PUT, so the purge under test is the one the endpoint itself performs after saving
+            // (See ProductController.Update) - including running it under a genuine HttpContext.
+            var products = tenantAdminScope.ServiceProvider.GetRequiredService<IProductController>();
+
+            var toUpdate = await products.Get(productId, TestContext.CancellationToken);
+            toUpdate.DescriptionText = updatedDescription;
+            toUpdate.DescriptionHTML = $"<p>{updatedDescription}</p>";
+
+            var updated = await products.Update(toUpdate, TestContext.CancellationToken);
+            Assert.AreEqual(updatedDescription, updated.DescriptionText);
+        }
+
+        // Both readers see the new description straight away, so the tags AppResponseCachePolicy writes for these two
+        // requests really are the ones ResponseCacheService.PurgeProductCache evicts.
+        var seenAfterPurge = await tenantUserProductView.Get(productShortId, TestContext.CancellationToken);
+        Assert.AreEqual(updatedDescription, seenAfterPurge.DescriptionText);
+
+        pageHtml = await GetProductPage(visitorHttpClient, productShortId);
+        Assert.Contains(updatedDescription, pageHtml);
+        Assert.DoesNotContain(originalDescription, pageHtml);
+
+        // ---- Step 3: the product is deleted behind the app's back, so nothing purges its cache ----
+
+        await DeleteProduct(server, productId);
+
+        await using (var scope = server.WebApp.Services.CreateAsyncScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            Assert.IsFalse(await dbContext.Products.IgnoreQueryFilters().AnyAsync(p => p.Id == productId, TestContext.CancellationToken),
+                "The product should be gone from the database at this point.");
+        }
+
+        // Nothing evicted the cached responses, so both readers keep being served the deleted product. Reaching the
+        // database would have produced a ResourceNotFoundException (API) and a not-found page (pre-rendered page).
+        var seenAfterDelete = await tenantUserProductView.Get(productShortId, TestContext.CancellationToken);
+        Assert.AreEqual(productName, seenAfterDelete.Name);
+        Assert.AreEqual(updatedDescription, seenAfterDelete.DescriptionText);
+
+        pageHtml = await GetProductPage(visitorHttpClient, productShortId);
+        Assert.Contains(productName, pageHtml);
+        Assert.Contains(updatedDescription, pageHtml);
+
+        // ---- Step 4: purging makes the deletion visible, which rules out anything but the cache in step 3 ----
+
+        // The row is gone, so ProductController.Delete would 404 before reaching its purge; this control step calls the
+        // shared purge service directly instead.
+        await using (var scope = server.WebApp.Services.CreateAsyncScope())
+        {
+            await PurgeProductCache(scope, productShortId);
+        }
+
+        await Assert.ThrowsExactlyAsync<ResourceNotFoundException>(
+            () => tenantUserProductView.Get(productShortId, TestContext.CancellationToken));
+
+        pageHtml = await GetProductPage(visitorHttpClient, productShortId);
+        Assert.DoesNotContain(productName, pageHtml);
+    }
+
+    /// <summary>
+    /// Inserts a product for the default fallback tenant. <c>IgnoreQueryFilters</c> is required for the reads because
+    /// this bare DB scope has no HttpContext, so the tenant-aware row level security query filter has no current tenant
+    /// to resolve and would otherwise throw (See <c>TenantProvider.GetCurrentTenantId</c>). The insert assigns the
+    /// tenant explicitly for the same reason (See <c>AppDbContext.OnSavingChanges</c>).
+    /// </summary>
+    private async Task<(Guid Id, int ShortId)> CreateProduct(AppTestServer server, string name, string description)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var categoryId = await dbContext.Products
+            .IgnoreQueryFilters()
+            .Where(p => p.TenantId == TenantConfiguration.FallbackTenantId)
+            .Select(p => p.CategoryId)
+            .FirstAsync(TestContext.CancellationToken);
+
+        var product = new Product
+        {
+            Id = Guid.NewGuid(),
+            // ShortId is unique across the whole table and the seed already occupies a low range, so stay well above it
+            // to survive other tests inserting their own products in parallel.
+            ShortId = Random.Shared.Next(1_000_000, int.MaxValue),
+            Name = name,
+            Price = 12_345M,
+            CategoryId = categoryId,
+            CreatedOn = DateTimeOffset.UtcNow,
+            DescriptionText = description,
+            DescriptionHTML = $"<p>{description}</p>",
+            TenantId = TenantConfiguration.FallbackTenantId
+        };
+
+        await dbContext.Products.AddAsync(product, TestContext.CancellationToken);
+        await dbContext.SaveChangesAsync(TestContext.CancellationToken);
+
+        return (product.Id, product.ShortId);
+    }
+
+    private async Task DeleteProduct(AppTestServer server, Guid productId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        await dbContext.Products
+            .IgnoreQueryFilters()
+            .Where(p => p.Id == productId)
+            .ExecuteDeleteAsync(TestContext.CancellationToken);
+    }
+
+    /// <summary>
+    /// Signs the given e-mail in within <paramref name="scope"/> and returns her resulting claims. The access token
+    /// lands in that scope's (in-memory) TestStorageService, so every typed API client resolved from the same scope
+    /// calls the server as her.
+    /// </summary>
+    private async Task<ClaimsPrincipal> SignIn(AsyncServiceScope scope, string email)
+    {
+        var authManager = scope.ServiceProvider.GetRequiredService<AuthManager>();
+
+        var requiresTwoFactor = await authManager.SignIn(new()
+        {
+            Email = email,
+            Password = Password
+        }, TestContext.CancellationToken);
+
+        Assert.IsFalse(requiresTwoFactor, $"'{email}' is not expected to have two factor authentication enabled.");
+
+        return (await authManager.GetAuthenticationStateAsync()).User;
+    }
+
+    /// <summary>
+    /// Runs <c>ResponseCacheService.PurgeProductCache</c>, which needs an HttpContext of its own to decide whether the
+    /// request came through a CDN, and there is none in a bare DI scope (See <c>ResponseCacheService.PurgeCache</c>).
+    /// </summary>
+    private async Task PurgeProductCache(AsyncServiceScope scope, int productShortId)
+    {
+        var httpContextAccessor = scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext ??= new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+
+        var responseCacheService = scope.ServiceProvider.GetRequiredService<ResponseCacheService>();
+
+        await responseCacheService.PurgeProductCache(productShortId);
+    }
+
+    /// <summary>
+    /// Fetches the pre-rendered public product page. A raw HttpClient is used rather than Playwright so that what gets
+    /// asserted is the exact HTML the server produced (or replayed from the output cache), with no client-side
+    /// re-rendering on top of it.
+    /// </summary>
+    private async Task<string> GetProductPage(HttpClient httpClient, int productShortId, bool assertOutputCachingIsActive = false)
+    {
+        using var response = await httpClient.GetAsync($"{PageUrls.Product}/{productShortId}", TestContext.CancellationToken);
+
+        if (assertOutputCachingIsActive)
+        {
+            // AppResponseCachePolicy reports what it decided for this request; Output:-1 would mean the page never
+            // reached the output cache, making the rest of this test meaningless.
+            Assert.IsTrue(response.Headers.TryGetValues("App-Cache-Response", out var appCacheResponse));
+            Assert.DoesNotContain("Output:-1", string.Concat(appCacheResponse!),
+                "Output caching should be active for the pre-rendered product page.");
+        }
+
+        return await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Configuration/AppConfigurationBuilderTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Configuration/AppConfigurationBuilderTests.cs
@@ -32,7 +32,7 @@ public class AppConfigurationBuilderTests
         // Provided by Boilerplate.Client.Core/appsettings.json.
         Assert.AreEqual("http://localhost:5030/", configuration["ServerAddress"]);
         // Provided by Boilerplate.Shared/appsettings.json - the lowest-priority layer - proving it is merged in too.
-        Assert.AreEqual("100000", configuration["MemoryCache:SizeLimit"]);
+        Assert.AreEqual("268435456", configuration["MemoryCache:SizeLimit"]);
     }
 
     [TestMethod]


### PR DESCRIPTION
Closes #12733

### 1. `GetExternalSignInUri` is no longer shared-cacheable

The URL this action returns embeds `origin = Request.GetWebAppUrl()`, and `GetWebAppUrl()` falls back to the `X-Origin` request header when the origin is not in the query string. `AppResponseCachePolicy` varies by host, query keys and culture, so `X-Origin` is in neither the output cache's vary key nor a CDN's cache key, and a stored response did not depend only on the inputs it was keyed by.

The `AppResponseCache` attribute is simply removed. Caching buys little here, and a vary rule would not be a real fix since CDNs do not honour `Vary` on arbitrary headers reliably.

### 2. A response the output cache refuses to store no longer advertises shared caching

`CacheRequestAsync` writes `Cache-Control` before the endpoint runs. `ServeResponseAsync` already set `AllowCacheStorage = false` for non-200 responses and for responses carrying a non-culture `Set-Cookie`, but left that header untouched, so CDNs and browsers kept caching a response ASP.NET Core had just declined to store. A 404 from `/api/v1/ProductView/Get/{id}` went out with `public, s-maxage=604800`, leaving a stale 404 on the edge for up to seven days after the product was created.

The header is now downgraded to `no-store, private` alongside `AllowCacheStorage`.

The `response.HasStarted is false` guard matters: `ServeResponseAsync` also runs for streamed responses, whose headers are already flushed and read-only — without it the middleware throws `InvalidOperationException: Headers are read-only, response has already started`. That path needs no downgrade anyway, since enabling shared caching is exactly what suppresses streaming pre-rendering (see `HttpRequestExtensions.IsStreamPrerenderingSuppressed`).

### Also included

`IdentityController.WebAuthn` assertion options:

- The cache key was built as `new string(challenge.Select(b => (char)b))`, putting NUL and control characters into the Redis key. It is now base64url encoded.
- The options were deliberately left in the cache until they expired, because the two-factor round trip verifies the same client response a second time. They are now evicted once the flow reaches its final step, so a WebAuthn challenge stops being reusable for the remainder of its 3 minute window. `SignIn` throws on an invalid two-factor code, so a failed attempt still leaves the options in place for a retry.

### Verification

- `dotnet build` on `Boilerplate.Server.Web` — succeeds, no new warnings.
- `dotnet test --filter "TestCategory=Caching"` — passes.
- `dotnet test --filter "TestCategory=SEO"` — 3/3 pass.

`Prerendering_WithOutputCaching_Should_ReturnCompleteNonStreamedHomePage` is what caught the missing `HasStarted` guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - External sign-in URLs are now generated per request and no longer reused from cache.
  - Output caching is better isolated by tenant and request path, and non-cacheable responses are reliably marked private and not stored.
  - WebAuthn two-factor verification now keeps intermediate state correctly and applies credential counter changes only on completion.
  - Culture prefixes in URLs are removed only when they appear at the start of the path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->