### PR TITLE
Add several automated test to bit Boilerplate (#12800)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -564,7 +564,17 @@
                         "src/Tests/Features/Identity/WebAuthnPasswordlessUITests.cs",
                         "src/Tests/Features/OpenApi/OpenApiScalarIntegrationTests.cs",
                         "src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs",
-                        "src/Tests/Features/Caching/ProductResponseCacheTests.cs"
+                        "src/Tests/Features/Caching/ProductResponseCacheTests.cs",
+                        "src/Tests/Features/Identity/TokenClassSeparationTests.cs",
+                        "src/Tests/Features/Identity/RoleClaimGrantAllowListTests.cs",
+                        "src/Tests/Features/Identity/WebAuthnCredentialOwnershipTests.cs",
+                        "src/Tests/Features/Attachments/AttachmentReplacementTests.cs",
+                        "src/Tests/Features/ErrorHandling/ProblemDetailsWireContractTests.cs",
+                        "src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs",
+                        "src/Tests/Features/Json/JsonOptionsContractTests.cs",
+                        "src/Tests/Features/Urls/AppQueryStringCollectionTests.cs",
+                        "src/Tests/Features/TemplateConfig/TemplateConfigurationTests.cs",
+                        "src/Tests/Features/Tenants/ReservedTenantNameTests.cs"
                     ]
                 },
                 {
@@ -694,6 +704,7 @@
                         "src/Client/Boilerplate.Client.Core/Components/Pages/Tenants/**",
                         "src/Server/Boilerplate.Server.Api/Features/Identity/Services/AppRoleValidator.cs",
                         "src/Tests/Features/Tenants/TenantInvitationUITests.cs",
+                        "src/Tests/Features/Tenants/ReservedTenantNameTests.cs",
                         "src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs"
                     ]
                 },

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/EntityTypeBuilderExtensions.cs
@@ -10,23 +10,8 @@ public static class EntityTypeBuilderExtensions
     {
         /// <summary>
         /// Adds a unique index (single or composite) whose uniqueness only applies to the rows where
-        /// <paramref name="filterColumn"/> has a value, so multiple NULLs remain allowed.
-        /// <para>
-        /// Every provider except MySQL gets that as a filtered index, with the column identifier quoted per provider.
-        /// MySQL has no filtered indexes at all - <c>MySqlMigrationsSqlGenerator.IndexOptions</c> silently DROPS the
-        /// filter - but it also treats NULLs as distinct in a plain unique index, which is exactly the semantics wanted
-        /// here, so the filter is simply omitted there rather than emitted and thrown away.
-        /// </para>
-        /// <para>
-        /// For <c>database == "Other"</c> the <c>[Bracket]</c> quoting of the <c>#else</c> branch is a SQL Server /
-        /// SQLite convention; adjust it for your provider before generating the first migration.
-        /// </para>
+        /// filterColumn has a value, so multiple NULLs remain allowed.
         /// </summary>
-        /// <param name="property">The indexed column(s), e.g. <c>t => t.Domain</c> or <c>t => new { t.A, t.B }</c>.</param>
-        /// <param name="filterColumn">
-        /// The column the filter tests. Defaults to <paramref name="property"/>, which only works for a single-column index;
-        /// a composite index must pass this explicitly (e.g. index on <c>new { A, TenantId }</c>, filter on <c>t => t.TenantId</c>).
-        /// </param>
         public IndexBuilder<T> HasUniqueIndexOnNullable(
             Expression<Func<T, object?>> property,
             Expression<Func<T, object?>>? filterColumn = null)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/EntityTypeBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class EntityTypeBuilderExtensions
             var columnName = GetMemberName(filterColumn ?? property);
             //#if (database == "PostgreSQL")
             index.HasFilter($"\"{columnName}\" IS NOT NULL");
-            //#elseif (database != "PostgreSQL" && database != "MySql")
+            //#elseif (database != "PostgreSQL")
             index.HasFilter($"[{columnName}] IS NOT NULL");
             //#endif
             //#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/EntityTypeBuilderExtensions.cs
@@ -35,12 +35,11 @@ public static class EntityTypeBuilderExtensions
 
             //#if (database != "MySql")
             var columnName = GetMemberName(filterColumn ?? property);
-            //#endif
             //#if (database == "PostgreSQL")
             index.HasFilter($"\"{columnName}\" IS NOT NULL");
-            //#endif
-            //#if (database != "PostgreSQL" && database != "MySql")
+            //#elseif (database != "PostgreSQL" && database != "MySql")
             index.HasFilter($"[{columnName}] IS NOT NULL");
+            //#endif
             //#endif
 
             return index;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Attachments/AttachmentReplacementTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Attachments/AttachmentReplacementTests.cs
@@ -1,0 +1,175 @@
+using ImageMagick;
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Tests.Features.Identity;
+using Boilerplate.Shared.Features.Attachments;
+using Boilerplate.Server.Api.Infrastructure.Data;
+using Boilerplate.Server.Api.Features.Identity.Models;
+
+namespace Boilerplate.Tests.Features.Attachments;
+
+/// <summary>
+/// <c>AttachmentController.UploadAttachment</c> is split into a validate phase and a mutate phase, and both halves of
+/// that split have already been paid for once:
+/// <list type="bullet">
+/// <item>It used to delete the existing rows and the existing blob <b>before</b> decoding the upload. A file that was
+/// too small, or that ImageMagick could not decode, therefore destroyed the picture the user already had while
+/// leaving <c>HasProfilePicture</c> true - so the profile pointed at a blob that no longer existed and no code path
+/// could restore or clear it.</item>
+/// <item>The first fix for that then went the other way and removed-and-re-added the rows in one
+/// <c>SaveChangesAsync</c>. <c>Attachment</c>'s key is composite - <c>{ Id, Kind }</c> - and <c>GetFilePath</c> is
+/// deterministic over exactly those two values, so the re-added rows collided with the tracked deleted ones and EF
+/// threw before reaching the database. Every <b>re-upload</b> failed while the first upload passed, which is the one
+/// case a happy-path test does not cover.</item>
+/// </list>
+/// Both are invisible without a second upload, in either direction, against an account that already has a picture.
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class AttachmentReplacementTests
+{
+    /// <summary>
+    /// Upload, then upload again with different content. The second call must succeed, must overwrite in place
+    /// (still exactly two rows, since the key is <c>{ Id, Kind }</c> and the path is derived from it), and the served
+    /// image must actually be the new one - a "successful" re-upload that leaves the old blob behind is the same bug
+    /// wearing a green test.
+    /// </summary>
+    [TestMethod]
+    public async Task ReUploadingAProfilePicture_Should_ReplaceItInPlace()
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var (_, userId) = await TestAccountUtils.CreateAndSignIn(server, scope, TestContext.CancellationToken);
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        try
+        {
+            await Upload(httpClient, SolidImage(MagickColors.Red));
+
+            var first = await Download(httpClient, userId);
+            Assert.AreEqual(2, await CountAttachments(server, userId), "One upload writes the small and the original kind.");
+
+            await Upload(httpClient, SolidImage(MagickColors.Blue));
+
+            Assert.AreEqual(2, await CountAttachments(server, userId),
+                "A re-upload must overwrite the existing rows, not add a second pair - the key is { Id, Kind } and the blob path is derived from it.");
+
+            CollectionAssert.AreNotEqual(first, await Download(httpClient, userId),
+                "The served image must be the one just uploaded; an in-place overwrite that never wrote the new bytes would look identical here.");
+        }
+        finally
+        {
+            await DeleteProfilePicture(httpClient);
+        }
+    }
+
+    /// <summary>
+    /// The rejection path. A 100x100 upload is refused because it is smaller than the 256x256 the small kind needs -
+    /// and the picture the user already had must be exactly as it was: same bytes served, still two rows, and
+    /// <c>HasProfilePicture</c> still true.
+    /// <para>
+    /// The <c>HasProfilePicture</c> assertion is the one that matters most. It is written server-side after a
+    /// successful upload and cleared only by <c>DeleteUserProfilePicture</c>, so a rejected upload that deleted the
+    /// rows left the flag true with nothing behind it, and the user could neither see their picture nor delete it.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task AnUploadRejectedAfterValidation_Should_LeaveTheExistingPictureUntouched()
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var (_, userId) = await TestAccountUtils.CreateAndSignIn(server, scope, TestContext.CancellationToken);
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        try
+        {
+            await Upload(httpClient, SolidImage(MagickColors.Red));
+            var before = await Download(httpClient, userId);
+
+            // The DI HttpClient turns a non-success response into an exception (See ExceptionDelegatingHandler); the
+            // ImageTooSmall body is plain text, so the status code is what identifies the rejection.
+            var rejected = await Assert.ThrowsExactlyAsync<HttpRequestException>(
+                () => Upload(httpClient, SolidImage(MagickColors.Blue, 100)),
+                "An image below the required size must be refused.");
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, rejected.StatusCode);
+
+            CollectionAssert.AreEqual(before, await Download(httpClient, userId),
+                "The refused upload must not have touched the stored blob.");
+
+            Assert.AreEqual(2, await CountAttachments(server, userId), "The refused upload must not have removed the existing rows.");
+
+            Assert.IsTrue(await HasProfilePicture(server, userId),
+                "HasProfilePicture must still be true. If a rejected upload can clear the blob while leaving this flag set, " +
+                "the profile permanently points at something that is not there.");
+        }
+        finally
+        {
+            await DeleteProfilePicture(httpClient);
+        }
+    }
+
+
+    private async Task<AppTestServer> StartServer()
+    {
+        var server = new AppTestServer();
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+        return server;
+    }
+
+    /// <summary>A solid-colour PNG, so two uploads differ in content in a way the served WebP cannot hide.</summary>
+    private static byte[] SolidImage(MagickColor color, uint size = 512)
+    {
+        using var image = new MagickImage(color, size, size);
+        return image.ToByteArray(MagickFormat.Png);
+    }
+
+    private async Task Upload(HttpClient httpClient, byte[] imageBytes)
+    {
+        using var form = new MultipartFormDataContent();
+        using var fileContent = new ByteArrayContent(imageBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        form.Add(fileContent, "file", "picture.png"); // The endpoint binds an IFormFile parameter named "file".
+
+        using var response = await httpClient.PostAsync("api/v1/Attachment/UploadUserProfilePicture", form, TestContext.CancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<byte[]> Download(HttpClient httpClient, Guid userId)
+    {
+        // attachmentId for a profile picture is the user id; the small kind is the resized WebP.
+        return await httpClient.GetByteArrayAsync(
+            $"api/v1/Attachment/GetAttachment/{userId}/{AttachmentKind.UserProfileImageSmall}", TestContext.CancellationToken);
+    }
+
+    private async Task DeleteProfilePicture(HttpClient httpClient)
+    {
+        // Best effort: the per-run account's blobs and rows outlive the run otherwise, and a test that fails early
+        // must not take the cleanup down with it.
+        try
+        {
+            using var _ = await httpClient.DeleteAsync("api/v1/Attachment/DeleteUserProfilePicture", CancellationToken.None);
+        }
+        catch (Exception) { }
+    }
+
+    private async Task<int> CountAttachments(AppTestServer server, Guid attachmentId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        return await dbContext.Attachments.CountAsync(att => att.Id == attachmentId, TestContext.CancellationToken);
+    }
+
+    private async Task<bool> HasProfilePicture(AppTestServer server, Guid userId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        return await dbContext.Set<User>().Where(u => u.Id == userId).Select(u => u.HasProfilePicture).SingleAsync(TestContext.CancellationToken);
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ErrorHandling/ProblemDetailsWireContractTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ErrorHandling/ProblemDetailsWireContractTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Text;
+
+namespace Boilerplate.Tests.Features.ErrorHandling;
+
+/// <summary>
+/// Every 4xx and 5xx the API produces is written by <c>ApiServerExceptionHandler.WriteAsync</c> as an
+/// <c>AppProblemDetails</c>, so this is the one wire format the whole product shares - and the template publishes an
+/// OpenAPI/Scalar surface aimed at consumers that are not this client.
+/// <para>
+/// It is also a format the template's own client cannot police: System.Text.Json deserialization is <b>last-wins</b>,
+/// so a body carrying the same member twice binds correctly here and is broken everywhere else - <c>JsonNode</c>
+/// throws on the first property access, a schema validator or first-wins parser reads the <i>other</i> copy, and on a
+/// validation failure that means reading an empty <c>payload</c> and losing every field-level message. The bug that
+/// caused it (declared properties plus <c>[JsonExtensionData]</c> entries of the same name, which STJ emits without a
+/// collision check) shipped on 100% of error responses and nothing noticed, because nothing pinned the format.
+/// </para>
+/// <para>
+/// The requests below are deliberately issued with a bare <see cref="HttpClient"/> rather than the DI one: the client
+/// pipeline turns an error response into a typed exception, which is exactly the layer that hides this.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class ProblemDetailsWireContractTests
+{
+    /// <summary>
+    /// A <c>KnownException</c> (404 from an anonymous endpoint). No member may appear twice, and <c>key</c> - the
+    /// member the client maps back onto an exception type - must be present with the exception's own key rather than
+    /// null.
+    /// </summary>
+    [TestMethod]
+    public async Task AKnownExceptionResponse_Should_CarryEveryMemberExactlyOnce()
+    {
+        await using var server = await StartServer();
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        // Anonymous, and nothing is stored under a random attachment id, so this is a deterministic ResourceNotFoundException.
+        using var response = await httpClient.GetAsync($"api/v1/Attachment/GetAttachment/{Guid.NewGuid()}/UserProfileImageSmall", TestContext.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode, $"Unexpected status. Body: {body}");
+
+        AssertNoDuplicateMembers(body);
+
+        var problemDetails = JsonDocument.Parse(body).RootElement;
+
+        Assert.AreEqual(nameof(ResourceNotFoundException), problemDetails.GetProperty("key").GetString(),
+            $"`key` is what the client turns back into an exception type. Body: {body}");
+        Assert.AreEqual(404, problemDetails.GetProperty("status").GetInt32(), $"Body: {body}");
+    }
+
+    /// <summary>
+    /// A <c>ResourceValidationException</c>, the case with the most to lose: its <c>payload</c> carries every
+    /// field-level message. A duplicate <c>payload</c> meant a first-wins consumer read the empty copy and reported a
+    /// validation failure with no reason attached.
+    /// </summary>
+    [TestMethod]
+    public async Task AValidationFailureResponse_Should_CarryExactlyOnePopulatedPayload()
+    {
+        await using var server = await StartServer();
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        // Neither a password nor an otp: SignInRequestDto.Validate rejects it, so InvalidModelStateResponseFactory
+        // throws a ResourceValidationException. A JSON content type also satisfies AutoCsrfProtectionFilter.
+        using var content = new StringContent("{}", Encoding.UTF8, "application/json");
+        using var response = await httpClient.PostAsync("api/v1/Identity/SignIn", content, TestContext.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode, $"Unexpected status. Body: {body}");
+
+        AssertNoDuplicateMembers(body);
+
+        var problemDetails = JsonDocument.Parse(body).RootElement;
+
+        Assert.IsTrue(problemDetails.TryGetProperty("payload", out var payload), $"A validation failure must carry its payload. Body: {body}");
+        Assert.IsGreaterThan(0, payload.GetProperty("details").GetArrayLength(),
+            $"The payload must hold the real field-level errors, not an empty placeholder. Body: {body}");
+    }
+
+
+    /// <summary>
+    /// <see cref="JsonDocument"/> silently keeps the last of two same-named members, so the duplicate has to be found
+    /// with a raw reader - a parse-and-compare test would have passed against the broken format.
+    /// </summary>
+    private static void AssertNoDuplicateMembers(string json)
+    {
+        Assert.IsFalse(string.IsNullOrWhiteSpace(json), "The error response has no body at all.");
+
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        List<string> memberNames = [];
+        var depth = 0;
+
+        while (reader.Read())
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.StartObject or JsonTokenType.StartArray:
+                    depth++;
+                    break;
+                case JsonTokenType.EndObject or JsonTokenType.EndArray:
+                    depth--;
+                    break;
+                case JsonTokenType.PropertyName when depth is 1:
+                    memberNames.Add(reader.GetString()!);
+                    break;
+            }
+        }
+
+        var duplicates = memberNames.GroupBy(name => name, StringComparer.Ordinal)
+                                    .Where(group => group.Count() > 1)
+                                    .Select(group => $"'{group.Key}' x{group.Count()}")
+                                    .ToArray();
+
+        Assert.IsEmpty(duplicates,
+            $"The error body repeats {string.Join(", ", duplicates)}. STJ deserialization is last-wins so this client " +
+            $"survives it, but JsonNode throws and a first-wins parser reads the wrong copy. Body: {json}");
+    }
+
+    private async Task<AppTestServer> StartServer()
+    {
+        var server = new AppTestServer();
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+        return server;
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+
+namespace Boilerplate.Tests.Features.ForceUpdate;
+
+/// <summary>
+/// <b>Pins an open finding (BP-079). Remove the <c>[Ignore]</c> when it is fixed.</b>
+/// <para>
+/// <c>ForceUpdateMiddleware</c> runs on <b>every</b> request, before authentication, and parses two request headers
+/// with three throwing APIs and no guards: <c>Headers["X-App-Platform"].Single()</c>,
+/// <c>Enum.Parse&lt;AppPlatformType&gt;(...)</c> and <c>Version.Parse(appVersion)</c>. Every one of them is fed
+/// directly from headers any anonymous caller controls, so each is a one-line request that turns into a 500 plus a
+/// <c>LogCritical</c> record - free, unauthenticated log noise on any endpoint, and a 500 where the caller should
+/// have got the real answer.
+/// </para>
+/// <para>
+/// The <c>Single()</c> case is the sharpest: the middleware only checks that <c>X-App-Version</c> is present, then
+/// reads <c>X-App-Platform</c> as though presence of the first guaranteed the second. Sending just
+/// <c>X-App-Version</c> - which is what a curl, a health prober or a partial client does - is enough.
+/// </para>
+/// <para>
+/// What unblocks this: read both headers defensively (<c>FirstOrDefault()</c>, <c>Enum.TryParse</c>,
+/// <c>Version.TryParse</c>) and simply skip the version check when the client did not supply a usable pair. The
+/// middleware's job is to force an update, not to validate headers - failing open is the correct direction here,
+/// since a caller that cannot state its version is not a client this check applies to.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class ForceUpdateHeaderHardeningTests
+{
+    /// <summary>
+    /// Each row is a header combination an anonymous caller can send today. The endpoint is an ordinary anonymous
+    /// GET whose real answer is 404; the assertion is simply that the client version headers did not change it into
+    /// a server fault.
+    /// </summary>
+    [TestMethod, Ignore("Pins BP-079: ForceUpdateMiddleware parses attacker-controlled headers with Single()/Enum.Parse/Version.Parse. Verified 2026-08-01 - all four rows return 500 UnknownException + LogCritical today.")]
+    [DataRow("1.0.0", null, DisplayName = "X-App-Platform missing -> Single() on an empty StringValues")]
+    [DataRow("1.0.0", "NotAPlatform", DisplayName = "unknown platform -> Enum.Parse throws")]
+    [DataRow("not-a-version", "Web", DisplayName = "unparsable version -> Version.Parse throws")]
+    [DataRow("1.0.0, 2.0.0", "Web", DisplayName = "repeated X-App-Version, which Kestrel joins into one comma-separated value")]
+    public async Task AMalformedClientVersionHeader_Should_NotFaultTheRequest(string appVersion, string? appPlatform)
+    {
+        await using var server = new AppTestServer();
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"api/v1/Attachment/GetAttachment/{Guid.NewGuid()}/UserProfileImageSmall");
+        request.Headers.TryAddWithoutValidation("X-App-Version", appVersion);
+
+        if (appPlatform is not null)
+        {
+            request.Headers.TryAddWithoutValidation("X-App-Platform", appPlatform);
+        }
+
+        using var response = await httpClient.SendAsync(request, TestContext.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode,
+            $"A header the caller controls must not turn the real 404 into a server fault. Body: {body}");
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/EmailUniquenessIndexTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/EmailUniquenessIndexTests.cs
@@ -45,13 +45,13 @@ public class EmailUniquenessIndexTests
             .Select(index => index.Properties.Select(p => p.Name).ToArray())
             .ToArray();
 
-        Assert.IsTrue(
-            uniqueIndexedColumnSets.Any(columns => columns is [nameof(User.NormalizedEmail)]),
+        Assert.Contains(
+            columns => columns is [nameof(User.NormalizedEmail)], uniqueIndexedColumnSets,
             "There must be a unique index on NormalizedEmail - the column UserStore.FindByEmailAsync queries with " +
             $"SingleOrDefaultAsync. Unique indexes found: [{string.Join(" | ", uniqueIndexedColumnSets.Select(c => string.Join(", ", c)))}].");
 
-        Assert.IsFalse(
-            uniqueIndexedColumnSets.Any(columns => columns is [nameof(User.Email)]),
+        Assert.DoesNotContain(
+            columns => columns is [nameof(User.Email)], uniqueIndexedColumnSets,
             "A unique index on the RAW Email column is not a substitute: under a case-sensitive collation it accepts " +
             "two rows that share one NormalizedEmail, and every later lookup for that address then throws.");
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IdentityEmailDeliveryTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IdentityEmailDeliveryTests.cs
@@ -67,7 +67,7 @@ public class IdentityEmailDeliveryTests
 
         var store = server.WebApp.Services.GetRequiredService<EmailCaptureStore>();
 
-        Assert.IsFalse(store.Captured.Any(e => e.IsTo(email) && e.Kind is CapturedEmailKind.ResetPassword),
+        Assert.DoesNotContain(e => e.IsTo(email) && e.Kind is CapturedEmailKind.ResetPassword, store.Captured,
             "The request was refused, so no reset-password e-mail may have gone out.");
 
         // The property worth protecting: the refused request left no trace on the account. Read off the row rather
@@ -144,7 +144,7 @@ public class IdentityEmailDeliveryTests
             .Where(key => localizer[key, marker].Value.Contains(marker, StringComparison.Ordinal))
             .ToArray();
 
-        Assert.AreEqual(0, offenders.Length,
+        Assert.IsEmpty(offenders,
             $"These subject lines still put the live code outside the encrypted body: {string.Join(", ", offenders)}.");
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/RoleAdministrationGuardTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/RoleAdministrationGuardTests.cs
@@ -35,7 +35,7 @@ public class RoleAdministrationGuardTests
         var globalAdminRoleId = await ReadRoleId(server, AppRoles.GlobalAdmin);
 
         var assignmentsBefore = await CountRoleAssignments(server, globalAdminRoleId);
-        Assert.IsTrue(assignmentsBefore > 0, "This test just granted itself the role, so there is at least one assignment.");
+        Assert.IsGreaterThan(0, assignmentsBefore, "This test just granted itself the role, so there is at least one assignment.");
 
         await Assert.ThrowsExactlyAsync<BadRequestException>(
             () => roleManagementController.RemoveAllUsersFromRole(globalAdminRoleId, TestContext.CancellationToken),
@@ -85,7 +85,7 @@ public class RoleAdministrationGuardTests
 
         var values = await ReadClaimValues(server, roleId, AppClaimTypes.MAX_PRIVILEGED_SESSIONS);
 
-        Assert.AreEqual(1, values.Length,
+        Assert.HasCount(1, values,
             $"A single-valued claim must end up as exactly one row; found [{string.Join(", ", values)}]. Two rows mean the " +
             "reader's Max() keeps the old value, so the cap can only ever be raised.");
         Assert.AreEqual("2", values[0], "The stored value must be the one the administrator just saved.");

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/RoleClaimGrantAllowListTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/RoleClaimGrantAllowListTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Server.Api.Infrastructure.Data;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+/// <summary>
+/// Role claims are copied verbatim into the access token (<c>AppUserClaimsPrincipalFactory.GenerateClaims</c>), and
+/// <c>AppJwtSecureDataFormat.Unprotect</c> then reads that token's <b>role</b> claims and hands out every global-admin
+/// feature to anyone in <c>g-admin</c>. So whatever claim type the role-management endpoints accept is, transitively,
+/// something a caller can put in their own token.
+/// <para>
+/// That is why <c>EnsureCallerCanGrantClaims</c> is an allow-list of the two claim types the roles page actually sets,
+/// not a block-list of the dangerous ones. A block-list of "features" alone left <c>ClaimTypes.Role = "g-admin"</c>
+/// wide open, which turned the ordinary <c>Roles_Manage</c> permission into silent global administrator: grant the
+/// role claim, refresh, and the token reader promotes you.
+/// </para>
+/// <para>
+/// Nothing about this is visible from the endpoint's own code - the request succeeds, the row is written, and the
+/// escalation only materialises two files away at token-read time. It is also exactly the shape a well-meaning
+/// "let administrators set arbitrary claims" change would reintroduce.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class RoleClaimGrantAllowListTests
+{
+    /// <summary>
+    /// The escalation itself, plus the three other claim types the app computes server-side per session. None of them
+    /// may be settable on a role: <c>s-id</c> / <c>p-s</c> / <c>e-s</c> are session facts, and a role-supplied copy is
+    /// merged into the principal alongside the real one.
+    /// </summary>
+    [TestMethod]
+    [DataRow(ClaimTypes.Role, AppRoles.GlobalAdmin, DisplayName = "role -> g-admin (full privilege escalation)")]
+    [DataRow(ClaimTypes.Role, "t-admin", DisplayName = "role -> t-admin")]
+    [DataRow(AppClaimTypes.PRIVILEGED_SESSION, "true", DisplayName = "p-s -> true")]
+    [DataRow(AppClaimTypes.ELEVATED_SESSION, "99999999999", DisplayName = "e-s -> far future")]
+    [DataRow(AppClaimTypes.SESSION_ID, "8ff71671-a1d6-4f97-abb9-d87d7b47d6e7", DisplayName = "s-id -> another session")]
+    [DataRow("anything-else", "whatever", DisplayName = "an unknown claim type")]
+    public async Task AddClaims_Should_RefuseEveryClaimTypeOutsideTheAllowList(string claimType, string claimValue)
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var (roleManagementController, grant) = await SignInAsGlobalAdmin(server, scope);
+        await using var globalAdminGrant = grant;
+
+        var roleId = await CreateRole(roleManagementController);
+
+        await Assert.ThrowsExactlyAsync<UnauthorizedException>(
+            () => roleManagementController.AddClaims(roleId, [new() { ClaimType = claimType, ClaimValue = claimValue }], TestContext.CancellationToken),
+            $"'{claimType}' is not one of the two claim types the roles page sets, so it must be refused even for a global admin.");
+
+        Assert.AreEqual(0, await CountClaims(server, roleId),
+            "A refused grant must write nothing - the check has to run before the rows are added.");
+    }
+
+    /// <summary>
+    /// <c>UpdateClaims</c> is a separate endpoint with its own body, and it writes through <c>DbContext</c> directly
+    /// rather than through <c>RoleManager</c>. It needs its own copy of the guard, and has to be asserted separately
+    /// or a refactor that keeps only <c>AddClaims</c> guarded reads as "still covered".
+    /// </summary>
+    [TestMethod]
+    public async Task UpdateClaims_Should_RefuseEveryClaimTypeOutsideTheAllowList()
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var (roleManagementController, grant) = await SignInAsGlobalAdmin(server, scope);
+        await using var globalAdminGrant = grant;
+
+        var roleId = await CreateRole(roleManagementController);
+
+        await Assert.ThrowsExactlyAsync<UnauthorizedException>(
+            () => roleManagementController.UpdateClaims(roleId,
+                [new() { ClaimType = ClaimTypes.Role, ClaimValue = AppRoles.GlobalAdmin }], TestContext.CancellationToken),
+            "UpdateClaims must apply the same allow-list as AddClaims; it is a second way into the same table.");
+
+        Assert.AreEqual(0, await CountClaims(server, roleId), "A refused update must write nothing.");
+    }
+
+    /// <summary>
+    /// One request, one legitimate claim and one forbidden claim. The whole request has to be refused - a guard that
+    /// filters instead of rejecting, or that only inspects the first entry, would let the escalation ride along with a
+    /// harmless feature grant.
+    /// </summary>
+    [TestMethod]
+    public async Task AddClaims_Should_RefuseTheWholeRequest_WhenOneClaimIsForbidden()
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var (roleManagementController, grant) = await SignInAsGlobalAdmin(server, scope);
+        await using var globalAdminGrant = grant;
+
+        var roleId = await CreateRole(roleManagementController);
+
+        await Assert.ThrowsExactlyAsync<UnauthorizedException>(
+            () => roleManagementController.AddClaims(roleId,
+            [
+                new() { ClaimType = AppClaimTypes.FEATURES, ClaimValue = AppFeatures.AdminPanel.Dashboard_View },
+                new() { ClaimType = ClaimTypes.Role, ClaimValue = AppRoles.GlobalAdmin }
+            ], TestContext.CancellationToken));
+
+        Assert.AreEqual(0, await CountClaims(server, roleId),
+            "Neither claim may be written: the legitimate one must not act as a carrier for the forbidden one.");
+    }
+
+
+    private async Task<AppTestServer> StartServer()
+    {
+        var server = new AppTestServer();
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+        return server;
+    }
+
+    /// <summary>
+    /// A per-run account promoted to global admin and elevated - the most privileged caller the app has, so a refusal
+    /// here is a refusal for everyone. The returned grant must be disposed, or the developer's database keeps the
+    /// extra administrator.
+    /// </summary>
+    private async Task<(IRoleManagementController Controller, TestAccountUtils.GlobalAdminGrant Grant)> SignInAsGlobalAdmin(
+        AppTestServer server, AsyncServiceScope scope)
+    {
+        var (email, userId) = await TestAccountUtils.CreateAndSignIn(server, scope, TestContext.CancellationToken);
+        var grant = await TestAccountUtils.MakeGlobalAdmin(server, scope, userId, TestContext.CancellationToken);
+        await TestAccountUtils.Elevate(server, scope, email, TestContext.CancellationToken);
+
+        return (scope.ServiceProvider.GetRequiredService<IRoleManagementController>(), grant);
+    }
+
+    private async Task<Guid> CreateRole(IRoleManagementController roleManagementController)
+    {
+        var role = await roleManagementController.Create(
+            new() { Id = Guid.CreateVersion7(), Name = $"ops-{Guid.NewGuid():N}" }, TestContext.CancellationToken);
+
+        return role.Id;
+    }
+
+    private async Task<int> CountClaims(AppTestServer server, Guid roleId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        return await dbContext.RoleClaims.CountAsync(rc => rc.RoleId == roleId, TestContext.CancellationToken);
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TestAccountUtils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TestAccountUtils.cs
@@ -92,7 +92,7 @@ public static class TestAccountUtils
         var userController = scope.ServiceProvider.GetRequiredService<IUserController>();
 
         var tenants = await userController.GetTenants(cancellationToken);
-        Assert.IsTrue(tenants.Count > 0, "A global admin should see every active tenant, and the template seeds one.");
+        Assert.IsNotEmpty(tenants, "A global admin should see every active tenant, and the template seeds one.");
 
         Assert.IsTrue(await scope.ServiceProvider.GetRequiredService<AuthManager>().SwitchTenant(tenants[0].Id, cancellationToken),
             "Switching into the seeded tenant should succeed for a global admin.");

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TokenClassSeparationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/TokenClassSeparationTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Server.Api.Infrastructure.Data;
+using Boilerplate.Client.Core.Infrastructure.Services;
+using Boilerplate.Client.Core.Infrastructure.Services.Contracts;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+/// <summary>
+/// Access tokens and refresh tokens are minted by the same <c>AppJwtSecureDataFormat</c>, from the same RSA key, with
+/// the same issuer and the same claim set - <c>AppBearerTokenOptionsConfigurator</c> builds two instances of one type
+/// and the only difference between the two JWTs is <c>exp</c>. What keeps them apart is a single line: each protector
+/// gets its own <c>aud</c> (<c>{Identity:Audience}</c> vs <c>{Identity:Audience}:RefreshToken</c>) and validates only
+/// its own.
+/// <para>
+/// That is a lot of security resting on one string concatenation that nothing else in the system references, and it
+/// is invisible on every happy path - both token classes keep working perfectly whether or not the separation exists.
+/// These two tests are the only thing that fails if it is removed, simplified, or if a future change reintroduces a
+/// shared audience.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class TokenClassSeparationTests
+{
+    /// <summary>
+    /// A 5-minute access token must not buy a 14-day session. Without the audience split, <c>Refresh</c> unprotects
+    /// it happily (the refresh protector sets <c>ValidateLifetime = false</c>), it carries <c>s-id</c>, the security
+    /// stamp and an <c>iat</c> inside the rotation tolerance, so every check passes and the caller walks away with a
+    /// fresh token pair. Anything that leaks an access token - a proxy log, a HAR file, an error report - would
+    /// therefore leak a two-week credential.
+    /// <para>
+    /// The second assertion covers the other half of the same defect: the rejection must happen <b>before</b> the
+    /// <c>UserSession</c> is loaded, or the <c>catch (UnauthorizedException) when (userSession is not null)</c>
+    /// handler deletes the session and a stale access token becomes a way to sign the victim out.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task AnAccessToken_Should_NotBeAcceptedAtTheRefreshEndpoint()
+    {
+        await using var server = await StartServerAndSignIn();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        await SignIn(scope);
+
+        var storageService = scope.ServiceProvider.GetRequiredService<IStorageService>();
+        var accessToken = await storageService.GetItem("access_token");
+        Assert.IsNotNull(accessToken, "Signing in should have stored an access token.");
+
+        var sessionId = IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: false).GetSessionId();
+
+        await Assert.ThrowsExactlyAsync<UnauthorizedException>(
+            () => scope.ServiceProvider.GetRequiredService<IIdentityController>()
+                       .Refresh(new() { RefreshToken = accessToken }, TestContext.CancellationToken),
+            "An access token presented as a refresh token must be rejected. The two JWTs differ only in `aud`.");
+
+        Assert.IsTrue(await SessionExists(server, sessionId),
+            "The rejection must come from the token protector, before Refresh loads the UserSession - otherwise the " +
+            "rotation-theft handler deletes the row and replaying a stale access token signs the real user out.");
+    }
+
+    /// <summary>
+    /// The mirror image: a 14-day refresh token must not authenticate ordinary API calls. If it does, a stolen
+    /// refresh token is a bearer credential for its full lifetime <b>and</b> the rotation tripwire never fires,
+    /// because a token that is never presented at <c>/Refresh</c> never advances <c>UserSession.RenewedOn</c> - so
+    /// the one control designed to detect exactly this theft stays silent for two weeks.
+    /// </summary>
+    [TestMethod]
+    public async Task ARefreshToken_Should_NotAuthenticateAnApiCall()
+    {
+        await using var server = await StartServerAndSignIn();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        await SignIn(scope);
+
+        var storageService = scope.ServiceProvider.GetRequiredService<IStorageService>();
+        var userController = scope.ServiceProvider.GetRequiredService<IUserController>();
+
+        // Sanity: with the real access token this call succeeds, so a failure below is about the token class and not
+        // about the request being malformed or the account being unusable.
+        Assert.AreEqual(TestData.DefaultTestEmail, (await userController.GetCurrentUser(TestContext.CancellationToken)).Email);
+
+        var refreshToken = await storageService.GetItem("refresh_token");
+        Assert.IsNotNull(refreshToken, "Signing in should have stored a refresh token.");
+
+        // TestAuthTokenProvider reads "access_token" from storage and AuthDelegatingHandler puts it in the
+        // Authorization header, so this is exactly what an attacker holding only the refresh token would send.
+        await storageService.SetItem("access_token", refreshToken);
+
+        await Assert.ThrowsExactlyAsync<UnauthorizedException>(
+            () => userController.GetCurrentUser(TestContext.CancellationToken),
+            "A refresh token sent as `Authorization: Bearer` must not authenticate an API call.");
+    }
+
+    private async Task<AppTestServer> StartServerAndSignIn()
+    {
+        var server = new AppTestServer();
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+        return server;
+    }
+
+    private Task SignIn(AsyncServiceScope scope)
+    {
+        return scope.ServiceProvider.GetRequiredService<AuthManager>().SignIn(new()
+        {
+            Email = TestData.DefaultTestEmail,
+            Password = TestData.DefaultTestPassword
+        }, TestContext.CancellationToken);
+    }
+
+    private async Task<bool> SessionExists(AppTestServer server, Guid sessionId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        return await dbContext.UserSessions.AnyAsync(us => us.Id == sessionId, TestContext.CancellationToken);
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/WebAuthnCredentialOwnershipTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/WebAuthnCredentialOwnershipTests.cs
@@ -1,0 +1,165 @@
+using Fido2NetLib;
+using Fido2NetLib.Objects;
+using System.Buffers.Text;
+using Microsoft.EntityFrameworkCore;
+using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Server.Api.Infrastructure.Data;
+using Boilerplate.Server.Api.Features.Identity.Models;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+/// <summary>
+/// <c>DeleteWebAuthnCredential</c> takes the credential id straight from the request body. The only thing scoping it
+/// to the caller is the <c>&amp;&amp; webAuthCred.UserId == userId</c> term in its <c>ExecuteDeleteAsync</c> predicate -
+/// there is no FIDO2 verification on this path, so that one term <b>is</b> the authorization check.
+/// <para>
+/// Credential ids are not secret: <c>GetWebAuthnAssertionOptions</c> hands out the descriptors of any user it is
+/// asked about, so an attacker does not have to guess one. Without the owner term, anyone signed in could strip the
+/// passkeys off any account - a targeted denial of the victim's sign-in method, and a way to force a fallback to a
+/// weaker one.
+/// </para>
+/// <para>
+/// The predicate is a single conjunct in a one-line query and reads perfectly plausibly with or without it, which is
+/// why it gets a test rather than a code comment.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class WebAuthnCredentialOwnershipTests
+{
+    /// <summary>
+    /// A signed-in stranger presenting someone else's credential id must be told the credential does not exist, and
+    /// the row must still be there afterwards. The "not found" wording is deliberate: the endpoint must not
+    /// distinguish "not yours" from "does not exist", or it becomes an oracle for which credential ids are real.
+    /// </summary>
+    [TestMethod]
+    public async Task DeleteWebAuthnCredential_Should_RefuseACredentialOwnedByAnotherUser()
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        // The victim is the seeded account; the credential row below is this test's own fixture and is removed again
+        // in the finally, so nothing is left behind that would make the app think passwordless is configured.
+        var victimUserId = await TestAccountUtils.ReadUserId(server, TestData.DefaultTestEmail, TestContext.CancellationToken);
+        var credentialId = await AddCredential(server, victimUserId);
+
+        try
+        {
+            // The attacker: an ordinary per-run account, signed in through the shipped endpoints.
+            await TestAccountUtils.CreateAndSignIn(server, scope, TestContext.CancellationToken);
+
+            var userController = scope.ServiceProvider.GetRequiredService<IUserController>();
+
+            await Assert.ThrowsExactlyAsync<ResourceNotFoundException>(
+                () => userController.DeleteWebAuthnCredential(AssertionFor(credentialId), TestContext.CancellationToken),
+                "Deleting a passkey must be scoped to the caller; the credential id alone is not authorization.");
+
+            Assert.IsTrue(await CredentialExists(server, credentialId),
+                "The victim's credential row must survive the refused delete.");
+        }
+        finally
+        {
+            await RemoveCredential(server, credentialId);
+        }
+    }
+
+    /// <summary>
+    /// Non-vacuity: with the same request shape, the owner's own credential really is deleted. Without this, the test
+    /// above would keep passing if the endpoint started refusing everything (a broken route, a changed body contract,
+    /// a model-binding failure) and would stop being about ownership at all.
+    /// </summary>
+    [TestMethod]
+    public async Task DeleteWebAuthnCredential_Should_RemoveTheCallersOwnCredential()
+    {
+        await using var server = await StartServer();
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var (_, userId) = await TestAccountUtils.CreateAndSignIn(server, scope, TestContext.CancellationToken);
+        var credentialId = await AddCredential(server, userId);
+
+        try
+        {
+            await scope.ServiceProvider.GetRequiredService<IUserController>()
+                       .DeleteWebAuthnCredential(AssertionFor(credentialId), TestContext.CancellationToken);
+
+            Assert.IsFalse(await CredentialExists(server, credentialId), "The caller's own credential must be deleted.");
+        }
+        finally
+        {
+            await RemoveCredential(server, credentialId);
+        }
+    }
+
+
+    /// <summary>
+    /// The body the browser posts. Only <c>RawId</c> is read server-side; it is built from the real
+    /// <see cref="AuthenticatorAssertionRawResponse"/> type so the wire shape (base64url, casing, the nested response
+    /// object) is whatever the library says it is rather than whatever this test guessed.
+    /// </summary>
+    private static JsonElement AssertionFor(byte[] credentialId)
+    {
+        var assertion = new AuthenticatorAssertionRawResponse
+        {
+            Id = Base64Url.EncodeToString(credentialId), // The browser sends the same value twice: base64url as `id`, raw as `rawId`.
+            RawId = credentialId,
+            Type = PublicKeyCredentialType.PublicKey,
+            ClientExtensionResults = new AuthenticationExtensionsClientOutputs(), // [Required] on the DTO, so model validation rejects the request without it.
+            Response = new AuthenticatorAssertionRawResponse.AssertionResponse
+            {
+                AuthenticatorData = [],
+                ClientDataJson = [],
+                Signature = []
+            }
+        };
+
+        return JsonSerializer.SerializeToElement(assertion, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    }
+
+    private async Task<AppTestServer> StartServer()
+    {
+        var server = new AppTestServer();
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+        return server;
+    }
+
+    /// <summary>
+    /// Writes a credential row directly, because the only way to create one through the app is a full FIDO2
+    /// registration ceremony, which needs a browser and an authenticator. Nothing this test asserts depends on the
+    /// row being cryptographically meaningful - the endpoint under test never looks at the key material.
+    /// </summary>
+    private async Task<byte[]> AddCredential(AppTestServer server, Guid userId)
+    {
+        var credentialId = Guid.NewGuid().ToByteArray();
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        await dbContext.WebAuthnCredential.AddAsync(new WebAuthnCredential
+        {
+            Id = credentialId,
+            UserId = userId,
+            RegDate = DateTimeOffset.UtcNow
+        }, TestContext.CancellationToken);
+
+        await dbContext.SaveChangesAsync(TestContext.CancellationToken);
+
+        return credentialId;
+    }
+
+    private async Task RemoveCredential(AppTestServer server, byte[] credentialId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        await dbContext.WebAuthnCredential.Where(c => c.Id == credentialId).ExecuteDeleteAsync(CancellationToken.None);
+    }
+
+    private async Task<bool> CredentialExists(AppTestServer server, byte[] credentialId)
+    {
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        return await dbContext.WebAuthnCredential.AnyAsync(c => c.Id == credentialId, TestContext.CancellationToken);
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Json/JsonOptionsContractTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Json/JsonOptionsContractTests.cs
@@ -1,0 +1,107 @@
+using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Server.Api.Infrastructure.Services;
+
+namespace Boilerplate.Tests.Features.Json;
+
+/// <summary>
+/// The four JSON option shapes in the template - <see cref="AppJsonContext"/>, <see cref="IdentityJsonContext"/>,
+/// <see cref="ServerJsonContext"/> and <c>JsonSerializerOptionsExtensions.ApplyDefaultOptions</c> - are kept in step
+/// by a comment ("Changes in this file should be applied on ... as well") and nothing else. A property added to one
+/// and forgotten on the others produces a wire or storage format that differs by code path, which no compiler and no
+/// happy-path test notices.
+/// <para>
+/// This pins the one property that has already cost a user-visible bug, plus the round trip it broke.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class JsonOptionsContractTests
+{
+    /// <summary>
+    /// <b>Dictionary keys are data, not property names.</b> <c>DictionaryKeyPolicy</c> applies on write only - STJ
+    /// never reverses it on read - so any policy at all makes a dictionary round trip lossy the moment a key is not
+    /// already in the policy's own casing.
+    /// <para>
+    /// The concrete cost: <c>WindowsStorageService</c> persists its whole key/value store as a
+    /// <c>Dictionary&lt;string, string?&gt;</c> through <see cref="AppJsonContext"/>. With a camelCase key policy the
+    /// key written as <c>"Culture"</c> came back as <c>"culture"</c>, <c>GetItem("Culture")</c> returned null, and the
+    /// Windows client discarded the user's chosen language on <b>every</b> restart - while the next write appended a
+    /// second <c>culture</c> member to the file. Nothing in the template needs a key policy: extension-data keys are
+    /// exempt from it and <c>Dictionary&lt;string, JsonElement&gt;</c> (JWT claims) is read-only.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void NoJsonOptionShape_Should_ApplyADictionaryKeyPolicy()
+    {
+        var applyDefaultOptions = new JsonSerializerOptions();
+        applyDefaultOptions.ApplyDefaultOptions();
+
+        (string Name, JsonSerializerOptions Options)[] shapes =
+        [
+            (nameof(AppJsonContext), AppJsonContext.Default.Options),
+            (nameof(IdentityJsonContext), IdentityJsonContext.Default.Options),
+            (nameof(ServerJsonContext), ServerJsonContext.Default.Options),
+            ("ApplyDefaultOptions", applyDefaultOptions)
+        ];
+
+        foreach (var (name, options) in shapes)
+        {
+            Assert.IsNull(options.DictionaryKeyPolicy,
+                $"{name} applies a DictionaryKeyPolicy. It rewrites keys on write and never undoes it on read, so every " +
+                "dictionary this serializes stops round-tripping - which is how the Windows client lost the saved culture " +
+                "on every restart. Property naming (PropertyNamingPolicy) is the separate, intended setting.");
+        }
+    }
+
+    /// <summary>
+    /// The behaviour the assertion above exists for, driven exactly as <c>WindowsStorageService.Save</c> /
+    /// <c>Restore</c> drive it. A key policy passes the assertion's sibling checks and still fails this one, which is
+    /// why both are here.
+    /// </summary>
+    [TestMethod]
+    public void ThePersistedStorageDictionary_Should_RoundTripItsKeysVerbatim()
+    {
+        // The real keys the clients store; "Culture" is the one whose casing does not survive a camelCase key policy.
+        var saved = new Dictionary<string, string?>
+        {
+            ["access_token"] = "at",
+            ["refresh_token"] = "rt",
+            ["Culture"] = "fa-IR",
+            ["bit-webauthn"] = "[]"
+        };
+
+        var json = JsonSerializer.Serialize(saved, AppJsonContext.Default.DictionaryStringString);
+        var restored = JsonSerializer.Deserialize(json, AppJsonContext.Default.DictionaryStringString)!;
+
+        Assert.AreEqual("fa-IR", restored.GetValueOrDefault("Culture"),
+            $"The key the app wrote must be the key the app reads back. Written json: {json}");
+
+        CollectionAssert.AreEquivalent(saved.Keys.ToArray(), restored.Keys.ToArray(),
+            $"No key may be rewritten on the way to disk. Written json: {json}");
+    }
+
+    /// <summary>
+    /// The property-name half of the same contract, asserted so removing the key policy cannot be "simplified" into
+    /// removing the naming policy: every DTO on the wire is camelCase, and the client and server agree only because
+    /// all four shapes say so.
+    /// </summary>
+    [TestMethod]
+    public void EveryJsonOptionShape_Should_AgreeOnCamelCasePropertyNames()
+    {
+        var applyDefaultOptions = new JsonSerializerOptions();
+        applyDefaultOptions.ApplyDefaultOptions();
+
+        foreach (var (name, options) in new (string, JsonSerializerOptions)[]
+        {
+            (nameof(AppJsonContext), AppJsonContext.Default.Options),
+            (nameof(IdentityJsonContext), IdentityJsonContext.Default.Options),
+            (nameof(ServerJsonContext), ServerJsonContext.Default.Options),
+            ("ApplyDefaultOptions", applyDefaultOptions)
+        })
+        {
+            Assert.AreSame(JsonNamingPolicy.CamelCase, options.PropertyNamingPolicy,
+                $"{name} must name properties in camelCase like the other three, or the same DTO gets two wire formats.");
+            Assert.IsTrue(options.PropertyNameCaseInsensitive, $"{name} must read properties case-insensitively like the other three.");
+            Assert.IsTrue(options.AllowTrailingCommas, $"{name} must allow trailing commas like the other three.");
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/TemplateConfig/TemplateConfigurationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/TemplateConfig/TemplateConfigurationTests.cs
@@ -1,0 +1,219 @@
+using System.Text.RegularExpressions;
+
+namespace Boilerplate.Tests.Features.TemplateConfig;
+
+/// <summary>
+/// Guards the two ways <c>.template.config/template.json</c> silently stops matching the source tree it describes.
+/// Neither shows up in a build, in a test run, or in a generated project - the template engine simply does less than
+/// it was asked to, and the first sign is a customer's generated project containing a file that should not be there.
+/// <list type="number">
+/// <item><b>A conditional naming a symbol that does not exist.</b> The engine evaluates an undeclared symbol as
+/// false, so the whole block is stripped from every generated project forever. A typo (<c>notifications</c> for
+/// <c>notification</c>) deletes a feature from the product with no diagnostic.</item>
+/// <item><b>An exclusion rule pointing at a path that no longer exists.</b> Move or rename a file and the rule that
+/// used to exclude it keeps sitting in <c>template.json</c> looking effective, while the file it was meant to remove
+/// now ships in configurations that must not have it.</item>
+/// </list>
+/// <para>
+/// This runs against the template's own working copy. A generated project has no <c>.template.config</c> directory,
+/// so there the test reports inconclusive rather than failing.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class TemplateConfigurationTests
+{
+    /// <summary>
+    /// Not a declared symbol, and deliberately so: <c>//#if (IsInsideProjectTemplate == true)</c> blocks are stripped
+    /// from every generated project and exist only so the bitplatform repository's own working copy builds.
+    /// </summary>
+    private const string TemplateOnlySymbol = "IsInsideProjectTemplate";
+
+    private static readonly string[] skippedDirectories = ["bin", "obj", ".git", ".vs", "node_modules", ".playwright-mcp", "App_Data"];
+
+    /// <summary>
+    /// Template conditionals are always written with a parenthesized condition - <c>#if (aspire == true)</c> - in
+    /// every host syntax (<c>//#if</c>, <c>@*#if</c>, <c>&lt;!--#if</c>, and bare in <c>.sln</c> / <c>.yml</c>).
+    /// C#'s own preprocessor directives never are (<c>#if Android</c>, <c>#if DEBUG</c>), which is what keeps the two
+    /// apart without maintaining a list of platform symbols.
+    /// <para>
+    /// The condition stops at the first <c>)</c> so that whatever follows on the line - <c>*@</c>, <c>--&gt;</c>, an
+    /// XML doc tag, a trailing comment - is not read as part of it.
+    /// </para>
+    /// </summary>
+    private static readonly Regex conditionalDirective = new(@"#(?:if|elseif)\s*\((?<condition>[^)\r\n]*)\)", RegexOptions.Compiled);
+
+    private static readonly Regex quotedLiteral = new("\"[^\"]*\"|'[^']*'", RegexOptions.Compiled);
+
+    private static readonly Regex identifier = new(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
+
+    private static readonly string[] conditionKeywords = ["true", "false", "null", "and", "or", "not"];
+
+    /// <summary>
+    /// Every symbol a conditional tests must be declared in <c>template.json</c>'s <c>symbols</c>. An undeclared one
+    /// is not an error the engine reports - it evaluates to false, so the guarded code is deleted from every
+    /// generated project in every configuration.
+    /// </summary>
+    [TestMethod]
+    public void EverySymbolUsedInAConditional_Should_BeDeclaredInTemplateJson()
+    {
+        var (templateRoot, template) = LoadTemplateJson();
+
+        var declaredSymbols = template.RootElement.GetProperty("symbols")
+            .EnumerateObject()
+            .Select(symbol => symbol.Name)
+            .Append(TemplateOnlySymbol)
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<string> undeclared = [];
+        var conditionalsSeen = 0;
+
+        foreach (var file in EnumerateTemplateFiles(templateRoot))
+        {
+            var lineNumber = 0;
+
+            foreach (var line in File.ReadLines(file))
+            {
+                lineNumber++;
+
+                var match = conditionalDirective.Match(line);
+                if (match.Success is false)
+                    continue;
+
+                conditionalsSeen++;
+
+                var condition = quotedLiteral.Replace(match.Groups["condition"].Value, " ");
+
+                foreach (Match token in identifier.Matches(condition))
+                {
+                    if (conditionKeywords.Contains(token.Value, StringComparer.OrdinalIgnoreCase))
+                        continue;
+
+                    if (declaredSymbols.Contains(token.Value))
+                        continue;
+
+                    undeclared.Add($"{Path.GetRelativePath(templateRoot, file)}:{lineNumber} -> '{token.Value}' in `{line.Trim()}`");
+                }
+            }
+        }
+
+        // Non-vacuity: this template has ~900 conditionals. A near-zero count means the scan found nothing to check
+        // (wrong root, changed directive syntax, a broken regex) and the assertion below would pass for free.
+        Assert.IsGreaterThan(100, conditionalsSeen, $"Only {conditionalsSeen} conditionals were found - the scan is not reaching the source tree.");
+
+        Assert.IsEmpty(undeclared,
+            "These conditionals name a symbol template.json does not declare, so the engine treats them as false and " +
+            $"strips the guarded code from EVERY generated project:{Environment.NewLine}{string.Join(Environment.NewLine, undeclared)}");
+    }
+
+    /// <summary>
+    /// Every exclusion / copy-only rule that names a concrete path must still resolve. Only literal paths and plain
+    /// <c>some/directory/**</c> entries are checked: the housekeeping globs (<c>**/*.user</c>, <c>**/[Bb]in/**</c>)
+    /// legitimately match nothing in a clean tree, and a rule that matches nothing today is only a problem when it
+    /// was written for something that used to be there.
+    /// </summary>
+    [TestMethod]
+    public void EveryConcretePathInATemplateRule_Should_StillExist()
+    {
+        var (templateRoot, template) = LoadTemplateJson();
+
+        List<string> missing = [];
+        var pathsChecked = 0;
+
+        foreach (var source in template.RootElement.GetProperty("sources").EnumerateArray())
+        {
+            if (source.TryGetProperty("modifiers", out var modifiers) is false)
+                continue;
+
+            foreach (var modifier in modifiers.EnumerateArray())
+            {
+                var condition = modifier.TryGetProperty("condition", out var conditionElement) ? conditionElement.GetString() : "<unconditional>";
+
+                foreach (var ruleName in (string[])["exclude", "copyOnly", "include", "rename"])
+                {
+                    if (modifier.TryGetProperty(ruleName, out var rule) is false || rule.ValueKind is not JsonValueKind.Array)
+                        continue;
+
+                    foreach (var pathElement in rule.EnumerateArray())
+                    {
+                        var path = pathElement.GetString();
+
+                        if (string.IsNullOrWhiteSpace(path))
+                            continue;
+
+                        pathsChecked++;
+
+                        if (ResolvesToSomething(templateRoot, path) is false)
+                            missing.Add($"{condition} / {ruleName}: '{path}'");
+                    }
+                }
+            }
+        }
+
+        // Non-vacuity, as above: template.json carries ~150 rule entries.
+        Assert.IsGreaterThan(50, pathsChecked, $"Only {pathsChecked} rule entries were read - template.json is not being parsed as expected.");
+
+        Assert.IsEmpty(missing,
+            "These template.json rules name a path that does not exist, so they exclude nothing - the file they were " +
+            "written for either moved (and now ships in configurations that must not have it) or is gone and the rule " +
+            $"is dead weight:{Environment.NewLine}{string.Join(Environment.NewLine, missing)}");
+    }
+
+    /// <summary>
+    /// True when the entry is a wildcard glob this test deliberately does not judge, or when it names something that
+    /// is really there.
+    /// </summary>
+    private static bool ResolvesToSomething(string templateRoot, string path)
+    {
+        var normalized = path.Replace('/', Path.DirectorySeparatorChar);
+
+        if (normalized.EndsWith($"{Path.DirectorySeparatorChar}**", StringComparison.Ordinal))
+        {
+            var directory = normalized[..^3];
+
+            // Still a glob somewhere else in the entry (src/Server/**/Data/Migrations/**) - not this test's business.
+            return directory.Contains('*') || directory.Contains('?')
+                || Directory.Exists(Path.Combine(templateRoot, directory));
+        }
+
+        if (normalized.Contains('*') || normalized.Contains('?') || normalized.Contains('['))
+            return true;
+
+        return File.Exists(Path.Combine(templateRoot, normalized))
+            || Directory.Exists(Path.Combine(templateRoot, normalized));
+    }
+
+    private static IEnumerable<string> EnumerateTemplateFiles(string templateRoot)
+    {
+        return Directory.EnumerateFiles(templateRoot, "*", SearchOption.AllDirectories)
+            .Where(file => Path.GetRelativePath(templateRoot, file)
+                               .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                               .Any(segment => skippedDirectories.Contains(segment, StringComparer.OrdinalIgnoreCase)) is false)
+            .Where(file => Path.GetExtension(file) is not (".png" or ".jpg" or ".jpeg" or ".gif" or ".ico" or ".woff" or ".woff2" or ".ttf" or ".dll" or ".pdb" or ".zip" or ".keystore" or ".p12" or ".pfx" or ".webp" or ".mp4"));
+    }
+
+    /// <summary>
+    /// Finds the template root by walking up from the test binaries. <c>template.json</c> carries <c>//</c> comments,
+    /// so it is not strict JSON.
+    /// </summary>
+    private static (string TemplateRoot, JsonDocument Template) LoadTemplateJson()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && File.Exists(Path.Combine(directory.FullName, ".template.config", "template.json")) is false)
+        {
+            directory = directory.Parent;
+        }
+
+        if (directory is null)
+        {
+            Assert.Inconclusive("No .template.config/template.json above the test binaries - this is a generated project, not the template's own tree.");
+            return default;
+        }
+
+        var template = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(directory.FullName, ".template.config", "template.json")),
+            new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
+
+        return (directory.FullName, template);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/ReservedTenantNameTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/ReservedTenantNameTests.cs
@@ -1,0 +1,161 @@
+using Boilerplate.Server.Api.Features.Tenants;
+
+namespace Boilerplate.Tests.Features.Tenants;
+
+/// <summary>
+/// <see cref="ReservedTenantNames"/> is the only thing standing between self-service tenant creation and a signed-up
+/// stranger capturing the deployment's own host.
+/// <para>
+/// <c>Tenant.Name</c> is the sub domain resolution key (See <c>TenantProvider</c>) and <c>Tenant.Domain</c> is matched
+/// against the request host, so a tenant named after the primary host's first label - or holding the primary host as
+/// its custom domain - answers <b>every anonymous request</b> to that host, and additionally decides which tenant's
+/// <c>demo</c> role each new sign-up is granted (See <c>UserManagerExtensions.CreateUserWithDemoRole</c>). Uniqueness
+/// alone does not help, because no tenant owns the deployment's own label.
+/// </para>
+/// <para>
+/// Everything here is a pure static function over strings, which is exactly why it earns a unit test rather than an
+/// integration one - and why it is easy to get subtly wrong. Three of the rules below are non-obvious and each of them
+/// would silently either open the hole or lock out legitimate tenants: the <c>Length &gt; 2</c> gate that mirrors
+/// <c>TenantProvider</c>, the parent zone a sub domain host reserves, and the suffix boundary that stops
+/// <c>myapp.com.attacker.com</c> matching <c>myapp.com</c>.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class ReservedTenantNameTests
+{
+    /// <summary>
+    /// The static list is the baseline: it must match regardless of casing or surrounding whitespace, because
+    /// <c>Tenant.Name</c> is resolved case-insensitively against the host's first label and the controller only trims
+    /// the custom domain, not the name.
+    /// </summary>
+    [TestMethod]
+    public void IsReserved_Should_MatchEveryListedLabel_RegardlessOfCasingOrPadding()
+    {
+        foreach (var reservedName in ReservedTenantNames.Names)
+        {
+            Assert.IsTrue(ReservedTenantNames.IsReserved(reservedName), $"'{reservedName}' is in the list and must be reserved.");
+            Assert.IsTrue(ReservedTenantNames.IsReserved(reservedName.ToUpperInvariant()), $"'{reservedName}' must be reserved case-insensitively.");
+            Assert.IsTrue(ReservedTenantNames.IsReserved($"  {reservedName} "), $"'{reservedName}' must be reserved after trimming.");
+        }
+
+        Assert.IsFalse(ReservedTenantNames.IsReserved("acme"), "An ordinary tenant name must still be allowed.");
+    }
+
+    /// <summary>
+    /// A blank name is the <c>[Required]</c> attribute's business. Returning true here would report "reserved name"
+    /// for an empty form field, which is a confusing error for a different problem.
+    /// </summary>
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void IsReserved_Should_IgnoreABlankName(string? name)
+    {
+        Assert.IsFalse(ReservedTenantNames.IsReserved(name, "acme.myapp.com"));
+    }
+
+    /// <summary>
+    /// The deployment's own sub domain label is reserved even though it is not in the static list - that is the whole
+    /// point of passing the request's hosts in. Note the host handed to the guard may itself be a tenant's sub domain
+    /// (the request can arrive on <c>acme.myapp.com</c>), which is why the first label of <b>every</b> supplied host
+    /// counts.
+    /// </summary>
+    [TestMethod]
+    [DataRow("acme", "acme.myapp.com", true)]
+    [DataRow("ACME", "acme.myapp.com", true)]
+    [DataRow("other", "acme.myapp.com", false)]
+    [DataRow("myapp", "acme.myapp.com", false)]
+    public void IsReserved_Should_ReserveTheFirstLabelOfEveryDeploymentHost(string name, string deploymentHost, bool expected)
+    {
+        Assert.AreEqual(expected, ReservedTenantNames.IsReserved(name, deploymentHost));
+    }
+
+    /// <summary>
+    /// <b>The apex gate.</b> <c>TenantProvider</c> only resolves a tenant from the sub domain when the host has more
+    /// than two labels (<c>host.Split('.') is { Length: &gt; 2 }</c>), so on <c>example.com</c> no sub domain lookup
+    /// ever happens and the first label reserves nothing. Reserving it anyway would refuse the perfectly ordinary
+    /// tenant name <c>example</c> on a deployment hosted at <c>example.com</c>, for no security gain.
+    /// <para>
+    /// Localhost development hits the same shape (<c>localhost</c> is a single label) - and <c>localhost</c> is in the
+    /// static list anyway, which is where it belongs.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    [DataRow("example", "example.com")]
+    [DataRow("myapp", "myapp.dev")]
+    public void IsReserved_Should_NotReserveTheFirstLabelOfAnApexHost(string name, string apexHost)
+    {
+        Assert.IsFalse(ReservedTenantNames.IsReserved(name, apexHost),
+            "An apex host performs no sub domain resolution, so its first label is claimable. This mirrors TenantProvider's `Length: > 2` gate exactly - widen one and the other must move too.");
+    }
+
+    /// <summary>
+    /// A missing or blank host in the list is skipped rather than treated as a match; the hosts come from request
+    /// state and configured trusted origins, either of which can legitimately be absent.
+    /// </summary>
+    [TestMethod]
+    public void IsReserved_Should_SkipBlankDeploymentHosts()
+    {
+        Assert.IsFalse(ReservedTenantNames.IsReserved("acme", null, "", "   "));
+        Assert.IsTrue(ReservedTenantNames.IsReserved("acme", null, "acme.myapp.com", ""),
+            "A blank entry must not stop the real hosts from being considered.");
+    }
+
+    /// <summary>
+    /// The custom-domain half. The deployment's own host is reserved, and so is <b>the zone above it</b> when the
+    /// supplied host carries a sub domain label: the request may well arrive on a tenant's own host
+    /// (<c>acme.myapp.com</c>), and taking that at face value would leave <c>myapp.com</c> - and every sibling
+    /// tenant's host - claimable by anyone.
+    /// </summary>
+    [TestMethod]
+    [DataRow("myapp.com", "myapp.com", true)]
+    [DataRow("myapp.com", "acme.myapp.com", true)]
+    [DataRow("other.myapp.com", "acme.myapp.com", true)]
+    [DataRow("MyApp.Com", "acme.myapp.com", true)]
+    [DataRow("acme.myapp.com", "acme.myapp.com", true)]
+    public void IsReservedDomain_Should_ReserveTheDeploymentHostAndItsParentZone(string domain, string deploymentHost, bool expected)
+    {
+        Assert.AreEqual(expected, ReservedTenantNames.IsReservedDomain(domain, deploymentHost));
+    }
+
+    /// <summary>
+    /// The suffix boundary. Matching on a bare <c>EndsWith</c> without the leading dot would let
+    /// <c>evilmyapp.com</c> or <c>myapp.com.attacker.com</c> look like they belong to the deployment - here the risk
+    /// runs the other way (a legitimate domain refused), but the same predicate is the one a widening "fix" would
+    /// break in the dangerous direction.
+    /// </summary>
+    [TestMethod]
+    [DataRow("notmyapp.com", "myapp.com")]
+    [DataRow("myapp.com.attacker.com", "myapp.com")]
+    [DataRow("myapp.competitor.com", "myapp.com")]
+    [DataRow("acme.com", "myapp.com")]
+    public void IsReservedDomain_Should_RequireAWholeLabelBoundary(string domain, string deploymentHost)
+    {
+        Assert.IsFalse(ReservedTenantNames.IsReservedDomain(domain, deploymentHost),
+            $"'{domain}' is a different registrable domain and must remain usable as a tenant's custom domain.");
+    }
+
+    /// <summary>
+    /// A <c>*</c> wildcard trusted origin (<c>https://*.myapp.com</c>, the entry that trusts every tenant sub domain)
+    /// reserves its whole zone, since the deployment answers on all of it.
+    /// </summary>
+    [TestMethod]
+    public void IsReservedDomain_Should_ReserveTheWholeZoneOfAWildcardHost()
+    {
+        Assert.IsTrue(ReservedTenantNames.IsReservedDomain("acme.myapp.com", "*.myapp.com"));
+        Assert.IsTrue(ReservedTenantNames.IsReservedDomain("myapp.com", "*.myapp.com"));
+        Assert.IsFalse(ReservedTenantNames.IsReservedDomain("acme.other.com", "*.myapp.com"));
+    }
+
+    /// <summary>
+    /// A blank custom domain simply means "resolve me by sub domain", so it is not the domain guard's business.
+    /// </summary>
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void IsReservedDomain_Should_IgnoreABlankDomain(string? domain)
+    {
+        Assert.IsFalse(ReservedTenantNames.IsReservedDomain(domain, "myapp.com"));
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/AppQueryStringCollectionTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/AppQueryStringCollectionTests.cs
@@ -1,0 +1,108 @@
+namespace Boilerplate.Tests.Features.Urls;
+
+/// <summary>
+/// <see cref="AppQueryStringCollection"/> is the one place the app takes a query string apart and puts it back
+/// together - every url the client builds (culture, returnUrl, OData <c>$filter</c>, the 401/403 recovery redirect)
+/// passes through it. Two properties have to hold, and both used to be broken in ways nothing would have noticed
+/// until a user hit them:
+/// <list type="bullet">
+/// <item>Parsing must never throw. A repeated key is legal in a url and arrives from ad networks and mail clients
+/// unbidden, so it cannot be allowed to become a 500 on an anonymous landing page - or, on the WASM client where the
+/// same parse runs during start-up, a blank screen.</item>
+/// <item>Values are held <b>decoded</b> and escaped <b>exactly once</b> on the way out. Escaping twice corrupts the
+/// value; unescaping a value that was added raw silently changes what the caller asked for.</item>
+/// </list>
+/// Both are pure functions with no dependencies, which is why this is a plain unit test rather than an integration one.
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class AppQueryStringCollectionTests
+{
+    /// <summary>
+    /// A repeated key is a valid url (<c>?utm_source=a&amp;utm_source=b</c>) and the collection is a dictionary, so
+    /// the parse has to choose rather than <c>Add</c> - which throws on the second occurrence. Last-wins matches what
+    /// browsers and <c>HttpUtility.ParseQueryString</c> callers expect from the last value in the string.
+    /// </summary>
+    [TestMethod]
+    public void Parse_Should_KeepTheLastValue_WhenAKeyIsRepeated()
+    {
+        var queryString = AppQueryStringCollection.Parse("?utm_source=a&utm_source=b&culture=fa-IR");
+
+        Assert.HasCount(2, queryString, "A repeated key must collapse to one entry, not throw and not duplicate.");
+        Assert.AreEqual("b", queryString["utm_source"]?.ToString(), "The last occurrence in the url wins.");
+        Assert.AreEqual("fa-IR", queryString["culture"]?.ToString(), "The other keys must survive the collapse.");
+    }
+
+    /// <summary>
+    /// The same for a key repeated with an identical value, and for the casing difference the collection's
+    /// <see cref="StringComparer.OrdinalIgnoreCase"/> comparer folds together - that comparer is what makes
+    /// <c>Add</c> throw on inputs a case-sensitive parser would have tolerated.
+    /// </summary>
+    [TestMethod]
+    [DataRow("?a=1&a=1")]
+    [DataRow("?a=1&A=2")]
+    [DataRow("?a=1&a=2&a=3")]
+    public void Parse_Should_NotThrow_OnAnyRepetitionShape(string query)
+    {
+        Assert.HasCount(1, AppQueryStringCollection.Parse(query));
+    }
+
+    /// <summary>
+    /// Keys and values come out of <see cref="AppQueryStringCollection.Parse"/> decoded, so a consumer reading
+    /// <c>returnUrl</c> or <c>$filter</c> gets the real value rather than its wire form.
+    /// </summary>
+    [TestMethod]
+    public void Parse_Should_DecodeExactlyOnce()
+    {
+        var queryString = AppQueryStringCollection.Parse("?q=100%20off&returnUrl=%2Fproducts%2F42");
+
+        Assert.AreEqual("100 off", queryString["q"]?.ToString());
+        Assert.AreEqual("/products/42", queryString["returnUrl"]?.ToString());
+    }
+
+    /// <summary>
+    /// The counterpart: values are added <b>raw</b> and escaped on the way out, never decoded first. A value that
+    /// legitimately contains a percent sign (a literal <c>100% off</c>, or an OData filter someone pre-encoded) must
+    /// come out with that percent escaped - decoding before re-encoding turns <c>100%20off</c> into <c>100 off</c> and
+    /// quietly changes the query the server runs.
+    /// </summary>
+    [TestMethod]
+    public void ToString_Should_EscapeExactlyOnce_AndNeverDecodeFirst()
+    {
+        Assert.AreEqual("q=100%25%20off", new AppQueryStringCollection { ["q"] = "100% off" }.ToString(),
+            "A literal percent in the value must be escaped, not treated as the start of an escape sequence.");
+
+        Assert.AreEqual("q=100%2520off", new AppQueryStringCollection { ["q"] = "100%20off" }.ToString(),
+            "A value that already looks encoded is still just a value: it is escaped, never decoded.");
+    }
+
+    /// <summary>
+    /// The property that matters most for OData, because <c>$filter</c> is the one value in the app that routinely
+    /// carries parentheses, commas, quotes and spaces: whatever is put in comes back out byte-identical after a full
+    /// encode/decode round trip.
+    /// </summary>
+    [TestMethod]
+    [DataRow("contains(name,'100% off')")]
+    [DataRow("contains(name,'a b')")]
+    [DataRow("/products/42?tab=specs&x=1")]
+    [DataRow("سلام دنیا")]
+    [DataRow("a+b")]
+    public void ParseOfToString_Should_RoundTripAValueUnchanged(string value)
+    {
+        var written = new AppQueryStringCollection { ["$filter"] = value }.ToString();
+
+        Assert.AreEqual(value, AppQueryStringCollection.Parse(written!)["$filter"]?.ToString(),
+            $"'{value}' did not survive the round trip; it was written as '{written}'.");
+    }
+
+    /// <summary>
+    /// An empty collection produces null rather than an empty string, because callers prepend the '?' themselves
+    /// (see <c>UriExtensions.GetUrlWithoutQueryParameter</c>) and a lone '?' is a different url.
+    /// </summary>
+    [TestMethod]
+    public void ToString_Should_ReturnNull_WhenEmpty()
+    {
+        Assert.IsNull(new AppQueryStringCollection().ToString());
+        Assert.IsNull(AppQueryStringCollection.Parse(null).ToString());
+        Assert.IsNull(AppQueryStringCollection.Parse("?").ToString());
+    }
+}


### PR DESCRIPTION
closes #12800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for profile-picture replacement and preservation after rejected uploads.
  * Added validation for error-response formatting, token separation, role-claim restrictions, WebAuthn ownership, JSON settings, tenant-name rules, URL query handling, and template configuration.
  * Added checks for malformed client-version headers and email uniqueness behavior.
  * Updated existing assertions to use current testing APIs.
* **Chores**
  * Expanded template exclusions for advanced and reserved-tenant-name tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->