### PR TITLE
Fix security headers issue with exception handler (#12802)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -574,7 +574,10 @@
                         "src/Tests/Features/Json/JsonOptionsContractTests.cs",
                         "src/Tests/Features/Urls/AppQueryStringCollectionTests.cs",
                         "src/Tests/Features/TemplateConfig/TemplateConfigurationTests.cs",
-                        "src/Tests/Features/Tenants/ReservedTenantNameTests.cs"
+                        "src/Tests/Features/Tenants/ReservedTenantNameTests.cs",
+                        "src/Tests/Features/OpenApi/OpenApiParameterContractTests.cs",
+                        "src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs",
+                        "src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Common/Acknowledgements.razor.cs
@@ -88,7 +88,6 @@ public partial class Acknowledgements
         new("libphonenumber-csharp", "https://twcclegg.github.io/libphonenumber-csharp", "https://github.com/twcclegg/libphonenumber-csharp", "Apache-2.0"),
         new("FluentEmail", "https://github.com/lukencode/FluentEmail", "https://github.com/lukencode/FluentEmail", "MIT"),
         new("FluentStorage", "https://github.com/robinrodricks/FluentStorage", "https://github.com/robinrodricks/FluentStorage", "MIT"),
-        new("NWebsec", "https://www.nwebsec.com", "https://github.com/NWebsec/NWebsec", "BSD-3-Clause"),
         new("DistributedLock", "https://github.com/madelson/DistributedLock", "https://github.com/madelson/DistributedLock", "MIT"),
         new("Velopack", "https://velopack.io", "https://github.com/velopack/velopack", "MIT"),
         new("Meziantou.Framework", "https://github.com/meziantou/Meziantou.Framework", "https://github.com/meziantou/Meziantou.Framework", "MIT"),

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/RetryDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/RetryDelegatingHandler.cs
@@ -31,6 +31,7 @@ public partial class RetryDelegatingHandler(HttpMessageHandler handler)
 
                 // There's no benefit in retrying known exceptions, for example when the Category's name is expected
                 // to be unique, retrying won't help.
+                // KnownException also includes TooManyRequestsException: Trying to retry a request that was throttled is not going to help, the server will still throttle the request.
                 if (exp is KnownException and not TransientException)
                     throw;
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -40,7 +40,6 @@
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.90" />
         <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
         <PackageVersion Include="MSTest" Version="4.3.2" />
-        <PackageVersion Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.17.0-beta.1" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.17.0-beta.1" />
         <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.17.0-beta.1" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.EmailConfirmation.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.EmailConfirmation.cs
@@ -2,7 +2,9 @@
 using Humanizer;
 using Boilerplate.Shared.Features.Identity.Dtos;
 using Boilerplate.Server.Api.Features.Identity.Models;
+using Microsoft.AspNetCore.RateLimiting;
 using Boilerplate.Server.Api.Features.Identity.Services;
+using Boilerplate.Server.Api.Infrastructure.RequestPipeline;
 
 namespace Boilerplate.Server.Api.Features.Identity;
 
@@ -10,7 +12,7 @@ public partial class IdentityController
 {
     [AutoInject] private IdentityEmailService emailService = default!;
 
-    [HttpPost]
+    [HttpPost, EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SendConfirmEmailToken(SendEmailTokenRequestDto request, CancellationToken cancellationToken)
     {
         var user = await userManager.FindByEmailAsync(request.Email!)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.PhoneConfirmation.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.PhoneConfirmation.cs
@@ -2,7 +2,9 @@
 using Humanizer;
 using Boilerplate.Shared.Features.Identity.Dtos;
 using Boilerplate.Server.Api.Features.Identity.Models;
+using Microsoft.AspNetCore.RateLimiting;
 using Boilerplate.Server.Api.Infrastructure.Services;
+using Boilerplate.Server.Api.Infrastructure.RequestPipeline;
 
 namespace Boilerplate.Server.Api.Features.Identity;
 
@@ -10,7 +12,7 @@ public partial class IdentityController
 {
     [AutoInject] private PhoneService phoneService = default!;
 
-    [HttpPost]
+    [HttpPost, EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SendConfirmPhoneToken(SendPhoneTokenRequestDto request, CancellationToken cancellationToken)
     {
         request.PhoneNumber = phoneService.NormalizePhoneNumber(request.PhoneNumber);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ResetPassword.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.ResetPassword.cs
@@ -6,11 +6,14 @@ using Boilerplate.Server.Api.Features.Identity.Models;
 using Microsoft.AspNetCore.SignalR;
 //#endif
 
+using Microsoft.AspNetCore.RateLimiting;
+using Boilerplate.Server.Api.Infrastructure.RequestPipeline;
+
 namespace Boilerplate.Server.Api.Features.Identity;
 
 public partial class IdentityController
 {
-    [HttpPost]
+    [HttpPost, EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SendResetPasswordToken(SendResetPasswordTokenRequestDto request, CancellationToken cancellationToken)
     {
         request.PhoneNumber = phoneService.NormalizePhoneNumber(request.PhoneNumber);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/IdentityController.cs
@@ -4,7 +4,9 @@ using Boilerplate.Shared.Features.Identity;
 using Boilerplate.Shared.Features.Identity.Dtos;
 using Boilerplate.Server.Api.Features.Identity.Models;
 using Boilerplate.Server.Api.Features.Identity.Services;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Authentication.BearerToken;
+using Boilerplate.Server.Api.Infrastructure.RequestPipeline;
 //#if (signalR == true)
 using Microsoft.AspNetCore.SignalR;
 using Boilerplate.Server.Api.Infrastructure.SignalR;
@@ -45,7 +47,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
     /// By leveraging summary tags in your controller's actions and DTO properties you can make your codes much easier to maintain.
     /// These comments will also be used in swagger/scalar docs and ui.
     /// </summary>
-    [HttpPost]
+    [HttpPost, EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SignUp(SignUpRequestDto request, CancellationToken cancellationToken)
     {
         request.PhoneNumber = phoneService.NormalizePhoneNumber(request.PhoneNumber);
@@ -89,7 +91,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
         await SendConfirmationToken(userToAdd, request.ReturnUrl, cancellationToken);
     }
 
-    [HttpPost, Produces<SignInResponseDto>()]
+    [HttpPost, Produces<SignInResponseDto>(), EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SignIn(SignInRequestDto request, CancellationToken cancellationToken)
     {
         request.PhoneNumber = phoneService.NormalizePhoneNumber(request.PhoneNumber);
@@ -423,7 +425,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
     /// <summary>
     /// For either otp or magic link
     /// </summary>
-    [HttpPost]
+    [HttpPost, EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SendOtp(IdentityRequestDto request, string? returnUrl = null, CancellationToken cancellationToken = default)
     {
         request.PhoneNumber = phoneService.NormalizePhoneNumber(request.PhoneNumber);
@@ -483,7 +485,7 @@ public partial class IdentityController : AppControllerBase, IIdentityController
         await Task.WhenAll(sendMessagesTasks);
     }
 
-    [HttpPost]
+    [HttpPost, EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]
     public async Task SendTwoFactorToken(SignInRequestDto request, CancellationToken cancellationToken)
     {
         request.PhoneNumber = phoneService.NormalizePhoneNumber(request.PhoneNumber);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/HttpRequestExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/Extensions/HttpRequestExtensions.cs
@@ -17,10 +17,14 @@ public static class HttpRequestExtensions
 
             var serverUrl = request.GetBaseUrl();
 
-            var origin = request.Query["origin"].Union(request.Headers["X-Origin"]).Select(o => new Uri(o)).FirstOrDefault();
+            var candidate = request.Query["origin"].Union(request.Headers["X-Origin"])
+                                                   .FirstOrDefault(o => string.IsNullOrWhiteSpace(o) is false);
 
-            if (origin is null)
+            if (candidate is null)
                 return serverUrl; // Assume that web app and server are hosted in one place.
+
+            if (Uri.TryCreate(candidate, UriKind.Absolute, out var origin) is false)
+                throw new BadRequestException($"Invalid origin {candidate}");
 
             if (origin == serverUrl || settings.IsTrustedOrigin(origin))
                 return origin;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/RequestPipeline/AppRateLimitPolicies.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/RequestPipeline/AppRateLimitPolicies.cs
@@ -1,0 +1,10 @@
+namespace Boilerplate.Server.Api.Infrastructure.RequestPipeline;
+
+public static class AppRateLimitPolicies
+{
+    /// <summary>
+    /// Applied with <c>[EnableRateLimiting(AppRateLimitPolicies.IDENTITY)]</c> to the anonymous credential
+    /// endpoints - the ones that verify a secret or send a message to a stranger.
+    /// </summary>
+    public const string IDENTITY = "identity";
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/RequestPipeline/ForceUpdateMiddleware.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/RequestPipeline/ForceUpdateMiddleware.cs
@@ -7,16 +7,13 @@ public class ForceUpdateMiddleware(RequestDelegate next, ServerApiSettings setti
 
     public async Task InvokeAsync(HttpContext context)
     {
-        if (context.Request.Headers.TryGetValue("X-App-Version", out var appVersionHeaderValue)
-            && appVersionHeaderValue.Any())
+        if (Version.TryParse(context.Request.Headers["X-App-Version"].FirstOrDefault(), out var appVersion)
+            && Enum.TryParse<AppPlatformType>(context.Request.Headers["X-App-Platform"].FirstOrDefault(), ignoreCase: true, out var appPlatformType)
+            && Enum.IsDefined(appPlatformType) // TryParse also accepts numeric strings, e.g. "999", which are not real platforms.
+            && settings.SupportedAppVersions?.GetMinimumSupportedAppVersion(appPlatformType) is { } minVersion
+            && appVersion < minVersion)
         {
-            var appVersion = appVersionHeaderValue.Single()!;
-            var appPlatformType = Enum.Parse<AppPlatformType>(context.Request.Headers["X-App-Platform"].Single()!);
-            var minVersion = settings.SupportedAppVersions!.GetMinimumSupportedAppVersion(appPlatformType);
-            if (minVersion != null && Version.Parse(appVersion) < minVersion)
-            {
-                throw new ClientNotSupportedException().WithData("Reason", $"The client version '{appVersion}' is not supported. Minimum supported version is '{minVersion}'.");
-            }
+            throw new ClientNotSupportedException().WithData("Reason", $"The client version '{appVersion}' is not supported. Minimum supported version is '{minVersion}'.");
         }
 
         await next(context);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Program.Services.cs
@@ -230,7 +230,22 @@ public static partial class Program
                     .AllowCredentials();
             });
         });
-        services.AddRateLimiter();
+
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            options.AddPolicy(AppRateLimitPolicies.IDENTITY, context =>
+                System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: context.User.IsAuthenticated()
+                        ? $"user:{context.User.GetUserId()}"
+                        : $"ip:{context.Connection.RemoteIpAddress}",
+                    factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 30,
+                        Window = TimeSpan.FromMinutes(1)
+                    }));
+        });
 
         services.AddSingleton(sp =>
         {
@@ -399,14 +414,15 @@ public static partial class Program
                 var isAuthorizedAction = context.Description.ActionDescriptor.EndpointMetadata.Any(em => em is AuthorizeAttribute);
                 var isODataEnabledAction = context.Description.ActionDescriptor.FilterDescriptors.Any(f => f.Filter is EnableQueryAttribute);
 
-                operation.Parameters = [new OpenApiParameter()
+                operation.Parameters ??= [];
+                operation.Parameters.Add(new OpenApiParameter()
                 {
                     In = ParameterLocation.Header,
                     Name = HeaderNames.Authorization,
                     Example = "Bearer XXX.YYY...",
                     Description = "Get your JWT token by signin-in through Identity/SignIn endpoint",
                     Required = isAuthorizedAction
-                }];
+                });
 
                 if (isODataEnabledAction)
                 {
@@ -435,12 +451,12 @@ public static partial class Program
         fluentEmailServiceBuilder.AddSmtpSender(() =>
         {
             var smtpConnectionString = configuration.GetRequiredConnectionString("smtp")!;
-            var endpoint = new Uri(GetConnectionStringValue(smtpConnectionString, "Endpoint", "localhost"));
+            var endpoint = new Uri(GetConnectionStringValue(smtpConnectionString, "Endpoint", "smtp://localhost:25"));
             var host = endpoint.Host;
             var port = endpoint.Port is -1 ? 25 : endpoint.Port;
             var userName = GetConnectionStringValue(smtpConnectionString, "UserName", string.Empty);
             var password = GetConnectionStringValue(smtpConnectionString, "Password", string.Empty);
-            var enableSsl = GetConnectionStringValue(smtpConnectionString, "EnableSsl", port == 465 || port == 587 ? "true" : "false") is not "false";
+            var enableSsl = GetConnectionStringValue(smtpConnectionString, "EnableSsl", port == 465 || port == 587 ? "true" : "false").Equals("false", StringComparison.OrdinalIgnoreCase) is false;
 
             SmtpClient smtpClient = new(host, port)
             {
@@ -799,13 +815,22 @@ public static partial class Program
         services.ConfigureHttpClientFactoryForExternalIdentityProviders();
     }
 
+    /// <summary>
+    /// Reads a single `key=value` entry out of a `;`-separated connection string.
+    /// Trimming and the case-insensitive comparison are required, not cosmetic: connection strings are commonly
+    /// written with a space after the separator, and a plain ordinal StartsWith on an untrimmed segment makes
+    /// every key after the first invisible - which silently drops SMTP credentials rather than failing loudly.
+    /// Only the FIRST '=' is consumed, so values containing '=' (e.g. base64 padding) survive intact.
+    /// </summary>
     private static string GetConnectionStringValue(string connectionString, string key, string? defaultValue = null)
     {
+        var prefix = $"{key}=";
         var parts = connectionString.Split(';');
         foreach (var part in parts)
         {
-            if (part.StartsWith($"{key}="))
-                return part[$"{key}=".Length..];
+            var trimmedPart = part.Trim();
+            if (trimmedPart.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return trimmedPart[prefix.Length..];
         }
         return defaultValue ?? throw new ArgumentException($"Invalid connection string: '{key}' not found.");
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/ServerApiSettings.cs
@@ -239,6 +239,7 @@ public class SupportedAppVersionsOptions
             AppPlatformType.MacOS => MinimumSupportedMacOSAppVersion,
             AppPlatformType.Windows => MinimumSupportedWindowsAppVersion,
             AppPlatformType.Web => MinimumSupportedWebAppVersion,
+            AppPlatformType.Linux => null, // No Linux client ships a minimum version, so there is nothing to enforce.
             _ => throw new ArgumentOutOfRangeException(nameof(platformType), platformType, null)
         };
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Boilerplate.Server.Shared.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Boilerplate.Server.Shared.csproj
@@ -10,7 +10,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NWebsec.AspNetCore.Middleware" />
         <PackageReference Include="AspNetCore.HealthChecks.System" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
@@ -102,59 +102,78 @@ public static class WebApplicationExtensions
             // NOTE: These headers represent a strong security baseline.
             // Depending on your application's requirements, you might need to relax or tighten these settings further.
 
-            // 1. Strict-Transport-Security (HSTS)
-            // Enforces HTTPS connections.
-            // TIP: For "HSTS Preload", it's easier to configure it on Cloudflare CDN
-            // or your web server, rather than hardcoding the preload directive here.
-            app.UseHsts();
+            // They are all written from a single Response.OnStarting callback, and that is load-bearing:
+            // UseExceptionHandler calls HttpResponse.Clear(), which drops the whole header collection, so any
+            // header written eagerly on the way in is ABSENT from every response the exception handler produces -
+            // including ordinary model-validation 400s, because InvalidModelStateResponseFactory throws.
+            // OnStarting callbacks survive Clear(), so the baseline applies to error responses too.
 
-            // 2. X-Content-Type-Options
-            // Prevents browsers from sniffing MIME types (stops executing text/plain as scripts).
-            app.UseXContentTypeOptions();
-
-            // 3. X-XSS-Protection
-            // Legacy header. Enables the browser's built-in XSS filter in block mode.
-            app.UseXXssProtection(options => options.EnabledWithBlockMode());
-
-            // 4. X-Frame-Options (XFO)
-            // Prevents Clickjacking by ensuring the site can only be framed by itself (SameOrigin).
-            app.UseXfo(options => options.SameOrigin());
-
-            // 5. Referrer-Policy
-            // Protects user privacy by only sending the origin (domain) when navigating to external sites.
-            app.UseReferrerPolicy(opts => opts.StrictOriginWhenCrossOrigin());
+            // Content-Security-Policy (CSP) - Mini Version
+            // 'object-src none': Blocks legacy plugins like Flash.
+            // 'frame-ancestors self': Modern replacement for X-Frame-Options.
+            // 'form-action self': Restricts forms to only submit to your own domain (prevents form hijacking).
+            var csp = "object-src 'none'; frame-ancestors 'self'; form-action 'self'; worker-src 'self';";
+            if (app.Environment.IsDevelopment() is false)
+            {
+                // In production, add 'upgrade-insecure-requests' to automatically upgrade any HTTP requests to HTTPS.
+                csp += " upgrade-insecure-requests;";
+            }
 
             app.Use(async (context, next) =>
             {
-                // 6. Permissions-Policy
-                // "Disables" sensitive hardware/API access to reduce the attack surface.
-                // Example: If building an E-Commerce or Delivery app, remove 'payment' or 'geolocation' from this list.
-                context.Response.Headers.Append("Permissions-Policy", "geolocation=(), camera=(), microphone=(), payment=(), usb=(), display-capture=()");
-
-                // 7. Cross-Origin-Resource-Policy (CORP)
-                // Set to 'cross-origin' to explicitly allow resources (images, fonts, etc.) to be loaded by
-                // clients on different origins/domains and Blazor Hybrid (WebView).
-                // NOTE: Using 'same-site' or 'same-origin' would block rendering in these multi-origin scenarios,
-                // but they also help prevent hotlinking and bandwidth theft from untrusted third-party sites.
-                // By choosing 'cross-origin', you allow *any* external site to embed your static assets, which can
-                // increase bandwidth costs and enable unauthorized re-use of your images/assets.
-                // Consider compensating controls such as CDN-level hotlink protection, WAF rules, rate limiting,
-                // and/or caching policies to mitigate potential abuse while still supporting hybrid/multi-origin clients.
-                context.Response.Headers.Append("Cross-Origin-Resource-Policy", "cross-origin");
-
-                // 8. Content-Security-Policy (CSP) - Mini Version
-                // 'object-src none': Blocks legacy plugins like Flash.
-                // 'frame-ancestors self': Modern replacement for X-Frame-Options.
-                // 'form-action self': Restricts forms to only submit to your own domain (prevents form hijacking).
-                var csp = "object-src 'none'; frame-ancestors 'self'; form-action 'self'; worker-src 'self';";
-                if (app.Environment.IsDevelopment() is false)
+                context.Response.OnStarting(() =>
                 {
-                    // In production, add 'upgrade-insecure-requests' to automatically upgrade any HTTP requests to HTTPS.
-                    csp += " upgrade-insecure-requests;";
-                }
-                context.Response.Headers.Append("Content-Security-Policy", csp);
-                // For a stricter, app-wide CSP that also works in all Interactive Blazor rendering modes,
-                // check out the ContentSecurityPolicy.razor component in Client.Core
+                    var headers = context.Response.Headers;
+
+                    // 1. Strict-Transport-Security (HSTS)
+                    // Enforces HTTPS connections. Emitted only over HTTPS and never for loopback, which is what
+                    // ASP.NET Core's own HstsMiddleware does - a browser ignores it on http:// anyway.
+                    // TIP: For "HSTS Preload", it's easier to configure it on Cloudflare CDN
+                    // or your web server, rather than hardcoding the preload directive here.
+                    if (context.Request.IsHttps && HstsExcludedHosts.Contains(context.Request.Host.Host) is false)
+                    {
+                        headers.StrictTransportSecurity = "max-age=2592000"; // 30 days, the framework default.
+                    }
+
+                    // 2. X-Content-Type-Options
+                    // Prevents browsers from sniffing MIME types (stops executing text/plain as scripts).
+                    headers.XContentTypeOptions = "nosniff";
+
+                    // 3. X-XSS-Protection
+                    // Legacy header. Enables the browser's built-in XSS filter in block mode.
+                    headers.XXSSProtection = "1; mode=block";
+
+                    // 4. X-Frame-Options (XFO)
+                    // Prevents Clickjacking by ensuring the site can only be framed by itself (SameOrigin).
+                    headers.XFrameOptions = "SAMEORIGIN";
+
+                    // 5. Referrer-Policy
+                    // Protects user privacy by only sending the origin (domain) when navigating to external sites.
+                    headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+
+                    // 6. Permissions-Policy
+                    // "Disables" sensitive hardware/API access to reduce the attack surface.
+                    // Example: If building an E-Commerce or Delivery app, remove 'payment' or 'geolocation' from this list.
+                    headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), display-capture=()";
+
+                    // 7. Cross-Origin-Resource-Policy (CORP)
+                    // Set to 'cross-origin' to explicitly allow resources (images, fonts, etc.) to be loaded by
+                    // clients on different origins/domains and Blazor Hybrid (WebView).
+                    // NOTE: Using 'same-site' or 'same-origin' would block rendering in these multi-origin scenarios,
+                    // but they also help prevent hotlinking and bandwidth theft from untrusted third-party sites.
+                    // By choosing 'cross-origin', you allow *any* external site to embed your static assets, which can
+                    // increase bandwidth costs and enable unauthorized re-use of your images/assets.
+                    // Consider compensating controls such as CDN-level hotlink protection, WAF rules, rate limiting,
+                    // and/or caching policies to mitigate potential abuse while still supporting hybrid/multi-origin clients.
+                    headers["Cross-Origin-Resource-Policy"] = "cross-origin";
+
+                    // 8. Content-Security-Policy (CSP)
+                    headers.ContentSecurityPolicy = csp;
+                    // For a stricter, app-wide CSP that also works in all Interactive Blazor rendering modes,
+                    // check out the ContentSecurityPolicy.razor component in Client.Core
+
+                    return Task.CompletedTask;
+                });
 
                 await next();
             });
@@ -162,4 +181,10 @@ public static class WebApplicationExtensions
             return app;
         }
     }
+
+    /// <summary>
+    /// The hosts ASP.NET Core's own <c>HstsMiddleware</c> excludes by default. Kept so the hand-written
+    /// Strict-Transport-Security below behaves exactly like <c>UseHsts()</c> did.
+    /// </summary>
+    private static readonly HashSet<string> HstsExcludedHosts = new(["localhost", "127.0.0.1", "::1"], StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs
@@ -3,61 +3,101 @@ using System.Net;
 namespace Boilerplate.Tests.Features.ForceUpdate;
 
 /// <summary>
-/// <b>Pins an open finding (BP-079). Remove the <c>[Ignore]</c> when it is fixed.</b>
+/// <b>Regression test for BP-079.</b>
 /// <para>
-/// <c>ForceUpdateMiddleware</c> runs on <b>every</b> request, before authentication, and parses two request headers
-/// with three throwing APIs and no guards: <c>Headers["X-App-Platform"].Single()</c>,
-/// <c>Enum.Parse&lt;AppPlatformType&gt;(...)</c> and <c>Version.Parse(appVersion)</c>. Every one of them is fed
-/// directly from headers any anonymous caller controls, so each is a one-line request that turns into a 500 plus a
-/// <c>LogCritical</c> record - free, unauthenticated log noise on any endpoint, and a 500 where the caller should
-/// have got the real answer.
+/// <c>ForceUpdateMiddleware</c> runs on <b>every</b> request, before authentication, and used to parse two
+/// request headers with throwing APIs and no guards: <c>Headers["X-App-Platform"].Single()</c>,
+/// <c>Enum.Parse&lt;AppPlatformType&gt;(...)</c>, <c>Version.Parse(...)</c> and <c>SupportedAppVersions!</c>.
+/// Every one of them is fed directly from headers any anonymous caller controls, so each turned a one-line
+/// request into a 500 plus a <c>LogCritical</c> record - free, unauthenticated log noise on any endpoint.
 /// </para>
 /// <para>
-/// The <c>Single()</c> case is the sharpest: the middleware only checks that <c>X-App-Version</c> is present, then
-/// reads <c>X-App-Platform</c> as though presence of the first guaranteed the second. Sending just
-/// <c>X-App-Version</c> - which is what a curl, a health prober or a partial client does - is enough.
+/// The <c>Single()</c> case was the sharpest: the middleware only checked that <c>X-App-Version</c> was present,
+/// then read <c>X-App-Platform</c> as though the presence of the first guaranteed the second. Sending just
+/// <c>X-App-Version</c> - what a curl, a health prober or a partial client does - was enough.
 /// </para>
 /// <para>
-/// What unblocks this: read both headers defensively (<c>FirstOrDefault()</c>, <c>Enum.TryParse</c>,
-/// <c>Version.TryParse</c>) and simply skip the version check when the client did not supply a usable pair. The
-/// middleware's job is to force an update, not to validate headers - failing open is the correct direction here,
-/// since a caller that cannot state its version is not a client this check applies to.
+/// The middleware's job is to force an update, not to validate headers, so every read now fails <b>open</b>:
+/// a caller that cannot state a usable version and platform is not a client the check applies to.
 /// </para>
 /// </summary>
 [TestClass, TestCategory("IntegrationTest")]
 public class ForceUpdateHeaderHardeningTests
 {
     /// <summary>
-    /// Each row is a header combination an anonymous caller can send today. The endpoint is an ordinary anonymous
-    /// GET whose real answer is 404; the assertion is simply that the client version headers did not change it into
-    /// a server fault.
+    /// Each row is a header combination an anonymous caller can send. The endpoint is an ordinary anonymous GET
+    /// whose real answer is 404, and that 404 is the assertion: the client version headers must not change it
+    /// into a server fault. The last row is the control - a perfectly well-formed pair must reach the same 404,
+    /// so a green result cannot come from the middleware rejecting everything.
     /// </summary>
-    [TestMethod, Ignore("Pins BP-079: ForceUpdateMiddleware parses attacker-controlled headers with Single()/Enum.Parse/Version.Parse. Verified 2026-08-01 - all four rows return 500 UnknownException + LogCritical today.")]
-    [DataRow("1.0.0", null, DisplayName = "X-App-Platform missing -> Single() on an empty StringValues")]
-    [DataRow("1.0.0", "NotAPlatform", DisplayName = "unknown platform -> Enum.Parse throws")]
-    [DataRow("not-a-version", "Web", DisplayName = "unparsable version -> Version.Parse throws")]
+    [TestMethod]
+    [DataRow("1.0.0", null, DisplayName = "X-App-Platform missing - used to be Single() on an empty StringValues")]
+    [DataRow("1.0.0", "NotAPlatform", DisplayName = "unknown platform - used to be Enum.Parse")]
+    [DataRow("1.0.0", "999", DisplayName = "numeric platform - Enum.TryParse accepts it, Enum.IsDefined must not")]
+    [DataRow("1.0.0", "Linux", DisplayName = "Linux - a real platform with no configured minimum version")]
+    [DataRow("not-a-version", "Web", DisplayName = "unparsable version - used to be Version.Parse")]
     [DataRow("1.0.0, 2.0.0", "Web", DisplayName = "repeated X-App-Version, which Kestrel joins into one comma-separated value")]
+    [DataRow("", "Web", DisplayName = "empty version")]
+    [DataRow("1.0.0", "web", DisplayName = "CONTROL: a valid pair, lower-cased - must be accepted and reach the same 404")]
     public async Task AMalformedClientVersionHeader_Should_NotFaultTheRequest(string appVersion, string? appPlatform)
     {
         await using var server = new AppTestServer();
+
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
-        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/v1/Attachment/GetAttachment/{Guid.NewGuid()}/UserProfileImageSmall");
-        request.Headers.TryAddWithoutValidation("X-App-Version", appVersion);
 
+        // Replace rather than add: the app's own RequestHeadersDelegatingHandler already sets both headers.
+        request.Headers.Remove("X-App-Version");
+        request.Headers.Remove("X-App-Platform");
+        request.Headers.TryAddWithoutValidation("X-App-Version", appVersion);
         if (appPlatform is not null)
         {
             request.Headers.TryAddWithoutValidation("X-App-Platform", appPlatform);
         }
 
-        using var response = await httpClient.SendAsync(request, TestContext.CancellationToken);
+        var exception = await Assert.ThrowsAsync<Exception>(async ()
+            => await httpClient.SendAsync(request, TestContext.CancellationToken));
 
-        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+        Assert.IsNotInstanceOfType<UnknownException>(exception,
+            $"A header the caller controls must not turn the real 404 into a server fault. Got: {exception}");
 
-        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode,
-            $"A header the caller controls must not turn the real 404 into a server fault. Body: {body}");
+        Assert.IsInstanceOfType<ResourceNotFoundException>(exception,
+            $"Expected the endpoint's own 404. Got: {exception}");
+    }
+
+    /// <summary>
+    /// The check itself must still work: a client below the configured minimum is refused with
+    /// <see cref="ClientNotSupportedException"/>. Without this, "never faults" could be satisfied by a middleware
+    /// that does nothing at all - which is exactly what a too-eager fail-open would produce.
+    /// </summary>
+    [TestMethod]
+    public async Task AClientBelowTheMinimumVersion_Should_StillBeRefused()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices(),
+            configureTestConfigurations: configuration =>
+            {
+                configuration["SupportedAppVersions:MinimumSupportedWebAppVersion"] = "9.9.9";
+            }).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"api/v1/Attachment/GetAttachment/{Guid.NewGuid()}/UserProfileImageSmall");
+        request.Headers.Remove("X-App-Version");
+        request.Headers.Remove("X-App-Platform");
+        request.Headers.TryAddWithoutValidation("X-App-Version", "1.0.0");
+        request.Headers.TryAddWithoutValidation("X-App-Platform", nameof(AppPlatformType.Web));
+
+        await Assert.ThrowsAsync<ClientNotSupportedException>(async ()
+            => await httpClient.SendAsync(request, TestContext.CancellationToken));
     }
 
     public TestContext TestContext { get; set; } = default!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateHeaderHardeningTests.cs
@@ -20,6 +20,12 @@ namespace Boilerplate.Tests.Features.ForceUpdate;
 /// The middleware's job is to force an update, not to validate headers, so every read now fails <b>open</b>:
 /// a caller that cannot state a usable version and platform is not a client the check applies to.
 /// </para>
+/// <para>
+/// <b>Why a bare <see cref="HttpClient"/> here</b>, unlike the other integration tests: the app's own
+/// <c>RequestHeadersDelegatingHandler</c> <i>adds</i> <c>X-App-Version</c> and <c>X-App-Platform</c> to every
+/// internal request, so the DI-resolved client cannot express "send exactly this header" - the value under test
+/// would arrive joined with the real one. These two headers are the input, so they have to be the only ones.
+/// </para>
 /// </summary>
 [TestClass, TestCategory("IntegrationTest")]
 public class ForceUpdateHeaderHardeningTests
@@ -27,8 +33,8 @@ public class ForceUpdateHeaderHardeningTests
     /// <summary>
     /// Each row is a header combination an anonymous caller can send. The endpoint is an ordinary anonymous GET
     /// whose real answer is 404, and that 404 is the assertion: the client version headers must not change it
-    /// into a server fault. The last row is the control - a perfectly well-formed pair must reach the same 404,
-    /// so a green result cannot come from the middleware rejecting everything.
+    /// into a server fault. The last row is the control - a well-formed pair must reach the same 404, so a green
+    /// result cannot come from the middleware simply rejecting everything.
     /// </summary>
     [TestMethod]
     [DataRow("1.0.0", null, DisplayName = "X-App-Platform missing - used to be Single() on an empty StringValues")]
@@ -38,42 +44,25 @@ public class ForceUpdateHeaderHardeningTests
     [DataRow("not-a-version", "Web", DisplayName = "unparsable version - used to be Version.Parse")]
     [DataRow("1.0.0, 2.0.0", "Web", DisplayName = "repeated X-App-Version, which Kestrel joins into one comma-separated value")]
     [DataRow("", "Web", DisplayName = "empty version")]
-    [DataRow("1.0.0", "web", DisplayName = "CONTROL: a valid pair, lower-cased - must be accepted and reach the same 404")]
+    [DataRow("1.0.0", "web", DisplayName = "CONTROL: a valid pair, lower-cased - accepted and reaches the same 404")]
     public async Task AMalformedClientVersionHeader_Should_NotFaultTheRequest(string appVersion, string? appPlatform)
     {
         await using var server = new AppTestServer();
 
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
-        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        using var response = await SendAttachmentRequest(server, appVersion, appPlatform);
 
-        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"api/v1/Attachment/GetAttachment/{Guid.NewGuid()}/UserProfileImageSmall");
-
-        // Replace rather than add: the app's own RequestHeadersDelegatingHandler already sets both headers.
-        request.Headers.Remove("X-App-Version");
-        request.Headers.Remove("X-App-Platform");
-        request.Headers.TryAddWithoutValidation("X-App-Version", appVersion);
-        if (appPlatform is not null)
-        {
-            request.Headers.TryAddWithoutValidation("X-App-Platform", appPlatform);
-        }
-
-        var exception = await Assert.ThrowsAsync<Exception>(async ()
-            => await httpClient.SendAsync(request, TestContext.CancellationToken));
-
-        Assert.IsNotInstanceOfType<UnknownException>(exception,
-            $"A header the caller controls must not turn the real 404 into a server fault. Got: {exception}");
-
-        Assert.IsInstanceOfType<ResourceNotFoundException>(exception,
-            $"Expected the endpoint's own 404. Got: {exception}");
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode,
+            $"A header the caller controls must not turn the real 404 into a server fault. Body: {body}");
     }
 
     /// <summary>
-    /// The check itself must still work: a client below the configured minimum is refused with
-    /// <see cref="ClientNotSupportedException"/>. Without this, "never faults" could be satisfied by a middleware
-    /// that does nothing at all - which is exactly what a too-eager fail-open would produce.
+    /// The check itself must still work: a client below the configured minimum is refused. Without this, "never
+    /// faults" would also be satisfied by a middleware that does nothing at all - which is exactly what a
+    /// too-eager fail-open produces.
     /// </summary>
     [TestMethod]
     public async Task AClientBelowTheMinimumVersion_Should_StillBeRefused()
@@ -81,23 +70,32 @@ public class ForceUpdateHeaderHardeningTests
         await using var server = new AppTestServer();
 
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices(),
-            configureTestConfigurations: configuration =>
-            {
-                configuration["SupportedAppVersions:MinimumSupportedWebAppVersion"] = "9.9.9";
-            }).Start(TestContext.CancellationToken);
+            configureTestConfigurations: configuration => configuration["SupportedAppVersions:MinimumSupportedWebAppVersion"] = "9.9.9")
+            .Start(TestContext.CancellationToken);
 
-        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        using var response = await SendAttachmentRequest(server, appVersion: "1.0.0", appPlatform: nameof(AppPlatformType.Web));
 
-        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode, $"An out-of-date client must be refused. Body: {body}");
+
+        Assert.Contains(nameof(ClientNotSupportedException), body, StringComparison.Ordinal);
+    }
+
+    private async Task<HttpResponseMessage> SendAttachmentRequest(AppTestServer server, string appVersion, string? appPlatform)
+    {
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/v1/Attachment/GetAttachment/{Guid.NewGuid()}/UserProfileImageSmall");
-        request.Headers.Remove("X-App-Version");
-        request.Headers.Remove("X-App-Platform");
-        request.Headers.TryAddWithoutValidation("X-App-Version", "1.0.0");
-        request.Headers.TryAddWithoutValidation("X-App-Platform", nameof(AppPlatformType.Web));
 
-        await Assert.ThrowsAsync<ClientNotSupportedException>(async ()
-            => await httpClient.SendAsync(request, TestContext.CancellationToken));
+        request.Headers.TryAddWithoutValidation("X-App-Version", appVersion);
+
+        if (appPlatform is not null)
+        {
+            request.Headers.TryAddWithoutValidation("X-App-Platform", appPlatform);
+        }
+
+        return await httpClient.SendAsync(request, TestContext.CancellationToken);
     }
 
     public TestContext TestContext { get; set; } = default!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/OpenApi/OpenApiParameterContractTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/OpenApi/OpenApiParameterContractTests.cs
@@ -35,7 +35,9 @@ public partial class OpenApiParameterContractTests
 
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
-        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
 
         var document = await httpClient.GetStringAsync("openapi/v1.json", TestContext.CancellationToken);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/OpenApi/OpenApiParameterContractTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/OpenApi/OpenApiParameterContractTests.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+
+namespace Boilerplate.Tests.Features.OpenApi;
+
+/// <summary>
+/// <b>Regression test for BP-161.</b>
+/// <para>
+/// The OpenAPI operation transformer registered in <c>Program.Services</c> used to do
+/// <c>operation.Parameters = [new OpenApiParameter { ... Authorization ... }]</c> - a wholesale <b>assignment</b>
+/// where an <b>append</b> was needed. Transformers run after the document service has already filled
+/// <c>operation.Parameters</c> from the endpoint's <c>ApiDescription</c>, so every path parameter and every
+/// non-OData query parameter was discarded; the seven OData query options were re-added afterwards, but only for
+/// <c>[EnableQuery]</c> actions, and nothing restored the route parameters.
+/// </para>
+/// <para>
+/// The published document then declared path templates such as <c>/api/v1/Product/Delete/{id}/{version}</c> with
+/// no corresponding <c>path</c> parameters, which OpenAPI 3.1 requires. Scalar's "Try it" had no field to fill in,
+/// and a client generated from the document took no id argument and requested the literal template.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public partial class OpenApiParameterContractTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Reads the real generated document and compares each path template's <c>{placeholders}</c> against the
+    /// <c>path</c> parameters the corresponding operations declare. The first assertion is a control: if the
+    /// document contained no templated path at all, a green "no offenders" result would be meaningless.
+    /// </summary>
+    [TestMethod]
+    public async Task ThePublishedOpenApiDocument_Should_DeclareEveryPathParameterItsTemplateUses()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        var document = await httpClient.GetStringAsync("openapi/v1.json", TestContext.CancellationToken);
+
+        using var json = JsonDocument.Parse(document);
+
+        var templatedPathCount = 0;
+        List<string> offenders = [];
+
+        foreach (var path in json.RootElement.GetProperty("paths").EnumerateObject())
+        {
+            string[] placeholders = [.. PathPlaceholder().Matches(path.Name).Select(match => match.Groups["name"].Value)];
+
+            if (placeholders.Length is 0)
+                continue;
+
+            templatedPathCount++;
+
+            foreach (var operation in path.Value.EnumerateObject())
+            {
+                string?[] declared = operation.Value.TryGetProperty("parameters", out var parameters)
+                    ? [.. parameters.EnumerateArray()
+                        .Where(parameter => parameter.TryGetProperty("in", out var location) && location.GetString() is "path")
+                        .Select(parameter => parameter.TryGetProperty("name", out var name) ? name.GetString() : null)]
+                    : [];
+
+                var missing = placeholders.Except(declared).ToArray();
+
+                if (missing.Length is not 0)
+                {
+                    offenders.Add($"{operation.Name.ToUpperInvariant()} {path.Name} declares no path parameter for {{{string.Join("}, {", missing)}}}");
+                }
+            }
+        }
+
+        Assert.IsGreaterThan(0, templatedPathCount, "Control: the generated document must contain at least one templated path, otherwise this test proves nothing.");
+
+        Assert.IsEmpty(offenders,
+            $"{offenders.Count} of the document's operations on {templatedPathCount} templated path(s) publish no path parameter:{Environment.NewLine}{string.Join(Environment.NewLine, offenders.Take(20))}");
+    }
+
+    [GeneratedRegex(@"\{(?<name>[^}]+)\}")]
+    private static partial Regex PathPlaceholder();
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs
@@ -1,4 +1,5 @@
 using Boilerplate.Shared.Features.Identity;
+using Boilerplate.Shared.Features.MinimalApiSample;
 
 namespace Boilerplate.Tests.Features.RateLimiting;
 
@@ -67,7 +68,8 @@ public class IdentityRateLimitTests
     /// <summary>
     /// The same burst against an endpoint that does NOT opt in must never be throttled. This is what
     /// distinguishes the named policy that shipped from the global limiter the finding argued against - a global
-    /// limiter would make this method fail.
+    /// limiter would make this method fail. Completing the loop IS the assertion: a 429 would surface as
+    /// <see cref="TooManyRequestsException"/> and fail the test on its own.
     /// </summary>
     [TestMethod]
     public async Task AnEndpointThatDoesNotOptIn_Should_NotBeRateLimited()
@@ -78,16 +80,14 @@ public class IdentityRateLimitTests
 
         await using var scope = server.WebApp.Services.CreateAsyncScope();
 
-        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+        var minimalApiSampleController = scope.ServiceProvider.GetRequiredService<IMinimalApiSampleController>();
 
         for (var i = 0; i < BurstSize; i++)
         {
-            // ExceptionDelegatingHandler turns a 429 into TooManyRequestsException, so simply completing the
-            // loop is the assertion. Any throw fails the test with its own message.
-            using var response = await httpClient.GetAsync(".well-known/jwks", TestContext.CancellationToken);
+            var result = await minimalApiSampleController.MinimalApiSample($"burst-{i}", queryStringParameter: null, TestContext.CancellationToken);
 
-            Assert.IsTrue(response.IsSuccessStatusCode,
-                $"Control: the un-opted-in endpoint must answer at all. Got {(int)response.StatusCode} on request {i + 1}.");
+            Assert.AreEqual($"burst-{i}", result.GetProperty("routeParameter").GetString(),
+                $"Control: the un-opted-in endpoint must keep answering. Failed on request {i + 1}.");
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+
+namespace Boilerplate.Tests.Features.RateLimiting;
+
+/// <summary>
+/// <b>Regression test for BP-160.</b>
+/// <para>
+/// <c>services.AddRateLimiter()</c> used to be called with the parameterless overload, which leaves
+/// <c>RateLimiterOptions.GlobalLimiter</c> null and registers no named policy - and no endpoint anywhere in the
+/// template carried <c>[EnableRateLimiting]</c>. Both <c>app.UseRateLimiter()</c> calls were therefore inert
+/// middleware: the anonymous credential endpoints had no throttling at all, in every configuration, while the
+/// pipeline read as though they did.
+/// </para>
+/// <para>
+/// This test pins both halves of the fix, because each can regress on its own and neither is visible from a
+/// build: the policy exists AND at least one endpoint opts into it (first method), and the policy is <b>named</b>
+/// rather than global, so it does not throttle the rest of the app - the Blazor circuit negotiate, the health
+/// probes and the Hangfire dashboard all sit behind the same <c>UseRateLimiter</c> call (second method).
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class IdentityRateLimitTests
+{
+    /// <summary>
+    /// <c>AppRateLimitPolicies.IDENTITY</c> permits 30 requests per minute per partition, and every request here
+    /// shares the loopback partition, so the burst must be cut off before it completes. The e-mail address is a
+    /// fresh Guid that no account owns: <c>SendConfirmEmailToken</c> answers 400 <c>UserNotFound</c> for it and
+    /// writes nothing, so this test cannot leave state behind in the shared development database.
+    /// </summary>
+    [TestMethod]
+    public async Task AnAnonymousIdentityEndpoint_Should_StopServingAfterTheBurstLimit()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        var statusCodes = await SendBurst(httpClient, "api/v1/Identity/SendConfirmEmailToken",
+            $$"""{"email":"{{Guid.NewGuid()}}@example.com"}""", count: 40);
+
+        // Control: the endpoint really is reachable and really is answering, so a missing 429 below would mean
+        // "not throttled", not "never got there".
+        Assert.IsTrue(statusCodes.Contains(HttpStatusCode.BadRequest),
+            $"Expected the endpoint's own 400 UserNotFound among the responses. Got: {Describe(statusCodes)}");
+
+        Assert.IsTrue(statusCodes.Contains(HttpStatusCode.TooManyRequests),
+            $"A 40-request burst against a rate-limited anonymous endpoint must be throttled. Got: {Describe(statusCodes)}");
+    }
+
+    /// <summary>
+    /// The same burst against an endpoint that does NOT opt in must never be throttled. This is what distinguishes
+    /// the named policy that shipped from the global limiter the finding explicitly argued against - a global
+    /// limiter would make this method fail.
+    /// </summary>
+    [TestMethod]
+    public async Task AnEndpointThatDoesNotOptIn_Should_NotBeRateLimited()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        var statusCodes = await SendBurst(httpClient, ".well-known/jwks", content: null, count: 40);
+
+        Assert.IsTrue(statusCodes.Contains(HttpStatusCode.OK),
+            $"Control: the un-opted-in endpoint must answer at all. Got: {Describe(statusCodes)}");
+
+        Assert.IsFalse(statusCodes.Contains(HttpStatusCode.TooManyRequests),
+            $"The rate limit must stay scoped to the endpoints that opt in, otherwise health probes and the Blazor "
+            + $"circuit share a bucket with it. Got: {Describe(statusCodes)}");
+    }
+
+    private async Task<HttpStatusCode[]> SendBurst(HttpClient httpClient, string route, string? content, int count)
+    {
+        List<HttpStatusCode> statusCodes = [];
+
+        for (var i = 0; i < count; i++)
+        {
+            using var body = content is null ? null : new StringContent(content, System.Text.Encoding.UTF8, "application/json");
+
+            using var response = content is null
+                ? await httpClient.GetAsync(route, TestContext.CancellationToken)
+                : await httpClient.PostAsync(route, body, TestContext.CancellationToken);
+
+            statusCodes.Add(response.StatusCode);
+        }
+
+        return [.. statusCodes];
+    }
+
+    private static string Describe(HttpStatusCode[] statusCodes)
+        => string.Join(", ", statusCodes.GroupBy(statusCode => statusCode).Select(group => $"{(int)group.Key} x{group.Count()}"));
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/RateLimiting/IdentityRateLimitTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+using Boilerplate.Shared.Features.Identity;
 
 namespace Boilerplate.Tests.Features.RateLimiting;
 
@@ -12,19 +12,21 @@ namespace Boilerplate.Tests.Features.RateLimiting;
 /// pipeline read as though they did.
 /// </para>
 /// <para>
-/// This test pins both halves of the fix, because each can regress on its own and neither is visible from a
-/// build: the policy exists AND at least one endpoint opts into it (first method), and the policy is <b>named</b>
-/// rather than global, so it does not throttle the rest of the app - the Blazor circuit negotiate, the health
-/// probes and the Hangfire dashboard all sit behind the same <c>UseRateLimiter</c> call (second method).
+/// Both halves of the fix are pinned, because each can regress on its own and neither is visible from a build:
+/// the policy exists AND an endpoint opts into it (first method), and it is <b>named</b> rather than global, so
+/// it does not throttle the rest of the app - the Blazor circuit negotiate, the health probes and the Hangfire
+/// dashboard all sit behind the same <c>UseRateLimiter</c> call (second method).
 /// </para>
 /// </summary>
 [TestClass, TestCategory("IntegrationTest")]
 public class IdentityRateLimitTests
 {
+    private const int BurstSize = 40; // AppRateLimitPolicies.IDENTITY permits 30 per minute.
+
     /// <summary>
-    /// <c>AppRateLimitPolicies.IDENTITY</c> permits 30 requests per minute per partition, and every request here
-    /// shares the loopback partition, so the burst must be cut off before it completes. The e-mail address is a
-    /// fresh Guid that no account owns: <c>SendConfirmEmailToken</c> answers 400 <c>UserNotFound</c> for it and
+    /// Driven through the app's own typed controller proxy, so the rejection arrives as the
+    /// <see cref="TooManyRequestsException"/> a real client would handle rather than as a bare status code.
+    /// The e-mail is a fresh Guid that no account owns: the endpoint answers <c>UserNotFound</c> for it and
     /// writes nothing, so this test cannot leave state behind in the shared development database.
     /// </summary>
     [TestMethod]
@@ -34,23 +36,37 @@ public class IdentityRateLimitTests
 
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
-        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
 
-        var statusCodes = await SendBurst(httpClient, "api/v1/Identity/SendConfirmEmailToken",
-            $$"""{"email":"{{Guid.NewGuid()}}@example.com"}""", count: 40);
+        var identityController = scope.ServiceProvider.GetRequiredService<IIdentityController>();
 
-        // Control: the endpoint really is reachable and really is answering, so a missing 429 below would mean
-        // "not throttled", not "never got there".
-        Assert.IsTrue(statusCodes.Contains(HttpStatusCode.BadRequest),
-            $"Expected the endpoint's own 400 UserNotFound among the responses. Got: {Describe(statusCodes)}");
+        var served = 0;
 
-        Assert.IsTrue(statusCodes.Contains(HttpStatusCode.TooManyRequests),
-            $"A 40-request burst against a rate-limited anonymous endpoint must be throttled. Got: {Describe(statusCodes)}");
+        for (var i = 0; i < BurstSize; i++)
+        {
+            try
+            {
+                await identityController.SendConfirmEmailToken(new() { Email = $"{Guid.NewGuid()}@example.com" }, TestContext.CancellationToken);
+            }
+            catch (TooManyRequestsException)
+            {
+                // Control: the endpoint really answered before it started refusing, so this is throttling
+                // rather than the request never getting there.
+                Assert.IsGreaterThan(0, served, "The endpoint must serve some requests before throttling starts.");
+                return;
+            }
+            catch (BadRequestException)
+            {
+                served++; // UserNotFound - the endpoint's own answer for an unknown e-mail.
+            }
+        }
+
+        Assert.Fail($"A burst of {BurstSize} requests against a rate-limited anonymous endpoint was never throttled ({served} served).");
     }
 
     /// <summary>
-    /// The same burst against an endpoint that does NOT opt in must never be throttled. This is what distinguishes
-    /// the named policy that shipped from the global limiter the finding explicitly argued against - a global
+    /// The same burst against an endpoint that does NOT opt in must never be throttled. This is what
+    /// distinguishes the named policy that shipped from the global limiter the finding argued against - a global
     /// limiter would make this method fail.
     /// </summary>
     [TestMethod]
@@ -60,38 +76,20 @@ public class IdentityRateLimitTests
 
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
-        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
 
-        var statusCodes = await SendBurst(httpClient, ".well-known/jwks", content: null, count: 40);
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
 
-        Assert.IsTrue(statusCodes.Contains(HttpStatusCode.OK),
-            $"Control: the un-opted-in endpoint must answer at all. Got: {Describe(statusCodes)}");
-
-        Assert.IsFalse(statusCodes.Contains(HttpStatusCode.TooManyRequests),
-            $"The rate limit must stay scoped to the endpoints that opt in, otherwise health probes and the Blazor "
-            + $"circuit share a bucket with it. Got: {Describe(statusCodes)}");
-    }
-
-    private async Task<HttpStatusCode[]> SendBurst(HttpClient httpClient, string route, string? content, int count)
-    {
-        List<HttpStatusCode> statusCodes = [];
-
-        for (var i = 0; i < count; i++)
+        for (var i = 0; i < BurstSize; i++)
         {
-            using var body = content is null ? null : new StringContent(content, System.Text.Encoding.UTF8, "application/json");
+            // ExceptionDelegatingHandler turns a 429 into TooManyRequestsException, so simply completing the
+            // loop is the assertion. Any throw fails the test with its own message.
+            using var response = await httpClient.GetAsync(".well-known/jwks", TestContext.CancellationToken);
 
-            using var response = content is null
-                ? await httpClient.GetAsync(route, TestContext.CancellationToken)
-                : await httpClient.PostAsync(route, body, TestContext.CancellationToken);
-
-            statusCodes.Add(response.StatusCode);
+            Assert.IsTrue(response.IsSuccessStatusCode,
+                $"Control: the un-opted-in endpoint must answer at all. Got {(int)response.StatusCode} on request {i + 1}.");
         }
-
-        return [.. statusCodes];
     }
-
-    private static string Describe(HttpStatusCode[] statusCodes)
-        => string.Join(", ", statusCodes.GroupBy(statusCode => statusCode).Select(group => $"{(int)group.Key} x{group.Count()}"));
 
     public TestContext TestContext { get; set; } = default!;
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs
@@ -1,3 +1,5 @@
+using Boilerplate.Shared.Features.Identity;
+
 namespace Boilerplate.Tests.Features.Urls;
 
 /// <summary>
@@ -22,19 +24,19 @@ namespace Boilerplate.Tests.Features.Urls;
 public class WebAppUrlOriginHardeningTests
 {
     /// <summary>
-    /// Every row is a value an anonymous caller can put on the query string. The request goes through the app's
-    /// own <see cref="HttpClient"/> (resolved from a request scope), so <c>ExceptionDelegatingHandler</c> turns
-    /// the response back into the typed exception a real client would see - which is what makes the assertion
-    /// meaningful: a <see cref="KnownException"/> is the endpoint answering, an <see cref="UnknownException"/> is
-    /// a server fault.
+    /// Each row is a value an anonymous caller can put on the query string, sent through the app's own typed
+    /// controller proxy so the response comes back as the exception a real client would see: a
+    /// <see cref="KnownException"/> is the endpoint answering, an <see cref="UnknownException"/> is a server
+    /// fault. The request body is empty on purpose - the endpoint's real answer is a validation failure, so
+    /// anything else means the origin decided the outcome. <c>null</c> is the control: no origin at all.
     /// </summary>
     [TestMethod]
-    [DataRow("?origin=", DisplayName = "present but empty -> treated as 'no origin supplied'")]
-    [DataRow("?origin=%20", DisplayName = "whitespace -> treated as 'no origin supplied'")]
-    [DataRow("?origin=notaurl", DisplayName = "not absolute -> the documented 400, not a 500")]
-    [DataRow("?origin=/relative", DisplayName = "relative -> the documented 400, not a 500")]
-    [DataRow("", DisplayName = "CONTROL: no origin at all -> the endpoint's own validation error")]
-    public async Task AMalformedOriginQueryValue_Should_NotFaultTheRequest(string queryString)
+    [DataRow("", DisplayName = "present but empty -> treated as 'no origin supplied'")]
+    [DataRow(" ", DisplayName = "whitespace -> treated as 'no origin supplied'")]
+    [DataRow("notaurl", DisplayName = "not absolute -> the documented 400, not a 500")]
+    [DataRow("/relative", DisplayName = "relative -> the documented 400, not a 500")]
+    [DataRow(null, DisplayName = "CONTROL: no origin at all -> the endpoint's own validation error")]
+    public async Task AMalformedOriginQueryValue_Should_NotFaultTheRequest(string? origin)
     {
         await using var server = new AppTestServer();
 
@@ -42,14 +44,11 @@ public class WebAppUrlOriginHardeningTests
 
         await using var scope = server.WebApp.Services.CreateAsyncScope();
 
-        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+        var identityController = scope.ServiceProvider.GetRequiredService<IIdentityController>()
+            .WithQueryIf(origin is not null, "origin", origin);
 
-        using var content = JsonContent.Create(new { }, options: scope.ServiceProvider.GetRequiredService<JsonSerializerOptions>());
-
-        // The body is empty on purpose: the endpoint's real answer is a validation failure, so anything other
-        // than a KnownException means the origin value - not the body - decided the outcome.
         var exception = await Assert.ThrowsAsync<Exception>(async ()
-            => await httpClient.PostAsync($"api/v1/Identity/SignIn{queryString}", content, TestContext.CancellationToken));
+            => await identityController.SignIn(new(), TestContext.CancellationToken));
 
         Assert.IsNotInstanceOfType<UnknownException>(exception,
             $"A caller-supplied origin must never turn into a server fault. Got: {exception}");
@@ -60,7 +59,7 @@ public class WebAppUrlOriginHardeningTests
 
     /// <summary>
     /// The other half of the fix: an origin that IS a well-formed absolute URI but is not trusted must still be
-    /// refused, and it must say so. Without this, "never 500" could be satisfied by accepting everything.
+    /// refused, and must say so. Without this, "never faults" could be satisfied by accepting everything.
     /// </summary>
     [TestMethod]
     public async Task AnUntrustedButWellFormedOrigin_Should_StillBeRefusedByName()
@@ -71,12 +70,11 @@ public class WebAppUrlOriginHardeningTests
 
         await using var scope = server.WebApp.Services.CreateAsyncScope();
 
-        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
-
-        using var content = JsonContent.Create(new { }, options: scope.ServiceProvider.GetRequiredService<JsonSerializerOptions>());
+        var identityController = scope.ServiceProvider.GetRequiredService<IIdentityController>()
+            .WithQuery("origin", "https://evil.example");
 
         var exception = await Assert.ThrowsAsync<Exception>(async ()
-            => await httpClient.PostAsync("api/v1/Identity/SignIn?origin=https://evil.example", content, TestContext.CancellationToken));
+            => await identityController.SignIn(new(), TestContext.CancellationToken));
 
         Assert.IsNotInstanceOfType<UnknownException>(exception, $"An untrusted origin is a 400, not a fault. Got: {exception}");
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs
@@ -1,5 +1,3 @@
-using System.Net;
-
 namespace Boilerplate.Tests.Features.Urls;
 
 /// <summary>
@@ -19,42 +17,70 @@ namespace Boilerplate.Tests.Features.Urls;
 /// happened while the controller was being <b>constructed</b> - before model binding, before any action body, and
 /// on <c>[AllowAnonymous]</c> endpoints (established as BP-155).
 /// </para>
-/// <para>
-/// A blank <c>?origin=</c> now correctly means "no origin supplied" rather than "bad origin", so it must succeed
-/// as far as the endpoint's own model validation - which is what the first row asserts.
-/// </para>
 /// </summary>
 [TestClass, TestCategory("IntegrationTest")]
 public class WebAppUrlOriginHardeningTests
 {
     /// <summary>
-    /// Every row is a value an anonymous caller can put on the query string. The endpoint is an anonymous POST
-    /// whose real answer for an empty body is a 400 model-validation failure, so the assertion is that the origin
-    /// value did not turn that 400 into a server fault. The last row is the control: with no origin at all the
-    /// request must already be a 400, which proves the request really reaches the pipeline rather than the
-    /// assertion holding vacuously.
+    /// Every row is a value an anonymous caller can put on the query string. The request goes through the app's
+    /// own <see cref="HttpClient"/> (resolved from a request scope), so <c>ExceptionDelegatingHandler</c> turns
+    /// the response back into the typed exception a real client would see - which is what makes the assertion
+    /// meaningful: a <see cref="KnownException"/> is the endpoint answering, an <see cref="UnknownException"/> is
+    /// a server fault.
     /// </summary>
     [TestMethod]
     [DataRow("?origin=", DisplayName = "present but empty -> treated as 'no origin supplied'")]
     [DataRow("?origin=%20", DisplayName = "whitespace -> treated as 'no origin supplied'")]
     [DataRow("?origin=notaurl", DisplayName = "not absolute -> the documented 400, not a 500")]
-    [DataRow("", DisplayName = "CONTROL: no origin at all -> the endpoint's real 400")]
+    [DataRow("?origin=/relative", DisplayName = "relative -> the documented 400, not a 500")]
+    [DataRow("", DisplayName = "CONTROL: no origin at all -> the endpoint's own validation error")]
     public async Task AMalformedOriginQueryValue_Should_NotFaultTheRequest(string queryString)
     {
         await using var server = new AppTestServer();
 
         await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
 
-        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
 
-        using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
 
-        using var response = await httpClient.PostAsync($"api/v1/Identity/SignIn{queryString}", content, TestContext.CancellationToken);
+        using var content = JsonContent.Create(new { }, options: scope.ServiceProvider.GetRequiredService<JsonSerializerOptions>());
 
-        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+        // The body is empty on purpose: the endpoint's real answer is a validation failure, so anything other
+        // than a KnownException means the origin value - not the body - decided the outcome.
+        var exception = await Assert.ThrowsAsync<Exception>(async ()
+            => await httpClient.PostAsync($"api/v1/Identity/SignIn{queryString}", content, TestContext.CancellationToken));
 
-        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode,
-            $"A caller-supplied origin must produce the documented 400, never a server fault. Body: {body}");
+        Assert.IsNotInstanceOfType<UnknownException>(exception,
+            $"A caller-supplied origin must never turn into a server fault. Got: {exception}");
+
+        Assert.IsInstanceOfType<KnownException>(exception,
+            $"Expected the endpoint's own error. Got: {exception}");
+    }
+
+    /// <summary>
+    /// The other half of the fix: an origin that IS a well-formed absolute URI but is not trusted must still be
+    /// refused, and it must say so. Without this, "never 500" could be satisfied by accepting everything.
+    /// </summary>
+    [TestMethod]
+    public async Task AnUntrustedButWellFormedOrigin_Should_StillBeRefusedByName()
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+
+        using var content = JsonContent.Create(new { }, options: scope.ServiceProvider.GetRequiredService<JsonSerializerOptions>());
+
+        var exception = await Assert.ThrowsAsync<Exception>(async ()
+            => await httpClient.PostAsync("api/v1/Identity/SignIn?origin=https://evil.example", content, TestContext.CancellationToken));
+
+        Assert.IsNotInstanceOfType<UnknownException>(exception, $"An untrusted origin is a 400, not a fault. Got: {exception}");
+
+        Assert.Contains("Invalid origin", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     public TestContext TestContext { get; set; } = default!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Urls/WebAppUrlOriginHardeningTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+
+namespace Boilerplate.Tests.Features.Urls;
+
+/// <summary>
+/// <b>Regression test for BP-162.</b>
+/// <para>
+/// <c>HttpRequestExtensions.GetWebAppUrl()</c> used to do
+/// <c>request.Query["origin"].Union(request.Headers["X-Origin"]).Select(o =&gt; new Uri(o)).FirstOrDefault()</c>,
+/// i.e. it handed raw caller-controlled text to a <b>throwing</b> <see cref="Uri"/> constructor <b>before</b> the
+/// trusted-origin check below it. The method's contract for an origin it does not like is
+/// <c>throw new BadRequestException($"Invalid origin {origin}")</c> - a 400 - and any value that is not an
+/// absolute URI never reached that line, becoming an unhandled <see cref="UriFormatException"/> instead: a 500
+/// plus a <c>LogCritical</c> record.
+/// </para>
+/// <para>
+/// It is anonymous and pre-authorization: <c>IdentityController</c> and <c>UserController</c> inject
+/// <c>IFido2</c>, whose scoped <c>Fido2Configuration</c> factory calls <c>GetWebAppUrl()</c>, so the throw
+/// happened while the controller was being <b>constructed</b> - before model binding, before any action body, and
+/// on <c>[AllowAnonymous]</c> endpoints (established as BP-155).
+/// </para>
+/// <para>
+/// A blank <c>?origin=</c> now correctly means "no origin supplied" rather than "bad origin", so it must succeed
+/// as far as the endpoint's own model validation - which is what the first row asserts.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class WebAppUrlOriginHardeningTests
+{
+    /// <summary>
+    /// Every row is a value an anonymous caller can put on the query string. The endpoint is an anonymous POST
+    /// whose real answer for an empty body is a 400 model-validation failure, so the assertion is that the origin
+    /// value did not turn that 400 into a server fault. The last row is the control: with no origin at all the
+    /// request must already be a 400, which proves the request really reaches the pipeline rather than the
+    /// assertion holding vacuously.
+    /// </summary>
+    [TestMethod]
+    [DataRow("?origin=", DisplayName = "present but empty -> treated as 'no origin supplied'")]
+    [DataRow("?origin=%20", DisplayName = "whitespace -> treated as 'no origin supplied'")]
+    [DataRow("?origin=notaurl", DisplayName = "not absolute -> the documented 400, not a 500")]
+    [DataRow("", DisplayName = "CONTROL: no origin at all -> the endpoint's real 400")]
+    public async Task AMalformedOriginQueryValue_Should_NotFaultTheRequest(string queryString)
+    {
+        await using var server = new AppTestServer();
+
+        await server.Build(services => services.AddIntegrationApiOnlyTestsServices()).Start(TestContext.CancellationToken);
+
+        using var httpClient = new HttpClient { BaseAddress = server.WebAppServerAddress };
+
+        using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        using var response = await httpClient.PostAsync($"api/v1/Identity/SignIn{queryString}", content, TestContext.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode,
+            $"A caller-supplied origin must produce the documented 400, never a server fault. Body: {body}");
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}


### PR DESCRIPTION
closes #12802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Added rate limiting to anonymous identity-related endpoints, returning HTTP 429 after excessive requests.
  * Improved security-header handling and HTTPS/HSTS behavior.
  * Hardened web app origin validation to reject malformed values safely.

* **Bug Fixes**
  * Improved SMTP endpoint and connection-string parsing.
  * Preserved existing OpenAPI authorization parameters.

* **Tests**
  * Added coverage for rate limiting, URL-origin validation, and OpenAPI parameter contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->