### PR TITLE
Fix static file caching for Development hot reload and CDN no-transform #12763

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -55,16 +55,23 @@ public static partial class Program
                 app.UseDirectoryBrowser();
             }
 
-            app.UseStaticFiles(options: new()
+            app.Use(async (context, next) =>
             {
-                OnPrepareResponse = staticFileResponseContext =>
+                context.Response.OnStarting(async () =>
                 {
-                    if (env.IsDevelopment() is false)
+                    if (env.IsDevelopment())
+                    {
+                        context.Response.GetTypedHeaders().CacheControl = new()
+                        {
+                            NoCache = true
+                        };
+                    }
+                    else
                     {
                         // Caching static files on the Browser and CDN's edge servers.
-                        if (staticFileResponseContext.Context.Request.Query.Any(q => string.Equals(q.Key, "v", StringComparison.InvariantCultureIgnoreCase)))
+                        if (context.Request.Query.Any(q => string.Equals(q.Key, "v", StringComparison.InvariantCultureIgnoreCase)))
                         {
-                            staticFileResponseContext.Context.Response.GetTypedHeaders().CacheControl = new()
+                            context.Response.GetTypedHeaders().CacheControl = new()
                             {
                                 Public = true,
                                 NoTransform = true,
@@ -72,8 +79,12 @@ public static partial class Program
                             };
                         }
                     }
-                }
+                });
+
+                await next.Invoke();
             });
+
+            app.UseStaticFiles();
 
             // https://yurl.chayev.com/
             app.UseWhen(context => context.Request.Path.StartsWithSegments("/.well-known"), wellKnownApp =>


### PR DESCRIPTION
## Summary

Reworks static-file caching into a middleware using `Response.OnStarting`, adds `no-cache` in Development, and keeps `NoTransform` for versioned production assets.

- **Development:** sends `Cache-Control: no-cache`, which fixes **SCSS changes sometimes not applying under Hot Reload / `dotnet watch`**.
- **Production:** keeps `Public` + `NoTransform` + `max-age` for versioned (`?v=`) assets. `NoTransform` prevents CDNs from re-compressing the already highly-compressed Blazor publish output, **reducing the size served behind the CDN**.

## Changes

- `Program.Middlewares`: replace `UseStaticFiles(OnPrepareResponse = ...)` with a middleware that sets `Cache-Control` on `Response.OnStarting` (no-cache in Development; `Public` + `NoTransform` + `max-age` for versioned assets in production), followed by `UseStaticFiles()`.
- Add `wwwroot/_framework/.gitkeep` to the Windows client so the folder is tracked (also helps `dotnet watch`).

## Related Issue

This closes #12763

