### PR TITLE
Offload startup CPU-bound work off the Blazor WebAssembly UI thread #12755

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs
@@ -53,61 +53,64 @@ public partial class AppClientCoordinator : AppComponentBase
 
         if (InPrerenderSession is false)
         {
-            unsubscribes.Add(PubSubService.Subscribe(ClientAppMessages.NAVIGATE_TO, async (uri) =>
+            await Task.Run(async () =>
             {
-                var uriValue = uri?.ToString()!;
-                var replace = uriValue.Contains("replace=true", StringComparison.InvariantCultureIgnoreCase);
-                var forceLoad = uriValue.Contains("forceLoad=true", StringComparison.InvariantCultureIgnoreCase);
-                NavigationManager.NavigateTo(uriValue.Replace("replace=true", "", StringComparison.InvariantCultureIgnoreCase).Replace("forceLoad=true", "", StringComparison.InvariantCultureIgnoreCase).TrimEnd('&'), forceLoad, replace);
-            }));
-            //#if (signalR == true)
-            unsubscribes.Add(PubSubService.Subscribe(SharedAppMessages.EXCEPTION_THROWN, async (payload) =>
-            {
-                if (payload is null) return;
-
-                var appProblemDetails = payload is JsonElement jsonDocument
-                    ? jsonDocument.Deserialize(JsonSerializerOptions.GetTypeInfo<AppProblemDetails>())! /* Message gets published from server through SignalR */
-                    : (AppProblemDetails)payload;
-
-                ExceptionHandler.Handle(appProblemDetails, displayKind: ExceptionDisplayKind.NonInterrupting);
-            }));
-            //#endif
-
-            if (AppPlatform.IsBlazorHybrid is false)
-            {
-                try
+                unsubscribes.Add(PubSubService.Subscribe(ClientAppMessages.NAVIGATE_TO, async (uri) =>
                 {
-                    BitButil.UseFastInvoke(); // Ensures that `TelemetryContext.Platform` is available to components using this value in their `OnInitAsync` method, such as `SignInPage.razor.cs`.
-                    var userAgentData = await userAgent.Extract();
-                    TelemetryContext.Platform = string.Join(' ', [userAgentData.Manufacturer, userAgentData.OsName, userAgentData.Name, "browser"]);
-                }
-                finally
+                    var uriValue = uri?.ToString()!;
+                    var replace = uriValue.Contains("replace=true", StringComparison.InvariantCultureIgnoreCase);
+                    var forceLoad = uriValue.Contains("forceLoad=true", StringComparison.InvariantCultureIgnoreCase);
+                    NavigationManager.NavigateTo(uriValue.Replace("replace=true", "", StringComparison.InvariantCultureIgnoreCase).Replace("forceLoad=true", "", StringComparison.InvariantCultureIgnoreCase).TrimEnd('&'), forceLoad, replace);
+                }));
+                //#if (signalR == true)
+                unsubscribes.Add(PubSubService.Subscribe(SharedAppMessages.EXCEPTION_THROWN, async (payload) =>
                 {
-                    BitButil.UseNormalInvoke();
-                }
-            }
-            TelemetryContext.TimeZone = await jsRuntime.GetTimeZone();
-            TelemetryContext.Culture = CultureInfo.CurrentCulture.Name;
-            TelemetryContext.PageUrl = HttpUtility.UrlDecode(NavigationManager.Uri);
+                    if (payload is null) return;
 
-            //#if (appInsights == true)
-            _ = appInsights.AddTelemetryInitializer(new()
-            {
-                Data = new()
+                    var appProblemDetails = payload is JsonElement jsonDocument
+                        ? jsonDocument.Deserialize(JsonSerializerOptions.GetTypeInfo<AppProblemDetails>())! /* Message gets published from server through SignalR */
+                        : (AppProblemDetails)payload;
+
+                    ExceptionHandler.Handle(appProblemDetails, displayKind: ExceptionDisplayKind.NonInterrupting);
+                }));
+                //#endif
+
+                if (AppPlatform.IsBlazorHybrid is false)
                 {
-                    ["ai.application.ver"] = TelemetryContext.AppVersion,
-                    ["ai.session.id"] = TelemetryContext.AppSessionId,
-                    ["ai.device.locale"] = TelemetryContext.Culture
+                    try
+                    {
+                        BitButil.UseFastInvoke(); // Ensures that `TelemetryContext.Platform` is available to components using this value in their `OnInitAsync` method, such as `SignInPage.razor.cs`.
+                        var userAgentData = await userAgent.Extract();
+                        TelemetryContext.Platform = string.Join(' ', [userAgentData.Manufacturer, userAgentData.OsName, userAgentData.Name, "browser"]);
+                    }
+                    finally
+                    {
+                        BitButil.UseNormalInvoke();
+                    }
                 }
+                TelemetryContext.TimeZone = await jsRuntime.GetTimeZone();
+                TelemetryContext.Culture = CultureInfo.CurrentCulture.Name;
+                TelemetryContext.PageUrl = HttpUtility.UrlDecode(NavigationManager.Uri);
+
+                //#if (appInsights == true)
+                _ = appInsights.AddTelemetryInitializer(new()
+                {
+                    Data = new()
+                    {
+                        ["ai.application.ver"] = TelemetryContext.AppVersion,
+                        ["ai.session.id"] = TelemetryContext.AppSessionId,
+                        ["ai.device.locale"] = TelemetryContext.Culture
+                    }
+                });
+                //#endif
+
+                NavigationManager.LocationChanged += NavigationManager_LocationChanged;
+                AuthManager.AuthenticationStateChanged += AuthenticationStateChanged;
+                //#if (signalR == true)
+                SubscribeToSignalRSharedAppMessages();
+                //#endif
+                await PropagateAuthState(firstRun: true, AuthenticationStateTask);
             });
-            //#endif
-
-            NavigationManager.LocationChanged += NavigationManager_LocationChanged;
-            AuthManager.AuthenticationStateChanged += AuthenticationStateChanged;
-            //#if (signalR == true)
-            SubscribeToSignalRSharedAppMessages();
-            //#endif
-            await PropagateAuthState(firstRun: true, AuthenticationStateTask);
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs
@@ -144,7 +144,7 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
 
     /// <summary>
     /// Handles the process of determining the user's authentication state based on the availability of access and refresh tokens.
-    /// 
+    ///
     /// - If no access / refresh token exists, an anonymous user object is returned to Blazor.
     /// - If an access token exists, a ClaimsPrincipal is created from it regardless of its expiration status. This ensures:
     ///   - Users can access anonymous-allowed pages without unnecessary delays caused by token refresh attempts **during app startup**.
@@ -219,7 +219,7 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
         if (string.IsNullOrEmpty(accessToken))
             return null;
 
-        var isValid = IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: true).IsAuthenticated();
+        var isValid = await Task.Run(() => IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: true).IsAuthenticated());
 
         if (isValid) return accessToken;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/LoggingDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/LoggingDelegatingHandler.cs
@@ -22,7 +22,7 @@ internal class LoggingDelegatingHandler(ILogger<HttpClient> logger, HttpMessageH
         var stopwatch = Stopwatch.StartNew();
         try
         {
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await Task.Run(() => base.SendAsync(request, cancellationToken), cancellationToken);
             if (AppPlatform.IsBrowser is false)
             {
                 logScopeData["HttpVersion"] = response.Version;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Boilerplate.Client.Web.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Boilerplate.Client.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,6 @@
         <BlazorWebAssemblyLoadAllGlobalizationData Condition="'$(InvariantGlobalization)' == 'false'">true</BlazorWebAssemblyLoadAllGlobalizationData>
         <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
         <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
-        <WasmEnableSIMD Condition="'$(Environment)' != 'Development'">true</WasmEnableSIMD>
         <!--/+:msbuild-conditional:noEmit -->
         <WasmStripILAfterAOT Condition=" '$(offlineDb)' == 'false'">true</WasmStripILAfterAOT>
         <WasmBuildNative Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''">true</WasmBuildNative>
@@ -72,18 +71,28 @@
         <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
     </PropertyGroup>
 
+    <!--
+        Blazor WebAssembly diagnostics https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/webassembly-event-pipe-diagnostics
+
+        Put the followings inside Boilerplate.Client.Web/wwwroot/Boilerplate.Client.Web.lib.module.js
+        export function afterWebAssemblyStarted(options, extensions) {  
+            globalThis.getDotnetRuntime(0).collectCpuSamples({durationSeconds: 10});
+            // Or un-comment the following line to collect metrics instead of CPU samples
+            // globalThis.getDotnetRuntime(0).collectMetrics({durationSeconds: 10}); 
+        }
+        
+        Or run this command in the browser console to collect GC dump:
+        globalThis.getDotnetRuntime(0).collectGcDump();
+
+        Convert nettrace file to json using dotnet-trace convert your-file-name.nettrace -f Chromium
+    -->
     <!-- 
-        <PropertyGroup>
-        
-            Blazor WebAssembly diagnostics
-            https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/webassembly-event-pipe-diagnostics
-        
+        <PropertyGroup>        
             <EnableDiagnostics>true</EnableDiagnostics>
             <MetricsSupport>true</MetricsSupport>
             <EventSourceSupport>true</EventSourceSupport>
             <WasmDebugLevel>0</WasmDebugLevel>
             <WasmPerformanceInstrumentation>all</WasmPerformanceInstrumentation>
-            
         </PropertyGroup>
     -->
 


### PR DESCRIPTION
## Summary

Wraps CPU-bound startup work in `Task.Run` so the browser can paint the UI first, and tidies the WebAssembly build/profiling configuration.

Even though multithreading is disabled by default in Blazor WebAssembly, `Task.Run` is still useful here: it moves the work to the end of the browser's task queue, so the UI gets a chance to render before the work runs — improving perceived startup responsiveness.

## Changes

- `AppClientCoordinator`: run the startup initialization block inside `Task.Run`.
- `AuthManager`: run `ParseAccessToken` / validation inside `Task.Run`.
- `LoggingDelegatingHandler`: dispatch `base.SendAsync` inside `Task.Run`.
- `Boilerplate.Client.Web.csproj`: remove `WasmEnableSIMD` (was enabled outside Development), and rewrite the Blazor WebAssembly diagnostics comment with clear profiling instructions (CPU samples, metrics, GC dump, and `dotnet-trace convert`).

## Related Issue

This closes #12755



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client startup and authentication processing reliability.
  * Improved HTTP request handling while preserving existing logging behavior.
* **Performance**
  * Updated asynchronous processing for startup, token validation, and HTTP operations.
* **Documentation**
  * Expanded guidance for collecting WebAssembly CPU samples, metrics, and garbage-collection diagnostics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->