### PR TITLE
Add Cursor rules and Aspire-aware AGENTS.md commands to the template #12765

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,8 +225,6 @@ ModelManifest.xml
 #kiro
 .kiro
 
-#cursor
-.cursor
 
 profile.arm.json
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.cursor/rules/agents.mdc
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.cursor/rules/agents.mdc
@@ -1,0 +1,10 @@
+---
+description: Project coding conventions, structure and behavioral directives
+alwaysApply: true
+---
+
+# Cursor Rules
+
+This project uses @AGENTS.md (at the repository root) as the single source of truth for all coding conventions, project structure, technology stack, and behavioral directives.
+
+**Before performing any task, read the full content of `/AGENTS.md`.**

--- a/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md
@@ -67,8 +67,13 @@ Before implementing any changes, you **MUST** complete the following:
 
 ## 4. Critical Command Reference
 
+<!--#if (aspire == true)-->
+-   **Build the project**: Run `dotnet build` in Boilerplate.Server.AppHost project root directory.
+-   **Run the project**: Run `dotnet watch` in Boilerplate.Server.AppHost project root directory. If needed, you may use the Playwright MCP tools to interact with the running UI to validate things (navigate, click, fill forms, take screenshots), and use `browser_evaluate` to run in-page JavaScript to accelerate the process (e.g. quickly locating elements, extracting data, or asserting state).
+<!--#else-->
 -   **Build the project**: Run `dotnet build` in Boilerplate.Server.Web project root directory.
 -   **Run the project**: Run `dotnet watch` in Boilerplate.Server.Web project root directory. If needed, you may use the Playwright MCP tools to interact with the running UI to validate things (navigate, click, fill forms, take screenshots), and use `browser_evaluate` to run in-page JavaScript to accelerate the process (e.g. quickly locating elements, extracting data, or asserting state).
+<!--#endif-->
 -   **Run tests**: Run `dotnet test` in Boilerplate.Tests project root directory.
 -   **Add new migrations**: Run `dotnet ef migrations add <MigrationName> --output-dir Data/Migrations --verbose` in Boilerplate.Server.Api project root directory.
 -   **Generate Resx C# code**: Run `dotnet build -t:PrepareResources` in Boilerplate.Shared project root directory.


### PR DESCRIPTION
## Summary

Adds Cursor IDE rules that defer to `AGENTS.md`, and makes the `AGENTS.md` build/run commands Aspire-aware.

## Changes

- `.gitignore`: stop ignoring `.cursor` so the template's Cursor rules are included.
- Add `.cursor/rules/agents.mdc` pointing to `/AGENTS.md` as the single source of truth for coding conventions and behavioral directives.
- `AGENTS.md`: conditionally document build/run via `Boilerplate.Server.AppHost` when `aspire` is enabled, otherwise `Boilerplate.Server.Web`.

## Related Issue

This closes #12765

