### PR TITLE
Cache CultureInfoManager default and supported cultures #12761

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Services/CultureInfoManager.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Services/CultureInfoManager.cs
@@ -15,9 +15,9 @@ public partial class CultureInfoManager
     false;
 #endif
 
-    public static CultureInfo DefaultCulture => CreateCultureInfo("en-US");
+    public static CultureInfo DefaultCulture => field ??= CreateCultureInfo("en-US");
 
-    public static (string DisplayName, CultureInfo Culture)[] SupportedCultures =>
+    public static (string DisplayName, CultureInfo Culture)[] SupportedCultures => field ??=
     [
         ("English US", CreateCultureInfo("en-US")),
         ("English UK", CreateCultureInfo("en-GB")),


### PR DESCRIPTION
## Summary

Caches the default and supported cultures so they are built once instead of on every access.

## Changes

- `CultureInfoManager`: back `DefaultCulture` and `SupportedCultures` with the `field` keyword (`field ??= ...`) so they are computed lazily and cached for the app lifetime.

## Related Issue

This closes #12761

