### PR TITLE
Add app chat bot tests to bit Boilerplate (#12811)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -609,7 +609,11 @@
                     "exclude": [
                         "src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs",
                         "src/Tests/Features/Mcp/GetCurrentDateTimeMcpIntegrationTests.cs",
-                        "src/Tests/Features/Chatbot/SystemPromptContractTests.cs"
+                        "src/Tests/Features/Chatbot/SystemPromptContractTests.cs",
+                        "src/Tests/Features/Chatbot/AiChatMessageWireContractTests.cs",
+                        "src/Tests/Features/Chatbot/AiChatPanelThemeUITests.cs",
+                        "src/Tests/Features/Chatbot/AppChatbotHistoryTests.cs",
+                        "src/Tests/Features/Chatbot/TestChatClient.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Diagnostic/DiagnosticController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Diagnostic/DiagnosticController.cs
@@ -26,6 +26,8 @@ public partial class DiagnosticController : AppControllerBase, IDiagnosticContro
 
         result.AppendLine($"Client IP: {HttpContext.Connection.RemoteIpAddress}");
 
+        result.AppendLine($"IsFromCDN: {Request.IsFromCDN().ToString().ToLowerInvariant()}");
+
         result.AppendLine($"Trace => {Request.HttpContext.TraceIdentifier}");
 
         // This endpoint must serve anonymous callers: the diagnostic modal is reachable by anonymous visitors

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/UserController.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Features/Identity/UserController.cs
@@ -661,10 +661,20 @@ public partial class UserController : AppControllerBase, IUserController
     /// keeps the old cookie. Built in one place so they cannot drift.
     /// </summary>
     /// <remarks>
-    /// The Domain is the WEB APP's host, not the api's, and that is load bearing rather than incidental: this cookie
-    /// exists so <c>ServerSideAuthTokenProvider</c> can read the access token while PRE-RENDERING, and pre-rendering
-    /// runs on the web app. Under <c>api == Standalone</c> the two are different hosts, so a host-only cookie (no
-    /// Domain) would stay on the api and the web app would pre-render every page as anonymous.
+    /// Why the access token is in a cookie at all: the client keeps it in storage and sends it as a Bearer header, but
+    /// PRE-RENDERING happens before any of that exists, so a cookie the browser attaches on its own is the only way
+    /// <c>ServerSideAuthTokenProvider</c> can tell who the user is on the first response.
+    /// <para>
+    /// That is also why the Domain is the WEB APP's host and not the api's - pre-rendering runs on the web app. Under
+    /// <c>api == Standalone</c> the two are different hosts, and a host-only cookie (no Domain) would stay on the api.
+    /// </para>
+    /// <para>
+    /// The constraint this puts on a deployment: the api host must domain-match the web app host, or the browser
+    /// DISCARDS the cookie (RFC 6265 5.3) and every page silently pre-renders as anonymous. Web <c>myapp.com</c> +
+    /// api <c>api.myapp.com</c> works; web <c>app.myapp.com</c> + api <c>app-api.myapp.com</c> does not, because those
+    /// two are siblings rather than parent and child. The accepted cost is that a cookie carrying a Domain also
+    /// reaches every OTHER subdomain of that host - there is no way to scope a cookie to two named hosts.
+    /// </para>
     /// </remarks>
     private CookieOptions BuildAccessTokenCookieOptions()
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/SignalR/AppChatbot.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Infrastructure/SignalR/AppChatbot.cs
@@ -47,7 +47,9 @@ public partial class AppChatbot
         string? signalRConnectionId,
         CancellationToken cancellationToken)
     {
-        chatMessages = [.. request.ChatMessagesHistory.Select(c => new ChatMessage(c.Role is AiChatMessageRole.Assistant ? ChatRole.Assistant : ChatRole.User, c.Content))];
+        chatMessages = [.. request.ChatMessagesHistory
+            .Where(c => c.Successful && string.IsNullOrWhiteSpace(c.Content) is false)
+            .Select(c => new ChatMessage(c.Role is AiChatMessageRole.Assistant ? ChatRole.Assistant : ChatRole.User, c.Content))];
 
         CultureInfo? culture = null;
         if (request.CultureId is not null && CultureInfoManager.InvariantGlobalization is false)
@@ -86,7 +88,6 @@ public partial class AppChatbot
         CancellationToken cancellationToken)
     {
         StringBuilder assistantResponse = new();
-        var streamCompleted = false;
         try
         {
             if (string.IsNullOrEmpty(variablesDefault))
@@ -129,7 +130,10 @@ public partial class AppChatbot
                 await responseChannel.Writer.WriteAsync(result, cancellationToken);
             }
 
-            streamCompleted = true;
+            if (assistantResponse.Length > 0)
+            {
+                chatMessages.Add(new(ChatRole.Assistant, assistantResponse.ToString()));
+            }
 
             await SendTerminalMarkerToClient(SharedAppMessages.MESSAGE_PROCESS_SUCCESS);
 
@@ -153,16 +157,6 @@ public partial class AppChatbot
         {
             exceptionHandler.Handle(exp, new() { { "SignalRConnectionId", signalRConnectionId } });
             await SendTerminalMarkerToClient(SharedAppMessages.MESSAGE_PROCESS_ERROR);
-        }
-        finally
-        {
-            if (assistantResponse.Length > 0)
-            {
-                // A cancelled or failed stream leaves a half finished answer. It is still kept, because the user has
-                // already seen it on screen and the next turn has to make sense against what is on screen - but it is
-                // marked, so the model does not read a truncated sentence as a complete previous answer of its own.
-                chatMessages.Add(new(ChatRole.Assistant, streamCompleted ? assistantResponse.ToString() : $"{assistantResponse} [interrupted]"));
-            }
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Chatbot/StartChatRequest.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Features/Chatbot/StartChatRequest.cs
@@ -27,7 +27,11 @@ public class AiChatMessage
     public AiChatMessageRole Role { get; set; }
     public string? Content { get; set; }
 
-    [JsonIgnore]
+    /// <summary>
+    /// False for an answer that was cancelled or failed mid-stream. The client keeps such a message on screen
+    /// (tagged as canceled), but the server drops it from the history it sends to the model, so a truncated
+    /// sentence is never replayed as a complete previous answer.
+    /// </summary>
     public bool Successful { get; set; } = true;
 }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AiChatMessageWireContractTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AiChatMessageWireContractTests.cs
@@ -1,0 +1,81 @@
+using Boilerplate.Shared.Features.Chatbot;
+
+namespace Boilerplate.Tests.Features.Chatbot;
+
+/// <summary>
+/// <c>AiChatMessage.Successful</c> is the typed signal for "this answer was cancelled or failed". The client sets it
+/// and renders it as the "Canceled" tag, and the server drops those turns from the history it resends to the model
+/// (See <see cref="AppChatbotHistoryTests"/>) - but only if the flag actually crosses the wire. It carried a
+/// <c>[JsonIgnore]</c> for exactly as long as the flag was a client-only concern, and putting it back would not break
+/// a single compile: the server would simply start treating every resent turn as successful again and replay
+/// truncated answers to the model after every reconnect.
+/// <para>
+/// Both shapes are asserted because the two ends of this hub method do not share one: the server's payload
+/// serializer is configured with <c>ApplyDefaultOptions</c> (See <c>AddJsonProtocol</c> in <c>Program.Services</c>)
+/// while the client feeds its <c>AppJsonContext</c> resolver chain into its own.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class AiChatMessageWireContractTests
+{
+    private static JsonSerializerOptions HubPayloadOptions
+    {
+        get
+        {
+            var options = new JsonSerializerOptions();
+            options.ApplyDefaultOptions();
+            return options;
+        }
+    }
+
+    [TestMethod]
+    public void AnUnsuccessfulTurn_Should_ReachTheServerAsUnsuccessful()
+    {
+        var request = new StartChatRequest
+        {
+            ChatMessagesHistory =
+            [
+                new() { Role = AiChatMessageRole.User, Content = "what is bit platform?" },
+                new() { Role = AiChatMessageRole.Assistant, Content = "bit platform is", Successful = false }
+            ]
+        };
+
+        foreach (var (name, json) in new[]
+        {
+            ("Hub payload options", JsonSerializer.Serialize(request, HubPayloadOptions)),
+            (nameof(AppJsonContext), JsonSerializer.Serialize(request, AppJsonContext.Default.StartChatRequest))
+        })
+        {
+            Assert.Contains("successful", json, StringComparison.OrdinalIgnoreCase,
+                $"{name} does not put AiChatMessage.Successful on the wire, so the server cannot tell a canceled answer from a real one and will replay truncated answers to the model. Payload: {json}");
+
+            var received = JsonSerializer.Deserialize<StartChatRequest>(json, HubPayloadOptions)!;
+
+            Assert.IsFalse(received.ChatMessagesHistory[1].Successful,
+                $"{name} lost the flag on the way back in. Payload: {json}");
+        }
+    }
+
+    /// <summary>
+    /// The property defaults to <c>true</c>, and that default is load bearing in the other direction: a payload that
+    /// omits it - an older client, or any other caller of this hub method - must have its history kept, not silently
+    /// discarded as one long string of canceled answers.
+    /// </summary>
+    [TestMethod]
+    public void ATurnThatOmitsTheFlag_Should_BeTreatedAsSuccessful()
+    {
+        const string json = /*lang=json,strict*/ """
+        {
+            "chatMessagesHistory": [
+                { "role": 0, "content": "what is bit platform?" },
+                { "role": 1, "content": "bit platform is a set of tools." }
+            ]
+        }
+        """;
+
+        var received = JsonSerializer.Deserialize<StartChatRequest>(json, HubPayloadOptions)!;
+
+        Assert.IsTrue(received.ChatMessagesHistory.All(message => message.Successful),
+            "A turn that does not carry the flag must be treated as a completed one, otherwise a client that does not send it loses its whole conversation on reconnect.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AiChatPanelThemeUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AiChatPanelThemeUITests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Extensions.AI;
+
+namespace Boilerplate.Tests.Features.Chatbot;
+
+/// <summary>
+/// The chatbot's whole point is that it can act on the app, not just talk about it - and the path from "the model
+/// decided to call a tool" to "the user's screen changed" runs through six components that no other test crosses at
+/// once. This one drives it end to end in a real browser:
+/// <list type="number">
+/// <item>The user opens the chat panel on the public home page and sends a message (real <c>AppAiChatPanel</c>, real <c>hubConnection.StreamAsync</c>).</item>
+/// <item><c>AppHub.StartChat</c> receives it and hands it to the real scoped <c>AppChatbot</c>, which resolves the real keyed SupportAgent with its real seeded system prompt and its real tool set.</item>
+/// <item>The model - and ONLY the model - is scripted: it answers with a <c>FunctionCallContent</c> for <c>SetApplicationTheme</c>, exactly as a real one would.</item>
+/// <item><c>FunctionInvokingChatClient</c> dispatches that to the real <c>AppChatbot.SetApplicationTheme</c>, which validates the argument and calls back through <c>IHubContext.Clients.Client(connectionId).InvokeAsync&lt;bool&gt;</c>.</item>
+/// <item><c>AppClientCoordinator</c>'s <c>CHANGE_THEME</c> handler runs <c>ThemeService.ToggleTheme</c> in the browser, which is observable as the <c>bit-theme</c> attribute on <c>&lt;html&gt;</c> (See <see cref="Theme.ThemeTogglePersistenceUITests"/>).</item>
+/// <item>The tool's return value goes back into the conversation, the scripted model turns it into prose, and that prose is streamed to the panel and rendered.</item>
+/// </list>
+/// <para>
+/// Scripting the model is what makes this a test rather than a demo: a real model may or may not decide to call the
+/// tool, may call it with "Dark" or "light mode", and costs money per run. Everything the template actually owns -
+/// the tool, the hub round trip, the client handler, the streaming - is real.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UITest"), Retry(2)]
+public partial class AiChatPanelThemeUITests : AppPageTest
+{
+    /// <summary>
+    /// The name <c>AIFunctionFactory.Create(SetApplicationTheme)</c> registers the tool under (See
+    /// <c>AppChatbot.GetAIFunctions</c>). It cannot be a <c>nameof</c> from here because the method is private; if it
+    /// is ever renamed, the scripted call finds no matching tool, no theme change happens, and this test fails.
+    /// </summary>
+    private const string SetApplicationThemeTool = "SetApplicationTheme";
+
+    [TestMethod]
+    public async Task Chatbot_Should_ChangeTheAppTheme_WhenTheModelCallsTheTool()
+    {
+        var chatClient = new TestChatClient();
+
+        await using var server = new AppTestServer(Context);
+
+        await server.Build(services =>
+        {
+            // The one and only fake in this test. See TestChatClient for why this seam - and not one of the
+            // template's own interfaces - is the right place to cut.
+            services.Replace(ServiceDescriptor.Singleton<IChatClient>(chatClient));
+        },
+        configuration =>
+        {
+            // Without a chat api key the AI agents are never registered and the panel would have nothing to talk to.
+            configuration["AI:OpenAI:ChatApiKey"] = "fake-key-never-used-by-these-tests";
+        }).Start(TestContext.CancellationToken);
+
+        await Page.GotoAsync(new Uri(server.WebAppServerAddress, PageUrls.Home).ToString(),
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        var htmlElement = Page.Locator("html");
+
+        // Read the starting theme instead of assuming one, then ask for the opposite - so the test proves a CHANGE
+        // rather than passing because the app already happened to be in the requested theme.
+        var initialTheme = await htmlElement.GetAttributeAsync("bit-theme");
+        Assert.IsFalse(string.IsNullOrEmpty(initialTheme), "The <html> element should carry a bit-theme attribute.");
+        var requestedTheme = initialTheme == "dark" ? "light" : "dark";
+
+        const string finalAnswer = "Done, I have switched the theme for you.";
+
+        chatClient.StreamingUpdates = (_, conversation) =>
+        {
+            // Second time round the tool has already run and its result is in the conversation, so the scripted
+            // model does what a real one does at that point: it stops calling tools and answers the user.
+            if (conversation.SelectMany(message => message.Contents).OfType<FunctionResultContent>().Any())
+                return [new ChatResponseUpdate(ChatRole.Assistant, finalAnswer)];
+
+            return
+            [
+                new ChatResponseUpdate(ChatRole.Assistant, (IList<AIContent>)
+                [
+                    new FunctionCallContent(callId: "theme-call-1", name: SetApplicationThemeTool,
+                        arguments: new Dictionary<string, object?> { ["theme"] = requestedTheme })
+                ])
+                {
+                    FinishReason = ChatFinishReason.ToolCalls
+                }
+            ];
+        };
+
+        var panel = await OpenChatPanel();
+
+        await SendChatMessage(panel, "please switch the app theme", chatClient);
+
+        // The payoff: the browser's own theme attribute, changed by nothing but the chatbot.
+        await Expect(htmlElement).ToHaveAttributeAsync("bit-theme", requestedTheme,
+            new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+
+        // The answer written after the tool ran reaches the panel, which proves the second half of the round trip -
+        // the tool result went back to the model and its prose was streamed to the user.
+        await Expect(panel.GetByText(finalAnswer))
+            .ToBeVisibleAsync(new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+
+        // The tool really executed on the server rather than the theme changing by some other route: its return
+        // value was fed back into the conversation. SetApplicationTheme returns "Theme changed to X successfully"
+        // only when the client reported an actual change.
+        // Every conversation is searched rather than the last one, because the hub also asks for follow-up
+        // suggestions (a separate agent, a separate conversation) and which of the two lands last is a race.
+        var toolResults = chatClient.ReceivedConversations
+            .SelectMany(conversation => conversation)
+            .SelectMany(message => message.Contents)
+            .OfType<FunctionResultContent>()
+            .Select(result => result.Result?.ToString())
+            .ToArray();
+
+        Assert.Contains(result => result?.Contains($"changed to {requestedTheme}", StringComparison.OrdinalIgnoreCase) is true, toolResults,
+            $"The SetApplicationTheme tool did not report a successful change back to the model. Results: [{string.Join(", ", toolResults)}].");
+    }
+
+    /// <summary>
+    /// Opens the floating chat button and waits for the panel, including its locally rendered greeting - which is
+    /// the signal that the panel is fully interactive rather than merely present in the DOM.
+    /// </summary>
+    private async Task<ILocator> OpenChatPanel()
+    {
+        await Page.Locator(".open-panel-button").ClickAsync();
+
+        var panel = Page.Locator(".panel-cnt");
+        await Expect(panel).ToBeVisibleAsync();
+        await Expect(panel.Locator("textarea")).ToBeVisibleAsync();
+
+        return panel;
+    }
+
+    /// <summary>
+    /// Types a message, sends it, and waits until the server really received it.
+    /// <para>
+    /// The wait is not decoration. SignalR traffic is invisible to Playwright's network waits and an anonymous
+    /// connection leaves no server-side row to poll (See <c>AppHub.ChangeAuthenticationStateImplementation</c>: a new
+    /// anonymous connection is deliberately not recorded), so the only observable proof that the message arrived is
+    /// the chatbot calling the model. And if the hub connection was not up yet, <c>AppAiChatPanel.StartChannel</c>
+    /// assigns its channel BEFORE <c>StreamAsync</c> throws, which leaves the panel with a channel that is never
+    /// read from - a plain resend would go nowhere. Clearing the chat is the shipped recovery for that
+    /// (<c>ClearChat</c> -> <c>RestartChannel</c>), so that is what the retry does.
+    /// </para>
+    /// </summary>
+    private async Task SendChatMessage(ILocator panel, string message, TestChatClient chatClient)
+    {
+        var conversationsBefore = chatClient.ReceivedConversations.Count;
+
+        for (var attempt = 1; attempt <= 2; attempt++)
+        {
+            if (attempt > 1)
+            {
+                await panel.GetByTitle(AppStrings.Clear).ClickAsync();
+            }
+
+            await panel.Locator("textarea").FillAsync(message);
+            await panel.Locator(".send-message-button").ClickAsync();
+
+            if (await WaitForServerToReceiveAMessage(chatClient, conversationsBefore, TimeSpan.FromSeconds(15)))
+                return;
+        }
+
+        Assert.Fail("The chat message never reached the server, so the hub connection was not established. " +
+                    "Nothing after this point can be meaningful.");
+    }
+
+    private async Task<bool> WaitForServerToReceiveAMessage(TestChatClient chatClient, int conversationsBefore, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (chatClient.ReceivedConversations.Count > conversationsBefore)
+                return true;
+
+            await Task.Delay(TimeSpan.FromMilliseconds(250), TestContext.CancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AppChatbotHistoryTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AppChatbotHistoryTests.cs
@@ -1,0 +1,284 @@
+using Microsoft.Extensions.AI;
+using System.Threading.Channels;
+using Boilerplate.Shared.Features.Chatbot;
+using Boilerplate.Server.Api.Infrastructure.SignalR;
+
+namespace Boilerplate.Tests.Features.Chatbot;
+
+/// <summary>
+/// The chat history <c>AppChatbot</c> keeps is a private <c>List&lt;ChatMessage&gt;</c> that nothing reads back: the
+/// only place its contents become observable is the message list handed to the model on the next turn. That is why
+/// these tests drive the real service against a scripted <see cref="TestChatClient"/> instead of asserting on state -
+/// what the model is shown IS the behaviour, and a wrong history is invisible in every other way until the assistant
+/// starts answering the wrong question.
+/// <para>
+/// Everything here is real except the model: the seeded system prompt is read from the database, the SupportAgent is
+/// resolved from DI with its real tools, and the answer travels through the real response channel.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public partial class AppChatbotHistoryTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// An answer that is cancelled half way is left on the user's screen, tagged as canceled - but it must not become
+    /// part of the conversation the model is shown, or the model reads a truncated sentence as a complete previous
+    /// answer of its own and continues from a thought it never finished. An earlier fix marked such a turn with an
+    /// <c>[interrupted]</c> suffix instead of dropping it, which put a marker string into the prompt and made the
+    /// model's view of the conversation differ from the client's.
+    /// </summary>
+    [TestMethod]
+    public async Task AnInterruptedAnswer_Should_NotBeReplayedToTheModel()
+    {
+        var chatClient = new TestChatClient
+        {
+            StreamingChunks = _ => ["bit platform is", " a set of tools"],
+            PauseAfterFirstChunk = new TaskCompletionSource()
+        };
+
+        await using var server = BuildServerWith(chatClient);
+        await server.Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpContext = SetCurrentHttpContext(scope.ServiceProvider, server.WebAppServerAddress);
+
+        var chatbot = scope.ServiceProvider.GetRequiredService<AppChatbot>();
+        await chatbot.StartChat(new StartChatRequest(), signalRConnectionId: "test-connection-id", TestContext.CancellationToken);
+
+        var responses = chatbot.GetStreamingChannel();
+
+        using var firstMessageCts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        var firstMessage = chatbot.ProcessNewMessage(generateFollowUpSuggestions: false, "what is bit platform?", httpContext.User, firstMessageCts.Token);
+
+        // Reading the first chunk back is what makes the interruption deterministic: the answer is provably half
+        // delivered - the user has seen this text - at the moment the message is cancelled.
+        Assert.AreEqual("bit platform is", await ReadNextResponse(responses, "the first streamed chunk of the answer"),
+            "The chatbot did not stream the model's first chunk through to the client.");
+
+        await firstMessageCts.CancelAsync();
+
+        // Interrupting a message is an ordinary, one-keystroke user action, not a fault.
+        await firstMessage;
+
+        // The terminal marker has to be sent with CancellationToken.None: on an unbounded channel WriteAsync
+        // short-circuits on an already-cancelled token without enqueuing anything, and the client advances its
+        // response counter only when a marker arrives - one missed marker silently discards every later answer.
+        Assert.AreEqual(SharedAppMessages.MESSAGE_PROCESS_ERROR, await ReadNextResponse(responses, "the terminal marker of the interrupted message"),
+            "An interrupted message must still emit its terminal marker, and it must be the error one - that is what the client renders as the 'Canceled' tag.");
+
+        // The next message is what exposes the history.
+        chatClient.PauseAfterFirstChunk = null;
+        chatClient.StreamingChunks = _ => ["Bit.BlazorUI is a component library."];
+
+        await chatbot.ProcessNewMessage(generateFollowUpSuggestions: false, "and what is Bit.BlazorUI?", httpContext.User, TestContext.CancellationToken);
+
+        var secondConversation = chatClient.ReceivedConversations[1];
+
+        Assert.IsFalse(secondConversation.Any(message => message.Role == ChatRole.Assistant),
+            $"The interrupted answer was replayed to the model as a finished assistant turn. Conversation: {Describe(secondConversation)}");
+
+        Assert.IsFalse(secondConversation.Any(message => message.Text?.Contains("interrupted", StringComparison.OrdinalIgnoreCase) is true),
+            $"A truncated turn was kept and tagged with a marker string. AiChatMessage.Successful already carries that signal typed, and the client already renders it. Conversation: {Describe(secondConversation)}");
+
+        Assert.IsTrue(secondConversation.Any(message => message.Role == ChatRole.User && message.Text == "what is bit platform?"),
+            $"The interrupted USER turn must survive - the user asked it and never got an answer, so the model still owes one. Conversation: {Describe(secondConversation)}");
+    }
+
+    /// <summary>
+    /// The other half of the same contract, so "drop the interrupted turn" can never be simplified into "drop the
+    /// assistant turn": a completed answer must reach the next turn whole, reassembled from every streamed chunk.
+    /// </summary>
+    [TestMethod]
+    public async Task ACompletedAnswer_Should_BeReplayedToTheModelInFull()
+    {
+        var chatClient = new TestChatClient { StreamingChunks = _ => ["bit platform ", "is a set ", "of tools."] };
+
+        await using var server = BuildServerWith(chatClient);
+        await server.Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpContext = SetCurrentHttpContext(scope.ServiceProvider, server.WebAppServerAddress);
+
+        var chatbot = scope.ServiceProvider.GetRequiredService<AppChatbot>();
+        await chatbot.StartChat(new StartChatRequest(), signalRConnectionId: "test-connection-id", TestContext.CancellationToken);
+
+        var responses = chatbot.GetStreamingChannel();
+
+        await chatbot.ProcessNewMessage(generateFollowUpSuggestions: false, "what is bit platform?", httpContext.User, TestContext.CancellationToken);
+
+        // Three chunks, then the success marker - the client needs that marker to stop its loader and to keep its
+        // response counter in step with the number of user turns.
+        Assert.AreEqual("bit platform ", await ReadNextResponse(responses, "the first streamed chunk"));
+        Assert.AreEqual("is a set ", await ReadNextResponse(responses, "the second streamed chunk"));
+        Assert.AreEqual("of tools.", await ReadNextResponse(responses, "the third streamed chunk"));
+        Assert.AreEqual(SharedAppMessages.MESSAGE_PROCESS_SUCCESS, await ReadNextResponse(responses, "the terminal marker of the completed message"));
+
+        await chatbot.ProcessNewMessage(generateFollowUpSuggestions: false, "and what is Bit.BlazorUI?", httpContext.User, TestContext.CancellationToken);
+
+        var secondConversation = chatClient.ReceivedConversations[1];
+
+        var assistantTurns = secondConversation.Where(message => message.Role == ChatRole.Assistant).ToArray();
+
+        Assert.HasCount(1, assistantTurns,
+            $"The completed answer must appear exactly once in the next turn's conversation. Conversation: {Describe(secondConversation)}");
+
+        Assert.AreEqual("bit platform is a set of tools.", assistantTurns[0].Text,
+            "The answer the model is shown must be every streamed chunk reassembled, with nothing added and nothing lost.");
+    }
+
+    /// <summary>
+    /// The server keeps the history in memory for the lifetime of one SignalR connection, so on a reconnect (or when
+    /// the panel is reopened) the client resends everything it has on screen - including the answers it tagged as
+    /// canceled. <c>StartChat</c> therefore has to drop exactly what <c>ProcessNewMessage</c> drops, or the model sees
+    /// one conversation before a reconnect and a different one after it.
+    /// <para>
+    /// This works only because <c>AiChatMessage.Successful</c> reaches the server at all: it used to be
+    /// <c>[JsonIgnore]</c>d, which made the flag a client-only affair (See <c>AiChatMessageWireContractTests</c>).
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task AResentHistory_Should_DropTheTurnsTheClientMarkedUnsuccessful()
+    {
+        var chatClient = new TestChatClient();
+
+        await using var server = BuildServerWith(chatClient);
+        await server.Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpContext = SetCurrentHttpContext(scope.ServiceProvider, server.WebAppServerAddress);
+
+        var chatbot = scope.ServiceProvider.GetRequiredService<AppChatbot>();
+
+        // Exactly what AppAiChatPanel holds after one answered question and one interrupted one: the greeting it
+        // renders locally, the two user turns, the truncated answer it tagged as canceled, and the empty assistant
+        // placeholder it creates for every in-flight answer.
+        await chatbot.StartChat(new StartChatRequest
+        {
+            ChatMessagesHistory =
+            [
+                new() { Role = AiChatMessageRole.Assistant, Content = "Hi, how can I help?" },
+                new() { Role = AiChatMessageRole.User, Content = "what is bit platform?" },
+                new() { Role = AiChatMessageRole.Assistant, Content = "bit platform is" , Successful = false },
+                new() { Role = AiChatMessageRole.User, Content = "and what is Bit.BlazorUI?" },
+                new() { Role = AiChatMessageRole.Assistant, Content = null }
+            ]
+        }, signalRConnectionId: "test-connection-id", TestContext.CancellationToken);
+
+        await chatbot.ProcessNewMessage(generateFollowUpSuggestions: false, "are they free?", httpContext.User, TestContext.CancellationToken);
+
+        var conversation = chatClient.ReceivedConversations[0];
+
+        Assert.IsFalse(conversation.Any(message => message.Text?.Contains("bit platform is", StringComparison.Ordinal) is true),
+            $"The canceled answer the client resent was replayed to the model. Conversation: {Describe(conversation)}");
+
+        Assert.IsFalse(conversation.Any(message => string.IsNullOrWhiteSpace(message.Text)),
+            $"The panel's empty placeholder for the in-flight answer was replayed to the model as a blank assistant turn. Conversation: {Describe(conversation)}");
+
+        // The greeting, the two earlier questions and the new one - plus the '### Variables:' system message.
+        Assert.HasCount(5, conversation, $"Conversation: {Describe(conversation)}");
+
+        Assert.AreEqual("are they free?", conversation[^1].Text, "The new user message must be the last thing the model reads.");
+    }
+
+    /// <summary>
+    /// The whole conversation is resent to the provider on every single message, so an unbounded history grows the
+    /// prompt - and the bill - until the provider rejects it for exceeding the context window. The cap has to bite
+    /// before the conversation is materialized, not after.
+    /// </summary>
+    [TestMethod]
+    public async Task AnOverlongConversation_Should_BeTrimmedBeforeItReachesTheModel()
+    {
+        const int maxChatMessages = 40; // Keep in step with AppChatbot.TrimChatHistory.
+
+        var chatClient = new TestChatClient();
+
+        await using var server = BuildServerWith(chatClient);
+        await server.Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var httpContext = SetCurrentHttpContext(scope.ServiceProvider, server.WebAppServerAddress);
+
+        var chatbot = scope.ServiceProvider.GetRequiredService<AppChatbot>();
+
+        await chatbot.StartChat(new StartChatRequest
+        {
+            ChatMessagesHistory = [.. Enumerable.Range(0, maxChatMessages * 2).Select(index => new AiChatMessage
+            {
+                Content = $"message {index}",
+                Role = index % 2 == 0 ? AiChatMessageRole.User : AiChatMessageRole.Assistant
+            })]
+        }, signalRConnectionId: "test-connection-id", TestContext.CancellationToken);
+
+        await chatbot.ProcessNewMessage(generateFollowUpSuggestions: false, "the newest question", httpContext.User, TestContext.CancellationToken);
+
+        var conversation = chatClient.ReceivedConversations[0];
+
+        // The '### Variables:' system message is prepended to the trimmed history rather than counted against it.
+        Assert.HasCount(maxChatMessages + 1, conversation,
+            "An 80 message history plus the new question must reach the model trimmed to the newest 40 turns (plus the Variables system message).");
+
+        Assert.AreEqual("the newest question", conversation[^1].Text, "Trimming must drop the OLDEST turns, never the newest.");
+
+        Assert.IsFalse(conversation.Any(message => message.Text == "message 0"),
+            $"The oldest turn survived a trim that was supposed to remove it. Conversation: {Describe(conversation)}");
+    }
+
+    /// <summary>
+    /// Builds the real server with the model - and only the model - replaced.
+    /// </summary>
+    private static AppTestServer BuildServerWith(TestChatClient chatClient)
+    {
+        return new AppTestServer().Build(services =>
+        {
+            services.AddIntegrationApiOnlyTestsServices();
+
+            // Every agent is built on the DI IChatClient (See AddAppAIAgents), so this single replacement removes the
+            // network, the api key and the non-determinism while leaving the agent itself untouched.
+            services.Replace(ServiceDescriptor.Singleton<IChatClient>(chatClient));
+        },
+        configuration =>
+        {
+            // Without a chat api key neither AddChatClient nor AddAppAIAgents runs, and the keyed "SupportAgent"
+            // would not exist at all. The value itself is never used: the client it builds is replaced above.
+            configuration["AI:OpenAI:ChatApiKey"] = "fake-key-never-used-by-these-tests";
+        });
+    }
+
+    /// <summary>
+    /// <c>AppChatbot</c> reads <c>IHttpContextAccessor</c> for the <c>{{WebAppUrl}}</c> variable, and - under
+    /// multitenancy - <c>TenantProvider</c> reads it again while the seeded system prompt is resolved.
+    /// <c>AppHub.StartChat</c> performs this same assignment for the same reason, because Azure SignalR never
+    /// populates the accessor itself.
+    /// </summary>
+    private static HttpContext SetCurrentHttpContext(IServiceProvider scopedServices, Uri serverAddress)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = scopedServices };
+        httpContext.Request.Scheme = serverAddress.Scheme;
+        httpContext.Request.Host = new HostString(serverAddress.Authority);
+
+        scopedServices.GetRequiredService<IHttpContextAccessor>().HttpContext = httpContext;
+
+        return httpContext;
+    }
+
+    private async Task<string> ReadNextResponse(ChannelReader<string> responses, string expected)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            return await responses.ReadAsync(timeout.Token);
+        }
+        catch (OperationCanceledException) when (TestContext.CancellationToken.IsCancellationRequested is false)
+        {
+            throw new AssertFailedException($"Nothing arrived on the chatbot's response channel within 30 seconds while waiting for {expected}.");
+        }
+    }
+
+    private static string Describe(IEnumerable<ChatMessage> conversation)
+    {
+        return string.Join(" | ", conversation.Select(message => $"{message.Role}: '{message.Text}'"));
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/TestChatClient.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/TestChatClient.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.AI;
+using System.Runtime.CompilerServices;
+
+namespace Boilerplate.Tests.Features.Chatbot;
+
+/// <summary>
+/// A scripted <see cref="IChatClient"/> that stands in for the language model.
+/// <para>
+/// This is not a mock of one of the template's own interfaces: <see cref="IChatClient"/> is the
+/// <c>Microsoft.Extensions.AI</c> abstraction every agent is built on (See <c>AddAppAIAgents</c>), so replacing the
+/// registration is the one seam that removes the model - and only the model. <c>AsAIAgent</c> still wraps whatever
+/// client it is given in a <c>FunctionInvokingChatClient</c>, so the agent under test keeps its real seeded system
+/// prompt, its real tool set and its real streaming pipeline.
+/// </para>
+/// <para>
+/// Two things make the tests deterministic. <see cref="ReceivedConversations"/> records the exact message list handed
+/// to the model on every call - which is the only place the chatbot's private history is observable - and
+/// <see cref="PauseAfterFirstChunk"/> stops a stream half way, so a test can interrupt a message at a known point
+/// rather than racing the wall clock.
+/// </para>
+/// </summary>
+public sealed class TestChatClient : IChatClient
+{
+    private int streamingCallCount;
+    private readonly List<ChatMessage[]> receivedConversations = [];
+
+    /// <summary>
+    /// Every conversation the chatbot has sent to the model so far, oldest first. Each entry is the complete message
+    /// list of one call, starting with the <c>### Variables:</c> system message the chatbot prepends.
+    /// </summary>
+    public IReadOnlyList<ChatMessage[]> ReceivedConversations
+    {
+        get { lock (receivedConversations) return [.. receivedConversations]; }
+    }
+
+    /// <summary>
+    /// The chunks the streamed answer is delivered in, per streaming call (0 is the first one). Splitting an answer
+    /// across several chunks is what lets a test assert the chatbot reassembles it.
+    /// </summary>
+    public Func<int, string[]> StreamingChunks { get; set; } = _ => ["Hi, how can I help?"];
+
+    /// <summary>
+    /// Takes over from <see cref="StreamingChunks"/> when a test needs to emit something other than text - in
+    /// practice a <c>FunctionCallContent</c>, which is how a model asks for a tool.
+    /// <para>
+    /// Emitting one is not a shortcut around the tool: <c>AsAIAgent</c> puts a <c>FunctionInvokingChatClient</c> in
+    /// front of this client, so the call is really dispatched to the real <c>AppChatbot</c> method with the real
+    /// arguments, its result is appended to the conversation, and this client is called a second time to produce the
+    /// answer the user finally reads.
+    /// </para>
+    /// <para>
+    /// It is handed the conversation as well as the call index, so a script can branch on what it is looking at -
+    /// "the tool result is already here, so answer" - rather than on a counter, which is both closer to how a model
+    /// behaves and immune to a retried message shifting the counter.
+    /// </para>
+    /// </summary>
+    public Func<int, ChatMessage[], ChatResponseUpdate[]>? StreamingUpdates { get; set; }
+
+    /// <summary>
+    /// When set, the stream stops after its first chunk and waits here. Tests never complete this task - they cancel
+    /// the message's own <see cref="CancellationToken"/> instead, which is exactly what the hub does when a new user
+    /// message arrives while the previous one is still streaming.
+    /// </summary>
+    public TaskCompletionSource? PauseAfterFirstChunk { get; set; }
+
+    /// <summary>
+    /// The answer to a non-streamed call. The follow-up suggestions agent asks for a strict json object, so the
+    /// default is a valid (empty) <c>AiChatFollowUpList</c>.
+    /// </summary>
+    public string NonStreamingResponse { get; set; } = /*lang=json,strict*/ """{"FollowUpSuggestions":[]}""";
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var conversation = Capture(messages);
+
+        var callIndex = Interlocked.Increment(ref streamingCallCount) - 1;
+
+        var updates = StreamingUpdates?.Invoke(callIndex, conversation)
+                      ?? [.. StreamingChunks(callIndex).Select(chunk => new ChatResponseUpdate(ChatRole.Assistant, chunk))];
+
+        var isFirstChunk = true;
+
+        foreach (var update in updates)
+        {
+            if (isFirstChunk is false && PauseAfterFirstChunk is not null)
+            {
+                // Throws OperationCanceledException the moment the test cancels the message, mid-answer.
+                await PauseAfterFirstChunk.Task.WaitAsync(cancellationToken);
+            }
+
+            isFirstChunk = false;
+
+            yield return update;
+        }
+    }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Capture(messages);
+
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, NonStreamingResponse)));
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        return serviceKey is null && serviceType.IsInstanceOfType(this) ? this : null;
+    }
+
+    public void Dispose() { }
+
+    private ChatMessage[] Capture(IEnumerable<ChatMessage> messages)
+    {
+        // Materialized immediately: the chatbot hands over a spread of its own mutable list, so holding the
+        // enumerable would let a later turn rewrite what an earlier call is supposed to have seen.
+        ChatMessage[] conversation = [.. messages];
+
+        lock (receivedConversations)
+        {
+            receivedConversations.Add(conversation);
+        }
+
+        return conversation;
+    }
+}


### PR DESCRIPTION
closes #12811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Diagnostic responses now indicate whether a request originated from a CDN.
  - Chatbot theme-change interactions are supported and verified through the application interface.

- **Bug Fixes**
  - Interrupted, failed, or empty chatbot responses are no longer replayed as completed messages.
  - Chat history now preserves successful responses and limits overly long conversations for more reliable interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->