### PR TITLE
Reset isNewUser when SignInPanel state resets #12769

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPanel.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Identity/SignIn/SignInPanel.razor.cs
@@ -91,6 +91,8 @@ public partial class SignInPanel
 
         webAuthnAssertion = null;
 
+        isNewUser = false;
+
         isOtpSent = false;
         model.Otp = null;
 


### PR DESCRIPTION
## Summary

Resets `isNewUser` as part of the `SignInPanel` state reset so it doesn't leak across sign-in attempts.

## Changes

- `SignInPanel`: set `isNewUser = false` alongside the other reset fields.

## Related Issue

This closes #12769

