### PR TITLE
Simplify PR title convention in contribution agent guide #12767

### DIFF
--- a/.github/agents/contribute-to-bitplatform.agent.md
+++ b/.github/agents/contribute-to-bitplatform.agent.md
@@ -101,15 +101,15 @@ git push origin <branch-name>
 ```
 
 ### PR Title
-Use conventional-commit format and include the Issue number with a `#` prefix:
+Include the Issue number with a `#` prefix:
 
 ```
-<prefix>(<scope>): <short description> #<issue-number>
+<short description> #<issue-number>
 ```
 
 Example:
 ```
-fix(BlazorUI): BitButton disabled state ignores pointer-events in Safari #1234
+Fix BitButton disabled state ignores pointer-events in Safari #1234
 ```
 
 ### PR Description Template


### PR DESCRIPTION
## Summary

Drops the conventional-commit requirement from the PR-title guidance in the contribution agent guide.

## Changes

- `.github/agents/contribute-to-bitplatform.agent.md`: PR title is now `<short description> #<issue-number>` (no `<prefix>(<scope>):` format), with the example updated to match.

## Related Issue

This closes #12767

