### PR TITLE
Fix SectionOutlet issues in Brouter (#12752)

### DIFF
--- a/src/Brouter/Bit.Brouter/Broute.cs
+++ b/src/Brouter/Bit.Brouter/Broute.cs
@@ -384,6 +384,15 @@ public class Broute : ComponentBase, IDisposable
         }
     }
 
+    /// <summary>
+    /// Re-renders this route so its output reflects the current <see cref="Matched"/> state. Used by
+    /// the navigation pipeline to unmount a departed route's content BEFORE the winning chain's
+    /// commit render mounts the new content (see Brouter.UnrenderDepartedRoutes): the departing
+    /// subtree must be disposed first so framework subscriptions it holds (e.g. a layout's
+    /// SectionOutlet) are released before the incoming subtree registers its own.
+    /// </summary>
+    internal void Refresh() => StateHasChanged();
+
     // The resolved retained-instance budget: per-route KeepAliveMax, else the global default.
     // Clamped to >= 1 so a misconfigured 0/negative value degrades to the singleton behavior
     // instead of rendering nothing.

--- a/src/Brouter/Bit.Brouter/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Brouter.cs
@@ -715,6 +715,29 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Unrenders the routes the pending commit removes from the screen (present in the previously
+    /// committed chain but not in the new one) BEFORE the winner's chain mounts. Each departed
+    /// route's Matched flag is already false, so a render request re-renders it without its content
+    /// region, unmounting AND disposing the departing subtree synchronously on this dispatcher.
+    /// That ordering is load-bearing: subscriptions the departing subtree holds must be released
+    /// before the incoming subtree registers its own - most notably a layout's SectionOutlet, where
+    /// a second subscriber on the same section ID is an InvalidOperationException (#12752). The
+    /// built-in Router never hits this because it keeps one RouteView/layout instance alive across
+    /// navigations; Brouter's per-route subtrees swap instead, so the swap must dispose-then-mount.
+    /// Routes present in both chains are untouched - their content survives the commit and keeps
+    /// its component instances (renavigation semantics). Leaf -> root, mirroring disposal order.
+    /// </summary>
+    private void UnrenderDepartedRoutes(List<Broute> matchedChain)
+    {
+        for (var i = _committedChain.Length - 1; i >= 0; i--)
+        {
+            var node = _committedChain[i];
+            if (matchedChain.Contains(node)) continue;
+            node.Refresh();
+        }
+    }
+
+    /// <summary>
     /// Runs the pre-render arrival preparation for a chain about to be committed (per-parameter
     /// keep-alive sibling deactivation - see <see cref="Broute.PrepareArrival"/>). Root -> leaf,
     /// like guards and loaders. Must run after the chain's parameters are committed and before the
@@ -2297,16 +2320,26 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             }
 
             // Route-lifecycle departures for the routes this commit removes from the screen. They
-            // must fire BEFORE SetMatched: its StateHasChanged renders synchronously on this
-            // dispatcher, unmounting (and disposing) the departing content - and the Disposing
-            // notification's contract is that its synchronous part runs first. Routes present in
-            // both chains aren't notified here: their content survives the commit untouched (the
+            // must fire BEFORE the unmount render below (a Disposing callback's synchronous part
+            // runs while the departing components are still alive). Routes present in both chains
+            // aren't notified here: their content survives the commit untouched (the
             // no-pending-render path never unmounted it) and resolves as a renavigation below.
             if (departuresNotified is false)
             {
                 NotifyChainDepartures(ctx, _committedChain, matchedChain);
                 // Departure callbacks run synchronously into user code and can start a new
                 // navigation; abandon this commit before it mutates state the newer one owns.
+                if (token.IsCancellationRequested || version != _navVersion) return;
+
+                // Unmount (and dispose) the departed routes' content before SetMatched mounts the
+                // new chain - the departing subtree's subscriptions (e.g. a layout's SectionOutlet)
+                // must be released before the new subtree registers its own; see
+                // UnrenderDepartedRoutes. The pending-UI render already unmounted everything when
+                // departuresNotified is true, so this only runs on the no-pending-render path.
+                UnrenderDepartedRoutes(matchedChain);
+                // The render disposes departing components synchronously; a Dispose can run user
+                // code that starts a new navigation - the same supersession hazard as the
+                // departure callbacks above.
                 if (token.IsCancellationRequested || version != _navVersion) return;
             }
 

--- a/src/Brouter/Bit.Brouter/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Brouter.cs
@@ -726,15 +726,26 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// navigations; Brouter's per-route subtrees swap instead, so the swap must dispose-then-mount.
     /// Routes present in both chains are untouched - their content survives the commit and keeps
     /// its component instances (renavigation semantics). Leaf -> root, mirroring disposal order.
+    /// Returns false when a Refresh's synchronous disposal started a new navigation that
+    /// superseded this one - the caller must abandon the commit immediately.
     /// </summary>
-    private void UnrenderDepartedRoutes(List<Broute> matchedChain)
+    private bool UnrenderDepartedRoutes(List<Broute> matchedChain)
     {
-        for (var i = _committedChain.Length - 1; i >= 0; i--)
+        // Each Refresh disposes the departed subtree synchronously, and a Dispose can run user
+        // code that starts a new navigation - which, if it commits synchronously, reassigns
+        // _committedChain out from under this loop. Snapshot the chain so the indices stay
+        // coherent, and stop at the first supersession so no further Refresh unmounts content
+        // on behalf of a navigation that will never commit (or that the newer one just mounted).
+        var departingChain = _committedChain;
+        var version = _navVersion;
+        for (var i = departingChain.Length - 1; i >= 0; i--)
         {
-            var node = _committedChain[i];
+            var node = departingChain[i];
             if (matchedChain.Contains(node)) continue;
             node.Refresh();
+            if (version != _navVersion) return false;
         }
+        return true;
     }
 
     /// <summary>
@@ -2336,10 +2347,11 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 // must be released before the new subtree registers its own; see
                 // UnrenderDepartedRoutes. The pending-UI render already unmounted everything when
                 // departuresNotified is true, so this only runs on the no-pending-render path.
-                UnrenderDepartedRoutes(matchedChain);
-                // The render disposes departing components synchronously; a Dispose can run user
+                // The renders dispose departing components synchronously; a Dispose can run user
                 // code that starts a new navigation - the same supersession hazard as the
-                // departure callbacks above.
+                // departure callbacks above. UnrenderDepartedRoutes detects that mid-loop and
+                // reports it; the token check covers cancellation without a version bump.
+                if (UnrenderDepartedRoutes(matchedChain) is false) return;
                 if (token.IsCancellationRequested || version != _navVersion) return;
             }
 

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SectionHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SectionHost.razor
@@ -1,0 +1,8 @@
+@* Regression host for issue #12752: a shared layout owns a SectionOutlet and every page fills it
+   with SectionContent - the standard shared-footer pattern. Navigating between the two pages must
+   not throw the framework's "There is already a subscriber to the content with the given section
+   ID" InvalidOperationException. *@
+<Brouter DefaultLayout="@typeof(SectionTestLayout)">
+    <Broute Path="/section-a" Component="@typeof(SectionPageA)" />
+    <Broute Path="/section-b" Component="@typeof(SectionPageB)" />
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SectionIds.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SectionIds.cs
@@ -1,0 +1,11 @@
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// Section identifiers shared by the section-outlet regression tests (issue #12752): the layout's
+/// SectionOutlet and every page's SectionContent reference the same identity object, mirroring the
+/// common shared-footer pattern.
+/// </summary>
+public static class SectionIds
+{
+    public static readonly object Footer = new();
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SectionOutletTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SectionOutletTests.cs
@@ -1,0 +1,54 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// Regression tests for issue #12752: navigating between pages that both provide SectionContent
+/// for the same SectionId (rendered into a shared layout's SectionOutlet) must not throw the
+/// framework's "There is already a subscriber to the content with the given section ID" error.
+/// </summary>
+[TestClass]
+public class SectionOutletTests : BunitTestContext
+{
+    [TestMethod]
+    public void Navigating_forward_between_pages_with_section_content_does_not_throw()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/section-a");
+
+        var cut = RenderComponent<SectionHost>();
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual("footer-from-a", cut.Find("[data-testid=footer-content]").TextContent));
+
+        nav.NavigateTo("http://localhost/section-b");
+
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual("footer-from-b", cut.Find("[data-testid=footer-content]").TextContent));
+
+        // The issue's "navigate away and back" step: returning to the first page must resubscribe
+        // cleanly too.
+        nav.NavigateTo("http://localhost/section-a");
+
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual("footer-from-a", cut.Find("[data-testid=footer-content]").TextContent));
+    }
+
+    [TestMethod]
+    public void Navigating_back_to_an_earlier_declared_route_with_section_content_does_not_throw()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/section-b");
+
+        var cut = RenderComponent<SectionHost>();
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual("footer-from-b", cut.Find("[data-testid=footer-content]").TextContent));
+
+        nav.NavigateTo("http://localhost/section-a");
+
+        cut.WaitForAssertion(() =>
+            Assert.AreEqual("footer-from-a", cut.Find("[data-testid=footer-content]").TextContent));
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SectionPageA.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SectionPageA.razor
@@ -1,0 +1,7 @@
+@using Microsoft.AspNetCore.Components.Sections
+
+<div data-testid="section-page-a">page-a</div>
+
+<SectionContent SectionId="SectionIds.Footer">
+    <span data-testid="footer-content">footer-from-a</span>
+</SectionContent>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SectionPageB.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SectionPageB.razor
@@ -1,0 +1,7 @@
+@using Microsoft.AspNetCore.Components.Sections
+
+<div data-testid="section-page-b">page-b</div>
+
+<SectionContent SectionId="SectionIds.Footer">
+    <span data-testid="footer-content">footer-from-b</span>
+</SectionContent>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/SectionTestLayout.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/SectionTestLayout.razor
@@ -1,0 +1,9 @@
+@using Microsoft.AspNetCore.Components.Sections
+@inherits LayoutComponentBase
+
+<div data-testid="section-layout">
+    @Body
+    <footer data-testid="section-footer">
+        <SectionOutlet SectionId="SectionIds.Footer" />
+    </footer>
+</div>


### PR DESCRIPTION
closes #12752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation between pages that share section content to prevent duplicate section subscription errors.
  * Improved route commit behavior by explicitly unmounting/disposing departed route subtrees before mounting the next matched content.
* **Tests**
  * Added regression tests covering forward and back navigation between routes sharing the same section ID.
  * Added dedicated test pages and a shared layout/section outlet setup to verify footer section content updates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->