### PR TITLE
Fix prerendering issues of Brouter (#12830)

### DIFF
--- a/src/Brouter/Bit.Brouter/Components/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Components/Brouter.cs
@@ -396,8 +396,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         // per-mount burst) never get here - the flag is still false - so startup cost is zero.
         if (_initialNavigationStarted)
         {
-            _rematchRequested = true;
-            ScheduleLateRegistrationRematch();
+            RequestLateRegistrationRematch();
         }
     }
     internal void UnregisterRoute(Broute route)
@@ -424,6 +423,13 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         }
         _routesDirty = true;
         _routeRegistrationVersion++;
+
+        // Deliberately asymmetric with RegisterRoute: no rematch is requested here. Unregistration
+        // runs from Broute.Dispose, which also fires while the whole router (or the whole circuit)
+        // is being torn down, so re-entering the navigation pipeline from it is not safe in general.
+        // The consequence is that removing the currently-committed route leaves the router showing
+        // nothing rather than falling back to NotFound until the next navigation - long-standing
+        // behavior, not introduced with the rematch. Fixing it needs a teardown-aware signal.
     }
 
     /// <summary>
@@ -679,11 +685,14 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     // against the grown route set, or its finally re-schedules the check once idle).
     private int _processingNavigation;
 
-    // Late-registration rematch bookkeeping (see RegisterRoute / ScheduleLateRegistrationRematch).
+    // Late-registration rematch bookkeeping (see RegisterRoute / RequestLateRegistrationRematch).
     // _rematchRequested: a post-boot registration happened and hasn't been evaluated yet.
-    // _rematchScheduled: an evaluation continuation is already queued (debounce).
+    // _rematchRenderPending: a render carrying the request to BrouterRematchRunner is already
+    // queued (debounce - every registration until that render lands folds into one evaluation).
+    // _rematchVersion: bumped per request so the runner always receives a changed parameter set.
     private bool _rematchRequested;
-    private bool _rematchScheduled;
+    private bool _rematchRenderPending;
+    private long _rematchVersion;
 
     /// <summary>
     /// Runs the initial navigation for the URL the app mounted at. Called by the boot navigator
@@ -711,44 +720,82 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Debounced evaluator for routes that registered after the initial navigation: once the
-    /// current render drain (and any in-flight navigation pipeline) is done, re-select the winner
-    /// for the current URL and - only when the grown route set actually changes it - re-run the
-    /// navigation so the screen reflects the route set that exists NOW. This is what turns a
-    /// too-early boot (see <see cref="BrouterInitializer"/>'s quiet-round heuristic), an async
-    /// wrapper finally mounting its routes, or a conditionally-rendered route appearing at its own
-    /// URL from "stuck until the next navigation" into a self-correcting extra render pass.
+    /// Flags that a post-boot registration needs the winner re-evaluated, and renders so
+    /// <see cref="BrouterRematchRunner"/> picks the request up as a parameter change.
     /// </summary>
-    private void ScheduleLateRegistrationRematch()
+    /// <remarks>
+    /// Routing the evaluation through a child component's lifecycle - rather than a detached
+    /// <c>InvokeAsync</c> continuation - is what makes the correction visible to static
+    /// prerendering. The renderer only waits (and only routes exceptions) for tasks returned from
+    /// component lifecycle methods; a bare dispatcher continuation is neither awaited by
+    /// <c>WaitForQuiescenceAsync</c> nor error-handled, so the prerenderer would serialize its HTML
+    /// before the correction ran - emitting an empty router for exactly the deep-wrapper case the
+    /// rematch exists to rescue - and any exception the pipeline deliberately rethrows (an SSR
+    /// redirect's <c>NavigationException</c>, a fail-closed <c>[Authorize]</c> guard) would vanish.
+    /// </remarks>
+    private void RequestLateRegistrationRematch()
     {
-        if (_rematchScheduled) return;
-        _rematchScheduled = true;
-        _ = InvokeAsync(async () =>
-        {
-            // One yield coalesces a whole render-drain's worth of registrations (an @if revealing
-            // several routes, a wrapper mounting a subtree) into a single evaluation.
-            await Task.Yield();
-            _rematchScheduled = false;
-            if (_disposed) return;
+        _rematchRequested = true;
 
-            // A pipeline is mid-flight: leave _rematchRequested set - its finally re-schedules
-            // this check once the router is idle, and evaluating against a half-committed chain
-            // here would produce a false winner-diff that supersedes (and so restarts) it.
-            if (_processingNavigation > 0) return;
-            _rematchRequested = false;
+        // Debounce: one render is enough to hand the runner the request, and every registration
+        // arriving before that render lands is folded into the same evaluation.
+        if (_rematchRenderPending || _disposed) return;
+        _rematchRenderPending = true;
+        _rematchVersion++;
+        StateHasChanged();
+    }
 
-            // Pure winner probe (SelectWinner never mutates): the registration only matters when
-            // it changes the outcome for the URL already on screen. Reference-comparing against
-            // the committed leaf also covers the not-found case (null == null -> no-op).
-            var winnerMatch = SelectWinner(CurrentLocation);
-            var committedLeaf = _committedChain.Length > 0 ? _committedChain[^1] : null;
-            if (ReferenceEquals(winnerMatch?.Route, committedLeaf)) return;
+    /// <summary>
+    /// Evaluator for routes that registered after the initial navigation, invoked from
+    /// <see cref="BrouterRematchRunner"/>'s lifecycle: once the current render drain (and any
+    /// in-flight navigation pipeline) is done, re-select the winner for the current URL and - only
+    /// when the grown route set actually changes it - re-run the navigation so the screen reflects
+    /// the route set that exists NOW. This is what turns a too-early boot (see
+    /// <see cref="BrouterInitializer"/>'s quiet-round heuristic), an async wrapper finally mounting
+    /// its routes, or a conditionally-rendered route appearing at its own URL from "stuck until the
+    /// next navigation" into a self-correcting extra render pass.
+    /// </summary>
+    internal Task RunPendingRematchAsync()
+    {
+        // Synchronous fast path: the runner's parameters are supplied on every render of this
+        // router, and almost none of those carry a pending request. Returning an already-completed
+        // task keeps them off the renderer's pending-task list entirely.
+        if (_rematchRequested is false || _disposed) return Task.CompletedTask;
 
-            // Same-URL re-navigation: routes present in both chains keep their instances
-            // (renavigation semantics), so only the corrected part of the tree re-renders.
-            // Replace: no history entry is involved in a route-set correction.
-            await ProcessNavigationAsync(CurrentLocation, CurrentLocation, decisionAlreadyMade: false, BrouterNavigationType.Replace);
-        });
+        return RunPendingRematchCoreAsync();
+    }
+
+    private async Task RunPendingRematchCoreAsync()
+    {
+        // One yield coalesces a whole render-drain's worth of registrations (an @if revealing
+        // several routes, a wrapper mounting a subtree) into a single evaluation, and lets the
+        // declaration cascade finish before we judge the winner. Unlike a detached continuation,
+        // this yield stays inside the prerenderer's quiescence wait: the renderer is awaiting THIS
+        // task, so the resumption is guaranteed to happen before the HTML is serialized.
+        await Task.Yield();
+
+        _rematchRenderPending = false;
+        if (_disposed) return;
+
+        // A pipeline is mid-flight: leave _rematchRequested set - its finally re-requests this
+        // check once the router is idle, and evaluating against a half-committed chain here would
+        // produce a false winner-diff that supersedes (and so restarts) it.
+        if (_processingNavigation > 0) return;
+        // A concurrent runner generation may have consumed the request while this one was yielding.
+        if (_rematchRequested is false) return;
+        _rematchRequested = false;
+
+        // Pure winner probe (SelectWinner never mutates): the registration only matters when
+        // it changes the outcome for the URL already on screen. Reference-comparing against
+        // the committed leaf also covers the not-found case (null == null -> no-op).
+        var winnerMatch = SelectWinner(CurrentLocation);
+        var committedLeaf = _committedChain.Length > 0 ? _committedChain[^1] : null;
+        if (ReferenceEquals(winnerMatch?.Route, committedLeaf)) return;
+
+        // Same-URL re-navigation: routes present in both chains keep their instances
+        // (renavigation semantics), so only the corrected part of the tree re-renders.
+        // Replace: no history entry is involved in a route-set correction.
+        await ProcessNavigationAsync(CurrentLocation, CurrentLocation, decisionAlreadyMade: false, BrouterNavigationType.Replace);
     }
 
     // The active router-level error boundary state (see RenderNavigationError). Non-null only when a
@@ -1391,6 +1438,16 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             b.OpenComponent<BrouterInitializer>(5);
             b.AddAttribute(6, nameof(BrouterInitializer.Router), this);
             b.AddAttribute(7, nameof(BrouterInitializer.ObservedVersion), _routeRegistrationVersion);
+            b.CloseComponent();
+
+            // Late-registration rematch runner: a permanently-mounted, never-rendering component
+            // whose only job is to give RunPendingRematchAsync a component lifecycle to return its
+            // task from, so the renderer awaits the correction (and error-handles it) instead of it
+            // running detached - see RequestLateRegistrationRematch. PendingVersion changes on every
+            // request so the parameter set is guaranteed to differ.
+            b.OpenComponent<BrouterRematchRunner>(8);
+            b.AddAttribute(9, nameof(BrouterRematchRunner.Router), this);
+            b.AddAttribute(10, nameof(BrouterRematchRunner.PendingVersion), _rematchVersion);
             b.CloseComponent();
             }));
             bo.CloseComponent();
@@ -2336,11 +2393,13 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
 
                     // During static server rendering / prerender, NavigationManager.NavigateTo throws
                     // NavigationException as the framework's redirect signal (a loader may redirect,
-                    // e.g. an auth gate). It must unwind out of the boot navigator's lifecycle (see
-                    // BrouterInitialNavigator) so the endpoint can
-                    // issue the HTTP redirect; swallowing it into OnError would drop the redirect
-                    // entirely. Scan for it before any other error handling so an SSR redirect wins
-                    // over a sibling loader's failure (root-most redirect wins if several threw).
+                    // e.g. an auth gate). It must unwind out of the lifecycle method that started
+                    // this pipeline (BrouterInitialNavigator's OnInitializedAsync for the boot
+                    // navigation, BrouterRematchRunner's OnParametersSetAsync for a late-registration
+                    // correction) so the endpoint can issue the HTTP redirect; swallowing it into
+                    // OnError would drop the redirect entirely. Scan for it before any other error
+                    // handling so an SSR redirect wins over a sibling loader's failure (root-most
+                    // redirect wins if several threw).
                     // Interactive NavigateTo never throws, so this is inert outside SSR.
                     foreach (var (_, error) in results)
                     {
@@ -2549,8 +2608,8 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         catch (NavigationException)
         {
             // SSR/prerender redirect signal (see the loader catch above). Let it propagate out of
-            // the boot navigator's lifecycle (see BrouterInitialNavigator) so the framework can
-            // turn it into an HTTP redirect. A guard or
+            // the lifecycle method that started this pipeline (see BrouterInitialNavigator /
+            // BrouterRematchRunner) so the framework can turn it into an HTTP redirect. A guard or
             // OnNavigating handler that redirects via NavigationManager during prerender lands here.
             throw;
         }
@@ -2612,13 +2671,15 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             }
 
             // A route registered while this pipeline was in flight and the deferred rematch check
-            // punted (see ScheduleLateRegistrationRematch): now that the router is idle again,
-            // re-schedule the evaluation. Runs on the dispatcher like the rest of this finally,
-            // and only fires from the outermost frame of a re-entrant pipeline stack.
+            // punted (see RunPendingRematchCoreAsync): now that the router is idle again, re-request
+            // the evaluation. Runs on the dispatcher like the rest of this finally, and only fires
+            // from the outermost frame of a re-entrant pipeline stack. The render this queues is
+            // itself part of the work the prerenderer waits for, so the correction still lands
+            // before static HTML is serialized.
             _processingNavigation--;
             if (_processingNavigation == 0 && _rematchRequested && _disposed is false)
             {
-                ScheduleLateRegistrationRematch();
+                RequestLateRegistrationRematch();
             }
         }
     }

--- a/src/Brouter/Bit.Brouter/Components/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Components/Brouter.cs
@@ -2626,6 +2626,23 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         }
         finally
         {
+            // Balance the entry increment FIRST, before any awaited or otherwise throwing cleanup
+            // below: a CompleteViewTransitionAsync that faults (interop torn down mid-navigation)
+            // must not strand the counter above zero, which would make every later rematch check
+            // punt forever (see RunPendingRematchCoreAsync).
+            //
+            // A route registered while this pipeline was in flight and the deferred rematch check
+            // punted (see RunPendingRematchCoreAsync): now that the router is idle again, re-request
+            // the evaluation. Runs on the dispatcher like the rest of this finally, and only fires
+            // from the outermost frame of a re-entrant pipeline stack. The render this queues is
+            // itself part of the work the prerenderer waits for, so the correction still lands
+            // before static HTML is serialized.
+            _processingNavigation--;
+            if (_processingNavigation == 0 && _rematchRequested && _disposed is false)
+            {
+                RequestLateRegistrationRematch();
+            }
+
             // Safety net for the pending-navigation UI: if this navigation revealed it but bailed before
             // clearing it above (e.g. a loader threw and we routed to OnError), and we're still the current
             // navigation, hide it now. Guarded by version so a superseded pipeline can't clear the flag out
@@ -2668,18 +2685,6 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             if (ReferenceEquals(Volatile.Read(ref _navCts), newCts) is false)
             {
                 newCts.Dispose();
-            }
-
-            // A route registered while this pipeline was in flight and the deferred rematch check
-            // punted (see RunPendingRematchCoreAsync): now that the router is idle again, re-request
-            // the evaluation. Runs on the dispatcher like the rest of this finally, and only fires
-            // from the outermost frame of a re-entrant pipeline stack. The render this queues is
-            // itself part of the work the prerenderer waits for, so the correction still lands
-            // before static HTML is serialized.
-            _processingNavigation--;
-            if (_processingNavigation == 0 && _rematchRequested && _disposed is false)
-            {
-                RequestLateRegistrationRematch();
             }
         }
     }

--- a/src/Brouter/Bit.Brouter/Components/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Components/Brouter.cs
@@ -321,6 +321,13 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     // called off-dispatcher this reasoning breaks and the access would need real synchronization.
     private Broute[] _routesSnapshot = [];
     private bool _routesDirty = true;
+
+    // Monotonic version of the registration set, bumped by every RegisterRoute/UnregisterRoute.
+    // The boot sentinel (BrouterInitializer) watches it to detect when the declaration tree has
+    // finished registering during the initial mount. Same single-dispatcher discipline as _routes.
+    private long _routeRegistrationVersion;
+    internal long RouteRegistrationVersion => _routeRegistrationVersion;
+
     internal void RegisterRoute(Broute route)
     {
         // Reject templates that would be ambiguous with an already-registered route. A hand-declared /
@@ -378,6 +385,20 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         }
         _routes.Add(route);
         _routesDirty = true;
+        _routeRegistrationVersion++;
+
+        // A route registering AFTER the initial navigation already ran can change the correct
+        // outcome for the URL currently on screen: a conditionally-rendered (@if) Broute appearing,
+        // routes mounted behind an async wrapper, or a wrapper chain deep enough that the boot
+        // sentinel fired before it finished rendering (see BrouterInitializer). Schedule a deferred
+        // winner re-evaluation; it resolves as a cheap no-op when the newcomer doesn't beat the
+        // committed route. Registrations during the initial declaration cascade (the common,
+        // per-mount burst) never get here - the flag is still false - so startup cost is zero.
+        if (_initialNavigationStarted)
+        {
+            _rematchRequested = true;
+            ScheduleLateRegistrationRematch();
+        }
     }
     internal void UnregisterRoute(Broute route)
     {
@@ -402,6 +423,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             route.TemplateCollisionKey = null;
         }
         _routesDirty = true;
+        _routeRegistrationVersion++;
     }
 
     /// <summary>
@@ -644,6 +666,91 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     private bool _noRouteMatched;
     private long _navVersion;
 
+    // True once the initial navigation has been fired (by the boot navigator, or short-circuited
+    // because a real navigation arrived first). Gates the boot sentinel's inert mode and arms the
+    // late-registration rematch. Same single-dispatcher discipline as the other nav-state fields.
+    private bool _initialNavigationStarted;
+    internal bool InitialNavigationStarted => _initialNavigationStarted;
+
+    // Depth of currently-executing ProcessNavigationAsync frames. A counter rather than a bool:
+    // a departure/dispose callback can call NavigateTo synchronously, whose LocationChanged
+    // handler's InvokeAsync inlines on the dispatcher and re-enters the pipeline. Used to defer
+    // the late-registration rematch while any pipeline is in flight (its own commit matches
+    // against the grown route set, or its finally re-schedules the check once idle).
+    private int _processingNavigation;
+
+    // Late-registration rematch bookkeeping (see RegisterRoute / ScheduleLateRegistrationRematch).
+    // _rematchRequested: a post-boot registration happened and hasn't been evaluated yet.
+    // _rematchScheduled: an evaluation continuation is already queued (debounce).
+    private bool _rematchRequested;
+    private bool _rematchScheduled;
+
+    /// <summary>
+    /// Runs the initial navigation for the URL the app mounted at. Called by the boot navigator
+    /// (see <see cref="BrouterInitializer"/>) once the declaration tree has settled - during the
+    /// first render batch, so a synchronous pipeline commits the matched route into that same
+    /// batch and the interactive takeover after prerender never flashes an empty router.
+    /// Idempotent: only the first call does anything.
+    /// </summary>
+    internal Task RunInitialNavigationAsync()
+    {
+        if (_initialNavigationStarted || _disposed) return Task.CompletedTask;
+        _initialNavigationStarted = true;
+
+        // A real navigation can arrive before the boot sentinel settles (a LocationChanged fired
+        // during the first batch). That pipeline already owns the navigation state and matched the
+        // newest URL - running a second, stale "initial" pipeline underneath it would supersede it
+        // and re-fire its hooks. Any pipeline having started (_navVersion moved) means boot is moot.
+        if (_navVersion != 0) return Task.CompletedTask;
+
+        // The From is Empty (we just mounted), the To is the URL we're at now. decisionAlreadyMade
+        // is false - the LocationChanging handler is not registered yet (and does not fire for the
+        // initial load anyway), so the full pipeline runs the guards here. The first mount is
+        // reported as a Push (a fresh navigation), never a Pop.
+        return ProcessNavigationAsync(BrouterLocation.Empty, CurrentLocation, decisionAlreadyMade: false, BrouterNavigationType.Push).AsTask();
+    }
+
+    /// <summary>
+    /// Debounced evaluator for routes that registered after the initial navigation: once the
+    /// current render drain (and any in-flight navigation pipeline) is done, re-select the winner
+    /// for the current URL and - only when the grown route set actually changes it - re-run the
+    /// navigation so the screen reflects the route set that exists NOW. This is what turns a
+    /// too-early boot (see <see cref="BrouterInitializer"/>'s quiet-round heuristic), an async
+    /// wrapper finally mounting its routes, or a conditionally-rendered route appearing at its own
+    /// URL from "stuck until the next navigation" into a self-correcting extra render pass.
+    /// </summary>
+    private void ScheduleLateRegistrationRematch()
+    {
+        if (_rematchScheduled) return;
+        _rematchScheduled = true;
+        _ = InvokeAsync(async () =>
+        {
+            // One yield coalesces a whole render-drain's worth of registrations (an @if revealing
+            // several routes, a wrapper mounting a subtree) into a single evaluation.
+            await Task.Yield();
+            _rematchScheduled = false;
+            if (_disposed) return;
+
+            // A pipeline is mid-flight: leave _rematchRequested set - its finally re-schedules
+            // this check once the router is idle, and evaluating against a half-committed chain
+            // here would produce a false winner-diff that supersedes (and so restarts) it.
+            if (_processingNavigation > 0) return;
+            _rematchRequested = false;
+
+            // Pure winner probe (SelectWinner never mutates): the registration only matters when
+            // it changes the outcome for the URL already on screen. Reference-comparing against
+            // the committed leaf also covers the not-found case (null == null -> no-op).
+            var winnerMatch = SelectWinner(CurrentLocation);
+            var committedLeaf = _committedChain.Length > 0 ? _committedChain[^1] : null;
+            if (ReferenceEquals(winnerMatch?.Route, committedLeaf)) return;
+
+            // Same-URL re-navigation: routes present in both chains keep their instances
+            // (renavigation semantics), so only the corrected part of the tree re-renders.
+            // Replace: no history entry is involved in a route-set correction.
+            await ProcessNavigationAsync(CurrentLocation, CurrentLocation, decisionAlreadyMade: false, BrouterNavigationType.Replace);
+        });
+    }
+
     // The active router-level error boundary state (see RenderNavigationError). Non-null only when a
     // commit-phase failure bubbled past every route boundary and Brouter.ErrorContent is set; rendered
     // by BuildRenderTree in place of routed content. Cleared at the start of each navigation.
@@ -868,15 +975,14 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     {
         base.OnInitialized();
 
-        // Validate here as well as in OnParametersSet: the first OnParametersSet only runs after the
-        // async initialization below completes, and a misconfiguration should fail the first render
-        // synchronously instead of surfacing as an unhandled async exception.
+        // Validate as early as possible so a misconfiguration fails the first render synchronously
+        // (OnParametersSet re-validates for later parameter updates).
         ValidateChildContentAlias();
 
-        // Compute discovered routes here (not only in OnParametersSet): the initial route match runs in
-        // OnInitializedAsync, before OnParametersSet, and the synthetic <Broute> children must already be
-        // present in the first render so they register in time to be matched on the initial navigation.
-        // OnParametersSet still re-checks afterwards to pick up runtime changes to the assembly set.
+        // Compute discovered routes here (not only in OnParametersSet): the synthetic <Broute>
+        // children must be present in the FIRST render so they register before the boot sentinel
+        // settles and the initial match runs (see BrouterInitializer). OnParametersSet still
+        // re-checks afterwards to pick up runtime changes to the assembly set.
         RefreshDiscoveredRoutesIfNeeded();
 
         _brouterService.Attach(this, _navManager);
@@ -991,8 +1097,10 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         if (added is false) return;
 
         // Recompute discovery with the grown runtime set, then let the renderer flush once so the
-        // new synthetic <Broute> children run OnInitialized and register - the same yield-to-register
-        // technique the initial mount uses (see OnInitializedAsync).
+        // new synthetic <Broute> children run OnInitialized and register before matching proceeds.
+        // (This mid-pipeline yield is fine: the current page stays visible while it happens, unlike
+        // the initial mount, where the boot sentinel keeps everything in one batch instead - see
+        // BrouterInitializer.)
         _discoveryComputed = false;
         RefreshDiscoveredRoutesIfNeeded();
         StateHasChanged();
@@ -1056,31 +1164,14 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         return BroutePrerenderState.TryRestore(persisted, out value, _loaderStateJsonOptions);
     }
 
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-
-        // Yield once so ComponentBase performs the initial synchronous render of our
-        // ChildContent. That first render is what causes the declared <Broute> children to
-        // register themselves with us (each one calls RegisterRoute from its own OnInitialized).
-        // Until they've registered there is nothing to match against, which is why the initial
-        // match cannot run any earlier than this.
-        //
-        // Doing the initial match here - rather than in OnAfterRenderAsync - is what enables
-        // static server prerendering. OnAfterRenderAsync never runs during prerender, so the old
-        // placement left the prerendered HTML empty (no route was ever matched server-side).
-        // OnInitializedAsync, by contrast, runs during prerender and the renderer awaits it - and
-        // the StateHasChanged it triggers - before serializing the HTML, so the matched route is
-        // included in the prerendered output. When the component later becomes interactive its
-        // lifecycle runs again and the match re-runs naturally.
-        await Task.Yield();
-
-        // Initial render: the From is Empty (we just mounted), the To is the URL we're at now.
-        // decisionAlreadyMade is false - the LocationChanging handler is not registered yet (and does
-        // not fire for the initial load anyway), so the full pipeline runs the guards here. The first
-        // mount is reported as a Push (a fresh navigation), never a Pop.
-        await ProcessNavigationAsync(BrouterLocation.Empty, CurrentLocation, decisionAlreadyMade: false, BrouterNavigationType.Push);
-    }
+    // NOTE: there is deliberately no OnInitializedAsync here. The initial navigation is fired by
+    // the boot sentinel chain that BuildRenderTree emits after the route declarations (see
+    // BrouterInitializer): it waits - inside the first render batch - for the declared <Broute>
+    // children to register, then runs the pipeline. The old implementation awaited Task.Yield()
+    // here instead, which worked but split the mount across two render batches; after prerendering,
+    // the first interactive batch then replaced the server-rendered HTML with an EMPTY router for a
+    // frame - a visible flash of blank content. Static prerendering still works: the sentinel and
+    // navigator run in component lifecycle the prerenderer awaits before serializing HTML.
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -1111,8 +1202,9 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             {
                 // Enabling navigation interception genuinely requires an interactive runtime, so it stays
                 // in OnAfterRenderAsync, which only runs once interactivity is established. Under prerender
-                // this method doesn't run at all - that's fine: the initial match already happened in
-                // OnInitializedAsync, and interception is enabled here once the component goes interactive.
+                // this method doesn't run at all - that's fine: the initial match already happened during
+                // the first render (see BrouterInitializer), and interception is enabled here once the
+                // component goes interactive.
                 //
                 // Enabling navigation interception is best-effort: on a disconnected circuit or an interop
                 // failure it can throw, but the navigation pipeline itself (and any subsequent reconnects /
@@ -1289,6 +1381,17 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             {
                 b.AddContent(4, ErrorContent(_navError));
             }
+
+            // Boot sentinel: fires the initial navigation once the declared/discovered route tree
+            // above has finished registering - within this same render batch, so the first frame
+            // already contains the matched page (see BrouterInitializer). Emitted last so every
+            // route frame above initializes before the sentinel does. ObservedVersion is baked at
+            // frame-build time (before this render's children register); the sentinel recursion
+            // accounts for that. Inert (renders empty) once the initial navigation has run.
+            b.OpenComponent<BrouterInitializer>(5);
+            b.AddAttribute(6, nameof(BrouterInitializer.Router), this);
+            b.AddAttribute(7, nameof(BrouterInitializer.ObservedVersion), _routeRegistrationVersion);
+            b.CloseComponent();
             }));
             bo.CloseComponent();
         }));
@@ -1373,8 +1476,14 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     {
         get
         {
+            // Broad catch on purpose: an un-populated RendererInfo throws InvalidOperationException
+            // in real Blazor, but test renderers throw their own types (bUnit's
+            // MissingRendererInfoException derives directly from Exception). Any failure to read
+            // it means "unknown host" - and letting the read take down the navigation pipeline
+            // (silently skipping everything after this probe) is far worse than defaulting to
+            // interactive, which merely skips the static-SSR-only 404 propagation.
             try { return RendererInfo.IsInteractive; }
-            catch (InvalidOperationException) { return true; }
+            catch (Exception) { return true; }
         }
     }
 
@@ -1852,7 +1961,7 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     private async ValueTask ProcessNavigationAsync(BrouterLocation from, BrouterLocation to, bool decisionAlreadyMade, BrouterNavigationType navType)
     {
         // Now that we own the renderer's dispatcher (via InvokeAsync from the LocationChanged
-        // handler, or directly from OnAfterRenderAsync for the initial render), publish the
+        // handler, or from the boot navigator's lifecycle for the initial render), publish the
         // target location atomically with the start of this pipeline. The whole pipeline below
         // reads `to` rather than CurrentLocation, so a later navigation publishing a newer
         // CurrentLocation cannot make our `ctx.To` desync from what we're matching against.
@@ -1899,6 +2008,10 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         // failed/superseded navigation can never leave the browser holding a frozen snapshot.
         var viewTransitionStarted = false;
         var viewTransitionStaged = false;
+
+        // See _processingNavigation: lets the late-registration rematch defer while any pipeline
+        // frame is in flight. Immediately before the try so the finally's decrement always balances.
+        _processingNavigation++;
 
         try
         {
@@ -2223,7 +2336,8 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
 
                     // During static server rendering / prerender, NavigationManager.NavigateTo throws
                     // NavigationException as the framework's redirect signal (a loader may redirect,
-                    // e.g. an auth gate). It must unwind out of OnInitializedAsync so the endpoint can
+                    // e.g. an auth gate). It must unwind out of the boot navigator's lifecycle (see
+                    // BrouterInitialNavigator) so the endpoint can
                     // issue the HTTP redirect; swallowing it into OnError would drop the redirect
                     // entirely. Scan for it before any other error handling so an SSR redirect wins
                     // over a sibling loader's failure (root-most redirect wins if several threw).
@@ -2435,7 +2549,8 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         catch (NavigationException)
         {
             // SSR/prerender redirect signal (see the loader catch above). Let it propagate out of
-            // OnInitializedAsync so the framework can turn it into an HTTP redirect. A guard or
+            // the boot navigator's lifecycle (see BrouterInitialNavigator) so the framework can
+            // turn it into an HTTP redirect. A guard or
             // OnNavigating handler that redirects via NavigationManager during prerender lands here.
             throw;
         }
@@ -2494,6 +2609,16 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             if (ReferenceEquals(Volatile.Read(ref _navCts), newCts) is false)
             {
                 newCts.Dispose();
+            }
+
+            // A route registered while this pipeline was in flight and the deferred rematch check
+            // punted (see ScheduleLateRegistrationRematch): now that the router is idle again,
+            // re-schedule the evaluation. Runs on the dispatcher like the rest of this finally,
+            // and only fires from the outermost frame of a re-entrant pipeline stack.
+            _processingNavigation--;
+            if (_processingNavigation == 0 && _rematchRequested && _disposed is false)
+            {
+                ScheduleLateRegistrationRematch();
             }
         }
     }

--- a/src/Brouter/Bit.Brouter/Components/BrouterInitializer.cs
+++ b/src/Brouter/Bit.Brouter/Components/BrouterInitializer.cs
@@ -1,0 +1,154 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.Brouter;
+
+/// <summary>
+/// The boot sentinel <see cref="Brouter"/> emits as the last frame of its child region, responsible
+/// for firing the initial navigation at the right moment - and, crucially, in the right render batch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The initial route match cannot run until the declared &lt;Broute&gt; children have registered,
+/// and registration happens as the declaration tree renders: each nesting level (every Broute, every
+/// CascadingValue between it and its children, every user component wrapped around routes) initializes
+/// one render-queue "wave" after its parent rendered. Brouter used to bridge that with
+/// <c>await Task.Yield()</c> in <c>OnInitializedAsync</c> - correct, but it forced the mount into TWO
+/// render batches: batch one rendered the (empty) unmatched router, batch two revealed the page. After
+/// prerendering that empty first interactive batch replaced the server-rendered HTML with nothing for
+/// a frame - a visible flash of blank content (prerendered page -&gt; blank -&gt; page).
+/// </para>
+/// <para>
+/// The sentinel keeps everything inside the FIRST batch instead, exploiting two renderer facts:
+/// a component created during a render initializes synchronously within the same render-queue drain,
+/// and its own first render is appended to the tail of that same queue. So a sentinel that re-emits
+/// itself as a child observes the route tree one wave later per generation - without ever leaving the
+/// batch. Each generation compares <see cref="Brouter.RouteRegistrationVersion"/> against what the
+/// previous generation saw: a change means declarations are still registering (keep waiting); once
+/// the version has stayed quiet for <see cref="RequiredQuietRounds"/> consecutive generations the
+/// tree is taken as settled and a <see cref="BrouterInitialNavigator"/> is emitted, whose
+/// OnInitializedAsync runs the initial navigation. A fully synchronous pipeline (no loaders) then
+/// commits the matched route into the same batch - the first frame the user sees already contains
+/// the page, and the interactive takeover after prerender is seamless.
+/// </para>
+/// <para>
+/// The quiet-round threshold is a heuristic for one reason: opaque wrapper components. A chain of
+/// user components between the router and its routes registers nothing for one wave per wrapper, and
+/// no library code can observe "the render queue still holds work that will register routes". The
+/// per-level cadence of the route tree itself (Broute render -&gt; CascadingValue render) goes quiet
+/// for at most one wave per level, so <see cref="RequiredQuietRounds"/> = 3 settles correctly for
+/// arbitrarily deep route nesting and up to three consecutive non-registering wrapper renders.
+/// Deeper wrapper stacks make the navigator fire before every route registered - which is exactly
+/// the late-registration case <see cref="Brouter.RegisterRoute"/>'s rematch handles: the outcome is
+/// corrected in a follow-up batch (no worse than the old two-batch mount), never silently wrong.
+/// </para>
+/// <para>
+/// Once <see cref="Brouter.InitialNavigationStarted"/> is true every sentinel renders empty, so the
+/// chain unwinds (children dispose) on its next render and steady-state cost is a single inert
+/// component. Static prerendering works unchanged: all of this runs in component lifecycle the
+/// prerenderer awaits, and a pending navigator task (loaders) is tracked for quiescence exactly
+/// like the old OnInitializedAsync was.
+/// </para>
+/// </remarks>
+internal sealed class BrouterInitializer : ComponentBase
+{
+    /// <summary>
+    /// Consecutive registration-quiet generations required before the route tree is considered
+    /// settled. See the class remarks for why 3: route nesting itself never goes quiet for more
+    /// than one consecutive wave, so this tolerates up to three stacked non-registering wrapper
+    /// components while costing only two extra (trivially cheap) sentinel renders per mount.
+    /// </summary>
+    internal const int RequiredQuietRounds = 3;
+
+    /// <summary>
+    /// Backstop against a pathological route tree that never stops registering (which would
+    /// otherwise grow the sentinel chain forever inside one batch). At the cap the navigator
+    /// fires regardless; the late-registration rematch corrects the outcome if needed.
+    /// </summary>
+    internal const int MaxGenerations = 256;
+
+    [Parameter] public Brouter Router { get; set; } = default!;
+
+    /// <summary>
+    /// The <see cref="Brouter.RouteRegistrationVersion"/> observed when this generation was emitted.
+    /// Parameter values are baked at frame-build time, i.e. BEFORE the same render's sibling Broutes
+    /// initialize - the first generation therefore always observes a change, which is fine: it just
+    /// spends one round.
+    /// </summary>
+    [Parameter] public long ObservedVersion { get; set; }
+
+    /// <summary>Consecutive quiet observations accumulated so far (reset to 0 by any change).</summary>
+    [Parameter] public int QuietRounds { get; set; }
+
+    /// <summary>This node's position in the sentinel chain, for the runaway cap.</summary>
+    [Parameter] public int Generation { get; set; }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        base.BuildRenderTree(builder);
+
+        // Inert once boot is done. Rendering empty here is also what unwinds the chain: the next
+        // render of each node diffs its child sentinel/navigator away.
+        if (Router.InitialNavigationStarted) return;
+
+        var current = Router.RouteRegistrationVersion;
+
+        if (Generation >= MaxGenerations)
+        {
+            RenderNavigator(builder);
+            return;
+        }
+
+        if (current != ObservedVersion)
+        {
+            // Declarations registered since the previous generation looked - keep observing.
+            RenderChildSentinel(builder, current, quietRounds: 0);
+            return;
+        }
+
+        var quiet = QuietRounds + 1;
+        if (quiet < RequiredQuietRounds)
+        {
+            RenderChildSentinel(builder, current, quiet);
+            return;
+        }
+
+        RenderNavigator(builder);
+    }
+
+    private void RenderChildSentinel(RenderTreeBuilder builder, long version, int quietRounds)
+    {
+        builder.OpenComponent<BrouterInitializer>(0);
+        builder.AddAttribute(1, nameof(Router), Router);
+        builder.AddAttribute(2, nameof(ObservedVersion), version);
+        builder.AddAttribute(3, nameof(QuietRounds), quietRounds);
+        builder.AddAttribute(4, nameof(Generation), Generation + 1);
+        builder.CloseComponent();
+    }
+
+    // Distinct sequence numbers from the sentinel branch so a branch switch diffs as a clean
+    // remove+insert rather than an in-place parameter morph of unrelated components.
+    private void RenderNavigator(RenderTreeBuilder builder)
+    {
+        builder.OpenComponent<BrouterInitialNavigator>(5);
+        builder.AddAttribute(6, nameof(BrouterInitialNavigator.Router), Router);
+        builder.CloseComponent();
+    }
+}
+
+/// <summary>
+/// Terminal node of the <see cref="BrouterInitializer"/> chain: runs the initial navigation from
+/// its OnInitializedAsync, which the renderer invokes synchronously while diffing the emitting
+/// sentinel - still inside the first render batch. A navigation with no async work (no guards or
+/// loaders awaiting) therefore commits its matched route into that same batch. When the pipeline
+/// does await, the incomplete lifecycle task is tracked by the renderer exactly as
+/// <c>Brouter.OnInitializedAsync</c>'s used to be: static prerendering waits for it before
+/// serializing HTML, and a <c>NavigationException</c> (the framework's SSR redirect signal, e.g.
+/// an auth gate's loader redirecting) propagates out of it so the endpoint can issue the HTTP
+/// redirect.
+/// </summary>
+internal sealed class BrouterInitialNavigator : ComponentBase
+{
+    [Parameter] public Brouter Router { get; set; } = default!;
+
+    protected override Task OnInitializedAsync() => Router.RunInitialNavigationAsync();
+}

--- a/src/Brouter/Bit.Brouter/Components/BrouterInitializer.cs
+++ b/src/Brouter/Bit.Brouter/Components/BrouterInitializer.cs
@@ -40,6 +40,8 @@ namespace Bit.Brouter;
 /// Deeper wrapper stacks make the navigator fire before every route registered - which is exactly
 /// the late-registration case <see cref="Brouter.RegisterRoute"/>'s rematch handles: the outcome is
 /// corrected in a follow-up batch (no worse than the old two-batch mount), never silently wrong.
+/// That correction is owned by <see cref="BrouterRematchRunner"/>'s lifecycle precisely so it holds
+/// under prerendering too - see that type's remarks for why a detached continuation does not.
 /// </para>
 /// <para>
 /// Once <see cref="Brouter.InitialNavigationStarted"/> is true every sentinel renders empty, so the
@@ -151,4 +153,39 @@ internal sealed class BrouterInitialNavigator : ComponentBase
     [Parameter] public Brouter Router { get; set; } = default!;
 
     protected override Task OnInitializedAsync() => Router.RunInitialNavigationAsync();
+}
+
+/// <summary>
+/// Permanently-mounted, never-rendering sibling of the <see cref="BrouterInitializer"/> chain whose
+/// only job is to own the lifecycle task for a late-registration rematch (see
+/// <c>Brouter.RequestLateRegistrationRematch</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A rematch cannot be fired from a detached <c>InvokeAsync</c> continuation, because the renderer
+/// only tracks tasks returned from component lifecycle methods. Static prerendering awaits exactly
+/// those (<c>WaitForQuiescenceAsync</c>) before serializing HTML, and routes exceptions from exactly
+/// those to its error handling. A detached continuation gets neither: the prerenderer would emit an
+/// empty router for the very deep-wrapper case the rematch exists to rescue, and an SSR redirect's
+/// <c>NavigationException</c> or a fail-closed <c>[Authorize]</c> guard would be swallowed silently.
+/// </para>
+/// <para>
+/// Routing the work through <c>OnParametersSetAsync</c> instead puts it on exactly the same footing
+/// as the initial navigation (which <see cref="BrouterInitialNavigator"/> returns from
+/// <c>OnInitializedAsync</c>): awaited by prerendering, and surfaced through the renderer on
+/// failure. The router re-renders on every request so this component's parameters are re-supplied;
+/// requests that turn out to be no-ops cost a single completed-task return.
+/// </para>
+/// </remarks>
+internal sealed class BrouterRematchRunner : ComponentBase
+{
+    [Parameter] public Brouter Router { get; set; } = default!;
+
+    /// <summary>
+    /// Bumped by every rematch request so the supplied parameter set always differs from the last -
+    /// the request itself lives in the router's state, this only guarantees delivery.
+    /// </summary>
+    [Parameter] public long PendingVersion { get; set; }
+
+    protected override Task OnParametersSetAsync() => Router.RunPendingRematchAsync();
 }

--- a/src/Brouter/Tests/Bit.Brouter.Tests/AmbiguousRouteTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/AmbiguousRouteTests.cs
@@ -115,7 +115,7 @@ public class AmbiguousRouteTests : BunitTestContext
         cut.Render(p => p.Add(h => h.Show, "b"));
 
         // Route b's late registration already triggers a winner re-evaluation at the current URL
-        // (see Brouter.ScheduleLateRegistrationRematch); the round-trip below additionally proves
+        // (see Brouter.RequestLateRegistrationRematch); the round-trip below additionally proves
         // a fresh navigation selects the re-registered template.
         nav.NavigateTo("http://localhost/elsewhere");
         nav.NavigateTo("http://localhost/dup");

--- a/src/Brouter/Tests/Bit.Brouter.Tests/AmbiguousRouteTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/AmbiguousRouteTests.cs
@@ -114,7 +114,9 @@ public class AmbiguousRouteTests : BunitTestContext
         cut.Render(p => p.Add(h => h.Show, "none"));
         cut.Render(p => p.Add(h => h.Show, "b"));
 
-        // Matching runs per navigation, not on registration, so navigate again to see route b win.
+        // Route b's late registration already triggers a winner re-evaluation at the current URL
+        // (see Brouter.ScheduleLateRegistrationRematch); the round-trip below additionally proves
+        // a fresh navigation selects the re-registered template.
         nav.NavigateTo("http://localhost/elsewhere");
         nav.NavigateTo("http://localhost/dup");
 

--- a/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
@@ -122,4 +122,27 @@ public class BrouterAuthorizationTests : BunitTestContext
             () => RenderComponent<DiscoveryHost>());
         StringAssert.Contains(exception.Message, "authorization");
     }
+
+    [TestMethod]
+    public async Task Authorize_page_reached_by_the_late_registration_rematch_fails_closed()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/secure");
+
+        // Mount at /secure before the route exists: nothing matches, so no auth check runs yet.
+        var cut = RenderComponent<LateRegisteredAuthHost>(p => p.Add(h => h.ShowSecure, false));
+
+        // Reveal the [Authorize] route. It now reaches the screen through the rematch rather than
+        // the boot navigation - a different pipeline entry point that must fail closed just the
+        // same. The rematch runs as a component lifecycle task (BrouterRematchRunner), so the
+        // fail-closed throw reaches the renderer instead of being swallowed by a detached
+        // continuation - which would leave the developer with no signal at all.
+        cut.Render(p => p.Add(h => h.ShowSecure, true));
+
+        var exception = await Context!.Renderer.UnhandledException.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.IsInstanceOfType<InvalidOperationException>(exception);
+        StringAssert.Contains(exception.Message, "authorization");
+        Assert.AreEqual(0, cut.FindAll("[data-testid=secure]").Count,
+            "an [Authorize] page must never render without an authorization check");
+    }
 }

--- a/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/BrouterAuthorizationTests.cs
@@ -93,33 +93,33 @@ public class BrouterAuthorizationTests : BunitTestContext
     }
 
     [TestMethod]
-    public async Task Authorize_page_fails_closed_under_the_DefaultLayout_only_composition()
+    public void Authorize_page_fails_closed_under_the_DefaultLayout_only_composition()
     {
         var nav = Services.GetRequiredService<BunitNavigationManager>();
         nav.NavigateTo("http://localhost/secure");
 
         // AutoAuthLayoutHost sets only DefaultLayout, composing the framework RouteView - which
         // performs no authorization check at all - so Brouter's own guard must throw rather than
-        // silently render the [Authorize] page.
-        _ = RenderComponent<AutoAuthLayoutHost>();
-
-        var exception = await Context!.Renderer.UnhandledException.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.IsInstanceOfType<InvalidOperationException>(exception);
+        // silently render the [Authorize] page. The single-batch initial mount (see
+        // BrouterInitializer) renders the matched page inside the first render pass, so the
+        // fail-closed throw surfaces synchronously from the mount itself.
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => RenderComponent<AutoAuthLayoutHost>());
         StringAssert.Contains(exception.Message, "authorization");
     }
 
     [TestMethod]
-    public async Task Authorize_page_rendered_natively_fails_closed()
+    public void Authorize_page_rendered_natively_fails_closed()
     {
         var nav = Services.GetRequiredService<BunitNavigationManager>();
         nav.NavigateTo("http://localhost/secure");
 
         // DiscoveryHost sets no Found and no auth parameters, so SecurePage would render natively -
         // which must throw rather than silently skip the [Authorize] check (mirroring RouteView).
-        _ = RenderComponent<DiscoveryHost>();
-
-        var exception = await Context!.Renderer.UnhandledException.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.IsInstanceOfType<InvalidOperationException>(exception);
+        // As above, the initial mount renders the page in the first render pass, so the throw
+        // surfaces synchronously from the mount.
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => RenderComponent<DiscoveryHost>());
         StringAssert.Contains(exception.Message, "authorization");
     }
 }

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialBatchProbe.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialBatchProbe.razor
@@ -1,0 +1,14 @@
+@* Records whether the routed content already existed at the first dispatcher yield after this
+   component initialized. Declared BEFORE the <Brouter> in its host, so this component initializes
+   first and its yield continuation is queued ahead of any continuation the router might post: it
+   therefore runs right after the mount's first render-queue drain - the moment the first batch
+   would be painted - and observes whether that batch already contained the matched content (new
+   single-batch boot) or an empty router (the old two-batch mount, i.e. the prerender flash). *@
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Yield();
+        InitialMountState.ContentPresentAtFirstYield = InitialMountState.ContentInstances > 0;
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountContent.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountContent.razor
@@ -1,0 +1,7 @@
+@* Routed page content whose creation InitialMountTests observe via InitialMountState. *@
+
+<div data-testid="im-content">content</div>
+
+@code {
+    protected override void OnInitialized() => InitialMountState.ContentInstances++;
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountDeepWrappedHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountDeepWrappedHost.razor
@@ -1,0 +1,22 @@
+@* Five stacked opaque wrappers before any route registers - deliberately deeper than the boot
+   sentinel's quiet-round tolerance, so the initial navigation fires before these routes exist.
+   Pins the safety net: the late registration must trigger a rematch that renders the correct
+   route anyway (a follow-up batch, like the old two-batch mount - never a permanently missed
+   route). *@
+
+<InitialBatchProbe />
+<Brouter>
+    <InitialMountWrapper>
+        <InitialMountWrapper>
+            <InitialMountWrapper>
+                <InitialMountWrapper>
+                    <InitialMountWrapper>
+                        <Broute Path="/home">
+                            <Content><InitialMountContent /></Content>
+                        </Broute>
+                    </InitialMountWrapper>
+                </InitialMountWrapper>
+            </InitialMountWrapper>
+        </InitialMountWrapper>
+    </InitialMountWrapper>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountHost.razor
@@ -1,0 +1,12 @@
+@* Flat routes behind the first-batch probe. Used by InitialMountTests to pin that the initial
+   mount reveals the matched route in the FIRST render batch (no blank flash after prerender). *@
+
+<InitialBatchProbe />
+<Brouter>
+    <Broute Path="/home">
+        <Content><InitialMountContent /></Content>
+    </Broute>
+    <Broute Path="/other">
+        <Content><div data-testid="im-other">other</div></Content>
+    </Broute>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountLateRouteHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountLateRouteHost.razor
@@ -1,0 +1,19 @@
+@* A route that only exists once ShowLate flips to true. Pins the late-registration rematch: when
+   the route appears while the app is already AT its URL, the router re-evaluates the winner and
+   renders it without requiring a navigation. *@
+
+<Brouter>
+    <Broute Path="/always">
+        <Content><div data-testid="im-always">always</div></Content>
+    </Broute>
+    @if (ShowLate)
+    {
+        <Broute Path="/late">
+            <Content><div data-testid="im-late">late</div></Content>
+        </Broute>
+    }
+</Brouter>
+
+@code {
+    [Parameter] public bool ShowLate { get; set; }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountNestedHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountNestedHost.razor
@@ -1,0 +1,18 @@
+@* A three-level nested chain behind the first-batch probe: registration cascades one render wave
+   per level (Broute render -> CascadingValue render -> child Broute init), which is exactly the
+   cadence the boot sentinel's quiet-round threshold must bridge without leaving the batch. *@
+
+<InitialBatchProbe />
+<Brouter>
+    <Broute Path="/docs">
+        <ChildContent>
+            <Broute Path="guide">
+                <ChildContent>
+                    <Broute Path="intro">
+                        <Content><InitialMountContent /></Content>
+                    </Broute>
+                </ChildContent>
+            </Broute>
+        </ChildContent>
+    </Broute>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountState.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountState.cs
@@ -1,0 +1,27 @@
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// Shared observation state for <c>InitialMountTests</c> (static like <see cref="NavigationLockState"/>;
+/// the test assembly runs without MSTest parallelization, so tests never race on it). Captures the
+/// property under test: whether the routed content already existed at the FIRST dispatcher yield
+/// after the mount began - i.e. whether the first render batch (the first frame the browser paints
+/// after prerendered HTML is replaced) already contained the matched route, or the mount flashed an
+/// empty router first.
+/// </summary>
+public static class InitialMountState
+{
+    /// <summary>Live instances of <c>InitialMountContent</c> (incremented in its OnInitialized).</summary>
+    public static int ContentInstances;
+
+    /// <summary>
+    /// Recorded by <c>InitialBatchProbe</c>: was the routed content already initialized when the
+    /// first posted continuation ran? Null until the probe has recorded.
+    /// </summary>
+    public static bool? ContentPresentAtFirstYield;
+
+    public static void Reset()
+    {
+        ContentInstances = 0;
+        ContentPresentAtFirstYield = null;
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountTests.cs
@@ -1,0 +1,108 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// Pins the single-batch initial mount (see <c>BrouterInitializer</c>): the first render batch of
+/// the mount must already contain the matched route's content. The old two-batch mount (an empty
+/// unmatched router in batch one, the page in batch two) is what caused a visible flash of blank
+/// content when the interactive pass replaced prerendered HTML. The <c>InitialBatchProbe</c>
+/// records the observable property directly: at the first dispatcher yield after the mount began
+/// - the moment the first batch would be painted - was the routed content already there?
+/// Also covers the late-registration safety net for route trees the boot sentinel cannot fully
+/// observe (deep wrapper chains, conditionally-rendered routes).
+/// </summary>
+[TestClass]
+public class InitialMountTests : BunitTestContext
+{
+    [TestInitialize]
+    public void ResetState() => InitialMountState.Reset();
+
+    private IRenderedComponent<THost> RenderHostAt<THost>(string url)
+        where THost : Microsoft.AspNetCore.Components.IComponent
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo(url);
+        return RenderComponent<THost>();
+    }
+
+    [TestMethod]
+    public void Initial_mount_reveals_flat_route_in_the_first_render_batch()
+    {
+        var cut = RenderHostAt<InitialMountHost>("http://localhost/home");
+
+        cut.WaitForAssertion(() => Assert.IsNotNull(cut.Find("[data-testid=im-content]")));
+        // The probe recorded true only if the content existed BEFORE the first dispatcher yield,
+        // i.e. inside the mount's first render batch - the no-blank-flash guarantee.
+        cut.WaitForAssertion(() => Assert.AreEqual(true, InitialMountState.ContentPresentAtFirstYield,
+            "the matched route must render within the initial render batch, not a later one"));
+    }
+
+    [TestMethod]
+    public void Initial_mount_reveals_nested_route_chain_in_the_first_render_batch()
+    {
+        var cut = RenderHostAt<InitialMountNestedHost>("http://localhost/docs/guide/intro");
+
+        cut.WaitForAssertion(() => Assert.IsNotNull(cut.Find("[data-testid=im-content]")));
+        cut.WaitForAssertion(() => Assert.AreEqual(true, InitialMountState.ContentPresentAtFirstYield,
+            "nested registration cascades one render wave per level; the boot sentinel must bridge " +
+            "all of them without leaving the first batch"));
+    }
+
+    [TestMethod]
+    public void Initial_mount_reveals_route_behind_a_wrapper_component_in_the_first_render_batch()
+    {
+        var cut = RenderHostAt<InitialMountWrappedHost>("http://localhost/home");
+
+        cut.WaitForAssertion(() => Assert.IsNotNull(cut.Find("[data-testid=im-content]")));
+        cut.WaitForAssertion(() => Assert.AreEqual(true, InitialMountState.ContentPresentAtFirstYield,
+            "a wrapper component adds a registration-silent render wave the sentinel must tolerate"));
+    }
+
+    [TestMethod]
+    public void Routes_behind_a_wrapper_chain_deeper_than_the_sentinel_tolerance_still_render()
+    {
+        // Five stacked wrappers out-wait the sentinel's quiet rounds, so the initial navigation
+        // fires before these routes registered. The late-registration rematch must then correct
+        // the outcome - the route may render a batch late here, but never not at all.
+        var cut = RenderHostAt<InitialMountDeepWrappedHost>("http://localhost/home");
+
+        cut.WaitForAssertion(() => Assert.IsNotNull(cut.Find("[data-testid=im-content]")));
+    }
+
+    [TestMethod]
+    public void Route_registered_after_mount_at_its_own_url_renders_without_a_navigation()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/late");
+
+        // Mount at /late while the /late route does not exist yet: nothing matches.
+        var cut = RenderComponent<InitialMountLateRouteHost>(p => p.Add(h => h.ShowLate, false));
+        cut.WaitForAssertion(() => Assert.AreEqual(0, cut.FindAll("[data-testid=im-late]").Count));
+
+        // Reveal the route. Its registration must trigger the winner re-evaluation and render it
+        // in place - no navigate-away-and-back required.
+        cut.Render(p => p.Add(h => h.ShowLate, true));
+
+        cut.WaitForAssertion(() => Assert.AreEqual("late", cut.Find("[data-testid=im-late]").TextContent));
+    }
+
+    [TestMethod]
+    public void Late_registration_that_does_not_change_the_winner_leaves_the_committed_route_alone()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/always");
+
+        var cut = RenderComponent<InitialMountLateRouteHost>(p => p.Add(h => h.ShowLate, false));
+        cut.WaitForAssertion(() => Assert.AreEqual("always", cut.Find("[data-testid=im-always]").TextContent));
+
+        // Registering an unrelated route must resolve as a no-op: /always stays rendered.
+        cut.Render(p => p.Add(h => h.ShowLate, true));
+
+        cut.WaitForAssertion(() => Assert.AreEqual("always", cut.Find("[data-testid=im-always]").TextContent));
+        Assert.AreEqual(0, cut.FindAll("[data-testid=im-late]").Count);
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountWrappedHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountWrappedHost.razor
@@ -1,0 +1,11 @@
+@* Routes declared behind a wrapper component (the common "extract routes into <AppRoutes/>"
+   pattern). The wrapper adds a registration-silent wave; the sentinel must still settle in-batch. *@
+
+<InitialBatchProbe />
+<Brouter>
+    <InitialMountWrapper>
+        <Broute Path="/home">
+            <Content><InitialMountContent /></Content>
+        </Broute>
+    </InitialMountWrapper>
+</Brouter>

--- a/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountWrapper.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/InitialMountWrapper.razor
@@ -1,0 +1,8 @@
+@* Pass-through wrapper: one opaque component layer between the router and its routes, adding one
+   registration-silent render wave the boot sentinel must tolerate. *@
+
+@ChildContent
+
+@code {
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/LateRegisteredAuthHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/LateRegisteredAuthHost.razor
@@ -1,0 +1,18 @@
+@* The [Authorize]-protected /secure page is declared behind an @if, so it registers AFTER the
+   initial navigation and reaches the screen through the late-registration rematch rather than the
+   boot path. Composed like DiscoveryHost (no Found, no auth parameters), so SecurePage would
+   render natively - which must fail closed. *@
+
+<Brouter>
+    <Broute Path="/home">
+        <Content><div data-testid="lra-home">home</div></Content>
+    </Broute>
+    @if (ShowSecure)
+    {
+        <Broute Path="/secure" Component="typeof(SecurePage)" />
+    }
+</Brouter>
+
+@code {
+    [Parameter] public bool ShowSecure { get; set; }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/PrerenderMountTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/PrerenderMountTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// Pins the initial mount against the REAL static prerenderer (<see cref="HtmlRenderer"/> - the
+/// same renderer that produces prerendered HTML in a Blazor Web App), rather than bUnit's
+/// interactive renderer. The distinction matters: the prerenderer serializes its HTML as soon as
+/// <c>WaitForQuiescenceAsync</c> completes, and that only awaits tasks returned from component
+/// lifecycle methods. Work posted to the dispatcher outside a lifecycle task simply never lands in
+/// the output, so a mount that "settles eventually" under bUnit can still prerender as an empty
+/// router. <c>InitialMountTests</c> covers the interactive side; this covers what the server emits.
+/// </summary>
+[TestClass]
+public class PrerenderMountTests
+{
+    private sealed class PrerenderNavigationManager : NavigationManager
+    {
+        public PrerenderNavigationManager(string uri) => Initialize("http://localhost/", uri);
+
+        protected override void NavigateToCore(string uri, bool forceLoad) { }
+    }
+
+    private sealed class NoopNavigationInterception : INavigationInterception
+    {
+        public Task EnableNavigationInterceptionAsync() => Task.CompletedTask;
+    }
+
+    // Mirrors real static SSR, where JS interop is unavailable: any call must fail rather than
+    // quietly succeed, so a regression that starts depending on interop during prerender is caught.
+    private sealed class UnavailableJSRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+            => throw new InvalidOperationException("JavaScript interop is not available during prerendering.");
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+            => throw new InvalidOperationException("JavaScript interop is not available during prerendering.");
+    }
+
+    private static async Task<string> PrerenderAsync<THost>(string url) where THost : IComponent
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddBitBrouterServices();
+        services.AddScoped<NavigationManager>(_ => new PrerenderNavigationManager(url));
+        services.AddScoped<INavigationInterception, NoopNavigationInterception>();
+        services.AddScoped<IJSRuntime, UnavailableJSRuntime>();
+        await using var provider = services.BuildServiceProvider();
+
+        await using var renderer = new HtmlRenderer(provider, provider.GetRequiredService<ILoggerFactory>());
+        return await renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var output = await renderer.RenderComponentAsync<THost>();
+            return output.ToHtmlString();
+        });
+    }
+
+    [TestMethod]
+    public async Task Prerender_emits_the_matched_flat_route()
+    {
+        var html = await PrerenderAsync<InitialMountHost>("http://localhost/home");
+
+        StringAssert.Contains(html, "im-content");
+    }
+
+    [TestMethod]
+    public async Task Prerender_emits_the_matched_nested_route_chain()
+    {
+        var html = await PrerenderAsync<InitialMountNestedHost>("http://localhost/docs/guide/intro");
+
+        StringAssert.Contains(html, "im-content");
+    }
+
+    [TestMethod]
+    public async Task Prerender_emits_a_route_declared_behind_a_wrapper_component()
+    {
+        var html = await PrerenderAsync<InitialMountWrappedHost>("http://localhost/home");
+
+        StringAssert.Contains(html, "im-content");
+    }
+
+    [TestMethod]
+    public async Task Prerender_emits_routes_behind_a_wrapper_chain_deeper_than_the_sentinel_tolerance()
+    {
+        // Five stacked wrappers out-wait the boot sentinel's quiet rounds, so the initial navigation
+        // fires before these routes registered and only the late-registration rematch can correct
+        // it. That correction has to be owned by a component lifecycle (BrouterRematchRunner) for
+        // the prerenderer to wait for it - fired detached, this prerenders as an empty router.
+        var html = await PrerenderAsync<InitialMountDeepWrappedHost>("http://localhost/home");
+
+        StringAssert.Contains(html, "im-content");
+    }
+
+    [TestMethod]
+    public async Task Prerender_emits_nothing_routed_when_no_route_matches()
+    {
+        var html = await PrerenderAsync<InitialMountHost>("http://localhost/no-such-page");
+
+        Assert.IsFalse(html.Contains("im-content"), "an unmatched URL must not emit routed content");
+        Assert.IsFalse(html.Contains("im-other"), "an unmatched URL must not emit routed content");
+    }
+}


### PR DESCRIPTION
closes #12830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initial navigation now displays the correct route during the first render, including nested and wrapped routes.
  * Routes registered shortly after mounting are detected and matched without requiring another navigation.
  * Prevented late, unrelated route registrations from replacing the currently selected route.
  * Improved navigation stability and handling across interactive and server-rendered environments.

* **Tests**
  * Added comprehensive coverage for initial rendering, nested routes, wrappers, late registration, and authorization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->