### PR TITLE
Add cloudflare purge cache by tag (#12788)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/07- ASP.NET Core Identity - Authentication & Authorization.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/07- ASP.NET Core Identity - Authentication & Authorization.md
@@ -1,991 +1,366 @@
 # Stage 7: ASP.NET Core Identity - Authentication & Authorization
 
-Welcome to **Stage 7** of the Boilerplate project tutorial! In this stage, you will explore the comprehensive **authentication and authorization system** built into the project. This production-ready identity system includes JWT-based authentication, role and permission management, session handling, two-factor authentication, and much more.
+This stage explains **how identity works in the Boilerplate** - the ideas and the decisions behind them, not a
+line-by-line tour. Once you have the model in your head, the code reads easily; every section links to the files
+where the real logic lives.
+
+The system is built on ASP.NET Core Identity and adds: JWT issuance the app fully controls, server-side session
+tracking, a role + permission model, one-time tokens, external providers, and (optionally) multi-tenancy.
+
+> WebAuthn, passkeys and passwordless sign-in are a separate topic - see
+> [Stage 24](/.docs/24-%20WebAuthn%20and%20Passwordless%20Authentication%20(Advanced).md).
+
+**Contents:** [Two ways in](#1-there-are-only-two-ways-in) · [Tokens & sessions](#2-tokens-and-sessions) ·
+[Authorization](#3-authorization) · [Multi-tenancy](#4-multi-tenancy) · [One-time tokens](#5-one-time-tokens) ·
+[External providers](#6-external-providers) · [Keycloak](#7-keycloak) · [Try it](#8-try-it-yourself)
 
 ---
 
-## Table of Contents
+## 1. There are only two ways in
 
-1. [Understanding Authentication Methods](#understanding-authentication-methods)
-   - [The Two Fundamental Methods](#the-two-fundamental-methods)
-   - [Two-Factor Authentication (2FA)](#two-factor-authentication-2fa)
-   - [Other Sign-In Methods Are Built on OTP](#other-sign-in-methods-are-built-on-otp)
-2. [Authentication Architecture](#authentication-architecture)
-   - [JWT Token-Based Authentication](#jwt-token-based-authentication)
-   - [Session Management](#session-management)
-   - [External Identity Support](#external-identity-support)
-3. [Authorization and Access Control](#authorization-and-access-control)
-   - [Role-Based and Permission-Based Authorization](#role-based-and-permission-based-authorization)
-   - [Policy-Based Authorization](#policy-based-authorization)
-   - [Custom Claim Types](#custom-claim-types)
-4. [Multi-Tenant](#multi-tenant)
-   - [How the Model Works](#how-the-model-works)
-   - [How a Request Resolves Its Tenant](#how-a-request-resolves-its-tenant)
-   - [Rules for Adding Tenant-Scoped Entities and Endpoints](#rules-for-adding-tenant-scoped-entities-and-endpoints)
-   - [Security Caveats](#security-caveats)
-5. [Identity Configuration](#identity-configuration)
-6. [Security Best Practices](#security-best-practices)
-7. [One-Time Token System](#one-time-token-system)
-8. [Advanced Topics](#advanced-topics)
-   - [JWT Token Signing with PFX Certificates](#jwt-token-signing-with-pfx-certificates)
-   - [Keycloak Integration](#keycloak-integration)
-9. [Hands-On Exploration](#hands-on-exploration)
-10. [Video Tutorial](#video-tutorial)
+Everything the UI offers reduces to one of these:
 
-**Important**: All topics related to WebAuthn, passkeys, and passwordless authentication are explained in [Stage 24](/.docs/24-%20WebAuthn%20and%20Passwordless%20Authentication%20(Advanced).md).
+1. **Identifier + password** - identifier being a username, email or phone number.
+2. **Identifier + OTP** - a 6-digit code delivered by email or SMS. Delivered as a clickable email link, this is
+   what users call a "magic link".
+
+Every other sign-in button - Google, GitHub, a passkey, a push notification code - finishes by generating an OTP
+and performing an **automatic OTP sign-in** behind the scenes.
+
+That indirection is deliberate. Because every path converges on the same final step:
+
+- 2FA is honoured no matter how the user started signing in,
+- sessions, lockout and claim issuance behave identically everywhere,
+- and there is a single pipeline to reason about instead of one per provider.
+
+> The username field exists but is commented out in the shipped sign-in/sign-up components, because most apps want
+> email or phone. Re-enable it if your business needs it.
+
+After the first step succeeds, **two-factor authentication** may still be required, depending on the user's own
+settings.
 
 ---
 
-## Understanding Authentication Methods
+## 2. Tokens and sessions
 
-Before diving into the technical architecture, it's important to understand that the Boilerplate project fundamentally supports only **two authentication methods**. All other sign-in options are built on top of these core methods.
+### The app mints its own JWTs
 
-### The Two Fundamental Methods
+Authentication is stateless: the client sends `Authorization: Bearer <access token>` on every call.
 
-**1. Identifier + Password**
-- **Identifier**: Username, Email, or Phone Number
-- **Password**: User's secret password
-- This is the traditional authentication method
+- **Access token** - short-lived (5 minutes by default). It carries the user's roles and permissions, so
+  authorizing a request needs no database round-trip.
+- **Refresh token** - long-lived (14 days by default). It is exchanged for a fresh pair at
+  `IdentityController.Refresh`, and is rotated on every use.
 
-**2. Identifier + OTP (One-Time Password)**
-- **Identifier**: Username, Email, or Phone Number  
-- **OTP**: A 6-digit code sent to the user
-- Also known as "Magic Link" authentication when delivered via email
+ASP.NET Core Identity's built-in bearer tokens are opaque, so the template replaces them:
+[`AppBearerTokenOptionsConfigurator`](/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppBearerTokenOptionsConfigurator.cs)
+swaps in [`AppJwtSecureDataFormat`](/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppJwtSecureDataFormat.cs),
+which writes and validates ordinary JWTs. That is what lets the client read claims out of the token, and what lets
+you hand the token to another service.
 
-> **Note about Username field**: In the default UI, the Username field is commented out to keep the interface clean and simple. If your business requires username-based authentication, you can easily re-enable it in the sign-in/sign-up components.
+A few properties worth knowing:
 
-### Two-Factor Authentication (2FA)
+- **Signing is asymmetric (RS256).** The private key comes from the app certificate loaded by
+  [`AppCertificateService`](/src/Server/Boilerplate.Server.Api/Infrastructure/Services/AppCertificateService.cs);
+  there is no signing secret in configuration. Generate your own before production - see
+  [`AppCertificate.md`](/src/Server/Boilerplate.Server.Api/AppCertificate.md). The app refuses to start outside
+  Development while the shipped self-signed certificate is still in use.
+- **The two token classes are not interchangeable.** The refresh token is issued under its own audience, and each
+  validator accepts only its own. Without that they would differ solely in lifetime, and a stolen refresh token
+  would work as an API credential for two weeks.
+- **Feature claims for admins are derived at read time**, not stored in the token - see
+  [Authorization](#3-authorization).
 
-Depending on user settings, **Two-Factor Authentication** may be triggered after the initial sign-in.
+### Sessions are tracked server-side
 
-### Other Sign-In Methods Are Built on OTP
+JWTs are stateless, but the app still keeps a
+[`UserSession`](/src/Server/Boilerplate.Server.Api/Features/Identity/Models/UserSession.cs) row per signed-in
+device, recording IP, approximate location, device and platform, app version, culture, and the SignalR connection
+id used to push notifications to that device.
 
-All alternative authentication methods in the Boilerplate ultimately generate a 6-digit OTP code and perform an **automatic OTP sign-in** behind the scenes:
+Its id travels in both tokens as the `s-id` claim, which is what makes **session revocation** possible: delete the
+row and that device can no longer refresh. Users manage their own sessions from the Settings page.
 
-| Method | How It Works |
-|--------|-------------|
-| **External Providers** (Google, Facebook, GitHub, etc.) | After successful OAuth flow, generates an OTP and auto-signs in |
-| **WebAuthn / Passkeys** (Fingerprint, Face ID) | After biometric verification, generates an OTP and auto-signs in |
-| **Magic Link** (Email link) | Clicking the link triggers OTP sign-in with the embedded token |
+**Privileged sessions** cap how many devices get full access at once (3 by default,
+`Identity:MaxPrivilegedSessionsCount`, overridable per user with the `mx-p-s` claim; `-1` means unlimited). Older
+sessions stay signed in but lose access to pages guarded by `PRIVILEGED_ACCESS`. Once a session is privileged it
+stays privileged. The Settings page is deliberately *not* guarded by this policy - otherwise a user could never
+reach the screen that lets them revoke a session and free a slot.
 
-This unified approach means:
-- ✅ **2FA is always respected** regardless of how the user signs in
-- ✅ **Session management works the same way** for all sign-in methods
-- ✅ **Simplified codebase** with a single authentication pipeline
+### Configuration
 
----
+Everything lives under the `Identity` section of
+[`appsettings.json`](/src/Server/Boilerplate.Server.Api/appsettings.json):
 
-## Authentication Architecture
+| Setting | Meaning |
+|---|---|
+| `Issuer` / `Audience` | Written into, and validated on, every token |
+| `BearerTokenExpiration` | Access token lifetime (`D.HH:mm:ss`) |
+| `RefreshTokenExpiration` | Refresh token lifetime |
+| `*TokenLifetime` | How long each kind of one-time token stays valid (email, phone, reset password, 2FA, OTP) |
+| `MaxPrivilegedSessionsCount` | Default privileged-session cap per user |
+| `Password` | Standard ASP.NET Core Identity complexity rules |
+| `SignIn:RequireConfirmedAccount` | Whether a confirmed email/phone is required to sign in |
 
-### JWT Token-Based Authentication
-
-The project uses **JWT (JSON Web Tokens)** for stateless authentication. Here's how it works:
-
-#### Key Characteristics
-
-- **Access Tokens**: Short-lived tokens (default: **5 minutes**) included in every API request via the `Authorization: Bearer <token>` header
-- **Refresh Tokens**: Long-lived tokens (default: **14 days**) stored securely on the client to obtain new access tokens without requiring the user to sign in again
-- **Token Generation**: Uses ASP.NET Core Identity's built-in bearer token authentication with the **HS512 algorithm**
-- **Security**: Tokens are signed using a secret key configured in [`appsettings.json`](/src/Server/Boilerplate.Server.Api/appsettings.json)
-
-#### Token Configuration
-
-You can configure token expiration in [`appsettings.json`](/src/Server/Boilerplate.Server.Api/appsettings.json):
-
-```json
-"Identity": {
-    "BearerTokenExpiration": "0.00:05:00",  // Format: D.HH:mm:ss (5 minutes)
-    "RefreshTokenExpiration": "14.00:00:00", // 14 days
-}
-```
-
----
-
-### Session Management
-
-Unlike traditional session cookies, this project implements **server-side session tracking** in the database while still using JWT tokens.
-
-#### The UserSession Entity
-
-User sessions are persisted in the database through the [`UserSession`](/src/Server/Boilerplate.Server.Api/Features/Identity/Models/UserSession.cs) entity:
-
-```csharp
-public partial class UserSession
-{
-    public Guid Id { get; set; }
-    public string? IP { get; set; }
-    public string? Address { get; set; }
-    public bool Privileged { get; set; }
-    public long StartedOn { get; set; }       // Unix timestamp
-    public long? RenewedOn { get; set; }      // Unix timestamp
-    public Guid UserId { get; set; }
-    public string? SignalRConnectionId { get; set; }
-    public string? DeviceInfo { get; set; }
-    public AppPlatformType? PlatformType { get; set; }
-    public string? CultureName { get; set; }
-    public string? AppVersion { get; set; }
-    // ... additional properties
-}
-```
-
-#### Key Features
-
-- **One Session Per Device**: Each active device/browser has its own `UserSession` record
-- **Detailed Tracking**: Sessions track IP address, device info, platform type, app version, and culture
-- **Real-Time Communication**: Sessions include SignalR connection IDs for push notifications
-- **User Control**: Users can view and manage all their active sessions from the Settings page
-
-#### Session ID in Tokens
-
-The session ID is embedded in both access and refresh tokens as a claim (`AppClaimTypes.SESSION_ID`). This enables:
-
-- **Session Revocation**: When a user revokes a session, its associated refresh token becomes invalid
-- **Forced Re-authentication**: Deleted sessions require users to sign in again on that device
-
-#### Session Creation Example
-
-From [`IdentityController.cs`](/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs):
-
-```csharp
-private async Task<UserSession> CreateUserSession(Guid userId, CancellationToken cancellationToken)
-{
-    var userSession = new UserSession
-    {
-        Id = Guid.NewGuid(),
-        UserId = userId,
-        StartedOn = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-        IP = HttpContext.Connection.RemoteIpAddress?.ToString(),
-        // Relying on Cloudflare CDN to retrieve location
-        Address = $"{Request.Headers["cf-ipcountry"]}, {Request.Headers["cf-ipcity"]}"
-    };
-
-    await UpdateUserSessionPrivilegeStatus(userSession, cancellationToken);
-    return userSession;
-}
-```
+Identity also brings the usual protections along, and the template does not weaken them: PBKDF2/HMAC-SHA512
+password hashing, security stamps that invalidate outstanding tokens when credentials change, concurrency stamps,
+and account lockout with backoff. reCAPTCHA protects sign-up when the `captcha` template option is enabled.
 
 ---
 
-### External Identity Support
+## 3. Authorization
 
-The project supports **external authentication providers** for Single Sign-On (SSO) and Social sign-in purposes.
+Two mechanisms, both delivered through the token:
 
-#### Supported Providers
+- **Roles** - coarse grouping (`g-admin`, `t-admin`, `demo`). A user can hold several.
+- **Permissions ("features")** - fine-grained capabilities, stored as claims on a user or on a role, and inherited
+  from every role the user holds.
 
-The following external identity providers have been already configured:
+Both are resolved once at sign-in and written into the token, which is why an authorization check costs nothing at
+request time. The trade-off is that changes take effect on the next token refresh rather than instantly.
 
-- **Google**
-- **Microsoft/Azure Entra/Azure AD B2C**
-- **Twitter (X)**
-- **Apple**
-- **GitHub**
-- **Facebook**
-- **Keycloak** Free, Open Source Identity and Access Management
+### Policies
 
-#### Configuration
+Three built-in policies, declared in [`AuthPolicies`](/src/Shared/Infrastructure/Services/AuthPolicies.cs) and
+registered in [`ISharedServiceCollectionExtensions`](/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs):
 
-External provider settings are configured in [`appsettings.json`](/src/Server/Boilerplate.Server.Api/appsettings.json) under the `Authentication` section:
+| Policy | Requires | Typical use |
+|---|---|---|
+| `PRIVILEGED_ACCESS` | This session is within the user's privileged-session cap | High-value pages: dashboard, catalog, todo |
+| `ELEVATED_ACCESS` | The user re-authenticated recently (a 6-digit code, or the first minutes of a 2FA sign-in) | Dangerous actions: deleting an account, managing roles |
+| `TENANT_SELECTED` | The token carries a tenant claim | Every endpoint that reads or writes tenant data |
 
-```json
-"Authentication": {
-    "Google": {
-        "ClientId": null,
-        "ClientSecret": null
-    },
-    "GitHub": {
-        "ClientId": null,
-        "ClientSecret": null
-    },
-    "AzureAD": {
-        "Instance": "https://login.microsoftonline.com/",
-        "TenantId": null,
-        "ClientId": null,
-        "ClientSecret": null,
-        "CallbackPath": "/signin-oidc"
-    }
-    // ... other providers
-}
-```
+`ELEVATED_ACCESS` is time-boxed: the claim holds the moment elevation expires, and the policy compares it against
+the current time. A stale value is therefore harmless, which is why it can be carried across token refreshes.
 
-#### External Sign-In Flow
+### Feature policies
 
-From [`IdentityController.ExternalSignIn.cs`](/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ExternalSignIn.cs):
+[`AppFeatures`](/src/Shared/Infrastructure/Services/AppFeatures.cs) declares the app's capabilities, grouped by
+area (`Management`, `System`, `AdminPanel`, `Todo`). The app **generates one policy per feature automatically**,
+so you never register them by hand - declaring a feature is enough to be able to `[Authorize]` on it.
 
-```csharp
-[HttpGet]
-public async Task<ActionResult> ExternalSignIn(string provider, string? returnUrl = null, 
-    int? localHttpPort = null, [FromQuery] string? origin = null)
-{
-    var redirectUrl = Url.Action(nameof(ExternalSignInCallback), "Identity", 
-        new { returnUrl, localHttpPort, origin });
-    var properties = signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl);
-    return new ChallengeResult(provider, properties);
-}
-```
+Feature values are terse strings like `"1.1"` rather than names, purely because they ride in every JWT and the
+payload should stay small.
 
-When a external sign-in is successful, the system:
-1. Retrieves user information from the external provider
-2. Either finds an existing user or creates a new one
-3. Automatically confirms email/phone if the provider provides them
-4. Generates a magic link for automatic sign-in (supports 2FA if enabled)
+Apply them like any other policy, and stack them freely - **all** attributes must pass:
 
----
-
-## Authorization and Access Control
-
-### Role-Based and Permission-Based Authorization
-
-The project implements a **hybrid authorization model** combining roles and permissions (claims).
-
-#### Users and Roles
-
-- Based on **ASP.NET Core Identity's** built-in `User` and `Role` entities
-- Users can be assigned to **multiple roles**
-- Roles are managed through the **Roles page** in the Admin Panel
-- Users are managed through the **Users page** in the Admin Panel
-
-#### Permissions (Claims)
-
-Fine-grained permission system using **claims**:
-
-- **User Claims**: Permissions assigned directly to individual users
-- **Role Claims**: Permissions assigned to roles (inherited by all users in that role)
-- Claims are added to the **JWT token payload** for efficient authorization checks (no database lookup needed)
-
----
-
-### Policy-Based Authorization
-
-The project defines **authorization policies** that can be used throughout the application.
-
-#### Policy Configuration
-
-Policies are defined in [`ISharedServiceCollectionExtensions.cs`](/src/Shared/Infrastructure/Extensions/ISharedServiceCollectionExtensions.cs):
-
-```csharp
-public void ConfigureAuthorizationCore() // an extension member on IServiceCollection
-{
-    services.AddSingleton<IAuthorizationHandler, FeatureRequirementHandler>();
-
-    services.AddAuthorizationCore(options =>
-    {
-        // Built-in policies
-        options.AddPolicy(AuthPolicies.PRIVILEGED_ACCESS,
-            x => x.RequireClaim(AppClaimTypes.PRIVILEGED_SESSION, "true"));
-        options.AddPolicy(AuthPolicies.ELEVATED_ACCESS,
-            x => x.RequireAssertion(ctx => ctx.User.GetElevatedSessionExpiresOn() > TimeProvider.GetUtcNow()));
-        // multitenant only:
-        options.AddPolicy(AuthPolicies.TENANT_SELECTED,
-            x => x.RequireAssertion(ctx => ctx.User.GetTenantId() is not null));
-
-        // Feature-based policies (automatically generated based on `AppFeatures`)
-        foreach (var feat in AppFeatures.GetGlobalAdminFeatures())
-        {
-            options.AddPolicy(feat.Value, policy => 
-                policy.AddRequirements(new AppFeatureRequirement(
-                    FeatureName: $"{feat.Group.Name}.{feat.Name}", 
-                    FeatureValue: feat.Value)));
-        }
-    });
-}
-```
-
-#### Built-in Authorization Policies
-
-Defined in [`AuthPolicies.cs`](/src/Shared/Infrastructure/Services/AuthPolicies.cs):
-
-**1. PRIVILEGED_ACCESS**
-```csharp
-/// <summary>
-/// Having this policy/claim in access token means the user is allowed to view pages that require privileged access.
-/// Currently, this policy applies only to the Todo and AdminPanel specific pages like dashboard page. 
-/// However, it can be extended to cover additional pages as needed. 
-/// 
-/// By default, each user is limited to 3 active sessions.
-/// The user's max privileged sessions' value is stored in <see cref="AppClaimTypes.MAX_PRIVILEGED_SESSIONS"/> claim.
-/// 
-/// Important: Do not apply this policy to the settings page, as users need access to manage and revoke their sessions there.
-/// </summary>
-public const string PRIVILEGED_ACCESS = nameof(PRIVILEGED_ACCESS);
-```
-- **Limits concurrent sessions** per user (default: **3 sessions**)
-- Prevents resource abuse by limiting active sessions
-- Applied to high-value pages like Dashboard, Products, Categories
-- Users can manage sessions from the Settings page
-
-**2. ELEVATED_ACCESS**
-```csharp
-/// <summary>
-/// Enables the user to execute potentially harmful operations, like account removal.
-/// This limited-time policy is activated upon successful verification via a secure 6-digit code
-/// or during the initial minutes of a sign-in session of users with 2FA enabled.
-/// </summary>
-public const string ELEVATED_ACCESS = nameof(ELEVATED_ACCESS);
-```
-- Requires **recent re-authentication** for sensitive operations
-- Used for dangerous actions like **account deletion**
-- Activated by entering a 6-digit code or during initial sign-in with 2FA enabled
-- **Time-limited** elevation (expires after a short period)
-
-**3. TENANT_SELECTED** *(multitenant only)*
-```csharp
-public const string TENANT_SELECTED = nameof(TENANT_SELECTED);
-```
-- Requires the access token to carry a `AppClaimTypes.TENANT_ID` claim, i.e. the user has selected a tenant
-- Protects tenant-data endpoints; all shipped tenant-data controllers already apply it
-
-#### Privileged Session Logic
-
-From [`IdentityController.cs`](/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs):
-
-```csharp
-private async Task UpdateUserSessionPrivilegeStatus(UserSession userSession, 
-    CancellationToken cancellationToken)
-{
-    var userId = userSession.UserId;
-
-    // Check if user has custom max session limit claim
-    var maxPrivilegedSessionsClaimValues = await userClaimsService
-        .GetClaimValues<int?>(userId, AppClaimTypes.MAX_PRIVILEGED_SESSIONS, cancellationToken);
-
-    // -1 means unlimited sessions
-    var hasUnlimitedPrivilegedSessions = maxPrivilegedSessionsClaimValues.Any(v => v == -1);
-
-    var maxPrivilegedSessionsCount = hasUnlimitedPrivilegedSessions 
-        ? -1 
-        : maxPrivilegedSessionsClaimValues.Max() ?? AppSettings.Identity.MaxPrivilegedSessionsCount;
-
-    // Determine if this session is privileged
-    var isPrivileged = hasUnlimitedPrivilegedSessions ||
-        userSession.Privileged is true || // Once privileged, stays privileged
-        await DbContext.UserSessions.CountAsync(
-            us => us.UserId == userSession.UserId && us.Privileged == true, 
-            cancellationToken) < maxPrivilegedSessionsCount;
-
-    // Add claims to the token
-    userClaimsPrincipalFactory.SessionClaims.Add(
-        new(AppClaimTypes.PRIVILEGED_SESSION, isPrivileged ? "true" : "false"));
-    userClaimsPrincipalFactory.SessionClaims.Add(
-        new(AppClaimTypes.MAX_PRIVILEGED_SESSIONS, 
-            maxPrivilegedSessionsCount.ToString(CultureInfo.InvariantCulture)));
-
-    userSession.Privileged = isPrivileged;
-}
-```
-
-#### Feature-Based Policies
-
-Defined in [`AppFeatures.cs`](/src/Shared/Infrastructure/Services/AppFeatures.cs):
-
-```csharp
-public class AppFeatures
-{
-    public class Management
-    {
-        public const string ManageAiPrompt = "1.0";
-        public const string ManageRoles = "1.1";
-        public const string ManageUsers = "1.2";
-    }
-
-    public class System
-    {
-        public const string ManageLogs = "2.0";
-        public const string ManageJobs = "2.1";
-    }
-
-    public class AdminPanel
-    {
-        public const string Dashboard = "3.0";
-        public const string ManageProductCatalog = "3.1";
-    }
-
-    public class Todo
-    {
-        public const string ManageTodo = "4.0";
-    }
-}
-```
-
-The project **automatically creates policies** for all features defined in `AppFeatures`. Each feature value (e.g., `"1.0"`) becomes a policy name.
-
-The reason behind small feature values is that they're stored in jwt token, so in order to keep jwt token payload small, such short, unique values have been assigned.
-
-#### Policy Usage Examples
-
-From actual pages in the project:
-
-**TodoPage.razor**:
-```csharp
-@attribute [Authorize(Policy = AuthPolicies.PRIVILEGED_ACCESS)]
-@attribute [Authorize(Policy = AppFeatures.Todo.ManageTodo)]
-```
-
-**UsersPage.razor**:
-```csharp
+```razor
 @attribute [Authorize(Policy = AuthPolicies.PRIVILEGED_ACCESS)]
 @attribute [Authorize(Policy = AppFeatures.Management.ManageUsers)]
 ```
 
-**DashboardPage.razor**:
-```csharp
-@attribute [Authorize(Policy = AuthPolicies.PRIVILEGED_ACCESS)]
-@attribute [Authorize(Policy = AppFeatures.AdminPanel.Dashboard)]
-```
+### Claims the server owns
 
-**Important**: When multiple `[Authorize]` attributes are used, **ALL policies must be satisfied** for the user to access the page.
+[`AppClaimTypes`](/src/Shared/Infrastructure/Services/AppClaimTypes.cs) lists the claim types the system computes
+itself: the session id, privileged-session flag and cap, elevation deadline, the granted feature list, the
+authentication method, and (under multi-tenancy) the current tenant.
 
----
+These are **per-session state, not data**. Never insert them into the `UserClaims` / `RoleClaims` tables and never
+accept them from an external provider - the server recomputes them on every sign-in, and a stored copy would
+either be ignored or, worse, believed.
 
-### Custom Claim Types
-
-#### System Claim Types
-
-Defined in [`AppClaimTypes.cs`](/src/Shared/Infrastructure/Services/AppClaimTypes.cs):
-
-```csharp
-/// <summary>
-/// These claims may not be added to RoleClaims/UserClaims tables.
-/// The system itself will assign these claims to the user based on AuthPolicies.
-/// </summary>
-public class AppClaimTypes
-{
-    public const string SESSION_ID = "s-id";
-    public const string PRIVILEGED_SESSION = "p-s";
-    public const string MAX_PRIVILEGED_SESSIONS = "mx-p-s";
-    public const string ELEVATED_SESSION = "e-s";
-    public const string FEATURES = "features";
-}
-```
-
-**Important**: These claims are **automatically added by the system** and should **not** be manually added to the database:
-
-- **`SESSION_ID`**: Unique identifier for the current user session => Guid value stored in UserSessions table
-- **`MAX_PRIVILEGED_SESSIONS`**: Maximum allowed privileged sessions for this user => -1 (Unlimited) or a positive number
-- **`PRIVILEGED_SESSION`**: Indicates if this session is privileged => "true" or "false"
-- **`ELEVATED_SESSION`**: Unix time seconds until which the session stays elevated (after recent authentication for sensitive operations). The `ELEVATED_ACCESS` policy checks it against the current time, so a passed value is harmless and can be carried across refresh token calls (e.g. tenant switches).
-- **`FEATURES`**: Contains the list of features/permissions values granted to the user => Array of AppFeature's values, for example ["1.1", "2.1"]
+Admin feature claims are a special case: rather than being stored, they are re-derived while the token is read -
+`g-admin` gets every feature, `t-admin` gets the tenant-scoped subset. So changing what an admin can do is a code
+change, not a data migration.
 
 ---
 
-## Multi-Tenant
+## 4. Multi-tenancy
 
-> **Availability**: This section applies only when the project is created with the **multi-tenant** template option enabled (`multitenant == true`). When it is disabled, none of the types below are generated and every entity is single-tenant.
+> Applies only when the project is generated with the **multi-tenant** option. Otherwise none of these types exist
+> and every entity is single-tenant.
 
-The Boilerplate implements multi-tenant as **row-level security**: a single tenant column on each tenant-owned table, plus a global EF Core query filter that transparently constrains every read to the caller's current tenant. Multiple tenants share the same database and the same user accounts; a user can belong to many tenants and switch between them.
+Multi-tenancy here is **row-level**: one database, one set of user accounts, and a tenant column on the tables that
+belong to a tenant. A user can belong to several tenants and switch between them; switching re-issues the token
+with a different tenant claim.
 
-### How the Model Works
+- [`Tenant`](/src/Server/Boilerplate.Server.Api/Features/Tenants/Tenant.cs) - its `Name` must be a valid sub-domain
+  label, because that is how anonymous requests resolve it. `IsActive` controls whether it can be used at all.
+- [`TenantUser`](/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantUser.cs) - membership. `AcceptedOn` is
+  null while the user has only been invited.
+- A seeded default tenant (`store`) owns all sample data and acts as the fallback.
 
-#### The `Tenant` and `TenantUser` entities
+### One filter, applied everywhere
 
-- [`Tenant`](/src/Server/Boilerplate.Server.Api/Features/Tenants/Tenant.cs) is the tenant itself. Its `Name` must satisfy sub-domain naming rules (see [`TenantDto.NAME_REGEX_PATTERN`](/src/Shared/Features/Tenants/Dtos/TenantDto.cs)) so the tenant can be resolved from a request sub-domain. `IsActive` controls whether the tenant can be signed/switched into.
-- [`TenantUser`](/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantUser.cs) is the many-to-many join between users and tenants. Its `AcceptedOn` is `null` while a user has only been **invited** (or has left), and is stamped the first time the user switches into the tenant (or up front for the user who created the tenant).
-- A seeded **default tenant** (`Name = "store"`, id `TenantConfiguration.FallbackTenantId`) is created by [`TenantConfiguration`](/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantConfiguration.cs). All data seeds live under it, and it is also used as the fallback tenant (see caveats below).
+An entity opts in by implementing
+[`ITenantAware`](/src/Server/Boilerplate.Server.Api/Features/Tenants/ITenantAware.cs) (a `TenantId` plus a `Tenant`
+navigation). `AppDbContext.OnModelCreating` then applies the same global query filter - and the same
+`OnDelete(NoAction)` relationship - to every such entity by reflection. You never write the filter yourself, and
+there is no other global filter in the model to compose with.
 
-#### `ITenantAware` and the global query filter
+Two limits matter more than anything else in this section:
 
-Any entity that should be isolated per tenant implements [`ITenantAware`](/src/Server/Boilerplate.Server.Api/Features/Tenants/ITenantAware.cs), which requires a `Guid TenantId` and a `Tenant` navigation:
+> **A query filter constrains reads only.** It does not stamp `TenantId` on insert, and it does not apply when you
+> update or delete a detached stub entity. Those paths are yours to get right.
 
-```csharp
-public interface ITenantAware
-{
-    public Guid TenantId { get; set; }
+> **Identity tables are scoped by convention, not by the filter.** `Role`, `UserRole`, `UserClaim` and
+> `UserSession` carry a *nullable* `TenantId` (null = global, e.g. the `g-admin` role) and deliberately do not
+> implement `ITenantAware`. Their scoping is enforced in code - by `UserClaimsService` when it builds a token, and
+> by the management controllers when they list or mutate. Any new query against them must carry its own predicate.
 
-    [ForeignKey(nameof(TenantId))]
-    public Tenant? Tenant { get; set; }
-}
-```
+### How a request finds its tenant
 
-In [`AppDbContext.OnModelCreating`](/src/Server/Boilerplate.Server.Api/Infrastructure/Data/AppDbContext.cs), a small reflection loop applies the **same tenant filter to every `ITenantAware` entity** - you never write the filter by hand:
+`TenantProvider` answers that question, in order:
 
-```csharp
-private void ConfigureTenantAwareEntities(ModelBuilder modelBuilder)
-{
-    foreach (var entityType in modelBuilder.Model.GetEntityTypes()
-        .Where(et => typeof(ITenantAware).IsAssignableFrom(et.ClrType)))
-    {
-        // reflectively calls SetTenantQueryFilter<TEntity>(modelBuilder)
-    }
-}
+| | Source | Applies to |
+|---|---|---|
+| 1 | Throws when there is no `HttpContext` | Background jobs - fails closed instead of guessing |
+| 2 | The signed-in user's tenant claim | Authenticated requests. Server-issued, therefore trusted |
+| 3 | A tenant whose custom `Domain` matches the whole request host | Anonymous requests on a vanity domain |
+| 4 | A tenant whose `Name` matches the host's sub-domain | Anonymous requests, e.g. public product pages |
+| 5 | The default tenant | Nothing else matched |
 
-private void SetTenantQueryFilter<TEntity>(ModelBuilder modelBuilder)
-    where TEntity : class, ITenantAware
-{
-    modelBuilder.Entity<TEntity>().HasQueryFilter(x => x.TenantId == CurrentTenantId);
-}
+Steps 3 and 4 read a cached lookup of active tenants, invalidated whenever a tenant is created or updated - so
+deactivating a tenant stops it serving anonymous traffic.
 
-private TenantProvider tenantProvider => field ??= this.GetService<TenantProvider>();
-private Guid CurrentTenantId => tenantProvider.GetCurrentTenantId();
-```
+`TenantProvider` must stay a **singleton**: `AppDbContext` is pooled and resolves it from the root provider, so
+making it scoped compiles but fails at the first query.
 
-> ⚠️ `AppDbContext` is registered with `AddDbContextPool` / `AddPooledDbContextFactory`, and the lazy resolution above goes through the **root** service provider. `TenantProvider` therefore has to stay a **singleton**; making it scoped compiles fine but throws on the first query.
+### Rules for adding tenant-scoped code
 
-Out of the box, `Product`, `Category`, and `SystemPrompt` are the `ITenantAware` entities. The filter is the **only** global query filter in the model, so there is no soft-delete or other filter to combine with.
+1. **Implement `ITenantAware`.** The filter comes for free. If a value must be unique per tenant, put `TenantId`
+   first in the index and add a migration.
+2. **Stamp `TenantId` yourself on create**, from the claim - never from the request DTO:
+   ```csharp
+   entityToAdd.TenantId = User.GetTenantId() ?? throw new InvalidOperationException();
+   ```
+   The shared DTOs deliberately expose no `TenantId` so a mapper cannot smuggle one in. Keep it that way.
+3. **Load before you update or delete.** A filtered read returns `null` for another tenant's row, which becomes a
+   404. Removing a hand-built stub bypasses the filter entirely. Carry the `Version` concurrency token through.
+4. **Guard the endpoint with `TENANT_SELECTED`**, so the tenant always comes from the signed claim and an
+   authenticated user without a tenant can never fall through to host-based resolution.
+5. **Scope identity data by hand** - roles, claims, sessions. See the note above.
+6. **Put the tenant id in your cache keys**, and don't mark tenant-varying responses as user-agnostic.
 
-> ⚠️ **Reads only.** A global query filter constrains `SELECT`s. It does **not** stamp `TenantId` on `INSERT`, and it does **not** apply to `DELETE`/`UPDATE` of a detached (stub) entity. Those paths must be handled explicitly - see the rules below.
+### Caveats worth knowing before you ship
 
-#### Identity tables are tenant-scoped by *convention*, not by the filter
-
-`Role`, `UserRole`, `UserClaim`, and `UserSession` each carry a **nullable** `TenantId` and deliberately do **not** implement `ITenantAware`:
-
-- `TenantId == null` → a **global** row (e.g. the `g-admin` role, or a claim that applies in every tenant).
-- `TenantId == <guid>` → the row only applies while the user is signed into that tenant.
-
-Because they are not `ITenantAware`, they get **no** global query filter; their tenant scoping is enforced manually in code:
-
-- At **token-issuance** time, [`UserClaimsService.GetClaims`](/src/Server/Boilerplate.Server.Api/Features/Identity/Services/UserClaimsService.cs) filters user claims and roles with `x.TenantId == null || x.TenantId == tenantId`, so a token only ever carries the current tenant's roles/claims plus global ones.
-- In the **management controllers** ([`RoleManagementController`](/src/Server/Boilerplate.Server.Api/Features/Identity/RoleManagementController.cs), [`UserManagementController`](/src/Server/Boilerplate.Server.Api/Features/Identity/UserManagementController.cs)), every query for a non-global admin is filtered by `TenantId == User.GetTenantId()`.
-
-Each tenant gets its own `t-admin` role; the `g-admin` (global admin) role is global. Feature claims are re-derived from the role on every request in [`AppJwtSecureDataFormat.Unprotect`](/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppJwtSecureDataFormat.cs) (`g-admin` → all features, `t-admin` → the tenant-scoped subset from `AppFeatures.GetTenantAdminFeatures()`).
-
-### How a Request Resolves Its Tenant
-
-The singleton [`TenantProvider`](/src/Server/Boilerplate.Server.Api/Features/Identity/Services/TenantProvider.cs) turns the current request into a `TenantId`, which `AppDbContext` reads through `CurrentTenantId`. Resolution order:
-
-| # | Source | When it applies |
-|---|--------|-----------------|
-| 1 | **Throw** if there is no `HttpContext` | Background jobs - fails closed rather than guessing a tenant |
-| 2 | **`t-id` claim** of the signed-in user (`User.GetTenantId()`) | Authenticated requests - the trusted, server-issued tenant |
-| 3 | **Custom domain**: the tenant whose `Tenant.Domain` equals the complete request `Host` | Anonymous requests on a vanity domain, e.g. `shop.contoso.com` |
-| 4 | **Sub-domain** of the request `Host` (matched against active tenants by `Tenant.Name`) | Anonymous requests, e.g. the public Sales product pages on `tenant.example.com` |
-| 5 | **Fallback** to `TenantConfiguration.FallbackTenantId` (the seeded `"store"` tenant) | Nothing else matched (apex domain, unknown sub-domain, authenticated user with no tenant) |
-
-The domain/sub-domain lookups (3 and 4) read a cached lookup of the **active** tenants (`TENANTS_CACHE_KEY`, invalidated whenever a tenant is created/updated), so a deactivated tenant stops serving its data to anonymous requests.
-
-```csharp
-public Guid GetCurrentTenantId()
-{
-    var httpContext = httpContextAccessor.HttpContext;
-    if (httpContext is null)                                            // (1) background job
-        throw new InvalidOperationException("TenantProvider doesn't function inside background jobs, use IgnoreQueryFilters to prevent it from being called.");
-
-    var user = httpContext.User;
-    if (user.IsAuthenticated() && user.GetTenantId() is Guid claimTenantId)
-        return claimTenantId;                                           // (2) claim
-
-    // ... custom domain lookup ...                                     // (3) custom domain
-    // ... sub-domain lookup ...                                        // (4) sub-domain
-    return TenantConfiguration.FallbackTenantId;                        // (5) fallback
-}
-```
-
-### Rules for Adding Tenant-Scoped Entities and Endpoints
-
-Follow these rules whenever you add a new tenant-owned entity or a create/update/delete endpoint.
-
-**1. Make the entity `ITenantAware`.** Implement the interface (add `TenantId` + `Tenant` nav). The global filter is applied automatically - no per-entity wiring needed. If a value must be unique *within* a tenant, make the index tenant-scoped, e.g. `builder.HasIndex(p => new { p.TenantId, p.Name }).IsUnique();`, then add a migration.
-
-**2. Stamp `TenantId` on create - server-side, from the trusted claim.** The query filter does not do this for you. Always:
-
-```csharp
-entityToAdd.TenantId = User.GetTenantId() ?? throw new InvalidOperationException();
-```
-
-Never bind `TenantId` from the client DTO. (The shared DTOs intentionally expose no `TenantId`, so the mapper cannot smuggle one - keep it that way.)
-
-**3. On update/delete, fetch the row through a filtered query first - never a detached stub.** Loading via `FindAsync` / `FirstOrDefaultAsync` / `Where(...)` applies the tenant filter, so a row in another tenant simply returns `null` (→ `ResourceNotFoundException`). Deleting or updating a hand-constructed stub (`Remove(new() { Id = id })`) **bypasses the filter** and can reach another tenant's row.
-
-Always carry the `long Version` concurrency token through updates/deletes.
-
-**4. Protect tenant-data endpoints with `TENANT_SELECTED`.** Add `[Authorize(Policy = AuthPolicies.TENANT_SELECTED)]` (the policy asserts `User.GetTenantId() is not null`). This guarantees the tenant comes from the signed claim and prevents an authenticated user *without* a tenant from ever falling through to sub-domain/fallback resolution. All shipped tenant-data controllers (`Product`, `Category`, `Chatbot`, `Dashboard`, `UserManagement`, `RoleManagement`) already do this.
-
-**5. Scope identity data (roles/claims/sessions) manually.** These tables are not `ITenantAware`. Set `TenantId` when creating tenant-scoped roles/claims, and when reading/mutating them for a non-global admin, filter by `TenantId == User.GetTenantId()` (and verify `TenantUser` membership with `AcceptedOn != null` where relevant), mirroring the existing management controllers.
-
-**6. Tenant-scope your cache keys.** Any cache entry that holds per-tenant data must include the tenant id in its key, e.g. `\$"SystemPrompt_{TenantProvider.GetCurrentTenantId()}_{promptKind}"`. For HTTP response/output caching of tenant-varying data, do not mark it `UserAgnostic` and make sure the cache key varies by tenant (or host).
-
-### Security Caveats
-
-- **`IgnoreQueryFilters()` removes tenant isolation.** Any query that calls it must **re-apply** a tenant check explicitly. The one legitimate use in the template - [`AttachmentController.EnsureProductIsInCurrentTenant`](/src/Server/Boilerplate.Server.Api/Features/Attachments/AttachmentController.cs) - bypasses the filter to look up a product's real tenant and then compares it against `TenantProvider.GetCurrentTenantId()`, rejecting cross-tenant products. Follow that pattern; never return `IgnoreQueryFilters()` results to a caller unscoped.
-- **Background jobs have no `HttpContext`.** `GetCurrentTenantId()` throws by design instead of silently using the fallback tenant, so a job that touches `ITenantAware` data has to use `IgnoreQueryFilters()` and re-apply the tenant predicate itself (`Where(x => x.TenantId == tenantId)`) for each tenant it processes.
-- **The fallback tenant is a fail-open surface.** Anonymous requests to the apex domain or an unknown sub-domain - and any authenticated request that reaches tenant data without a tenant claim - resolve to the seeded `"store"` tenant. Keep real or sensitive data out of the default tenant, and pin the accepted hosts (`AllowedHosts`) so the sub-domain that selects a tenant cannot be spoofed via the `Host` header. Only expose genuinely public, per-tenant data through anonymous, sub-domain-resolved endpoints.
-- **Identity tables are not filtered by the model.** Because `Role`/`UserRole`/`UserClaim`/`UserSession` rely on manual scoping, any new query against them must add the `TenantId == User.GetTenantId()` (or `TenantId == null`) predicate itself - the global filter will not save you.
-- **Privilege changes are eventually-consistent (short-lived tokens).** When an admin **removes** a user from a tenant, `RemoveUserFromCurrentTenant` revokes that user's sessions signed into the tenant (deletes them + a SignalR `SESSION_REVOKED` nudge, like `KickOutTenantUsers`), so the removed member cannot refresh back in. When a user **leaves** a tenant themselves, their session is instead re-pointed to their next tenant and the client refreshes immediately (they keep their own access). In every case a JWT is stateless and there is no per-request session/security-stamp check on ordinary API calls, so an *already-issued* access token stays valid until it expires (default 5 minutes) - that residual window is inherent to short-lived JWTs and applies to all privilege changes.
+- **`IgnoreQueryFilters()` removes isolation.** The one legitimate use in the template (looking up a product's real
+  tenant to reject cross-tenant access) re-applies the check by hand immediately. Follow that shape.
+- **Background jobs have no tenant.** They must ignore the filter and apply their own predicate per tenant.
+- **The fallback tenant is fail-open.** Anonymous traffic on an unknown host lands there, so keep sensitive data
+  out of it.
+- **The host that selects a tenant is not pinned by `AllowedHosts`.** Resolution goes through the request's
+  web-app URL, which honours a client-supplied origin when that origin is trusted. The list that actually governs
+  it is `TrustedOrigins`. A wildcard entry - which a per-tenant client app needs - deliberately lets any caller
+  select any tenant by header; enumerate origins explicitly if you don't want that.
+- **A tenant's custom `Domain` outranks its sub-domain and is self-service.** Reserved-name checks stop a tenant
+  claiming a host the deployment itself answers on, but nothing can tell whether a third-party domain really
+  belongs to that tenant. Verify ownership out of band (DNS/ACME challenge, or admin approval) before saving one.
+- **Privilege changes are eventually consistent.** Removing a user from a tenant revokes their sessions in that
+  tenant, but an already-issued access token stays valid until it expires. That window is inherent to short-lived
+  JWTs.
 
 ---
 
-## Identity Configuration
+## 5. One-time tokens
 
-### IdentitySettings in appsettings.json
+Confirmation codes, magic links, password resets, 2FA and elevation codes all share one mechanism, and it is worth
+understanding once.
 
-**Location**: [`/src/Server/Boilerplate.Server.Api/appsettings.json`](/src/Server/Boilerplate.Server.Api/appsettings.json)
+The `User` entity keeps a `…RequestedOn` timestamp per token kind. When a token is generated, that timestamp is set
+to now **and embedded in the token's purpose string**. Validation regenerates the purpose from the *current*
+timestamp and compares.
 
-**Configuration Options**:
+Everything else follows from that single trick:
 
-```json
-"Identity": {
-    "Issuer": "Boilerplate",
-    "Audience": "Boilerplate",
-    "BearerTokenExpiration": "0.00:05:00",
-    "RefreshTokenExpiration": "14.00:00:00",
-    "EmailTokenLifetime": "0.00:02:00",
-    "PhoneNumberTokenLifetime": "0.00:02:00",
-    "ResetPasswordTokenLifetime": "0.00:02:00",
-    "TwoFactorTokenLifetime": "0.00:02:00",
-    "OtpTokenLifetime": "0.00:02:00",
-    "MaxPrivilegedSessionsCount": 3,
-    "Password": {
-        "RequireDigit": "false",
-        "RequiredLength": "6",
-        "RequireNonAlphanumeric": "false",
-        "RequireUppercase": "false",
-        "RequireLowercase": "false"
-    },
-    "SignIn": {
-        "RequireConfirmedAccount": true
-    }
-}
-```
+- Requesting a new token silently invalidates every earlier one - the old purpose string no longer matches.
+- Consuming a token sets the timestamp to `null`, so it cannot be replayed.
+- Expiry is just "now minus `RequestedOn` exceeds the configured lifetime".
+- The same timestamp rate-limits requests, so a user cannot spam themselves with codes.
 
-#### Key Settings Explained
-
-- **BearerTokenExpiration**: How long access tokens remain valid (default: 5 minutes)
-- **RefreshTokenExpiration**: How long refresh tokens remain valid (default: 14 days)
-- **EmailTokenLifetime**: Email confirmation token lifetime (default: 2 minutes)
-- **TwoFactorTokenLifetime**: 2FA code validity period (default: 2 minutes)
-- **MaxPrivilegedSessionsCount**: Default limit for privileged sessions per user
-- **Password Requirements**: Configures password complexity rules
-- **RequireConfirmedAccount**: Whether email/phone confirmation is required for sign-in
+In practice: a reset requested at 10:00 stops working the moment another is requested at 10:05, and the 10:05 one
+dies the instant it is used.
 
 ---
 
-## Security Best Practices
+## 6. External providers
 
-The identity system follows **industry-standard security best practices**:
+Google, Microsoft/Entra, Apple, Facebook, GitHub, Twitter (X) and Keycloak are pre-wired. Each is enabled simply by
+filling in its client id and secret under the `Authentication` section of `appsettings.json` - a provider with no
+credentials is not registered and its button does not appear.
 
-### 1. Password Hashing
-- Uses **PBKDF2 with HMAC-SHA512**
-- **100,000 iterations** for strong protection against brute-force attacks
+The flow is ordinary OAuth/OIDC, with a Boilerplate-specific ending:
 
-### 2. Concurrency Stamps
-- **Prevents concurrent modification conflicts**
-- Each entity has a `ConcurrencyStamp` that changes on every update
+1. The user is redirected to the provider and comes back to the callback.
+2. The app looks for an existing link; failing that, it looks for a local account with the same email or phone.
+3. If nothing matches, a new user is created. Providers that manage their own roles (Keycloak) get no local role;
+   consumer providers get the demo role.
+4. A magic link is generated and the user is signed in through the normal OTP path - so 2FA still applies.
 
-### 3. Security Stamps
-- **Invalidates all tokens** when changed
-- Updated automatically after 2FA configuration, password changes, etc.
-
-### 4. Account Lockout
-- **Protects against brute-force attacks**
-- Exponential backoff with increasing lockout duration
-
-### 5. One-Time Tokens
-- **All tokens can only be used once**
-- Tokens expire after their configured lifetime
-- See detailed explanation in the next section
-
-### 6. Token Expiration
-- **Short-lived access tokens** (5 minutes) minimize the window for token theft
-- Refresh tokens allow seamless user experience without compromising security
-
-### 7. Google reCAPTCHA
-- **Protects sign-up endpoints** from bot attacks
-- Configurable in appsettings.json
+> ⚠️ **Before adding your own provider, check that it verifies email addresses.**
+> Step 2 attaches an incoming identity to an *existing* account purely on the identifier the provider asserts. That
+> is what makes "sign in with Google" reach the account you originally created with a password, and it is safe for
+> the providers shipped here, which only ever hand out addresses their owner has proven control of.
+> It is **not** safe for a provider whose users choose their own unverified address - a self-hosted Keycloak realm
+> with self-registration, Entra with personal accounts, or any OIDC provider you add. There, anyone could claim
+> someone else's address and take over their account. In that case, require the provider's `email_verified` claim
+> before that fallback, or replace it with an explicit link-your-account flow.
 
 ---
 
-## One-Time Token System
+## 7. Keycloak
 
-The project implements a **secure one-time token system** with automatic expiration and invalidation.
+Keycloak is included as a full identity server for development: with .NET Aspire enabled it starts automatically as
+a container, pre-loaded from
+[`dev-realm.json`](/src/Server/Boilerplate.Server.AppHost/Infrastructure/Realms/dev-realm.json) with demo accounts.
 
-### How It Works
+| Username | Password | Group |
+|---|---|---|
+| test | 123456 | `g-admin` |
+| bob | bob | `demo` |
+| alice | alice | `demo` |
 
-#### Token Request Tracking
+The realm also carries a `t-admin` group, used when multi-tenancy is enabled.
 
-Each token type has a corresponding `RequestedOn` timestamp in the [`User`](/src/Server/Boilerplate.Server.Api/Features/Identity/Models/User.cs) entity:
+**How it maps.** Keycloak **groups** become ASP.NET Core **roles**, and Keycloak **user attributes** become claims.
+Keycloak's own *roles* (which are a different concept) are not mapped. Tokens are still issued by the app, not by
+Keycloak - Keycloak authenticates, the app decides what the resulting token says.
 
-```csharp
-public partial class User : IdentityUser<Guid>
-{
-    /// <summary>
-    /// The date and time of the last token request. 
-    /// Ensures only the latest generated token is valid and can only be used once.
-    /// </summary>
-    public DateTimeOffset? EmailTokenRequestedOn { get; set; }
-    public DateTimeOffset? PhoneNumberTokenRequestedOn { get; set; }
-    public DateTimeOffset? ResetPasswordTokenRequestedOn { get; set; }
-    public DateTimeOffset? TwoFactorTokenRequestedOn { get; set; }
-    public DateTimeOffset? OtpRequestedOn { get; set; }
-    public DateTimeOffset? ElevatedAccessTokenRequestedOn { get; set; }
-}
-```
+**Revalidation.** A user counts as Keycloak-backed when the deployment has Keycloak configured *and* a Keycloak
+refresh token is stored for them - not based on how they happened to sign in this time. Whenever a token is issued,
+that refresh token is exchanged for fresh claims; if Keycloak rejects it because the account was disabled or
+deleted, sign-in fails. This is *near*-real-time, not instant: while a previously fetched Keycloak access token is
+still valid it is reused without contacting the server.
 
-#### Token Generation
+> **Keycloak is a trusted claims authority, by design.** Its groups become roles and its `features` attribute
+> becomes app permissions directly - so whoever administers the realm can grant application-level global admin.
+> That is the intended trade-off of federating identity. The exception is the per-session claims the server owns
+> (session id, privileged/elevated session, tenant): those are dropped from the copy, so a realm attribute cannot
+> forge an elevated session or select a tenant.
 
-When a token is generated, the `RequestedOn` timestamp is set to the **current time** and **embedded in the token purpose string**.
-
-From [`IdentityController.EmailConfirmation.cs`](/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.EmailConfirmation.cs):
-
-```csharp
-private async Task SendConfirmEmailToken(User user, string? returnUrl, 
-    CancellationToken cancellationToken)
-{
-    // Set the request timestamp
-    user.EmailTokenRequestedOn = DateTimeOffset.Now;
-    var result = await userManager.UpdateAsync(user);
-
-    if (result.Succeeded is false)
-        throw new ResourceValidationException(result.Errors
-            .Select(e => new LocalizedString(e.Code, e.Description)).ToArray())
-            .WithData("UserId", user.Id);
-
-    var email = user.Email!;
-    
-    // Generate token with embedded timestamp
-    var token = await userManager.GenerateUserTokenAsync(
-        user, 
-        TokenOptions.DefaultPhoneProvider, 
-        FormattableString.Invariant($"VerifyEmail:{email},{user.EmailTokenRequestedOn?.ToUniversalTime()}")
-    );
-    
-    var link = new Uri(HttpContext.Request.GetWebAppUrl(), 
-        $"{PageUrls.Confirm}?email={Uri.EscapeDataString(email)}&emailToken={Uri.EscapeDataString(token)}&culture={CultureInfo.CurrentUICulture.Name}");
-
-    await emailService.SendEmailToken(user, email, token, link, cancellationToken);
-}
-```
-
-#### Token Validation
-
-When validating a token, the system checks:
-
-1. **Expiration**: Has the token lifetime elapsed since `RequestedOn`?
-2. **One-Time Use**: Does the token match the **latest** `RequestedOn` timestamp?
-3. **Invalidation**: Is the `RequestedOn` timestamp set to `null` (invalidated)?
-
-From [`IdentityController.EmailConfirmation.cs`](/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.EmailConfirmation.cs):
-
-```csharp
-[HttpPost, Produces<TokenResponseDto>()]
-public async Task ConfirmEmail(ConfirmEmailRequestDto request, CancellationToken cancellationToken)
-{
-    var user = await userManager.FindByEmailAsync(request.Email!)
-        ?? throw new BadRequestException(Localizer[nameof(AppStrings.UserNotFound)])
-            .WithData("Email", request.Email);
-
-    // Check if token has expired
-    var expired = (DateTimeOffset.Now - user.EmailTokenRequestedOn) 
-        > AppSettings.Identity.EmailTokenLifetime;
-
-    if (expired)
-        throw new BadRequestException(nameof(AppStrings.ExpiredToken))
-            .WithData("UserId", user.Id);
-
-    // Verify the token with embedded timestamp
-    var tokenIsValid = await userManager.VerifyUserTokenAsync(
-        user, 
-        TokenOptions.DefaultPhoneProvider, 
-        FormattableString.Invariant($"VerifyEmail:{request.Email},{user.EmailTokenRequestedOn?.ToUniversalTime()}"), 
-        request.Token!
-    );
-
-    if (tokenIsValid is false)
-    {
-        await userManager.AccessFailedAsync(user);
-        throw new BadRequestException(nameof(AppStrings.InvalidToken))
-            .WithData("UserId", user.Id);
-    }
-
-    // Confirm the email
-    await userEmailStore.SetEmailConfirmedAsync(user, true, cancellationToken);
-    await userManager.UpdateAsync(user);
-
-    // Invalidate the token by setting RequestedOn to null
-    user.EmailTokenRequestedOn = null;
-    var updateResult = await userManager.UpdateAsync(user);
-    if (updateResult.Succeeded is false)
-        throw new ResourceValidationException(updateResult.Errors
-            .Select(e => new LocalizedString(e.Code, e.Description)).ToArray())
-            .WithData("UserId", user.Id);
-
-    // Auto sign-in after confirmation
-    var token = await userManager.GenerateUserTokenAsync(user, 
-        TokenOptions.DefaultPhoneProvider, 
-        FormattableString.Invariant($"Otp_Email,{user.OtpRequestedOn?.ToUniversalTime()}"));
-
-    await SignIn(new() { Email = request.Email, Otp = token }, cancellationToken);
-}
-```
-
-### Key Benefits
-
-✅ Only the **most recently requested token** is valid  
-✅ Tokens are **automatically invalidated** after successful use  
-✅ Tokens **expire** after their configured lifetime  
-✅ If a user requests a new token, **all previous tokens become invalid**  
-✅ User can't ask for a token frequently
-
-### Example Scenario
-
-Let's walk through a password reset scenario:
-
-1. **10:00 AM**: User requests a password reset
-   - Token A is generated
-   - `ResetPasswordTokenRequestedOn = 10:00`
-
-2. **10:05 AM**: User requests another password reset (maybe they didn't receive the email)
-   - Token B is generated
-   - `ResetPasswordTokenRequestedOn = 10:05`
-
-3. **Token A is now invalid**
-   - Token A was generated at 10:00
-   - But the current `ResetPasswordTokenRequestedOn` is 10:05
-   - Token A will fail validation
-
-4. **User uses Token B successfully**
-   - Token B is validated
-   - Password is reset
-   - `ResetPasswordTokenRequestedOn` is set to `null`
-
-5. **Token B can never be used again**
-   - Even if someone intercepts Token B, it's already invalidated
+**Sharing tokens with other services.** Signing is already asymmetric, so hand another service the *public* key and
+let it validate normally. The private key never leaves the API.
 
 ---
 
-## Advanced Topics
+## 8. Try it yourself
 
-### Keycloak Integration
+Run the project and walk through these - it is faster than reading:
 
-Bit Boilerplate includes built-in support for **Keycloak**, a free, open-source identity and access management solution. Keycloak provides enterprise-grade features like:
-
-- Centralized user management
-- Single Sign-On (SSO) across multiple applications
-- Fine-grained authorization
-- User federation (LDAP, Active Directory)
-
-#### Keycloak in .NET Aspire
-
-When you run the project with .NET Aspire enabled (default configuration), Keycloak is automatically started as a containerized service. This provides a complete identity server for development and testing without any manual setup.
-
-#### Demo User Accounts
-
-The Keycloak instance comes pre-configured with the following demo accounts (Provided by [src\Server\Boilerplate.Server.AppHost\Infrastructure\Realms\dev-realm.json](..\src\Server\Boilerplate.Server.AppHost\Infrastructure\Realms\dev-realm.json)):
-
-| Username | Password | Role | Description |
-|----------|----------|--------------|-------------|
-| test | 123456 | g-admin (Global admin) | Full administrative access |
-| bob | bob | demo | Standard demo user |
-| alice | alice | demo | Standard demo user |
-
-Note: The realm also contains a `t-admin` (tenant admin) group that maps to each tenant's admin role when the multi-tenant feature is enabled.
-
-#### How Keycloak Mapping Works
-
-The Boilerplate template integrates Keycloak with ASP.NET Core Identity through a custom mapping system in [`AppUserClaimsPrincipalFactory`](/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppUserClaimsPrincipalFactory.cs):
-
-**1. Groups → Roles**
-- Keycloak **groups** are mapped to ASP.NET Core Identity **roles**
-- Users inherit all roles from their group memberships
-
-**2. Attributes → Claims**
-- **User attributes** in Keycloak become individual claims
-- **Group attributes** are also mapped to claims
-
-**3. Keycloak Roles → Custom Mapping** (Not required with the current project setup)
-- Keycloak's built-in **roles** (distinct from groups) are **not automatically mapped**
-- These roles follow a different structure than ASP.NET Core Identity roles
-
-#### Real-Time Claim Synchronization
-
-The `AppUserClaimsPrincipalFactory` retrieves the latest claims from Keycloak on every ASP.NET Core Identity token refresh:
-
-**Security Benefits:**
-- **Automatic Deactivation**: If a user is disabled or deleted in Keycloak, access is immediately revoked
-- **Fresh Claims**: Every token refresh fetches the latest permissions from Keycloak
-- **Session Validation**: Expired or revoked Keycloak sessions trigger `UnauthorizedException`
-
-#### JWT Token Issuance Flow
-
-Despite using Keycloak for authentication, the final JWT tokens are still issued by **ASP.NET Core Identity**:
-
-1. User signs in through Keycloak (via OpenID Connect)
-2. `AppUserClaimsPrincipalFactory` retrieves claims from Keycloak
-3. ASP.NET Core Identity merges Keycloak claims with local claims
-4. A new JWT is issued and signed using the configured secret (or PFX certificate)
-5. The JWT is sent to the client and used for all subsequent API requests
-
-**Validation:**
-- When the JWT is sent back to the backend, **ASP.NET Core Identity validates it**
-
-#### Using JWTs with Other Backend Services
-
-If you want to share the JWT with other backend services (e.g., microservices), follow these steps:
-
-1. **Switch to PFX Certificates** (as described in the previous section)
-2. **Share the Public Key** with other services
-3. Other services use `AddJwtAuthentication` to validate the token
+- **Sign up** with email or phone, confirm it, then try signing up again with the same identifier.
+- **Sign in** with a password, then with a magic link. Get the password wrong repeatedly and watch lockout kick in.
+- **Enable 2FA** in Settings with an authenticator app, then sign in again. Try a recovery code.
+- **Sign in from several browsers**, list the sessions in Settings, revoke one, and watch that device drop out.
+- **Reset a password**, then try the same link twice, and try an expired one.
+- **Sign in with an external provider** and see how the account gets linked and confirmed.
+- **Give a user different roles and features** and see which pages appear and which 403.
+- **Sign in from more than three devices** and watch the fourth lose access to privileged pages while staying
+  signed in.
 
 ---
 
-## Hands-On Exploration
+## Video tutorial
 
-**Run the Project**: To fully understand the identity features, run the project and test the following:
+📺 **[Comprehensive Identity System Walkthrough](https://youtu.be/-3viBEtJHLo)** (~15 minutes) - registration,
+password and OTP sign-in, 2FA, session management and revocation, password reset, roles and permissions, external
+providers, privileged sessions and elevated access.
 
-### 1. Sign Up
-- Create a new account with email or phone number
-- Test the email/phone confirmation flow
-- Try signing up with an existing email/phone (should fail)
+### AI Wiki: answered questions
 
-### 2. Sign In
-- Test **password-based authentication**
-- Test **OTP authentication** (magic link)
-- Test **account lockout** after multiple failed attempts
-
-### 3. Two-Factor Authentication (2FA)
-- Enable 2FA in Settings using an authenticator app
-- Test the **two-step sign-in** process
-- Try entering incorrect 2FA codes
-- Test **recovery codes**
-
-### 4. Session Management
-- Sign in from multiple devices/browsers
-- View all active sessions in the **Settings page**
-- **Revoke specific sessions** and observe forced re-authentication
-
-### 5. Password Reset
-- Test the **forgot password** flow
-- Request a reset token via email/phone
-- Try using an expired token
-- Try using an already-used token
-
-### 6. External Providers
-- Try **External sign-in** with the configured demo provider
-- Observe how email confirmation works with external providers
-
-### 7. Permissions and Policies
-- Create a user with different roles
-- Test access to pages with **PRIVILEGED_ACCESS** policy
-- Test feature-based policies (e.g., `ManageUsers`, `Dashboard`)
-
-### 8. Privileged Session Limiting
-- Sign in from more than 3 devices
-- Observe which sessions become "privileged"
-- Test accessing pages with `PRIVILEGED_ACCESS` policy from non-privileged sessions
-
----
-
-## Video Tutorial
-
-**Highly Recommended**: To see all these features in action and understand the complete identity system, watch this **15-minute video tutorial**:
-
-### 📺 [Watch: Comprehensive Identity System Walkthrough](https://youtu.be/-3viBEtJHLo)
-
-**This video demonstrates**:
-- User registration and email/phone confirmation
-- Password and OTP-based authentication
-- Two-factor authentication setup and usage
-- Session management and revocation
-- Password reset flow
-- Role and permission management
-- External provider integration
-- Privileged session limiting
-- Elevated access for sensitive operations
-
----
-
-### AI Wiki: Answered Questions
 * [How does a `refresh token` function in a Boilerplate project template?](https://deepwiki.com/search/how-does-a-refresh-token-funct_6a75fa66-ab98-4367-bd1a-24b081fbf88c)
 * [What would happen when I use [AuthorizedApi]](https://deepwiki.com/search/what-would-happen-when-i-use-a_c525d59d-5c55-489b-8f95-69f6df7c743d)
 * [Give me high level overview of two factor auth setup and usage flows](https://deepwiki.com/search/give-me-high-level-overview-of_1883503f-2e34-41ca-821a-1246d332990f)
 
-Ask your own question [here](https://wiki.bitplatform.dev)
+Ask your own question [here](https://wiki.bitplatform.dev).
 
 ---

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
@@ -139,10 +139,10 @@ The `AppResponseCachePolicy` class (located in `/src/Server/Boilerplate.Server.S
 - **Development Mode Handling**: Disables client cache in development for easier debugging
 - **Request Type Detection**: Different behavior for Blazor pages vs API requests
 
-Note: **Multi-Language Limitation**: For non-invariant globalization, client and edge caching are disabled for pre-rendered Blazor pages.
-It's because it doesn't work with the free Tier of Cloudflare CDN and needs Enterprise plan that supports tag based purging with multiple dimensions (culture + URL).
-You can switch to AWS CloudFront or Azure Frontdoor which support this feature for lower/free plans.
-Output cache still works correctly for multi-language scenarios.
+Note: **Multi-Language Limitation**: For non-invariant globalization, client and edge caching are disabled for
+pre-rendered Blazor pages. Varying the edge cache on `Accept-Language` requires a custom cache key, which Cloudflare
+only offers on the Enterprise plan; AWS CloudFront allows it on any account (Azure Front Door does not - it drops the
+header when caching is on). Output cache is unaffected: it varies by culture itself.
 
 **Cache Duration Logic:**
 
@@ -193,14 +193,40 @@ public async ValueTask CacheRequestAsync(OutputCacheContext context, Cancellatio
         outputCacheTtl = -1;
     }
 
-    // The entry is tagged with the request path only, without the query string: purging is done by bare path
-    // ("/product/5"), while QueryKeys = "*" gives every query string variant its own entry. Tagging those with
-    // their full PathAndQuery would leave "/product/5?utm_source=x" unpurgeable for the rest of its lifetime.
-    context.Tags.Add(new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).AbsolutePath.ToLowerInvariant());
+    // The entry is tagged with the bare request path - no culture, no query string - because purging is done by bare
+    // path ("/product/5") while each of those dimensions gives a request its own entry.
+    var cacheTag = CreateCacheTag(new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).AbsolutePath);
+
+    context.Tags.Add(cacheTag);                                  // ASP.NET Core output cache
+    context.HttpContext.Response.Headers["Cache-Tag"] = cacheTag; // CDN edge cache, when edge caching is on
 
     // ... set cache headers and output cache policy
 }
 ```
+
+**The same tag on both shared layers:** the two purgeable layers are tagged identically, so one
+`PurgeCache("/product/5")` invalidates both. `Cache-Tag` is only emitted when the response is actually edge cacheable,
+and it is dropped again (along with `Cache-Control`) if the response turns out not to be cacheable. Cloudflare consumes
+the header and strips it before the response reaches the visitor.
+
+**One tag, every variant.** A single page is stored under several cache entries - the culture splits it (`/fa-IR/product/5`
+and `/en-US/product/5` are different paths, and the output cache additionally varies by `Culture`), and `QueryKeys = "*"`
+gives `?utm_source=x` an entry of its own. They all carry the *same* tag, because `GetUrlWithoutCulture()` drops the
+culture (both the `/fa-IR/` path segment and a `?culture=` parameter) and `AbsolutePath` drops the query string. That is
+what lets the purging code name nothing but the bare path:
+
+```csharp
+await responseCacheService.PurgeCache($"/product/{shortId}");   // clears fa-IR, en-US, ?utm_source=..., all of it
+```
+
+Had the tag mirrored the full URL, every language and every tracking-parameter variant of a page would have stayed
+stale until it expired on its own - and the purging code would have had to enumerate cultures and query strings it has
+no way of knowing about.
+
+A cache-tag must be printable ASCII without spaces, and the header is a comma separated list, so `CreateCacheTag`
+percent-encodes those two characters and lowercases the path (tags are case-insensitive). If a path is longer than the
+1,024 character limit Cloudflare accepts in a purge call, edge caching is switched off for that request instead - an
+edge entry that could never be purged is worse than no edge entry at all.
 
 **Responses that are never stored:** a response is kept out of every cache unless it is a `200 OK` that hands out no
 cookies (the culture cookie is exempt, since the cache varies by culture anyway). That keeps a 404 for a product created
@@ -261,14 +287,17 @@ public partial class ResponseCacheService
     /// </summary>
     public async Task PurgeCache(params string[] relativePaths)
     {
-        // Purge from ASP.NET Core output cache. Lowercased to match the tag the policy writes.
-        foreach (var relativePath in relativePaths)
+        // The tag both layers stored the entry under (See AppResponseCachePolicy).
+        var tags = relativePaths.Select(AppResponseCachePolicy.CreateCacheTag).Distinct().ToArray();
+
+        // Purge from ASP.NET Core output cache
+        foreach (var tag in tags)
         {
-            await outputCacheStore.EvictByTagAsync(relativePath.ToLowerInvariant(), default);
+            await outputCacheStore.EvictByTagAsync(tag, default);
         }
         
-        // Purge from Cloudflare CDN
-        await PurgeCloudflareCache(relativePaths);
+        // Purge from Cloudflare CDN, by the same tags
+        await PurgeCloudflareCache(tags);
     }
 
     /// <summary>
@@ -311,9 +340,25 @@ public async Task Delete(Guid id, string version, CancellationToken cancellation
 }
 ```
 
-**Important Note:** 
-- For successful cache purging, the request URL must **exactly match** the URL passed to `PurgeCache()`. 
-- Query strings and route parameters must match precisely.
+**Purging by cache-tag, not by URL:**
+
+Both purgeable layers are invalidated by **tag**, and the tag is the request **path** alone. On the CDN side that is
+Cloudflare's [purge by cache-tag](https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/), which
+since 2025 is available on **every plan, including Free** - it used to be Enterprise-only, which is why this used to be
+a purge by URL. Purging by tag is strictly better here:
+
+| | Purge by URL (before) | Purge by tag (now) |
+|---|---|---|
+| Query string variants | only the exact URL, so `/product/5?utm_source=x` survived | all variants of the path, at once |
+| Culture variants | only the URL as written, so `/fa-IR/product/5` survived a purge of `/product/5` | all cultures of the path, at once |
+| Multiple hostnames | one URL per domain had to be listed and purged (`AdditionalDomains`) | every hostname of the zone, at once |
+| API calls per purge | one per (domain × path) batch | one per zone, up to 100 tags each |
+
+That last row matters on the Free plan, whose purge rate limit is **5 requests per minute per account**.
+
+**Important Note:**
+- The path passed to `PurgeCache()` must **exactly match** the request path (route parameters included); its query
+  string is irrelevant, since every query variant of that path is purged together.
 - This only purges **CDN edge cache** and **ASP.NET Core output cache** (the purgeable layers)
 - **Browser cache** and **Client In-Memory Cache** cannot be purged remotely (this is why `MaxAge` should be used cautiously)
 
@@ -516,13 +561,10 @@ This prevents accidentally serving User A's data to User B through shared caches
     "EnableCdnEdgeCaching": true  // CDN edge caching
   },
   "Cloudflare": {
-    "ZoneId": "your-cloudflare-zone-id",
     "ApiToken": "your-cloudflare-api-token",
-    "AdditionalDomains": [
-      "https://sales.bitplatform.ai",
-      "https://sales.bitplatform.com",
-      "https://sales.bitplatform.uk"
-    ]
+    // One zone covers all of its hostnames. List several only if your app is served from domains
+    // that belong to different Cloudflare zones (e.g. sales.bitplatform.com and sales.bitplatform.uk).
+    "ZoneIds": [ "your-cloudflare-zone-id" ]
   },
   // Shared/appsettings.json - shared by the server AND every client (WASM, MAUI, Windows)
   "MemoryCache": {
@@ -608,6 +650,7 @@ This shows the TTL (in seconds) for each cache layer. Use browser DevTools Netwo
 ```
 Cache-Control: public, max-age=300, s-maxage=3600
 Vary: Origin, X-Origin
+Cache-Tag: /product/5
 App-Cache-Response: Output:3600,Edge:3600,Client:300
 ```
 
@@ -616,27 +659,15 @@ Interpretation:
 - `s-maxage=3600`: CDN edge and output cache for 1 hour
 - `public`: Can be cached in shared caches (CDN)
 - `Vary`: the request headers a shared cache must include in its key
+- `Cache-Tag`: what the CDN edge entry can later be purged by. Only present when edge caching is on for the request,
+  and only visible when you hit the origin directly - Cloudflare strips it on the way to the visitor
 - `Output:-1` (or `Edge:-1` / `Client:-1`) means that layer was disabled for this request - by configuration, by the
   caller being authenticated on a non-`UserAgnostic` endpoint, or by the request being a pre-rendered Blazor page
 
 A response that turns out not to be cacheable (anything other than `200 OK`, or one that sets a cookie) is downgraded to
-`Cache-Control: no-store, private` on its way out, regardless of what `App-Cache-Response` announced earlier in the
-request.
+`Cache-Control: no-store, private` on its way out and loses its `Cache-Tag`, regardless of what `App-Cache-Response`
+announced earlier in the request.
 
----
-
-### Automated Test
-
-`src/Tests/Features/Caching/ProductResponseCacheTests.cs` exercises the whole loop end to end with
-`EnableOutputCaching` and `PrerenderEnabled` both on: it fills the output cache from two directions (the tenant-user
-calling the `UserAgnostic` product API, and an anonymous visitor loading the pre-rendered product page), has the
-tenant-admin edit the product through `ProductController.Update` and asserts both readers see the change immediately,
-then deletes the row straight from the database and asserts both readers keep being served the deleted product - the
-proof that the responses are coming from the cache and not the database.
-
-Note it needs `ProductController` (Admin module) and `ProductViewController` (Sales module) at the same time, and
-`module` is a single-choice template parameter, so it is excluded from generated projects and only runs against the
-template's own source tree.
 
 ---
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
@@ -223,8 +223,11 @@ Had the tag mirrored the full URL, every language and every tracking-parameter v
 stale until it expired on its own - and the purging code would have had to enumerate cultures and query strings it has
 no way of knowing about.
 
-A cache-tag must be printable ASCII without spaces, and the header is a comma separated list, so `CreateCacheTag`
-percent-encodes those two characters and lowercases the path (tags are case-insensitive). If a path is longer than the
+A cache-tag must be printable ASCII without spaces, and the header is a comma separated list. `CreateCacheTag` runs the
+path through `Uri` to percent-encode anything that qualifies (a non-ASCII route such as `/محصول/5` included), encodes
+the comma `Uri` leaves alone, and lowercases the result - tags are case-insensitive. That canonicalization is
+idempotent, which is what lets the same method serve both sides: the policy hands it an already escaped
+`Uri.AbsolutePath`, while a caller of `PurgeCache` hands it a path typed out by hand. If a path is longer than the
 1,024 character limit Cloudflare accepts in a purge call, edge caching is switched off for that request instead - an
 edge entry that could never be purged is worse than no edge entry at all.
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ExternalSignIn.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ExternalSignIn.cs
@@ -90,6 +90,7 @@ public partial class IdentityController
                 await userManager.AddLoginAsync(user, info);
             }
 
+            // Confirmation is only as good as the provider's own verification of the identifier
             if (string.IsNullOrEmpty(email) is false && string.Equals(email, user.Email, StringComparison.OrdinalIgnoreCase) && await userManager.IsEmailConfirmedAsync(user) is false)
             {
                 await userEmailStore.SetEmailConfirmedAsync(user, true, cancellationToken);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
@@ -370,16 +370,15 @@ public partial class IdentityController : AppControllerBase, IIdentityController
 
             var newPrincipal = await signInManager.CreateUserPrincipalAsync(user!);
 
+            await DbContext.SaveChangesAsync(cancellationToken);
+
             return SignIn(newPrincipal, authenticationScheme: IdentityConstants.BearerScheme);
         }
         catch (UnauthorizedException) when (userSession is not null)
         {
             DbContext.UserSessions.Remove(userSession);
-            throw;
-        }
-        finally
-        {
             await DbContext.SaveChangesAsync(cancellationToken);
+            throw;
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/RoleManagementController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/RoleManagementController.cs
@@ -41,7 +41,13 @@ public partial class RoleManagementController : AppControllerBase, IRoleManageme
         var canManageAllTenants = User.HasFeature(AppFeatures.Management.Tenants_Manage_Global);
 
         return roleManager.Roles
-                          .WhereIf(canManageAllTenants is false, r => r.TenantId == currentTenantId) // Non Global admins may only see the roles of the current tenant.
+                          // Non Global admins may only see the roles of the current tenant.
+                          .WhereIf(canManageAllTenants is false, r => r.TenantId == currentTenantId)
+                          // A global admin sees every tenant's roles only while NO tenant is selected; once one is, the
+                          // list narrows to that tenant's roles plus the global ones (g-admin), which is the same
+                          // scoping UserClaimsService applies when it builds a token. Otherwise the page grows by one
+                          // t-admin (and one demo, ...) per tenant and stops being usable.
+                          .WhereIf(canManageAllTenants && currentTenantId is not null, r => r.TenantId == null || r.TenantId == currentTenantId)
                           .Project();
         //#endif
         //#if (IsInsideProjectTemplate == true)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppIdentityErrorDescriber.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppIdentityErrorDescriber.cs
@@ -9,8 +9,20 @@ public partial class AppIdentityErrorDescriber : IdentityErrorDescriber
         return new()
         {
             Code = code,
-            Description = localizer[code, args]
+            Description = TryLocalize(code, args)
         };
+    }
+
+    string TryLocalize(string code, params object[] args)
+    {
+        try
+        {
+            return localizer[code, args];
+        }
+        catch (FormatException)
+        {
+            return localizer[code];
+        }
     }
 
     public override IdentityError ConcurrencyFailure() => CreateIdentityError(nameof(IdentityStrings.ConcurrencyFailure));
@@ -43,7 +55,7 @@ public partial class AppIdentityErrorDescriber : IdentityErrorDescriber
 
     public override IdentityError PasswordRequiresUpper() => CreateIdentityError(nameof(IdentityStrings.PasswordRequiresUpper));
 
-    public override IdentityError PasswordTooShort(int length) => CreateIdentityError(nameof(IdentityStrings.PasswordTooShort));
+    public override IdentityError PasswordTooShort(int length) => CreateIdentityError(nameof(IdentityStrings.PasswordTooShort), length);
 
     public override IdentityError RecoveryCodeRedemptionFailed() => CreateIdentityError(nameof(IdentityStrings.RecoveryCodeRedemptionFailed));
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppJwtSecureDataFormat.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppJwtSecureDataFormat.cs
@@ -13,6 +13,7 @@ public partial class AppJwtSecureDataFormat
     : ISecureDataFormat<AuthenticationTicket>
 {
     private readonly string tokenType;
+    private readonly string audience;
     private readonly RsaSecurityKey privateKey;
     private readonly TimeProvider timeProvider;
     private readonly ServerApiSettings appSettings;
@@ -31,6 +32,11 @@ public partial class AppJwtSecureDataFormat
         this.appSettings = appSettings;
         this.timeProvider = timeProvider;
 
+        // The two token classes are otherwise indistinguishable - same key, same issuer, same claim shape - so each
+        // gets its own audience and validates only its own. Without that, a refresh token would authenticate ordinary
+        // api calls for its full 14 day lifetime, and an access token replayed at Refresh would mint a new session.
+        audience = tokenType is "AccessToken" ? appSettings.Identity.Audience : $"{appSettings.Identity.Audience}:{tokenType}";
+
         privateKey = AppCertificateService.GetPrivateSecurityKey(configuration);
 
         validationParameters = new()
@@ -46,7 +52,7 @@ public partial class AppJwtSecureDataFormat
             ValidateLifetime = tokenType is "AccessToken", /* IdentityController.Refresh will validate expiry itself while refreshing the token */
 
             ValidateAudience = true,
-            ValidAudience = appSettings.Identity.Audience,
+            ValidAudience = audience,
 
             ValidateIssuer = true,
             ValidIssuer = appSettings.Identity.Issuer,
@@ -72,7 +78,7 @@ public partial class AppJwtSecureDataFormat
             var validJwt = (JwtSecurityToken)validToken;
             var properties = new AuthenticationProperties() { ExpiresUtc = validJwt.ValidTo };
 
-            var identity = new ClaimsIdentity(principal.Identity, principal.Claims, IdentityConstants.BearerScheme, ClaimTypes.NameIdentifier, ClaimTypes.Role);
+            var identity = new ClaimsIdentity(principal.Identity, null, IdentityConstants.BearerScheme, ClaimTypes.NameIdentifier, ClaimTypes.Role);
 
             if (principal.IsInRole(AppRoles.GlobalAdmin))
             {
@@ -120,7 +126,7 @@ public partial class AppJwtSecureDataFormat
             .CreateJwtSecurityToken(new SecurityTokenDescriptor
             {
                 Issuer = appSettings.Identity.Issuer,
-                Audience = appSettings.Identity.Audience,
+                Audience = audience,
                 IssuedAt = timeProvider.GetUtcNow().UtcDateTime,
                 Expires = data.Properties.ExpiresUtc!.Value.UtcDateTime,
                 SigningCredentials = new SigningCredentials(privateKey, SecurityAlgorithms.RsaSha256Signature),

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppUserClaimsPrincipalFactory.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppUserClaimsPrincipalFactory.cs
@@ -50,36 +50,49 @@ public partial class AppUserClaimsPrincipalFactory(UserClaimsService userClaimsS
     }
 
     /// <summary>
-    /// Retrieves additional claims from Keycloak and adds them to the user's claims, if the user has been externally authenticated via Keycloak.
-    /// It also prevents disabled/deleted keycloak users from accessing the application by throwing an UnauthorizedException.
+    /// The following claims are managed by the server and should not be overridden by Keycloak claims.
+    /// </summary>
+    private static readonly string[] serverManagedClaimTypes =
+    [
+        AppClaimTypes.SESSION_ID,
+        AppClaimTypes.PRIVILEGED_SESSION,
+        AppClaimTypes.ELEVATED_SESSION,
+        //#if (multitenant == true)
+        AppClaimTypes.TENANT_ID,
+        //#endif
+        ClaimTypes.NameIdentifier,
+        "iss", "aud", "exp", "nbf", "iat", "jti"
+    ];
+
+    /// <summary>
+    /// Retrieves additional claims from Keycloak and adds them to the user's claims, if the user is backed by Keycloak.
+    /// It also prevents disabled/deleted keycloak users from accessing the application by throwing an UnauthorizedException,
+    /// but only once the cached keycloak access token has expired (See <see cref="GetKeycloakAccessToken"/>).
     /// </summary>
     private async Task RetrieveKeycloakClaims(User user, ClaimsIdentity aspnetCoreIdentityClaims)
     {
-        if (aspnetCoreIdentityClaims.HasClaim(AppClaimTypes.METHOD, "External") is false)
-            return; // User was not authenticated via Keycloak
-
         var keycloakBaseUrl = configuration["KEYCLOAK_HTTP"] ?? configuration["Authentication:Keycloak:KeycloakUrl"];
-        if (string.IsNullOrEmpty(keycloakBaseUrl) is false)
-        {
-            var keycloakRefreshToken = await UserManager.GetAuthenticationTokenAsync(user, "Keycloak", "refresh_token");
-            if (string.IsNullOrEmpty(keycloakRefreshToken) is false)
-            {
-                var realm = configuration["Authentication:Keycloak:Realm"] ?? throw new InvalidOperationException("Authentication:Keycloak:Realm configuration is required");
-                string? keycloakAccessToken = await GetKeycloakAccessToken(user, keycloakRefreshToken, realm);
-                var handler = new JwtSecurityTokenHandler();
-                var parsedKeycloakAccessToken = handler.ReadJwtToken(keycloakAccessToken);
-                var keycloakClaims = parsedKeycloakAccessToken.Claims
-                    .Select(claim => new Claim(
-                        JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.TryGetValue(claim.Type, out var mapped)
-                            ? mapped
-                            : claim.Type,
-                        claim.Value))
-                    .ToList();
+        if (string.IsNullOrEmpty(keycloakBaseUrl))
+            return; // Keycloak is not configured for this deployment.
 
-                foreach (var claim in keycloakClaims.Where(c => aspnetCoreIdentityClaims.HasClaim(c.Type, c.Value) is false))
-                    aspnetCoreIdentityClaims.AddClaim(claim);
-            }
-        }
+        var keycloakRefreshToken = await UserManager.GetAuthenticationTokenAsync(user, "Keycloak", "refresh_token");
+        if (string.IsNullOrEmpty(keycloakRefreshToken)) return;
+
+        var realm = configuration["Authentication:Keycloak:Realm"] ?? throw new InvalidOperationException("Authentication:Keycloak:Realm configuration is required");
+        string? keycloakAccessToken = await GetKeycloakAccessToken(user, keycloakRefreshToken, realm);
+        var handler = new JwtSecurityTokenHandler();
+        var parsedKeycloakAccessToken = handler.ReadJwtToken(keycloakAccessToken);
+        var keycloakClaims = parsedKeycloakAccessToken.Claims
+            .Select(claim => new Claim(
+                JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.TryGetValue(claim.Type, out var mapped)
+                    ? mapped
+                    : claim.Type,
+                claim.Value))
+            .Where(claim => serverManagedClaimTypes.Contains(claim.Type) is false)
+            .ToList();
+
+        foreach (var claim in keycloakClaims.Where(c => aspnetCoreIdentityClaims.HasClaim(c.Type, c.Value) is false))
+            aspnetCoreIdentityClaims.AddClaim(claim);
     }
 
     private async Task<string> GetKeycloakAccessToken(User user, string? keycloakRefreshToken, string realm)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/GoogleRecaptchaService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/GoogleRecaptchaService.cs
@@ -18,7 +18,7 @@ public partial class GoogleRecaptchaService
             { "response", googleRecaptchaResponse }
         });
 
-        var response = await httpClient.PostAsync("api/siteverify", payload, cancellationToken);
+        using var response = await httpClient.PostAsync("api/siteverify", payload, cancellationToken);
 
         if (response.IsSuccessStatusCode is false)
             return false;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/GoogleRecaptchaService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/Services/GoogleRecaptchaService.cs
@@ -12,10 +12,16 @@ public partial class GoogleRecaptchaService
     {
         if (string.IsNullOrWhiteSpace(googleRecaptchaResponse)) return false;
 
-        var url = $"api/siteverify?secret={AppSettings.GoogleRecaptchaSecretKey}&response={googleRecaptchaResponse}";
-        var response = await httpClient.PostAsync(url, null, cancellationToken);
+        using var payload = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "secret", AppSettings.GoogleRecaptchaSecretKey! },
+            { "response", googleRecaptchaResponse }
+        });
 
-        response.EnsureSuccessStatusCode();
+        var response = await httpClient.PostAsync("api/siteverify", payload, cancellationToken);
+
+        if (response.IsSuccessStatusCode is false)
+            return false;
 
         var result = await response.Content.ReadFromJsonAsync(jsonSerializerOptions.GetTypeInfo<GoogleRecaptchaVerificationResponse>(), cancellationToken);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/ReservedTenantNames.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/ReservedTenantNames.cs
@@ -48,4 +48,53 @@ public static class ReservedTenantNames
 
         return false;
     }
+
+    /// <summary>
+    /// True when <paramref name="domain"/> may not be used as a tenant's custom domain, because it is a host the
+    /// deployment itself answers on, or sits underneath one.
+    /// </summary>
+    public static bool IsReservedDomain(string? domain, params string?[] deploymentHosts)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+            return false; // A blank custom domain simply means "resolve me by sub domain".
+
+        domain = domain.Trim();
+
+        foreach (var zone in deploymentHosts.SelectMany(GetReservedZones))
+        {
+            if (string.Equals(domain, zone, StringComparison.OrdinalIgnoreCase)
+                || domain.EndsWith($".{zone}", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The zones a deployment host reserves. The host itself, plus its parent when it carries a sub domain label,
+    /// because the request this is validated against may well arrive on a tenant's own sub domain
+    /// (<c>acme.myapp.com</c>) - taking that host at face value would leave <c>myapp.com</c> and every sibling
+    /// tenant's host claimable. A <c>*</c> wildcard from a TrustedOrigins entry reserves its whole zone.
+    /// </summary>
+    private static IEnumerable<string> GetReservedZones(string? deploymentHost)
+    {
+        if (string.IsNullOrWhiteSpace(deploymentHost))
+            yield break;
+
+        var host = deploymentHost.Trim().TrimEnd('.');
+
+        if (host.StartsWith("*.", StringComparison.Ordinal))
+        {
+            yield return host[2..];
+            yield break;
+        }
+
+        if (host.Contains('*'))
+            yield break; // A mid-label wildcard (tenant-*.myapp.com) describes no single zone.
+
+        yield return host;
+
+        if (host.Split('.') is { Length: > 2 } labels)
+            yield return string.Join('.', labels[1..]);
+    }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantController.cs
@@ -217,6 +217,11 @@ public partial class TenantController : AppControllerBase, ITenantController
 
         if (tenant.Domain is not null
             && (entry.State is EntityState.Added || entry.Property(t => t.Domain).IsModified)
+            && ReservedTenantNames.IsReservedDomain(tenant.Domain, [Request.GetBaseUrl().Host, Request.GetWebAppUrl().Host, .. serverSharedSettings.TrustedOrigins.Select(ServerSharedSettings.GetTrustedOriginHost)]))
+            throw new ResourceValidationException((nameof(TenantDto.Domain), [Localizer[nameof(AppStrings.ReservedTenantDomain), tenant.Domain]]));
+
+        if (tenant.Domain is not null
+            && (entry.State is EntityState.Added || entry.Property(t => t.Domain).IsModified)
             && await DbContext.Tenants.AnyAsync(t => t.Id != tenant.Id && t.Domain == tenant.Domain, cancellationToken))
             throw new ResourceValidationException((nameof(TenantDto.Domain), [Localizer[nameof(AppStrings.DuplicateTenantDomain), tenant.Domain]]));
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantManagementController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Tenants/TenantManagementController.cs
@@ -111,6 +111,11 @@ public partial class TenantManagementController : AppControllerBase, ITenantMana
 
         if (tenant.Domain is not null
             && (entry.State is EntityState.Added || entry.Property(t => t.Domain).IsModified)
+            && ReservedTenantNames.IsReservedDomain(tenant.Domain, [Request.GetBaseUrl().Host, Request.GetWebAppUrl().Host, .. serverSharedSettings.TrustedOrigins.Select(ServerSharedSettings.GetTrustedOriginHost)]))
+            throw new ResourceValidationException((nameof(TenantDto.Domain), [Localizer[nameof(AppStrings.ReservedTenantDomain), tenant.Domain]]));
+
+        if (tenant.Domain is not null
+            && (entry.State is EntityState.Added || entry.Property(t => t.Domain).IsModified)
             && await DbContext.Tenants.AnyAsync(t => t.Id != tenant.Id && t.Domain == tenant.Domain, cancellationToken))
             throw new ResourceValidationException((nameof(TenantDto.Domain), [Localizer[nameof(AppStrings.DuplicateTenantDomain), tenant.Domain]]));
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
@@ -23,6 +23,7 @@ public partial class ResponseCacheService
     [AutoInject] private IOutputCacheStore outputCacheStore = default!;
     //#if (cloudflare == true)
     [AutoInject] private ServerApiSettings serverApiSettings = default!;
+    [AutoInject] private JsonSerializerOptions jsonSerializerOptions = default!;
     //#else
     [AutoInject] private IHttpContextAccessor httpContextAccessor = default!;
     //#endif
@@ -82,9 +83,42 @@ public partial class ResponseCacheService
                 request.Headers.Add("Authorization", $"Bearer {apiToken}");
                 request.Content = JsonContent.Create(new { tags = tagsChunk });
                 using var response = await httpClient.SendAsync(request);
-                response.EnsureSuccessStatusCode();
+
+                // The status code alone does not say whether the purge happened: Cloudflare reports that in the body's
+                // `success` flag and gives the reason in `errors`. A purge that quietly did nothing is the worst
+                // outcome here, since the stale page then sits on the edge until it expires on its own.
+                if (response.IsSuccessStatusCode is false)
+                    throw new InvalidOperationException($"Cloudflare cache purge of zone '{zoneId}' failed with {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+
+                var result = await response.Content.ReadFromJsonAsync(jsonSerializerOptions.GetTypeInfo<CloudflarePurgeResponse>());
+
+                if (result?.Success is not true)
+                {
+                    var errors = result?.Errors?.Select(err => $"{err.Code}: {err.Message}") ?? [];
+                    throw new InvalidOperationException($"Cloudflare cache purge of zone '{zoneId}' was rejected. {string.Join(" | ", errors)}".Trim());
+                }
             }
         }
     }
     //#endif
 }
+
+//#if (cloudflare == true)
+/// <summary>
+/// The envelope every Cloudflare API v4 response is wrapped in.
+/// https://developers.cloudflare.com/api/resources/cache/methods/purge/
+/// </summary>
+public class CloudflarePurgeResponse
+{
+    public bool Success { get; set; }
+
+    public CloudflareResponseInfo[]? Errors { get; set; }
+}
+
+public class CloudflareResponseInfo
+{
+    public int Code { get; set; }
+
+    public string? Message { get; set; }
+}
+//#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ResponseCacheService.cs
@@ -1,5 +1,6 @@
 //+:cnd:noEmit
 using Microsoft.AspNetCore.OutputCaching;
+using Boilerplate.Server.Shared.Infrastructure.Services;
 
 namespace Boilerplate.Server.Api.Infrastructure.Services;
 
@@ -10,27 +11,39 @@ namespace Boilerplate.Server.Api.Infrastructure.Services;
 /// 2. Caching JSON and dynamic files responses on CDN edge servers and ASP.NET Core's Output Cache by using `AppResponseCache` attribute in controllers like `StatisticsController`, `AttachmentController` and minimal apis.
 /// 3. Caching pre-rendered HTML results of Blazor pages on CDN edge servers and ASP.NET Core's Output by using `AppResponseCache` attribute in pages like HomePage.razor
 /// 
-/// - Note: For successful cache purging, the request URL must exactly match the URL passed to <see cref="PurgeCache(string[])"/>.  
+/// - Note: Both the output cache and the CDN edge cache are purged by tag, and the tag is the request path alone
+///   (See <see cref="AppResponseCachePolicy.CreateCacheTag(string)"/>). So the path passed to <see cref="PurgeCache(string[])"/>
+///   must match the request path exactly, while its query string is irrelevant: every variant of the path is purged at once.
 /// </summary>
 public partial class ResponseCacheService
 {
+    // Required by AddHttpClient<ResponseCacheService> even when no CDN is configured: the typed client factory only
+    // knows how to build this service through a constructor that takes an HttpClient.
     [AutoInject] private HttpClient httpClient = default!;
     [AutoInject] private IOutputCacheStore outputCacheStore = default!;
+    //#if (cloudflare == true)
     [AutoInject] private ServerApiSettings serverApiSettings = default!;
+    //#else
     [AutoInject] private IHttpContextAccessor httpContextAccessor = default!;
+    //#endif
 
     public async Task PurgeCache(params string[] relativePaths)
     {
-        foreach (var relativePath in relativePaths)
+        // Both the output cache entry and the CDN edge entry are stored under this tag (See AppResponseCachePolicy).
+        var tags = relativePaths.Select(AppResponseCachePolicy.CreateCacheTag).Distinct().ToArray();
+
+        foreach (var tag in tags)
         {
-            await outputCacheStore.EvictByTagAsync(relativePath.ToLowerInvariant(), default);
+            await outputCacheStore.EvictByTagAsync(tag, default);
         }
         //#if (cloudflare == true)
-        await PurgeCloudflareCache(relativePaths);
+        await PurgeCloudflareCache(tags);
         //#else
         // If you're using CDN like GCore or others, make sure to purge the Edge Cache of your CDN.
-        // The Cloudflare Cache API is already integrated into the Boilerplate, but for other CDNs, 
-        // you'll need to implement the caching logic yourself.
+        // The Cloudflare Cache API is already integrated into the Boilerplate, but for other CDNs,
+        // you'll need to implement the caching logic yourself. AppResponseCachePolicy already stamps every edge
+        // cacheable response with the tag to purge it by, under Cloudflare's `Cache-Tag` header name; other CDNs read
+        // the same idea from a different header (Fastly's `Surrogate-Key`, Akamai's `Edge-Cache-Tag`, ...).
         if (httpContextAccessor.HttpContext!.Request.IsFromCDN())
         {
             throw new NotImplementedException();
@@ -46,25 +59,32 @@ public partial class ResponseCacheService
     //#endif
 
     //#if (cloudflare == true)
-    private async Task PurgeCloudflareCache(string[] relativePaths)
+    /// <summary>
+    /// Purges the edge cache by cache-tag, the way the output cache is purged. <see cref="AppResponseCachePolicy"/>
+    /// stamps every edge cacheable response with a <c>Cache-Tag</c> header carrying the same tag, so one call here
+    /// invalidates the page under every query string it was cached with and on every hostname of the zone - neither of
+    /// which a purge by URL could do, since the edge keeps a separate entry per full URL.
+    /// Purge by tag is available on all Cloudflare plans, including the free one.
+    /// </summary>
+    private async Task PurgeCloudflareCache(string[] tags)
     {
         if (serverApiSettings?.Cloudflare?.Configured is not true)
             return;
 
-        var zoneId = serverApiSettings.Cloudflare.ZoneId;
         var apiToken = serverApiSettings.Cloudflare.ApiToken;
 
-        var files = serverApiSettings.Cloudflare.AdditionalDomains
-            .Union([httpContextAccessor.HttpContext!.Request.GetBaseUrl(), httpContextAccessor.HttpContext!.Request.GetWebAppUrl()])
-            .SelectMany(baseUri => relativePaths.Select(path => new Uri(baseUri, path)))
-            .Distinct()
-            .ToArray();
-
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{zoneId}/purge_cache");
-        request.Headers.Add("Authorization", $"Bearer {apiToken}");
-        request.Content = JsonContent.Create(new { files });
-        using var response = await httpClient.SendAsync(request);
-        response.EnsureSuccessStatusCode();
+        foreach (var zoneId in serverApiSettings.Cloudflare.ZoneIds)
+        {
+            // Cloudflare accepts at most 100 tags per purge call.
+            foreach (var tagsChunk in tags.Chunk(100))
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, $"{zoneId}/purge_cache");
+                request.Headers.Add("Authorization", $"Bearer {apiToken}");
+                request.Content = JsonContent.Create(new { tags = tagsChunk });
+                using var response = await httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+            }
+        }
     }
     //#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ServerJsonContext.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Services/ServerJsonContext.cs
@@ -18,6 +18,9 @@ namespace Boilerplate.Server.Api.Infrastructure.Services;
 //#if (captcha == "reCaptcha")
 [JsonSerializable(typeof(GoogleRecaptchaVerificationResponse))]
 //#endif
+//#if (cloudflare == true)
+[JsonSerializable(typeof(CloudflarePurgeResponse))]
+//#endif
 [JsonSerializable(typeof(AuthenticatorResponse))]
 public partial class ServerJsonContext : JsonSerializerContext
 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Middlewares.cs
@@ -42,11 +42,11 @@ public static partial class Program
         app.UseStaticFiles();
 
         app.UseCors();
-        app.UseRateLimiter();
 
         app.UseMiddleware<ForceUpdateMiddleware>();
 
         app.UseAuthentication();
+        app.UseRateLimiter(); // After UseAuthentication, so rate limit partitions can use HttpContext.User.
         app.UseAuthorization();
 
         app.UseOutputCache();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -830,7 +830,7 @@ public static partial class Program
         {
             var cloudflareApiToken = appSettings.Cloudflare.ApiToken;
             healthChecksBuilder.AddUrlGroup(
-                new Uri($"https://api.cloudflare.com/client/v4/zones/{appSettings.Cloudflare.ZoneId}"),
+                appSettings.Cloudflare.ZoneIds.Select(zoneId => new Uri($"https://api.cloudflare.com/client/v4/zones/{zoneId}")),
                 name: "cloudflare",
                 tags: [],
                 configureClient: (_, client) =>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
@@ -187,17 +187,15 @@ public class CloudflareOptions
 {
     public string? ApiToken { get; set; }
 
-    public string? ZoneId { get; set; }
-
     /// <summary>
-    /// The <see cref="ResponseCacheService"/> clears the cache for the current domain by default.
-    /// If multiple Cloudflare-hosted domains point to your origin backend, you will need to
-    /// purge the cache for each of them individually.
+    /// The zones whose edge cache <see cref="ResponseCacheService"/> purges.
+    /// A purge by cache-tag covers every hostname of a zone, so a single entry is enough unless the app is served
+    /// from domains that belong to different Cloudflare zones (e.g. myapp.com and myapp.uk).
     /// </summary>
-    public Uri[] AdditionalDomains { get; set; } = [];
+    public string[] ZoneIds { get; set; } = [];
 
     public bool Configured => string.IsNullOrEmpty(ApiToken) is false &&
-        string.IsNullOrEmpty(ZoneId) is false;
+        ZoneIds.Length > 0;
 }
 //#endif
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
@@ -54,6 +54,12 @@ public partial class ServerApiSettings : ServerSharedSettings
 
     public SupportedAppVersionsOptions? SupportedAppVersions { get; set; }
 
+    /// <summary>
+    /// The root ConnectionStrings section. Bound so <see cref="Validate"/> can reject the shared development
+    /// defaults shipped in appsettings.json outside of Development.
+    /// </summary>
+    public Dictionary<string, string?>? ConnectionStrings { get; set; }
+
     public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         var validationResults = base.Validate(validationContext).ToList();
@@ -83,6 +89,11 @@ public partial class ServerApiSettings : ServerSharedSettings
 
         if (AppEnvironment.IsDevelopment() is false)
         {
+            if (ConnectionStrings?.GetValueOrDefault("smtp") is "Endpoint=smtp://smtp.ethereal.email:587;UserName=madisen7@ethereal.email;Password=QYcYfjBXjqxMAZfZya")
+            {
+                throw new InvalidOperationException("The smtp connection string is not set. Please set it in the server's appsettings.json file.");
+            }
+
             //#if (captcha == "reCaptcha")
             if (GoogleRecaptchaSecretKey is "6LdMKr4pAAAAANvngWNam_nlHzEDJ2t6SfV6L_DS")
             {
@@ -91,7 +102,7 @@ public partial class ServerApiSettings : ServerSharedSettings
             //#endif
 
             //#if (notification == true)
-            if (AdsPushVapid?.PrivateKey is "dMIR1ICj-lDWYZ-ZYCwXKyC2ShYayYYkEL-oOPnpq9c" || AdsPushVapid?.Subject is "mailto:test@bitplatform.dev")
+            if (AdsPushVapid?.PrivateKey is "dMIR1ICj-lDWYZ-ZYCwXKyC2ShYayYYkEL-oOPnpq9c" || AdsPushVapid?.Subject is "mailto:you@example.com")
             {
                 throw new InvalidOperationException("The AdsPushVapid's PrivateKey and Subject are not set. Please set them in the server's appsettings.json file.");
             }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -213,10 +213,8 @@
     //#if (cloudflare == true)
     "Cloudflare": {
         "ApiToken": null,
-        "ZoneId": null,
-        "AdditionalDomains": [],
-        "AdditionalDomains_Comment": "The ResponseCacheService clears the cache for the current domain by default. If multiple Cloudflare-hosted domains point to your backend, you will need to purge the cache for each of them individually.",
-        "AdditionalDomains_Sample": [ "https://sales.bitplatform.dev" ]
+        "ZoneIds": [],
+        "ZoneIds_Comment": "The ResponseCacheService purges the edge cache by cache-tag, which covers every hostname of a zone at once. Add more than one zone id only if your app is served from domains belonging to different Cloudflare zones."
     },
     //#endif
     "ResponseCaching": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Infrastructure/Realms/dev-realm.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Infrastructure/Realms/dev-realm.json
@@ -250,6 +250,21 @@
                         "claim.name": "email",
                         "jsonType.label": "String"
                     }
+                },
+                {
+                    "id": "email-verified-mapper",
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "emailVerified",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "email_verified",
+                        "jsonType.label": "boolean"
+                    }
                 }
             ]
         },

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
@@ -13,6 +13,29 @@ namespace Boilerplate.Server.Shared.Infrastructure.Services;
 public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings settings) : IOutputCachePolicy
 {
     /// <summary>
+    /// The header a CDN reads the cache-tags of a response from. Cloudflare associates them with the cached object
+    /// and strips the header before the response reaches the visitor.
+    /// </summary>
+    public const string CacheTagHeaderName = "Cache-Tag";
+
+    /// <summary>
+    /// CDN rejects a longer cache-tag in a purge call.
+    /// </summary>
+    private const int MaxCacheTagLength = 1024;
+
+    /// <summary>
+    /// The tag both the ASP.NET Core output cache entry and the CDN edge entry are stored under, so that a single
+    /// <c>ResponseCacheService.PurgeCache("/product/5")</c> invalidates both.
+    /// A cache-tag may hold printable ASCII only and is written to the header as part of a comma separated list, so
+    /// the two characters a URL path can legally carry but a tag cannot are percent encoded here. The same encoding
+    /// is applied on the purge side, so the two always agree.
+    /// </summary>
+    public static string CreateCacheTag(string relativePath)
+    {
+        return relativePath.ToLowerInvariant().Replace(",", "%2c").Replace(" ", "%20");
+    }
+
+    /// <summary>
     /// Updates the <see cref="OutputCacheContext"/> before the cache middleware is invoked.
     /// At that point the cache middleware can still be enabled or disabled for the request.
     /// </summary>
@@ -48,10 +71,13 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
         }
         //#endif
 
-        // Path only, without the query string: ResponseCacheService.PurgeCache is always called with bare paths ("/product/5"),
-        // while QueryKeys = "*" gives every query string variant its own entry. Tagging those with their full PathAndQuery would
-        // leave /product/5?utm_source=x unpurgeable for the rest of its lifetime.
-        var requestPath = new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).AbsolutePath.ToLowerInvariant();
+        // The bare path, with neither the culture nor the query string in it, because ResponseCacheService.PurgeCache is
+        // always called with bare paths ("/product/5") while the dimensions above each give a request its own entry:
+        // QueryKeys = "*" splits by query string, VaryByValues["Culture"] splits by culture, and /fa-IR/product/5 is a
+        // different path from /en-US/product/5 to begin with. Tagging an entry with any of that would leave
+        // /product/5?utm_source=x - or the whole Persian half of the site - unpurgeable for the rest of its lifetime.
+        // One tag for all of them means one purge clears every variant of the page, which is the point.
+        var cacheTag = CreateCacheTag(new Uri(context.HttpContext.Request.GetUri().GetUrlWithoutCulture()).AbsolutePath);
 
         var sharedMaxAge = responseCacheAtt.SharedMaxAge == -1 ? responseCacheAtt.MaxAge : responseCacheAtt.SharedMaxAge;
 
@@ -94,6 +120,15 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
             outputCacheTtl = -1;
         }
 
+        if (cacheTag.Length > MaxCacheTagLength)
+        {
+            // The tag is what ResponseCacheService purges the edge entry by, and a tag this long cannot be passed to
+            // the purge API, so the entry would stay on the edge until it expired on its own. An edge entry that can
+            // never be invalidated is worse than no edge entry at all. The output cache is not affected: it holds the
+            // whole tag and is purged in process.
+            edgeCacheTtl = -1;
+        }
+
         // Edge - Client Cache
         if (clientCacheTtl != -1 || edgeCacheTtl != -1)
         {
@@ -110,6 +145,14 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
             // zone. Without that rule the edge keeps a single variant per URL and hands it to callers of every origin.
             context.HttpContext.Response.Headers.Append(HeaderNames.Vary, "Origin, X-Origin");
 
+            if (edgeCacheTtl > 0)
+            {
+                // What ResponseCacheService.PurgeCache purges the edge entry by. Unlike a purge by URL, a purge by tag
+                // reaches every query string variant the URL was cached under and every hostname of the zone in a
+                // single API call, which also keeps the purge within the rate limit of Cloudflare's free plan.
+                context.HttpContext.Response.Headers[CacheTagHeaderName] = cacheTag;
+            }
+
             context.HttpContext.Response.OnStarting(static state =>
             {
                 var response = (HttpResponse)state;
@@ -117,6 +160,9 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
                 if (IsResponseCacheable(response) is false)
                 {
                     response.GetTypedHeaders().CacheControl = new() { NoStore = true, Private = true };
+                    // Nothing is going to be cached under it, and a CDN that does not consume the header would
+                    // otherwise pass it on to the visitor.
+                    response.Headers.Remove(CacheTagHeaderName);
                 }
 
                 return Task.CompletedTask;
@@ -126,7 +172,7 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
         // ASP.NET Core Output Cache
         if (outputCacheTtl > 0)
         {
-            context.Tags.Add(requestPath);
+            context.Tags.Add(cacheTag);
             context.AllowCacheLookup = true;
             context.AllowCacheStorage = true;
             context.ResponseExpirationTimeSpan = TimeSpan.FromSeconds(outputCacheTtl);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
@@ -26,14 +26,19 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
     /// <summary>
     /// The tag both the ASP.NET Core output cache entry and the CDN edge entry are stored under, so that a single
     /// <c>ResponseCacheService.PurgeCache("/product/5")</c> invalidates both.
-    /// A cache-tag may hold printable ASCII only and is written to the header as part of a comma separated list, so
-    /// the two characters a URL path can legally carry but a tag cannot are percent encoded here. The same encoding
-    /// is applied on the purge side, so the two always agree.
     /// </summary>
     public static string CreateCacheTag(string relativePath)
     {
-        return relativePath.ToLowerInvariant().Replace(",", "%2c").Replace(" ", "%20");
+        var path = new Uri(CacheTagBaseUri, relativePath).AbsolutePath;
+
+        return path.ToLowerInvariant().Replace(",", "%2c");
     }
+
+    /// <summary>
+    /// Only there to let <see cref="CreateCacheTag"/> canonicalize a relative path through <see cref="Uri"/>; the host
+    /// is never part of a tag.
+    /// </summary>
+    private static readonly Uri CacheTagBaseUri = new("http://localhost");
 
     /// <summary>
     /// Updates the <see cref="OutputCacheContext"/> before the cache middleware is invoked.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -99,11 +99,13 @@ public static partial class Program
 
             //#if (api == "Integrated")
             app.UseCors();
-            app.UseRateLimiter();
             app.UseMiddleware<ForceUpdateMiddleware>();
             //#endif
 
             app.UseAuthentication();
+            //#if (api == "Integrated")
+            app.UseRateLimiter(); // After UseAuthentication, so rate limit partitions can use HttpContext.User.
+            //#endif
             app.UseAuthorization();
 
             app.UseOutputCache();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -125,8 +125,7 @@
     },
     "Cloudflare": {
         "ApiToken": null,
-        "ZoneId": null,
-        "AdditionalDomains": []
+        "ZoneIds": []
     },
     "Azure": {
         "SignalR": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
@@ -1458,6 +1458,9 @@
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>النطاق '{0}' مستخدم بالفعل.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>النطاق '{0}' محجوز ولا يمكن استخدامه.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>لم تقم بتحديد أي مستأجر بعد. بدّل إلى أحد مستأجريك أو أنشئ مستأجرًا جديدًا للبدء.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
@@ -1458,6 +1458,9 @@ Nach Erreichen von {0} haben zusätzliche Anmeldungen reduzierte Funktionen.</va
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>Die Domain '{0}' ist bereits vergeben.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>Die Domain '{0}' ist reserviert und kann nicht verwendet werden.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>Sie haben noch keinen Mandanten ausgewählt. Wechseln Sie zu einem Ihrer Mandanten oder erstellen Sie einen neuen, um loszulegen.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
@@ -1458,6 +1458,9 @@ Después de alcanzar {0}, los inicios de sesión adicionales tendrán funciones 
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>El dominio '{0}' ya está en uso.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>El dominio '{0}' está reservado y no se puede utilizar.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>Aún no has seleccionado ningún inquilino. Cambia a uno de tus inquilinos o crea uno nuevo para comenzar.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
@@ -1458,6 +1458,9 @@
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>دامنه '{0}' تکراری است.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>دامنه '{0}' رزرو شده است و قابل استفاده نیست.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>شما هنوز مستأجری را انتخاب نکرده‌اید. به یکی از مستأجران خود تغییر دهید یا مستأجر جدیدی ایجاد کنید تا شروع کنید.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
@@ -1458,6 +1458,9 @@ Après avoir atteint {0}, les connexions supplémentaires auront des fonctions r
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>Le domaine '{0}' est déjà utilisé.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>Le domaine '{0}' est réservé et ne peut pas être utilisé.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>Vous n'avez pas encore sélectionné de locataire. Passez à l'un de vos locataires ou créez-en un nouveau pour commencer.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
@@ -1458,6 +1458,9 @@
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>डोमेन '{0}' पहले से उपयोग में है।</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>डोमेन '{0}' आरक्षित है और इसका उपयोग नहीं किया जा सकता।</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>आपने अभी तक कोई टेनेंट नहीं चुना है। शुरू करने के लिए अपने किसी टेनेंट पर स्विच करें या एक नया टेनेंट बनाएं।</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
@@ -1458,6 +1458,9 @@ Na het bereiken van {0} zullen extra aanmeldingen verminderde functies hebben.</
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>Het domein '{0}' is al in gebruik.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>Het domein '{0}' is gereserveerd en kan niet worden gebruikt.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>Je hebt nog geen tenant geselecteerd. Wissel naar een van je tenants of maak een nieuwe aan om te beginnen.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -1458,6 +1458,9 @@ After reaching {0}, extra sign-ins will have reduced functions.</value>
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>The domain '{0}' is already taken.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>The domain '{0}' is reserved and cannot be used.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>You haven't selected a tenant yet. Switch to one of your tenants or create a new one to get started.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
@@ -1458,6 +1458,9 @@ Efter att ha nått {0} kommer extra inloggningar att ha reducerade funktioner.</
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>Domänen '{0}' är redan upptagen.</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>Domänen '{0}' är reserverad och kan inte användas.</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>Du har inte valt någon tenant ännu. Byt till en av dina tenants eller skapa en ny för att komma igång.</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
@@ -1458,6 +1458,9 @@
     <data name="DuplicateTenantDomain" xml:space="preserve">
     <value>域名 '{0}' 已被占用。</value>
   </data>
+    <data name="ReservedTenantDomain" xml:space="preserve">
+    <value>域名 '{0}' 为保留域名，无法使用。</value>
+  </data>
     <data name="SelectTenantMessage" xml:space="preserve">
     <value>您尚未选择任何租户。切换到您的某个租户，或创建一个新租户即可开始。</value>
   </data>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ProductResponseCacheTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ProductResponseCacheTests.cs
@@ -5,6 +5,7 @@ using Boilerplate.Server.Api.Features.Tenants;
 using Boilerplate.Server.Api.Features.Products;
 using Boilerplate.Server.Api.Infrastructure.Data;
 using Boilerplate.Server.Api.Infrastructure.Services;
+using Boilerplate.Server.Shared.Infrastructure.Services;
 using Boilerplate.Client.Core.Infrastructure.Services;
 
 namespace Boilerplate.Tests.Features.Caching;
@@ -24,14 +25,16 @@ public partial class ProductResponseCacheTests
     /// product's <c>UserAgnostic</c> API response and its pre-rendered public page really are stored in ASP.NET Core's
     /// output cache, that a write through the app reaches them, and that a change made behind the app's back does not.
     /// <list type="number">
-    /// <item>A product is inserted straight into the database for the default fallback tenant, then read twice: once as
-    /// the signed-in tenant-user through <c>ProductViewController.Get</c> (which is <c>UserAgnostic</c>, so it is cached
-    /// even for an authenticated caller, keyed by her tenant - See <c>AppResponseCachePolicy</c>), and once anonymously
-    /// as the pre-rendered <c>/product/{shortId}</c> page. Both responses are now in the output cache.</item>
+    /// <item>A product is inserted straight into the database for the default fallback tenant, then read as the
+    /// signed-in tenant-user through <c>ProductViewController.Get</c> (which is <c>UserAgnostic</c>, so it is cached
+    /// even for an authenticated caller, keyed by her tenant - See <c>AppResponseCachePolicy</c>), and anonymously as
+    /// the pre-rendered <c>/product/{shortId}</c> page - the latter under both culture prefixes and with a query string,
+    /// each of which lands in the output cache as an entry of its own. All of them are now in the output cache.</item>
     /// <item>The tenant-admin - the member holding <c>ProductCatalog_Manage</c> for that tenant - edits the description
-    /// through the real <c>ProductController.Update</c> endpoint, which purges the product right after saving. Both
-    /// readers immediately see the new description, which proves the tags <c>AppResponseCachePolicy</c> writes match the
-    /// paths <c>ResponseCacheService.PurgeProductCache</c> evicts.</item>
+    /// through the real <c>ProductController.Update</c> endpoint, which purges the product right after saving. Every
+    /// reader immediately sees the new description, which proves the tags <c>AppResponseCachePolicy</c> writes match the
+    /// paths <c>ResponseCacheService.PurgeProductCache</c> evicts - and, since that purge only ever names the bare path,
+    /// that the culture and query string an entry was cached under are no part of its tag.</item>
     /// <item>The product is then deleted straight from the database, bypassing the app and therefore the purge. Both
     /// readers keep seeing the deleted product, which is the definitive proof that their responses are being served from
     /// the output cache rather than re-read from the database.</item>
@@ -83,9 +86,24 @@ public partial class ProductResponseCacheTests
         // actually returned.
         using var visitorHttpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
 
-        var pageHtml = await GetProductPage(visitorHttpClient, productShortId, assertOutputCachingIsActive: true);
-        Assert.Contains(productName, pageHtml);
-        Assert.Contains(originalDescription, pageHtml);
+        // The same page, requested four ways. Each of them gets its own output cache entry - the path is part of the
+        // key, the entry varies by culture, and QueryKeys = "*" gives every query string its own entry - yet they all
+        // carry the one tag AppResponseCachePolicy derives from the bare, culture-less path. So the single purge that
+        // the admin's edit triggers in step 2 has to clear all four at once.
+        string[] pageUrls =
+        [
+            $"{PageUrls.Product}/{productShortId}",
+            $"/en-US{PageUrls.Product}/{productShortId}",
+            $"/fa-IR{PageUrls.Product}/{productShortId}",
+            $"{PageUrls.Product}/{productShortId}?utm_source={marker}"
+        ];
+
+        foreach (var pageUrl in pageUrls)
+        {
+            var html = await GetProductPage(visitorHttpClient, pageUrl, assertOutputCachingIsActive: true);
+            Assert.Contains(productName, html, $"'{pageUrl}' should render the product.");
+            Assert.Contains(originalDescription, html, $"'{pageUrl}' should render the product.");
+        }
 
         // ---- Step 2: the tenant-admin edits the description through the real write endpoint ----
 
@@ -110,14 +128,19 @@ public partial class ProductResponseCacheTests
             Assert.AreEqual(updatedDescription, updated.DescriptionText);
         }
 
-        // Both readers see the new description straight away, so the tags AppResponseCachePolicy writes for these two
-        // requests really are the ones ResponseCacheService.PurgeProductCache evicts.
+        // Both readers see the new description straight away, so the tags AppResponseCachePolicy writes for these
+        // requests really are the ones ResponseCacheService.PurgeProductCache evicts. For the page that also means the
+        // one purge reached every culture and every query string variant of it, none of which the purging code knows
+        // anything about - it only ever names the bare path "/product/{shortId}".
         var seenAfterPurge = await tenantUserProductView.Get(productShortId, TestContext.CancellationToken);
         Assert.AreEqual(updatedDescription, seenAfterPurge.DescriptionText);
 
-        pageHtml = await GetProductPage(visitorHttpClient, productShortId);
-        Assert.Contains(updatedDescription, pageHtml);
-        Assert.DoesNotContain(originalDescription, pageHtml);
+        foreach (var pageUrl in pageUrls)
+        {
+            var html = await GetProductPage(visitorHttpClient, pageUrl);
+            Assert.Contains(updatedDescription, html, $"'{pageUrl}' should have been purged by the product's update.");
+            Assert.DoesNotContain(originalDescription, html, $"'{pageUrl}' should have been purged by the product's update.");
+        }
 
         // ---- Step 3: the product is deleted behind the app's back, so nothing purges its cache ----
 
@@ -136,9 +159,12 @@ public partial class ProductResponseCacheTests
         Assert.AreEqual(productName, seenAfterDelete.Name);
         Assert.AreEqual(updatedDescription, seenAfterDelete.DescriptionText);
 
-        pageHtml = await GetProductPage(visitorHttpClient, productShortId);
-        Assert.Contains(productName, pageHtml);
-        Assert.Contains(updatedDescription, pageHtml);
+        foreach (var pageUrl in pageUrls)
+        {
+            var html = await GetProductPage(visitorHttpClient, pageUrl);
+            Assert.Contains(productName, html, $"'{pageUrl}' should still be served from the cache.");
+            Assert.Contains(updatedDescription, html, $"'{pageUrl}' should still be served from the cache.");
+        }
 
         // ---- Step 4: purging makes the deletion visible, which rules out anything but the cache in step 3 ----
 
@@ -152,8 +178,67 @@ public partial class ProductResponseCacheTests
         await Assert.ThrowsExactlyAsync<ResourceNotFoundException>(
             () => tenantUserProductView.Get(productShortId, TestContext.CancellationToken));
 
-        pageHtml = await GetProductPage(visitorHttpClient, productShortId);
-        Assert.DoesNotContain(productName, pageHtml);
+        foreach (var pageUrl in pageUrls)
+        {
+            var html = await GetProductPage(visitorHttpClient, pageUrl);
+            Assert.DoesNotContain(productName, html, $"'{pageUrl}' should have been purged.");
+        }
+    }
+
+    /// <summary>
+    /// Proves that an edge cacheable response carries the <c>Cache-Tag</c> header the CDN edge entry is later purged by,
+    /// and that the tag is exactly the one <c>ResponseCacheService.PurgeProductCache</c> sends to Cloudflare.
+    /// The requests deliberately differ in query string, casing and culture: the edge keeps a separate entry per full
+    /// URL, so a tag that mirrored any of those would leave the other variants stranded on the edge until they expired
+    /// on their own - which is the whole reason the purge is by tag rather than by URL.
+    /// </summary>
+    [TestMethod]
+    public async Task EdgeCaching_Should_TagResponses_WithThePathTheyArePurgedBy()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(
+            configureTestServices: services => services.AddIntegrationApiOnlyTestsServices().FakeExternalStatistics(),
+            configureTestConfigurations: configuration =>
+            {
+                configuration["ResponseCaching:EnableCdnEdgeCaching"] = "true";
+            }).Start(TestContext.CancellationToken);
+
+        var marker = Guid.NewGuid().ToString("N");
+        var (_, productShortId) = await CreateProduct(server, $"tagged-product-{marker}", $"description-{marker}");
+
+        // A bare HttpClient keeps the client-side message handlers out of the way, so the headers asserted below are
+        // the ones the server actually wrote.
+        using var visitorHttpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        var requestPath = $"/api/v1/ProductView/Get/{productShortId}";
+        using var response = await visitorHttpClient.GetAsync($"{requestPath}?utm_source=test", TestContext.CancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        // Edge:-1 would mean the response was never meant for the edge, making the rest of this test meaningless.
+        Assert.IsTrue(response.Headers.TryGetValues("App-Cache-Response", out var appCacheResponse));
+        Assert.DoesNotContain("Edge:-1", string.Concat(appCacheResponse!),
+            "Edge caching should be active for this anonymous, UserAgnostic API response.");
+
+        Assert.IsTrue(response.Headers.TryGetValues(AppResponseCachePolicy.CacheTagHeaderName, out var cacheTag),
+            "An edge cacheable response must tell the CDN which tag to store it under, otherwise it could never be purged.");
+
+        var tag = string.Concat(cacheTag!);
+        Assert.AreEqual($"/api/v1/productview/get/{productShortId}", tag);
+        Assert.AreEqual(AppResponseCachePolicy.CreateCacheTag(requestPath), tag,
+            "The tag on the response must be the one ResponseCacheService purges the path by.");
+
+        // The very same read in Persian. An API takes its culture from Accept-Language rather than from a path segment,
+        // so this is where the culture could leak into the tag on this endpoint; the page equivalent - /fa-IR/product/5
+        // and /en-US/product/5 collapsing onto one tag - is covered by the output cache test above.
+        using var faRequest = new HttpRequestMessage(HttpMethod.Get, requestPath);
+        faRequest.Headers.AcceptLanguage.Add(new("fa-IR"));
+        using var faResponse = await visitorHttpClient.SendAsync(faRequest, TestContext.CancellationToken);
+        faResponse.EnsureSuccessStatusCode();
+
+        Assert.IsTrue(faResponse.Headers.TryGetValues(AppResponseCachePolicy.CacheTagHeaderName, out var faCacheTag));
+        Assert.AreEqual(tag, string.Concat(faCacheTag!),
+            "The culture a response was produced in must not be part of the tag it is purged by.");
     }
 
     /// <summary>
@@ -244,9 +329,9 @@ public partial class ProductResponseCacheTests
     /// asserted is the exact HTML the server produced (or replayed from the output cache), with no client-side
     /// re-rendering on top of it.
     /// </summary>
-    private async Task<string> GetProductPage(HttpClient httpClient, int productShortId, bool assertOutputCachingIsActive = false)
+    private async Task<string> GetProductPage(HttpClient httpClient, string pageUrl, bool assertOutputCachingIsActive = false)
     {
-        using var response = await httpClient.GetAsync($"{PageUrls.Product}/{productShortId}", TestContext.CancellationToken);
+        using var response = await httpClient.GetAsync(pageUrl, TestContext.CancellationToken);
 
         if (assertOutputCachingIsActive)
         {
@@ -254,7 +339,7 @@ public partial class ProductResponseCacheTests
             // reached the output cache, making the rest of this test meaningless.
             Assert.IsTrue(response.Headers.TryGetValues("App-Cache-Response", out var appCacheResponse));
             Assert.DoesNotContain("Output:-1", string.Concat(appCacheResponse!),
-                "Output caching should be active for the pre-rendered product page.");
+                $"Output caching should be active for the pre-rendered product page at '{pageUrl}'.");
         }
 
         return await response.Content.ReadAsStringAsync(TestContext.CancellationToken);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ProductResponseCacheTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ProductResponseCacheTests.cs
@@ -239,6 +239,12 @@ public partial class ProductResponseCacheTests
         Assert.IsTrue(faResponse.Headers.TryGetValues(AppResponseCachePolicy.CacheTagHeaderName, out var faCacheTag));
         Assert.AreEqual(tag, string.Concat(faCacheTag!),
             "The culture a response was produced in must not be part of the tag it is purged by.");
+
+        // A non-ASCII route reaches CreateCacheTag escaped when the policy reads it out of Uri.AbsolutePath, but raw
+        // when a caller of PurgeCache types it out. Tags are matched literally, so the two forms have to converge -
+        // otherwise such a page would be tagged with bytes Cloudflare rejects and could never be purged.
+        Assert.AreEqual(AppResponseCachePolicy.CreateCacheTag("/%D9%85%D8%AD%D8%B5%D9%88%D9%84/5"),
+                        AppResponseCachePolicy.CreateCacheTag("/محصول/5"));
     }
 
     /// <summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TwoFactorAuthTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TwoFactorAuthTests.cs
@@ -145,8 +145,8 @@ public partial class TwoFactorAuthTests : AppPageTest
         // No elevated-access token e-mail was sent: the 2FA sign-in already elevated the session. Read every e-mail the
         // server captured straight from its in-memory store (See TestIdentityEmailService / EmailCaptureStore).
         var capturedEmails = server.WebApp.Services.GetRequiredService<EmailCaptureStore>().Captured;
-        Assert.IsFalse(
-            capturedEmails.Any(capturedEmail => capturedEmail.IsTo(email) && capturedEmail.Kind is CapturedEmailKind.ElevatedAccess),
+        Assert.DoesNotContain(
+            capturedEmail => capturedEmail.IsTo(email) && capturedEmail.Kind is CapturedEmailKind.ElevatedAccess, capturedEmails,
             "The 2FA sign-in already elevated the session, so deleting the account must not send an elevated-access token e-mail.");
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
@@ -1,15 +1,19 @@
+using Microsoft.AspNetCore.Identity;
 using Boilerplate.Tests.Infrastructure.Components;
 using Boilerplate.Tests.Infrastructure.Services;
+using Boilerplate.Server.Api.Infrastructure.Data;
+using Boilerplate.Server.Api.Features.Tenants;
+using Boilerplate.Server.Api.Features.Identity.Models;
 
 namespace Boilerplate.Tests.Features.Identity;
 
 [TestClass, TestCategory("UITest"), Retry(2)]
 public partial class UserGroupFeatureManagementUITests : AppPageTest
 {
-    // The seeded store tenant admin (a t-admin, not a global admin) and a regular member of the same tenant's
-    // demo user-group. See UserConfiguration, UserRoleConfiguration and TenantUserConfiguration.
+    // The seeded store tenant admin (a t-admin, not a global admin). See UserConfiguration and UserRoleConfiguration.
+    // She is only ever the ACTOR here: the user-group she edits and the member who signs in are both created per run,
+    // so this test never mutates anything another test - or its own next run - depends on.
     private const string StoreAdminEmail = "store-admin@bitplatform.dev";
-    private const string StoreUserEmail = "store-user@bitplatform.dev";
     private const string Password = "123456";
 
     // The "Manage roles" (a.k.a. "User groups") page is gated behind the Roles_Manage feature. In the role editor's
@@ -24,43 +28,101 @@ public partial class UserGroupFeatureManagementUITests : AppPageTest
     /// <summary>
     /// End-to-end feature-set journey proving a user-group's features flow into its members' access tokens at sign-in:
     /// <list type="number">
-    /// <item>The tenant admin grants the "Manage roles" (Roles_Manage) feature to the seeded demo user-group (needs elevated access).</item>
-    /// <item>A demo member (store-user) signs in and, because her fresh token now carries the feature, can reach the Manage roles page.</item>
-    /// <item>The tenant admin removes that feature from the demo user-group again (still elevated, so no new prompt).</item>
-    /// <item>The demo member signs out and back in; her new token no longer carries the feature, so the Manage roles page is off-limits.</item>
+    /// <item>The tenant admin grants the "Manage roles" (Roles_Manage) feature to a user-group (needs elevated access).</item>
+    /// <item>A member of that group signs in and, because her fresh token now carries the feature, can reach the Manage roles page.</item>
+    /// <item>The tenant admin removes that feature from the user-group again (still elevated, so no new prompt).</item>
+    /// <item>The member signs out and back in; her new token no longer carries the feature, so the Manage roles page is off-limits.</item>
     /// </list>
     /// </summary>
     [TestMethod]
-    public async Task TenantAdmin_GrantAndRevokeDemoGroupFeature_Should_ControlMemberAccess()
+    public async Task TenantAdmin_GrantAndRevokeUserGroupFeature_Should_ControlMemberAccess()
     {
         await using var server = new AppTestServer(Context);
         await server.Build().Start(TestContext.CancellationToken);
         var serverAddress = server.WebAppServerAddress;
 
+        // The database outlives the test run, so the group and the member are created here rather than taken from the
+        // seed. Editing a seeded user-group would mean a run that dies between the grant and the revoke leaves an admin
+        // feature on a group every other test's users belong to - poisoning every later run until someone wipes the
+        // database by hand. Owning the arrangement outright removes that entire class of failure.
+        var (userGroupName, memberEmail) = await CreateUserGroupWithMember(server);
+
         // ---- Browser 1: the tenant admin (the default Page / Context) ----
         await SignInWithPassword(Page, serverAddress, StoreAdminEmail, Password);
 
-        // She adds the Manage roles page to the demo user-group's feature set.
-        await SetDemoGroupRolesManageFeature(Page, server, granted: true);
+        // She adds the Manage roles page to the user-group's feature set.
+        await SetUserGroupRolesManageFeature(Page, server, userGroupName, granted: true);
 
-        // ---- Browser 2: the demo member, in her own isolated browser context ----
+        // ---- Browser 2: the group's member, in her own isolated browser context ----
         await using var memberContext = await Browser.NewContextAsync(ContextOptions());
         await SetBlazorWebAssemblyServerAddress(serverAddress, memberContext);
         var memberPage = await memberContext.NewPageAsync();
         memberPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
 
-        // Her first sign-in happens after the grant, so her token carries the demo group's freshly added feature and she
+        // Her first sign-in happens after the grant, so her token carries the group's freshly added feature and she
         // can reach the Manage roles page.
-        await SignInWithPassword(memberPage, serverAddress, StoreUserEmail, Password);
+        await SignInWithPassword(memberPage, serverAddress, memberEmail, Password);
         await AssertManageRolesPageAccessible(memberPage, serverAddress, accessible: true);
 
-        // ---- Browser 1: the admin removes the feature from the demo user-group again ----
-        await SetDemoGroupRolesManageFeature(Page, server, granted: false);
+        // ---- Browser 1: the admin removes the feature from the user-group again ----
+        await SetUserGroupRolesManageFeature(Page, server, userGroupName, granted: false);
 
         // ---- Browser 2: features are captured at sign-in, so only after re-authenticating does she lose access ----
         await SignOut(memberPage, serverAddress);
-        await SignInWithPassword(memberPage, serverAddress, StoreUserEmail, Password);
+        await SignInWithPassword(memberPage, serverAddress, memberEmail, Password);
         await AssertManageRolesPageAccessible(memberPage, serverAddress, accessible: false);
+    }
+
+    /// <summary>
+    /// Creates this run's own user-group in the seeded store tenant plus one member of it, both named after a fresh Guid
+    /// so concurrent or repeated runs can never collide. The member starts with no features at all, which is what makes
+    /// the "off-limits" half of the journey meaningful.
+    /// </summary>
+    private async Task<(string UserGroupName, string MemberEmail)> CreateUserGroupWithMember(AppTestServer server)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+
+        // Short enough to stay readable in the user-groups list, which is where the test clicks it.
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var userGroupName = $"test-{suffix}";
+        var memberEmail = $"{userGroupName}@bitplatform.dev";
+
+        var userGroup = new Role
+        {
+            Name = userGroupName,
+            NormalizedName = userGroupName.ToUpperInvariant(),
+            TenantId = TenantConfiguration.FallbackTenantId
+        };
+        await dbContext.Roles.AddAsync(userGroup, TestContext.CancellationToken);
+        await dbContext.SaveChangesAsync(TestContext.CancellationToken);
+
+        // Through the UserManager so the password is hashed and the user is normalized exactly as a real sign-up would be.
+        var member = new User { Email = memberEmail, UserName = memberEmail, EmailConfirmed = true, LockoutEnabled = true };
+        var result = await userManager.CreateAsync(member, Password);
+        Assert.IsTrue(result.Succeeded,
+            $"Creating the test member failed: {string.Join(", ", result.Errors.Select(error => error.Description))}");
+
+        await dbContext.UserRoles.AddAsync(new()
+        {
+            UserId = member.Id,
+            RoleId = userGroup.Id,
+            TenantId = TenantConfiguration.FallbackTenantId
+        }, TestContext.CancellationToken);
+
+        // An ACCEPTED tenant membership is what makes a tenant get selected at her sign-in; without it her token carries
+        // no tenant, so the group's tenant-scoped feature claims would never reach it (See IdentityController.GetTenantId).
+        await dbContext.TenantUsers.AddAsync(new()
+        {
+            TenantId = TenantConfiguration.FallbackTenantId,
+            UserId = member.Id,
+            AcceptedOn = DateTimeOffset.UtcNow
+        }, TestContext.CancellationToken);
+
+        await dbContext.SaveChangesAsync(TestContext.CancellationToken);
+
+        return (userGroupName, memberEmail);
     }
 
     private async Task SignInWithPassword(IPage page, Uri serverAddress, string email, string password)
@@ -76,17 +138,17 @@ public partial class UserGroupFeatureManagementUITests : AppPageTest
     }
 
     /// <summary>
-    /// Adds or removes the Roles_Manage feature on the seeded demo user-group from the Manage roles page. The first
+    /// Adds or removes the Roles_Manage feature on the given user-group from the Manage roles page. The first
     /// (grant) call needs elevated access - an elevated token is e-mailed (and dev-logged) and an OTP prompt appears;
     /// the later (revoke) call reuses that still-valid elevation, so no new prompt shows.
     /// </summary>
-    private async Task SetDemoGroupRolesManageFeature(IPage page, AppTestServer server, bool granted)
+    private async Task SetUserGroupRolesManageFeature(IPage page, AppTestServer server, string userGroupName, bool granted)
     {
         await page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.Roles).ToString(),
             new() { WaitUntil = WaitUntilState.NetworkIdle });
 
-        // Select the seeded demo user-group, then open the Features tab where each feature has an add/remove toggle.
-        await page.GetByText(AppRoles.Demo, new() { Exact = true }).ClickAsync();
+        // Select this run's user-group, then open the Features tab where each feature has an add/remove toggle.
+        await page.GetByText(userGroupName, new() { Exact = true }).ClickAsync();
         await page.GetByText(AppStrings.Features, new() { Exact = true }).ClickAsync();
 
         // The toggle button sits right after the feature's label in the same row. Its glyph reflects the current state:
@@ -94,18 +156,18 @@ public partial class UserGroupFeatureManagementUITests : AppPageTest
         var toggle = page.GetByText(RolesManageFeatureName, new() { Exact = true }).Locator("xpath=following::button[1]");
         var targetStateIcon = granted ? RemoveFeatureIconSelector : AddFeatureIconSelector;
 
-        // The toggle stays disabled (and its glyph reads as unassigned) until the selected role's claims finish loading, so
+        // The toggle stays disabled (and its glyph reads as unassigned) until the selected group's claims finish loading, so
         // wait for it to become enabled before trusting its glyph.
         await Expect(toggle).ToBeEnabledAsync();
 
-        // Be tolerant of the demo user-group already being in the wanted state (e.g. a feature the seed already granted):
-        // if the toggle is already showing the target glyph there is nothing to do and no elevation is needed.
-        if (await toggle.Locator(targetStateIcon).IsVisibleAsync())
-            return;
+        // The group is this run's own, so its starting state is known: unassigned before the grant, assigned before the
+        // revoke. Say so out loud - finding it already in the target state means the toggle resolved to the wrong row (or
+        // the claims never loaded), and failing here beats silently skipping the mutation and blaming the assertion later.
+        await Expect(toggle.Locator(granted ? AddFeatureIconSelector : RemoveFeatureIconSelector)).ToBeVisibleAsync();
 
         await toggle.ClickAsync();
 
-        // Mutating a role's features needs elevated access. The first such mutation in the session pops the OTP prompt (and
+        // Mutating a group's features needs elevated access. The first such mutation in the session pops the OTP prompt (and
         // an elevated token is e-mailed / dev-logged); later mutations reuse that still-valid elevation, so no prompt shows.
         // Wait briefly for the prompt and only fill it when it actually appears, rather than assuming which call elevates.
         try

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
@@ -147,8 +147,19 @@ public partial class UserGroupFeatureManagementUITests : AppPageTest
         await page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.Roles).ToString(),
             new() { WaitUntil = WaitUntilState.NetworkIdle });
 
+        // Everything is scoped to the user-groups card. The page's own side menu is a nav too, and a long group list can
+        // end up underneath it - which shows up as Playwright reporting that the menu "intercepts pointer events".
+        var userGroupsCard = page.Locator(".roles-card");
+
+        // Searching narrows the list to this run's group, so the click target is unambiguous and sits at the top of the card.
+        await userGroupsCard.GetByPlaceholder(AppStrings.SearchRolesPlaceholder).FillAsync(userGroupName);
+
+        // The search box is debounced, so the list is briefly still the unfiltered one. Wait for a group that is always
+        // there (demo) to drop out before clicking, rather than racing the re-render.
+        await Expect(userGroupsCard.GetByText(AppRoles.Demo, new() { Exact = true })).ToBeHiddenAsync();
+
         // Select this run's user-group, then open the Features tab where each feature has an add/remove toggle.
-        await page.GetByText(userGroupName, new() { Exact = true }).ClickAsync();
+        await userGroupsCard.GetByText(userGroupName, new() { Exact = true }).ClickAsync();
         await page.GetByText(AppStrings.Features, new() { Exact = true }).ClickAsync();
 
         // The toggle button sits right after the feature's label in the same row. Its glyph reflects the current state:

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Mcp/GetCurrentDateTimeMcpIntegrationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Mcp/GetCurrentDateTimeMcpIntegrationTests.cs
@@ -71,7 +71,7 @@ public partial class GetCurrentDateTimeMcpIntegrationTests
 
         // The GetCurrentDateTime tool must be advertised by the server (See [McpServerTool] in AppChatbot.Tools.cs).
         var tools = await mcpClient.ListToolsAsync(cancellationToken: TestContext.CancellationToken);
-        Assert.IsTrue(tools.Any(t => t.Name == "GetCurrentDateTime"), "The MCP server must expose the GetCurrentDateTime tool.");
+        Assert.Contains(t => t.Name == "GetCurrentDateTime", tools, "The MCP server must expose the GetCurrentDateTime tool.");
 
         // Invoke it for the UTC timezone; the tool converts the (faked) UtcNow into that timezone and echoes it back as text.
         var result = await mcpClient.CallToolAsync("GetCurrentDateTime",
@@ -80,13 +80,13 @@ public partial class GetCurrentDateTimeMcpIntegrationTests
 
         var text = result.Content.OfType<TextContentBlock>().First().Text;
 
-        Assert.IsTrue(result.IsError is not true, $"The GetCurrentDateTime tool call returned an error. Result: '{text}'.");
+        Assert.AreNotEqual(true, result.IsError, $"The GetCurrentDateTime tool call returned an error. Result: '{text}'.");
 
         // The tool formats the instant with the round-trip ("o") format. Assert on a second-precision prefix of the faked
         // UTC time so the check is immune to sub-second/offset formatting differences, plus that it names the timezone.
         var expectedUtc = TimeZoneInfo.ConvertTime(fakeTimeProvider.GetUtcNow(), TimeZoneInfo.Utc);
-        Assert.IsTrue(text.Contains(expectedUtc.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)),
+        Assert.Contains(expectedUtc.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture), text,
             $"Tool result did not contain the faked current date/time. Result: '{text}'.");
-        Assert.IsTrue(text.Contains("UTC"), $"Tool result did not mention the requested timezone. Result: '{text}'.");
+        Assert.Contains("UTC", text, $"Tool result did not mention the requested timezone. Result: '{text}'.");
     }
 }


### PR DESCRIPTION
closes #12788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cache-tag-based invalidation across application and CDN caches, including support for multiple CDN zones.
  - Added validation preventing tenants from using reserved deployment domains.
  - Improved tenant-aware role visibility for global administrators.
  - Enhanced Keycloak claim synchronization and token audience handling.
  - Added localized messages for reserved tenant domains.

- **Bug Fixes**
  - Improved refresh-token session persistence and reCAPTCHA failure handling.
  - Fixed localized password validation fallback behavior.

- **Documentation**
  - Reorganized authentication, authorization, caching, multi-tenancy, and external identity provider guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->