### PR TITLE
Use UnsafeAccessor instead of reflection for WASM config providers #12759

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IConfigurationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IConfigurationBuilderExtensions.cs
@@ -1,10 +1,14 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 namespace Microsoft.Extensions.Configuration;
 
 public static partial class IConfigurationBuilderExtensions
 {
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_providers")]
+    private static extern ref List<IConfigurationProvider> GetProviders(WebAssemblyHostConfiguration configuration);
+
     extension(IConfigurationBuilder builder)
     {
         /// <summary>
@@ -68,8 +72,8 @@ public static partial class IConfigurationBuilderExtensions
 
             if (AppPlatform.IsBrowser)
             {
-                var providersField = builder.GetType().GetField("_providers", BindingFlags.NonPublic | BindingFlags.Instance)!;
-                providersField.SetValue(builder, (((IConfigurationRoot)configBuilder).Providers).Union(((IConfigurationRoot)builder).Providers).ToList());
+                GetProviders((WebAssemblyHostConfiguration)builder) =
+                    [.. ((IConfigurationRoot)configBuilder).Providers.Union(((IConfigurationRoot)builder).Providers)];
             }
             else if (AppPlatform.IsBlazorHybrid)
             {


### PR DESCRIPTION
## Summary

Replaces the runtime reflection used to access `WebAssemblyHostConfiguration._providers` with a compile-time `[UnsafeAccessor]` accessor.

## Changes

- `IConfigurationBuilderExtensions`: add a `[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_providers")]` accessor and use it to set the merged provider list, replacing `GetField(..., BindingFlags.NonPublic | BindingFlags.Instance)` + `SetValue`.

## Related Issue

This closes #12759



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved browser configuration initialization by replacing reflection-based provider merging with a more efficient approach.
* **Compatibility**
  * Preserved existing configuration behavior for browser-based applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->