### PR TITLE
Fix persist cookie feature of theme in BlazorUI demo website (#12826)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Utils/Theme/BitThemeSsr.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Utils/Theme/BitThemeSsr.cs
@@ -116,8 +116,11 @@ public static class BitThemeSsr
     }
 
     /// <summary>
-    /// The single resolution both public overloads format: an ordered list so the string form keeps
-    /// emitting <c>bit-theme-system bit-theme-default="…"</c> in that order.
+    /// The single resolution both public overloads format. A list rather than a map because the
+    /// string overload joins these in order and is pinned to emit
+    /// <c>bit-theme-system bit-theme-default="…"</c> that way round. The map overload carries the
+    /// order no further than <see cref="Dictionary{TKey, TValue}"/> happens to, which is fine:
+    /// splatting is order-insensitive.
     /// </summary>
     private static List<KeyValuePair<string, object>> BuildRootThemeAttributePairs(string? persistedPreference, string? defaultTheme)
     {

--- a/src/BlazorUI/Bit.BlazorUI/Utils/Theme/BitThemeSsr.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Utils/Theme/BitThemeSsr.cs
@@ -81,6 +81,46 @@ public static class BitThemeSsr
     /// </remarks>
     public static string BuildRootThemeAttributes(string? persistedPreference, string? defaultTheme = null)
     {
+        return string.Join(' ', BuildRootThemeAttributePairs(persistedPreference, defaultTheme).Select(pair =>
+            // A bool marker carries no value (bit-theme-system), a token is emitted as name="value".
+            pair.Value is bool ? pair.Key : $"{pair.Key}=\"{pair.Value}\""));
+    }
+
+    /// <summary>
+    /// <see cref="BuildRootThemeAttributes(string?, string?)"/> as an attribute map, for splatting
+    /// onto the root element of a Razor host page: <c>&lt;html lang="en" @attributes="…"&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// The string overload can only be interpolated into raw markup, which a <c>.razor</c> host
+    /// (<c>App.razor</c> in a Blazor Web App) cannot do for a tag it also has to close - emitting the
+    /// opening <c>&lt;html&gt;</c> as a <c>MarkupString</c> leaves the literal <c>&lt;/html&gt;</c>
+    /// unbalanced and fails to compile. Both overloads are built from the same resolution, so they
+    /// cannot drift apart.
+    /// <para>
+    /// Marker attributes carry <see langword="true"/> rather than a string, which is how Blazor
+    /// renders a valueless attribute; theme names are already normalized and validated (see the
+    /// remarks on <see cref="BuildRootThemeAttributes(string?, string?)"/>).
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyDictionary<string, object> BuildRootThemeAttributeMap(string? persistedPreference, string? defaultTheme = null)
+    {
+        var pairs = BuildRootThemeAttributePairs(persistedPreference, defaultTheme);
+
+        var map = new Dictionary<string, object>(pairs.Count, StringComparer.Ordinal);
+        foreach (var (key, value) in pairs)
+        {
+            map[key] = value;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// The single resolution both public overloads format: an ordered list so the string form keeps
+    /// emitting <c>bit-theme-system bit-theme-default="…"</c> in that order.
+    /// </summary>
+    private static List<KeyValuePair<string, object>> BuildRootThemeAttributePairs(string? persistedPreference, string? defaultTheme)
+    {
         var preference = NormalizeThemeToken(persistedPreference);
         var fallback = NormalizeThemeToken(defaultTheme);
 
@@ -89,23 +129,23 @@ public static class BitThemeSsr
         if (preference == BitThemePresets.System)
         {
             return fallback is null || fallback == BitThemePresets.System
-                ? BitThemeAttributeNames.ThemeSystem
-                : $"{BitThemeAttributeNames.ThemeSystem} {BitThemeAttributeNames.ThemeDefault}=\"{fallback}\"";
+                ? [new(BitThemeAttributeNames.ThemeSystem, true)]
+                : [new(BitThemeAttributeNames.ThemeSystem, true), new(BitThemeAttributeNames.ThemeDefault, fallback)];
         }
 
         // Concrete persisted preference → paint it directly (no flash).
         if (preference is not null)
         {
-            return $"{BitThemeAttributeNames.Theme}=\"{preference}\"";
+            return [new(BitThemeAttributeNames.Theme, preference)];
         }
 
         // No stored preference: use the configured default theme, or follow the OS if none.
         if (fallback is not null && fallback != BitThemePresets.System)
         {
-            return $"{BitThemeAttributeNames.Theme}=\"{fallback}\"";
+            return [new(BitThemeAttributeNames.Theme, fallback)];
         }
 
-        return BitThemeAttributeNames.ThemeSystem;
+        return [new(BitThemeAttributeNames.ThemeSystem, true)];
     }
 
     /// <summary>

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
@@ -36,16 +36,21 @@
     // stored (or the visitor follows the OS), which the inline head script below resolves. Tampered
     // values are rejected and treated as "nothing stored".
     var rootThemeAttributes = BitThemeSsr.BuildRootThemeAttributeMap(themePreference);
-    // Browser chrome color: matched to the theme when we know it, otherwise left at the dark default
-    // that app.ts corrects on boot (only a system-following visitor reaches that case). "Ends with
-    // dark" is the same rule app.ts and the app's own stylesheets use, so presets like fluent-dark
-    // are classified the same way everywhere.
-    var themeIsLight = rootThemeAttributes.TryGetValue(BitThemeAttributeNames.Theme, out var themeName)
-                       && themeName is string name
-                       && name.EndsWith("dark", StringComparison.Ordinal) is false;
-    var themeColor = themeIsLight ? "#ffffff" : "#0d1117";
+    // Browser chrome color. "Ends with dark" is the same rule app.ts and the app's own stylesheets
+    // use, so presets like fluent-dark are classified the same way everywhere.
+    const string darkThemeColor = "#0d1117";
+    const string lightThemeColor = "#ffffff";
+    // Null while the visitor follows the OS, which the server cannot read. The tag then has to guess,
+    // and the script under it carries the client's answer back - see there.
+    var resolvedTheme = rootThemeAttributes.TryGetValue(BitThemeAttributeNames.Theme, out var themeName)
+                        ? themeName as string
+                        : null;
+    var themeColor = resolvedTheme?.EndsWith("dark", StringComparison.Ordinal) is false ? lightThemeColor : darkThemeColor;
     // The accented palette, so a visitor who picked one of the "Make it yours" colors is not shown
     // the packaged blue first. Null unless a non-default accent is stored - see BuildPrerenderCss.
+    // Startup/Services.cs reads this same cookie a second time and cascades it as PrerenderedAccentColor,
+    // which is what marks the right swatch as active; this half only paints. Two reads rather than one
+    // because a host page cannot cascade a value and a component cannot write into <head>.
     var accentCss = AppAccentColorService.BuildPrerenderCss(HttpContext.Request.Cookies[AppAccentColorService.CookieName]);
 }
 
@@ -67,13 +72,33 @@
         @* Next to the theme bootstrap because it is the same job: get the palette right before the
            first paint rather than repainting it on hydration. Outranks the packaged palette on
            specificity, so it works from <head> regardless of where the stylesheets are (see
-           BuildPrerenderCss). The id is how the client drops it once it owns the overlay. *@
+           BuildPrerenderCss). The id is how the client drops it once it owns the overlay.
+           Keep this AFTER the inline script above - the ordering is load-bearing, not tidiness. The
+           two rules below are split on bit-theme, and that script is what puts the attribute on <html>
+           for a visitor who follows the OS. Emitted first, the :not() rule would match the not-yet-set
+           attribute and paint a dark-OS visitor the light accent palette. *@
         <style id="@AppAccentColorService.PrerenderStyleElementId">@((MarkupString)accentCss)</style>
     }
     <ResourcePreloader />
     <base href="/" />
     <meta charset="utf-8" />
     <meta name="theme-color" content="@themeColor" /><!-- Kept as a single tag: app.ts (BitTheme.init onChange) updates this content dynamically via querySelector based on the active theme. -->
+    @if (resolvedTheme is null)
+    {
+        @* The tag above had to guess (the dark default), because this visitor follows the OS and only
+           the client can resolve that - which the inline script at the top of <head> has already done,
+           onto <html>. Read it back and correct the tag here, while the browser is still parsing
+           <head>. app.ts does this same job on every later toggle, but it cannot cover the first paint:
+           app.js loads at the end of <body>, long after the address bar has been painted. Rewrites the
+           one tag rather than adding a media-qualified second one, which would shadow it for the
+           querySelector both this and app.ts rely on. *@
+        <Script>
+            document.querySelector('meta[name="theme-color"]').content =
+                (document.documentElement.getAttribute('@BitThemeAttributeNames.Theme') || '').endsWith('dark')
+                    ? '@darkThemeColor'
+                    : '@lightThemeColor';
+        </Script>
+    }
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <!-- No static <title> here: the per-page title is emitted through <HeadOutlet> (PageOutlet's <PageTitle>),

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
@@ -26,18 +26,54 @@
     var renderMode = noPrerender
         ? (includeWasm ? AppRenderMode.NoPrerenderBlazorWebAssembly : AppRenderMode.NoPrerenderBlazorServer)
         : (includeWasm ? AppRenderMode.Current : AppRenderMode.BlazorServer);
+
+    // The theme the visitor picked, mirrored into a cookie by the client (bit-theme-persist-cookie
+    // below) because localStorage - where the client script keeps the same value - cannot be read
+    // from here. Without it every prerendered response painted a hardcoded dark, and anyone on light
+    // watched the whole page flip once the client came up.
+    var themePreference = HttpContext.Request.Cookies[BitThemeCookie.PreferenceCookieName];
+    // Emits bit-theme="<name>" for a concrete choice, or the bit-theme-system marker when nothing is
+    // stored (or the visitor follows the OS), which the inline head script below resolves. Tampered
+    // values are rejected and treated as "nothing stored".
+    var rootThemeAttributes = BitThemeSsr.BuildRootThemeAttributeMap(themePreference);
+    // Browser chrome color: matched to the theme when we know it, otherwise left at the dark default
+    // that app.ts corrects on boot (only a system-following visitor reaches that case). "Ends with
+    // dark" is the same rule app.ts and the app's own stylesheets use, so presets like fluent-dark
+    // are classified the same way everywhere.
+    var themeIsLight = rootThemeAttributes.TryGetValue(BitThemeAttributeNames.Theme, out var themeName)
+                       && themeName is string name
+                       && name.EndsWith("dark", StringComparison.Ordinal) is false;
+    var themeColor = themeIsLight ? "#ffffff" : "#0d1117";
+    // The accented palette, so a visitor who picked one of the "Make it yours" colors is not shown
+    // the packaged blue first. Null unless a non-default accent is stored - see BuildPrerenderCss.
+    var accentCss = AppAccentColorService.BuildPrerenderCss(HttpContext.Request.Cookies[AppAccentColorService.CookieName]);
 }
 
 <!DOCTYPE html>
-<!-- bit-theme-view-transition: theme toggles cross-fade via the View Transitions API
-     (skipped automatically on unsupported browsers / prefers-reduced-motion). -->
-<html lang="en" bit-theme="dark" bit-theme-view-transition>
+@* bit-theme-persist / bit-theme-persist-cookie: the client keeps the chosen theme in localStorage AND
+   in the cookie read above, which is what lets the server render the right theme in the first place.
+   bit-theme-view-transition: theme toggles cross-fade via the View Transitions API (skipped
+   automatically on unsupported browsers / prefers-reduced-motion). *@
+<html lang="en" @attributes="rootThemeAttributes" bit-theme-persist bit-theme-persist-cookie bit-theme-view-transition>
 
 <head>
+    @* First thing in the document: re-resolves bit-theme from localStorage / the preference cookie
+       before anything is painted. The attributes above are already correct for a visitor whose cookie
+       reached us, so this is what covers the rest - following the OS (which the server cannot read),
+       and a localStorage value newer than the cookie. *@
+    @((MarkupString)BitThemeSsr.InlineHeadScript)
+    @if (accentCss is not null)
+    {
+        @* Next to the theme bootstrap because it is the same job: get the palette right before the
+           first paint rather than repainting it on hydration. Outranks the packaged palette on
+           specificity, so it works from <head> regardless of where the stylesheets are (see
+           BuildPrerenderCss). The id is how the client drops it once it owns the overlay. *@
+        <style id="@AppAccentColorService.PrerenderStyleElementId">@((MarkupString)accentCss)</style>
+    }
     <ResourcePreloader />
     <base href="/" />
     <meta charset="utf-8" />
-    <meta name="theme-color" content="#0d1117" /><!-- Kept as a single tag: app.ts (BitTheme.init onChange) updates this content dynamically via querySelector based on the active theme. -->
+    <meta name="theme-color" content="@themeColor" /><!-- Kept as a single tag: app.ts (BitTheme.init onChange) updates this content dynamically via querySelector based on the active theme. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <!-- No static <title> here: the per-page title is emitted through <HeadOutlet> (PageOutlet's <PageTitle>),

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Startup/Services.cs
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Startup/Services.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using Bit.BlazorUI.Demo.Server.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Bit.BlazorUI.Demo.Client.Core.Components;
+using Bit.BlazorUI.Demo.Client.Core.Services;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.ResponseCompression;
@@ -59,6 +60,13 @@ public static class Services
             return httpContext?.Items?.ContainsKey("RenderForMcpClient") is true
                 || httpContext?.Request?.Query?.ContainsKey("showallcodes") is true;
         });
+
+        // The accent the visitor picked, so the prerendered markup marks the right swatch as active.
+        // The matching palette reaches the same response as a stylesheet rule from App.razor; this
+        // only carries the value into the component tree. Null once the circuit outlives the request
+        // (no HttpContext) - by then the client has read its own stores.
+        services.AddCascadingValue("PrerenderedAccentColor", sp =>
+            sp.GetRequiredService<IHttpContextAccessor>().HttpContext?.Request.Cookies[AppAccentColorService.CookieName]);
 
         services.Configure<ForwardedHeadersOptions>(options =>
         {

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Startup/Services.cs
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Startup/Services.cs
@@ -62,9 +62,11 @@ public static class Services
         });
 
         // The accent the visitor picked, so the prerendered markup marks the right swatch as active.
-        // The matching palette reaches the same response as a stylesheet rule from App.razor; this
-        // only carries the value into the component tree. Null once the circuit outlives the request
-        // (no HttpContext) - by then the client has read its own stores.
+        // The matching palette reaches the same response as a stylesheet rule from App.razor, which
+        // reads this same cookie for itself; this only carries the value into the component tree,
+        // where MainLayout picks it up and round-trips it through the prerender state for the
+        // interactive pass. Null once the circuit outlives the request (no HttpContext) - by then the
+        // client has read its own stores.
         services.AddCascadingValue("PrerenderedAccentColor", sp =>
             sp.GetRequiredService<IHttpContextAccessor>().HttpContext?.Request.Cookies[AppAccentColorService.CookieName]);
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/ThemingPage.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/ThemingPage.razor
@@ -767,6 +767,16 @@ BitThemeSsr.BuildRootThemeAttributes(preference, defaultTheme: BitThemePresets.F
             <br />
 
             <BitText>
+                In a Blazor Web App the root document is <BitTag>App.razor</BitTag>, and a <BitTag>MarkupString</BitTag> cannot open a tag that the same file has to close. Use <BitTag>BuildRootThemeAttributeMap</BitTag> there and splat it &mdash; it resolves identically, marker attributes included:
+            </BitText>
+
+            <br />
+
+            <CodeBox Language="razor">&lt;html lang="en" @@attributes="BitThemeSsr.BuildRootThemeAttributeMap(preference)" bit-theme-persist bit-theme-persist-cookie&gt;</CodeBox>
+
+            <br />
+
+            <BitText>
                 With <BitTag>bit-theme-persist-cookie</BitTag> on <BitTag>&lt;html&gt;</BitTag>, the runtime script mirrors every theme change into the <BitTag>bit-theme-preference</BitTag> cookie automatically, keeping the client (<BitTag>localStorage</BitTag>) and server (cookie) stores in sync &mdash; no manual <BitTag>BitThemeNotifications.ThemeChanged</BitTag> subscription is needed for that.
             </BitText>
         </BitCard>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Scripts/app.ts
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Scripts/app.ts
@@ -99,6 +99,10 @@ function getInnerText(element: HTMLElement) {
     return element?.innerText;
 }
 
+function removeElementById(id: string) {
+    document.getElementById(id)?.remove();
+}
+
 const windowResizeListeners: { [key: string]: () => void } = {};
 
 function registerWindowResizeListener(id: string, dotnetObj: any, methodName: string) {
@@ -117,6 +121,26 @@ function unregisterWindowResizeListener(id: string) {
     delete windowResizeListeners[id];
 }
 
+// Cookies are how a client-side preference reaches the server, which needs it to prerender the page
+// the way the visitor left it - localStorage is unreachable from there. Lax + the 400-day cap
+// browsers clamp to, mirroring what the library writes for its own theme-preference cookie.
+function setCookie(name: string, value: string, maxAgeSeconds: number) {
+    const secure = location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax${secure}`;
+}
+
+function getCookie(name: string): string | null {
+    const prefix = `${name}=`;
+    const match = document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith(prefix));
+    if (match == null) return null;
+
+    try {
+        return decodeURIComponent(match.substring(prefix.length));
+    } catch {
+        return match.substring(prefix.length);
+    }
+}
+
 declare namespace BitBlazorUI {
     class Theme { static init(options: any): void; }
 }
@@ -127,6 +151,10 @@ declare namespace BitBlazorUI {
 BitBlazorUI.Theme.init({
     system: true,
     persist: true,
+    // Mirror every theme change into the bit-theme-preference cookie so the server can paint the
+    // right theme into the prerendered markup (see App.razor). Without it the server would fall back
+    // to following the OS and the app would flash the wrong theme for visitors who picked one.
+    persistCookie: true,
     onChange: (newTheme: string, oldTheme: string) => {
         const name = (newTheme ?? '').toLowerCase();
         const isDark = name === 'dark' || name.endsWith('-dark');

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
@@ -110,9 +110,10 @@ public partial class AppAccentColorService : IDisposable
 
         // localStorage first, cookie second: they are written together, so they only diverge when
         // one of them is unavailable (localStorage throws in Safari private mode / blocked-storage
-        // setups, and a visitor can clear cookies alone). Either one on its own restores the accent.
-        var stored = NormalizeAccent(await _js.Invoke<string?>("localStorage.getItem", StorageKey))
-                  ?? NormalizeAccent(await _js.Invoke<string?>("getCookie", CookieName));
+        // setups, and a visitor can clear cookies alone). Either one on its own restores the accent,
+        // which is why each read is isolated - see TryReadAsync.
+        var stored = NormalizeAccent(await TryReadAsync("localStorage.getItem", StorageKey))
+                  ?? NormalizeAccent(await TryReadAsync("getCookie", CookieName));
 
         // The overlay is applied even when the prerender seed already put us on this accent: the
         // server painted it through a stylesheet rule, which the WebAssembly and Hybrid clients never
@@ -147,11 +148,11 @@ public partial class AppAccentColorService : IDisposable
 
         ActiveAccent = hex;
 
-        await _js.InvokeVoid("localStorage.setItem", StorageKey, hex);
+        await TryWriteAsync("localStorage.setItem", StorageKey, hex);
 
         // Mirrored into a cookie so the next navigation's prerender can paint this accent server-side
         // - localStorage is unreachable from there, which is what made the color flash on every load.
-        await _js.InvokeVoid("setCookie", CookieName, hex, CookieMaxAgeSeconds);
+        await TryWriteAsync("setCookie", CookieName, hex, CookieMaxAgeSeconds);
 
         await ApplyToCurrentThemeAsync(hex);
 
@@ -219,6 +220,42 @@ public partial class AppAccentColorService : IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Reads one store, treating an unreachable one as "nothing persisted here". Neither store is
+    /// guaranteed to answer - a browser set to block site data throws on the very first localStorage
+    /// access, and Safari's private mode throws on write - and a store that refuses must not take the
+    /// other one, nor the applied overlay, down with it.
+    /// </summary>
+    private async Task<string?> TryReadAsync(string function, string key)
+    {
+        try
+        {
+            return await _js.Invoke<string?>(function, key);
+        }
+        catch (JSException ex)
+        {
+            _logger.LogWarning(ex, "Reading the persisted accent through {Function} failed.", function);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes one store, tolerating an unreachable one. The pick still applies for this session (and
+    /// is restored on the next load from whichever store did take it); losing one of them is not a
+    /// reason to leave the visitor on the old color. See <see cref="TryReadAsync"/>.
+    /// </summary>
+    private async Task TryWriteAsync(string function, params object?[] args)
+    {
+        try
+        {
+            await _js.InvokeVoid(function, args);
+        }
+        catch (JSException ex)
+        {
+            _logger.LogWarning(ex, "Persisting the accent through {Function} failed.", function);
+        }
     }
 
     private async Task ApplyToCurrentThemeAsync(string hex)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
@@ -112,8 +112,32 @@ public partial class AppAccentColorService : IDisposable
         // one of them is unavailable (localStorage throws in Safari private mode / blocked-storage
         // setups, and a visitor can clear cookies alone). Either one on its own restores the accent,
         // which is why each read is isolated - see TryReadAsync.
-        var stored = NormalizeAccent(await TryReadAsync("localStorage.getItem", StorageKey))
-                  ?? NormalizeAccent(await TryReadAsync("getCookie", CookieName));
+        var fromStorage = NormalizeAccent(await TryReadAsync("localStorage.getItem", StorageKey));
+        var stored = fromStorage ?? NormalizeAccent(await TryReadAsync("getCookie", CookieName));
+
+        // Nothing restored and nothing seeded, so there is no overlay to apply - and no prerendered
+        // <style> to drop either, because BuildPrerenderCss emits none for the packaged Blue. This is
+        // the path almost every visit takes, so it is worth keeping off the interop calls below.
+        if (stored is null && ActiveAccent is BitAccentColorPresets.Blue) return;
+
+        // Both stores are rewritten from whichever one answered, because ApplyAsync - the only other
+        // writer - needs a fresh pick to run, so a divergence left standing here would be permanent:
+        //  - the cookie on every visit, because its ~400-day cap is absolute, and because a visitor
+        //    who picked an accent before this cookie existed has only the localStorage copy. Without
+        //    this the server keeps prerendering the packaged Blue and the accent keeps flashing in.
+        //  - localStorage only when it did not answer: it either threw, or was cleared while the
+        //    cookie survived.
+        // The theme half of the pair already self-heals the same way - BitTheme.init's set() rewrites
+        // the preference cookie on boot.
+        if (stored is not null)
+        {
+            await TryInvokeVoidAsync("setCookie", CookieName, stored, CookieMaxAgeSeconds);
+
+            if (fromStorage is null)
+            {
+                await TryInvokeVoidAsync("localStorage.setItem", StorageKey, stored);
+            }
+        }
 
         // The overlay is applied even when the prerender seed already put us on this accent: the
         // server painted it through a stylesheet rule, which the WebAssembly and Hybrid clients never
@@ -139,8 +163,10 @@ public partial class AppAccentColorService : IDisposable
         // The server's first-paint copy has done its job, and the overlay just applied covers the
         // same ground. Leaving it would make a later switch back to Blue - which only clears the
         // overlay - look like it did nothing, because the rule would keep repainting the accent the
-        // page happened to load with. Removed after the apply so nothing paints unaccented in between.
-        await _js.InvokeVoid("removeElementById", PrerenderStyleElementId);
+        // page happened to load with. Removed after the apply so nothing paints unaccented in between,
+        // and through the tolerant path because a circuit that dropped mid-restore must not surface
+        // here as an unhandled error - the overlay is already applied by this point.
+        await TryInvokeVoidAsync("removeElementById", PrerenderStyleElementId);
     }
 
     /// <summary>
@@ -153,11 +179,11 @@ public partial class AppAccentColorService : IDisposable
 
         ActiveAccent = hex;
 
-        await TryWriteAsync("localStorage.setItem", StorageKey, hex);
+        await TryInvokeVoidAsync("localStorage.setItem", StorageKey, hex);
 
         // Mirrored into a cookie so the next navigation's prerender can paint this accent server-side
         // - localStorage is unreachable from there, which is what made the color flash on every load.
-        await TryWriteAsync("setCookie", CookieName, hex, CookieMaxAgeSeconds);
+        await TryInvokeVoidAsync("setCookie", CookieName, hex, CookieMaxAgeSeconds);
 
         await ApplyToCurrentThemeAsync(hex);
 
@@ -231,7 +257,8 @@ public partial class AppAccentColorService : IDisposable
     /// Reads one store, treating an unreachable one as "nothing persisted here". Neither store is
     /// guaranteed to answer - a browser set to block site data throws on the very first localStorage
     /// access, and Safari's private mode throws on write - and a store that refuses must not take the
-    /// other one, nor the applied overlay, down with it.
+    /// other one, nor the applied overlay, down with it. See the remarks on
+    /// <see cref="TryInvokeVoidAsync"/> for why the catch is this wide.
     /// </summary>
     private async Task<string?> TryReadAsync(string function, string key)
     {
@@ -239,7 +266,7 @@ public partial class AppAccentColorService : IDisposable
         {
             return await _js.Invoke<string?>(function, key);
         }
-        catch (JSException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "Reading the persisted accent through {Function} failed.", function);
             return null;
@@ -247,19 +274,28 @@ public partial class AppAccentColorService : IDisposable
     }
 
     /// <summary>
-    /// Writes one store, tolerating an unreachable one. The pick still applies for this session (and
-    /// is restored on the next load from whichever store did take it); losing one of them is not a
-    /// reason to leave the visitor on the old color. See <see cref="TryReadAsync"/>.
+    /// Invokes one store write (or the prerender-style cleanup), tolerating a call that cannot get
+    /// through. The pick still applies for this session, and is restored on the next load from
+    /// whichever store did take it; losing one of them is not a reason to leave the visitor on the
+    /// old color. See <see cref="TryReadAsync"/>.
     /// </summary>
-    private async Task TryWriteAsync(string function, params object?[] args)
+    /// <remarks>
+    /// Catches <see cref="Exception"/> rather than <see cref="JSException"/> because that is not what
+    /// actually fails here: a browser that blocks site data throws a <see cref="JSException"/>, but
+    /// the far more common failure on the Server render mode is the circuit going away
+    /// (<see cref="JSDisconnectedException"/>, which derives straight from <see cref="Exception"/>) or
+    /// the interop call timing out (<see cref="TaskCanceledException"/>). Narrowing to
+    /// <see cref="JSException"/> let exactly those unwind the whole restore.
+    /// </remarks>
+    private async Task TryInvokeVoidAsync(string function, params object?[] args)
     {
         try
         {
             await _js.InvokeVoid(function, args);
         }
-        catch (JSException ex)
+        catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Persisting the accent through {Function} failed.", function);
+            _logger.LogWarning(ex, "Invoking {Function} for the accent failed.", function);
         }
     }
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
@@ -117,18 +117,23 @@ public partial class AppAccentColorService : IDisposable
 
         // The overlay is applied even when the prerender seed already put us on this accent: the
         // server painted it through a stylesheet rule, which the WebAssembly and Hybrid clients never
-        // receive - and which is about to be dropped below in any case.
-        if (stored is not null)
+        // receive - and which is about to be dropped below in any case. That last part is also why it
+        // is applied when neither store answered: the seed then stands on its own, and dropping the
+        // rule without replacing it would leave the page on the packaged palette while the swatches
+        // still mark the seeded color as active.
+        var accent = stored ?? ActiveAccent;
+
+        // Only a store can report a change here - matching the seed, or falling back to it, is what
+        // the swatches already rendered.
+        var changed = stored is not null && stored != ActiveAccent;
+
+        ActiveAccent = accent;
+
+        await ApplyToCurrentThemeAsync(accent);
+
+        if (changed)
         {
-            var changed = stored != ActiveAccent;
-            ActiveAccent = stored;
-
-            await ApplyToCurrentThemeAsync(stored);
-
-            if (changed)
-            {
-                AccentChanged?.Invoke(this, EventArgs.Empty);
-            }
+            AccentChanged?.Invoke(this, EventArgs.Empty);
         }
 
         // The server's first-paint copy has done its job, and the overlay just applied covers the

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Services/AppAccentColorService.cs
@@ -4,7 +4,8 @@ namespace Bit.BlazorUI.Demo.Client.Core.Services;
 
 /// <summary>
 /// Owns the accent color the home page's "Make it yours" swatches pick: the applied theme overlay,
-/// the localStorage copy that survives a refresh, and the re-derivation a dark/light switch needs.
+/// the localStorage + cookie copies that survive a refresh, and the re-derivation a dark/light
+/// switch needs.
 /// </summary>
 /// <remarks>
 /// This lives above the home page because the accent applies to the whole app. A component that only
@@ -17,6 +18,24 @@ public partial class AppAccentColorService : IDisposable
 {
     // Prefixed so it cannot collide with the library's own bit-current-theme key.
     private const string StorageKey = "bit-blazorui-demo-accent";
+
+    /// <summary>
+    /// The cookie mirroring <see cref="StorageKey"/>. localStorage is unreachable while the server
+    /// prerenders, so the accent is written to a cookie as well and the server paints the accented
+    /// palette into the first response - see <see cref="BuildPrerenderCss"/>. Named after the
+    /// storage key so the two stores are recognizably one preference.
+    /// </summary>
+    public const string CookieName = StorageKey;
+
+    // ~400 days, the upper bound modern browsers clamp persistent cookies to. Matches what the
+    // library's own theme-preference cookie uses.
+    private const int CookieMaxAgeSeconds = 34560000;
+
+    /// <summary>
+    /// Id of the <c>&lt;style&gt;</c> element carrying <see cref="BuildPrerenderCss"/>, so
+    /// <see cref="InitializeAsync"/> can drop it once the client owns the overlay.
+    /// </summary>
+    public const string PrerenderStyleElementId = "app-prerender-accent";
 
     /// <summary>
     /// The swatches the home page offers, and the only values <see cref="ApplyAsync"/> honors: a
@@ -32,6 +51,9 @@ public partial class AppAccentColorService : IDisposable
         ("Teal", BitAccentColorPresets.Teal),
         ("Rose", BitAccentColorPresets.Rose),
     ];
+
+    /// <summary>Rendered <see cref="BuildPrerenderCss"/> output, keyed by accent hex. See its remarks.</summary>
+    private static readonly ConcurrentDictionary<string, string> _prerenderCss = new(StringComparer.Ordinal);
 
     [AutoInject] private IJSRuntime _js = default!;
     [AutoInject] private BitThemeManager _themeManager = default!;
@@ -50,8 +72,28 @@ public partial class AppAccentColorService : IDisposable
     public event EventHandler? AccentChanged;
 
     /// <summary>
+    /// Adopts the accent the server read from <see cref="CookieName"/>, so the prerendered markup
+    /// already marks the right swatch as active instead of blinking from Blue to the visitor's color
+    /// once the client comes up. Paints nothing: the matching palette is emitted into the same
+    /// response by <see cref="BuildPrerenderCss"/>. A missing or unrecognized value is ignored.
+    /// </summary>
+    public void SeedFromPrerender(string? hex)
+    {
+        // The interactive pass has already read the authoritative store; letting a (possibly stale)
+        // cascaded value overwrite it afterwards would undo a fresh pick.
+        if (_initialized) return;
+
+        var accent = NormalizeAccent(hex);
+        if (accent is null || accent == ActiveAccent) return;
+
+        ActiveAccent = accent;
+
+        AccentChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
     /// Restores the persisted accent, applies it, and starts tracking dark/light switches. Reading
-    /// localStorage needs interactivity, so callers have to wait for the first render; calling it
+    /// the stores needs interactivity, so callers have to wait for the first render; calling it
     /// during prerendering is a no-op that leaves the service ready to initialize on the retry.
     /// Safe to call repeatedly - only the first interactive call does the work.
     /// </summary>
@@ -66,15 +108,33 @@ public partial class AppAccentColorService : IDisposable
         // JS notifier registration, which can only succeed once the client is live.
         _themeNotifications.ThemeChanged += OnThemeChanged;
 
-        var stored = await _js.Invoke<string?>("localStorage.getItem", StorageKey);
-        if (stored is null || stored == ActiveAccent) return;
-        if (Presets.Any(p => p.Hex == stored) is false) return;
+        // localStorage first, cookie second: they are written together, so they only diverge when
+        // one of them is unavailable (localStorage throws in Safari private mode / blocked-storage
+        // setups, and a visitor can clear cookies alone). Either one on its own restores the accent.
+        var stored = NormalizeAccent(await _js.Invoke<string?>("localStorage.getItem", StorageKey))
+                  ?? NormalizeAccent(await _js.Invoke<string?>("getCookie", CookieName));
 
-        ActiveAccent = stored;
+        // The overlay is applied even when the prerender seed already put us on this accent: the
+        // server painted it through a stylesheet rule, which the WebAssembly and Hybrid clients never
+        // receive - and which is about to be dropped below in any case.
+        if (stored is not null)
+        {
+            var changed = stored != ActiveAccent;
+            ActiveAccent = stored;
 
-        await ApplyToCurrentThemeAsync(stored);
+            await ApplyToCurrentThemeAsync(stored);
 
-        AccentChanged?.Invoke(this, EventArgs.Empty);
+            if (changed)
+            {
+                AccentChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        // The server's first-paint copy has done its job, and the overlay just applied covers the
+        // same ground. Leaving it would make a later switch back to Blue - which only clears the
+        // overlay - look like it did nothing, because the rule would keep repainting the accent the
+        // page happened to load with. Removed after the apply so nothing paints unaccented in between.
+        await _js.InvokeVoid("removeElementById", PrerenderStyleElementId);
     }
 
     /// <summary>
@@ -89,9 +149,76 @@ public partial class AppAccentColorService : IDisposable
 
         await _js.InvokeVoid("localStorage.setItem", StorageKey, hex);
 
+        // Mirrored into a cookie so the next navigation's prerender can paint this accent server-side
+        // - localStorage is unreachable from there, which is what made the color flash on every load.
+        await _js.InvokeVoid("setCookie", CookieName, hex, CookieMaxAgeSeconds);
+
         await ApplyToCurrentThemeAsync(hex);
 
         AccentChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// The stylesheet the server emits so a prerendered page paints <paramref name="accentHex"/>
+    /// immediately, instead of the packaged palette that the client would then have to repaint.
+    /// Returns <see langword="null"/> when there is nothing to override - no stored accent, an
+    /// unrecognized one, or Blue, which is the packaged palette's own primary.
+    /// </summary>
+    /// <remarks>
+    /// Both schemes are emitted, each scoped to the <c>bit-theme</c> attribute that the library's
+    /// inline head script resolves before first paint. That keeps this independent of the theme
+    /// preference: the server does not have to know (and, while following the OS, cannot know)
+    /// whether the visitor lands on dark or light, and a later theme toggle is covered by the same
+    /// two rules.
+    /// <para>
+    /// The doubled <c>:root:root</c> is there for specificity, not for matching: the packaged
+    /// palette declares the same tokens at <c>:root[bit-theme=…]</c>, so an equal-specificity rule
+    /// would only win by coming later in the document and this would have to be emitted after every
+    /// stylesheet. Outranking it instead lets the block sit in <c>&lt;head&gt;</c>, where it is in
+    /// the CSSOM from the first byte of body.
+    /// </para>
+    /// </remarks>
+    public static string? BuildPrerenderCss(string? accentHex)
+    {
+        var hex = NormalizeAccent(accentHex);
+
+        if (hex is null || hex == BitAccentColorPresets.Blue) return null;
+
+        // Deriving a palette from a seed is real work (OKLCH conversions over ~280 tokens) and there
+        // are only six of them, so the rendered CSS is built once per accent rather than per request.
+        return _prerenderCss.GetOrAdd(hex, static hex =>
+        {
+            // The dark/light split matches the app's own [bit-theme$=dark] convention, so "fluent-dark"
+            // and any other dark preset land on the dark palette too.
+            return $":root:root[bit-theme$=dark]{{{Declarations(BitThemeFactory.CreateDarkThemeFromSeed(hex))}}}" +
+                   $":root:root:not([bit-theme$=dark]){{{Declarations(BitThemeFactory.CreateLightThemeFromSeed(hex))}}}";
+
+            static string Declarations(BitTheme theme)
+            {
+                return string.Concat(BitThemeUtilities.ToCssVariables(theme).Select(v => $"{v.Key}:{v.Value};"));
+            }
+        });
+    }
+
+    /// <summary>
+    /// Matches a value from any of the (attacker-editable) stores against <see cref="Presets"/>,
+    /// returning the canonical hex or <see langword="null"/>. Nothing outside the presets is ever
+    /// handed to <see cref="BitThemeFactory"/> or written into the document.
+    /// </summary>
+    private static string? NormalizeAccent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        var candidate = value.Trim();
+
+        foreach (var (_, hex) in Presets)
+        {
+            // Case-insensitive so a hand-edited "#8764b8" still resolves; the preset's own casing is
+            // returned, keeping ActiveAccent comparable by ordinal equality everywhere else.
+            if (string.Equals(hex, candidate, StringComparison.OrdinalIgnoreCase)) return hex;
+        }
+
+        return null;
     }
 
     private async Task ApplyToCurrentThemeAsync(string hex)

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Shared/MainLayout.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Shared/MainLayout.razor.cs
@@ -16,6 +16,35 @@ public partial class MainLayout : IDisposable
     [AutoInject] private AppAccentColorService _accentColorService = default!;
 
 
+    /// <summary>
+    /// The accent the server read from its cookie while prerendering (see App.razor in the server
+    /// project). Null on the clients, which have no such cookie to cascade - they restore the accent
+    /// from their own stores once interactive.
+    /// </summary>
+    [CascadingParameter(Name = nameof(PrerenderedAccentColor))] public string? PrerenderedAccentColor { get; set; }
+
+
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            // Before the first render, so the swatches - which render below this layout - mark the
+            // visitor's accent in the prerendered markup rather than flipping to it on hydration.
+            // Round-tripped through the prerender state because the interactive client runs in its
+            // own service scope, where the cascaded (HttpContext-backed) value is gone: without it
+            // the swatches would drop back to Blue for the renders between hydration and the point
+            // where AppAccentColorService can reach localStorage.
+            _accentColorService.SeedFromPrerender(await _prerenderStateService.GetValue(
+                nameof(PrerenderedAccentColor), () => Task.FromResult(PrerenderedAccentColor)));
+
+            await base.OnInitializedAsync();
+        }
+        catch (Exception exp)
+        {
+            _exceptionHandler.Handle(exp);
+        }
+    }
 
     protected override void OnInitialized()
     {

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Utils/Theme/BitThemeSsrTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Utils/Theme/BitThemeSsrTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Bunit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -162,5 +163,49 @@ public sealed class BitThemeSsrTests
         // marker with no injected attribute or markup - never the tampered value.
         Assert.AreEqual("bit-theme-system",
             BitThemeSsr.BuildRootThemeAttributes("system", defaultTheme: "\"><b>"));
+    }
+
+    [TestMethod]
+    public void BuildRootThemeAttributeMapEmitsMarkersAsBooleansAndNamesAsStrings()
+    {
+        // Blazor renders a bool `true` attribute as a valueless marker and a string as name="value",
+        // so the map has to distinguish the two - that is the whole point of the overload.
+        var concrete = BitThemeSsr.BuildRootThemeAttributeMap("dark");
+        CollectionAssert.AreEquivalent(new[] { BitThemeAttributeNames.Theme }, concrete.Keys.ToArray());
+        Assert.AreEqual("dark", concrete[BitThemeAttributeNames.Theme]);
+
+        var system = BitThemeSsr.BuildRootThemeAttributeMap("system", defaultTheme: "light");
+        CollectionAssert.AreEquivalent(
+            new[] { BitThemeAttributeNames.ThemeSystem, BitThemeAttributeNames.ThemeDefault },
+            system.Keys.ToArray());
+        Assert.AreEqual(true, system[BitThemeAttributeNames.ThemeSystem]);
+        Assert.AreEqual("light", system[BitThemeAttributeNames.ThemeDefault]);
+    }
+
+    [DataTestMethod]
+    [DataRow(null, null, DisplayName = "nothing stored")]
+    [DataRow("   ", null, DisplayName = "blank preference")]
+    [DataRow("dark", null, DisplayName = "concrete preference")]
+    [DataRow("  Fluent-DARK  ", null, DisplayName = "unnormalized preference")]
+    [DataRow("system", null, DisplayName = "system without default")]
+    [DataRow("system", "light", DisplayName = "system with default")]
+    [DataRow(null, "light", DisplayName = "default only")]
+    [DataRow("\"><script>alert(1)</script>", null, DisplayName = "tampered preference")]
+    [DataRow("system", "\"><b>", DisplayName = "tampered default")]
+    public void BuildRootThemeAttributeMapMatchesTheStringOverload(string? preference, string? defaultTheme)
+    {
+        // Both overloads are formatted from one resolution; this pins them together so a change to
+        // either can't silently give the Razor host a different first paint than the raw-string host.
+        // Compared as sets: attribute order is meaningless to a splat (and the string overload's own
+        // ordering is already pinned by BuildRootThemeAttributesSystemFollowsOsAndCarriesDefault).
+        var rendered = BitThemeSsr.BuildRootThemeAttributeMap(preference, defaultTheme)
+                                  .Select(a => a.Value is bool ? a.Key : $"{a.Key}=\"{a.Value}\"")
+                                  .OrderBy(a => a, StringComparer.Ordinal);
+
+        var expected = BitThemeSsr.BuildRootThemeAttributes(preference, defaultTheme)
+                                  .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                                  .OrderBy(a => a, StringComparer.Ordinal);
+
+        CollectionAssert.AreEqual(expected.ToArray(), rendered.ToArray());
     }
 }


### PR DESCRIPTION
closes #12826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent theme selection across visits, including system and default themes.
  * Improved server-rendered pages to apply the selected theme immediately and update browser theme-color metadata.
  * Added persistent accent-color selection with smoother restoration during initialization.
  * Added view-transition support for theme changes.
* **Documentation**
  * Added guidance for configuring persistent themes in Blazor Web Apps.
* **Bug Fixes**
  * Prevented temporary accent styles from remaining after initialization.
  * Improved restoration when saved theme or accent settings are unavailable or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->