### PR TITLE
Add new features for master-detail in BitDataGrid (#12777)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
@@ -1732,7 +1732,8 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
     /// materialized sources (<see cref="ICollection{T}"/>) are pruned so a lazy
     /// <see cref="IEnumerable{T}"/> isn't enumerated an extra time. Controlled state is skipped
     /// (<see cref="SelectedItems"/>/<see cref="ExpandedDetailItems"/> are authoritative there and are
-    /// re-applied on every parameter set).
+    /// re-applied on every parameter set). A pruned row goes from expanded to collapsed like any other
+    /// collapse, so it is reported through <see cref="OnDetailToggle"/> too.
     /// </summary>
     private async Task PruneStaleRowStateAsync()
     {
@@ -1742,8 +1743,9 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         {
             if (ExpandedDetailItems is null && _expandedDetailsSet is { Count: > 0 })
             {
+                var collapsed = _expandedDetailsSet.ToList();
                 _expandedDetailsSet.Clear();
-                await NotifyDetailsAsync();
+                await NotifyDetailsChangedAsync(collapsed, false);
             }
             if (SelectedItems is null && _selectedSet is { Count: > 0 })
             {
@@ -1760,8 +1762,12 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
 
         if (ExpandedDetailItems is null && _expandedDetailsSet is { Count: > 0 })
         {
-            var collapsed = _expandedDetailsSet.RemoveWhere(i => !keys.Contains(GetKey(i)));
-            if (collapsed > 0) await NotifyDetailsAsync();
+            var collapsed = _expandedDetailsSet.Where(i => !keys.Contains(GetKey(i))).ToList();
+            if (collapsed.Count > 0)
+            {
+                foreach (var item in collapsed) _expandedDetailsSet.Remove(item);
+                await NotifyDetailsChangedAsync(collapsed, false);
+            }
         }
 
         if (SelectedItems is null && _selectedSet is { Count: > 0 })
@@ -1842,13 +1848,7 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         }
         if (changed.Count == 0) return;
 
-        if (OnDetailToggle.HasDelegate)
-        {
-            foreach (var item in changed)
-                await OnDetailToggle.InvokeAsync(new BitDataGridDetailEventArgs<TItem> { Item = item, Expanded = true });
-        }
-
-        await NotifyDetailsAsync();
+        await NotifyDetailsChangedAsync(changed, true);
     }
 
     /// <summary>Collapses every expanded detail row, raising <see cref="OnDetailToggle"/> once per row.</summary>
@@ -1859,10 +1859,20 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         var changed = _expandedDetailsSet.ToList();
         _expandedDetailsSet.Clear();
 
+        await NotifyDetailsChangedAsync(changed, false);
+    }
+
+    /// <summary>
+    /// Reports a batch of rows whose expanded state just changed: <see cref="OnDetailToggle"/> once per
+    /// row (so a per-row listener sees the same events it would for one-at-a-time toggling), then the
+    /// new set through <see cref="ExpandedDetailItemsChanged"/>.
+    /// </summary>
+    private async Task NotifyDetailsChangedAsync(List<TItem> changed, bool expanded)
+    {
         if (OnDetailToggle.HasDelegate)
         {
             foreach (var item in changed)
-                await OnDetailToggle.InvokeAsync(new BitDataGridDetailEventArgs<TItem> { Item = item, Expanded = false });
+                await OnDetailToggle.InvokeAsync(new BitDataGridDetailEventArgs<TItem> { Item = item, Expanded = expanded });
         }
 
         await NotifyDetailsAsync();

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
@@ -1820,25 +1820,45 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         await NotifyDetailsAsync();
     }
 
-    /// <summary>Expands the detail content of every row of the current view (all rows matching the
-    /// active filters, not only the rendered page). No-op without a <see cref="DetailTemplate"/>.</summary>
+    /// <summary>Expands the detail content of every row of the current view. In local mode that is
+    /// every row matching the active filters, not only the rendered page; in server, queryable and
+    /// infinite modes the grid only holds the rows fetched so far, so only those are expanded.
+    /// Raises <see cref="OnDetailToggle"/> once per newly expanded row.
+    /// No-op without a <see cref="DetailTemplate"/>.</summary>
     public async Task ExpandAllDetailsAsync()
     {
         if (!HasDetailTemplate) return;
 
-        var changed = false;
-        foreach (var item in _view) changed |= _expandedDetails.Add(item);
-        if (!changed) return;
+        var changed = new List<TItem>();
+        foreach (var item in _view)
+        {
+            if (_expandedDetails.Add(item)) changed.Add(item);
+        }
+        if (changed.Count == 0) return;
+
+        if (OnDetailToggle.HasDelegate)
+        {
+            foreach (var item in changed)
+                await OnDetailToggle.InvokeAsync(new BitDataGridDetailEventArgs<TItem> { Item = item, Expanded = true });
+        }
 
         await NotifyDetailsAsync();
     }
 
-    /// <summary>Collapses every expanded detail row.</summary>
+    /// <summary>Collapses every expanded detail row, raising <see cref="OnDetailToggle"/> once per row.</summary>
     public async Task CollapseAllDetailsAsync()
     {
         if (_expandedDetailsSet is not { Count: > 0 }) return;
 
+        var changed = _expandedDetailsSet.ToList();
         _expandedDetailsSet.Clear();
+
+        if (OnDetailToggle.HasDelegate)
+        {
+            foreach (var item in changed)
+                await OnDetailToggle.InvokeAsync(new BitDataGridDetailEventArgs<TItem> { Item = item, Expanded = false });
+        }
+
         await NotifyDetailsAsync();
     }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
@@ -214,6 +214,38 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
     [Parameter] public RenderFragment? ToolbarTemplate { get; set; }
     [Parameter] public RenderFragment<TItem>? DetailTemplate { get; set; }
 
+    // -------------------------------------------------------- Master detail
+    /// <summary>
+    /// Renders the expand/collapse toggle column on the inline-start edge of every row while a
+    /// <see cref="DetailTemplate"/> is set. Default: <c>true</c>. Turn it off to drive the detail
+    /// rows purely from the row itself (<see cref="ExpandDetailOnRowClick"/>) or from code
+    /// (<see cref="ToggleDetailAsync"/> and friends); the detail rows still render, only the toggle
+    /// column disappears.
+    /// </summary>
+    [Parameter] public bool ShowDetailToggle { get; set; } = true;
+
+    /// <summary>
+    /// Expands (and collapses) a row's detail content when the row itself is clicked, so the toggle
+    /// button is no longer the only way in. Combines with <see cref="SelectionMode"/>: a click both
+    /// selects the row and toggles its detail. Clicks inside the reorder/select/command cells are
+    /// excluded, since those cells own their own interaction.
+    /// </summary>
+    [Parameter] public bool ExpandDetailOnRowClick { get; set; }
+
+    /// <summary>
+    /// Rows whose detail content is expanded, as a two-way bindable list. Binding it takes control of
+    /// the expanded state (the grid then only reports changes back through it), which is what lets a
+    /// parent expand or collapse details declaratively. Leave it unset to let the grid keep the state
+    /// itself and use <see cref="ExpandDetailAsync"/>/<see cref="CollapseDetailAsync"/> instead.
+    /// </summary>
+    [Parameter] public IReadOnlyList<TItem>? ExpandedDetailItems { get; set; }
+
+    /// <summary>Raised with the new set of expanded rows whenever a detail row is expanded or collapsed.</summary>
+    [Parameter] public EventCallback<IReadOnlyList<TItem>> ExpandedDetailItemsChanged { get; set; }
+
+    /// <summary>Raised when a single row's detail content is expanded or collapsed.</summary>
+    [Parameter] public EventCallback<BitDataGridDetailEventArgs<TItem>> OnDetailToggle { get; set; }
+
     // ---------------------------------------------------------- Localization
     /// <summary>All user-visible strings rendered by the grid. Assign a customized
     /// <see cref="BitDataGridStrings"/> to localize the UI; defaults to English.</summary>
@@ -233,7 +265,10 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
     // selection survives data refreshes that produce new TItem instances with the same key.
     private HashSet<TItem>? _selectedSet;
     private HashSet<TItem> _selected => _selectedSet ??= new HashSet<TItem>(new KeySelectionComparer(GetKey));
-    private readonly HashSet<object> _expandedDetails = new();
+    // Expanded detail rows, keyed the same way as the selection so an expanded row survives a data
+    // refresh that produces a new TItem instance with the same key.
+    private HashSet<TItem>? _expandedDetailsSet;
+    private HashSet<TItem> _expandedDetails => _expandedDetailsSet ??= new HashSet<TItem>(new KeySelectionComparer(GetKey));
     private readonly HashSet<object> _collapsedGroups = new();
 
     // tree mode
@@ -686,6 +721,10 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
             ApplyControlledSelection();
         }
         _lastSelectionMode = SelectionMode;
+
+        // Expanded detail rows are controlled the same way as the selection: while the parent binds
+        // ExpandedDetailItems it owns the state, so it is re-applied on every parameter set.
+        if (ExpandedDetailItems is not null) ApplyControlledExpandedDetails();
 
         // Only (re)load data when an external input that affects it actually changes.
         // Refreshing on every parameter set would cause an infinite loop in server mode:
@@ -1685,8 +1724,9 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
     /// Removes selection and expanded-detail entries whose rows are no longer present in the (replaced)
     /// client-side data source. A null source counts as empty (all row state is dropped); otherwise only
     /// materialized sources (<see cref="ICollection{T}"/>) are pruned so a lazy
-    /// <see cref="IEnumerable{T}"/> isn't enumerated an extra time. Controlled selection is skipped
-    /// (<see cref="SelectedItems"/> is authoritative there and is re-applied on every parameter set).
+    /// <see cref="IEnumerable{T}"/> isn't enumerated an extra time. Controlled state is skipped
+    /// (<see cref="SelectedItems"/>/<see cref="ExpandedDetailItems"/> are authoritative there and are
+    /// re-applied on every parameter set).
     /// </summary>
     private async Task PruneStaleRowStateAsync()
     {
@@ -1694,7 +1734,11 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         // returning early here would leave removed rows selected/expanded (and strongly referenced).
         if (Items is null)
         {
-            _expandedDetails.Clear();
+            if (ExpandedDetailItems is null && _expandedDetailsSet is { Count: > 0 })
+            {
+                _expandedDetailsSet.Clear();
+                await NotifyDetailsAsync();
+            }
             if (SelectedItems is null && _selectedSet is { Count: > 0 })
             {
                 _selectedSet.Clear();
@@ -1708,7 +1752,11 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         var keys = new HashSet<object>();
         foreach (var item in source) keys.Add(GetKey(item));
 
-        _expandedDetails.RemoveWhere(k => !keys.Contains(k));
+        if (ExpandedDetailItems is null && _expandedDetailsSet is { Count: > 0 })
+        {
+            var collapsed = _expandedDetailsSet.RemoveWhere(i => !keys.Contains(GetKey(i)));
+            if (collapsed > 0) await NotifyDetailsAsync();
+        }
 
         if (SelectedItems is null && _selectedSet is { Count: > 0 })
         {
@@ -1731,17 +1779,86 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
     internal async Task HandleRowClickAsync(TItem item)
     {
         if (OnRowClick.HasDelegate) await OnRowClick.InvokeAsync(item);
-        if (SelectionMode == BitDataGridSelectionMode.Single && _editItem is null)
+
+        // While a row is being edited, clicks must not disturb the edit: moving the single-selection or
+        // expanding a detail row would shift the editors out from under the pointer mid-edit.
+        if (_editItem is not null) return;
+
+        if (SelectionMode == BitDataGridSelectionMode.Single)
             await ToggleRowSelectionAsync(item, true);
+
+        if (ExpandDetailOnRowClick)
+            await ToggleDetailAsync(item);
     }
 
     // ------------------------------------------------------ Detail rows
-    internal bool IsDetailExpanded(TItem item) => _expandedDetails.Contains(GetKey(item));
-    internal void ToggleDetail(TItem item)
+    /// <summary>True when the given row's <see cref="DetailTemplate"/> content is currently expanded.</summary>
+    public bool IsDetailExpanded(TItem item) => _expandedDetails.Contains(item);
+
+    /// <summary>Expands the given row's detail content. No-op without a <see cref="DetailTemplate"/>,
+    /// or when the row is already expanded.</summary>
+    public Task ExpandDetailAsync(TItem item) => SetDetailExpandedAsync(item, true);
+
+    /// <summary>Collapses the given row's detail content.</summary>
+    public Task CollapseDetailAsync(TItem item) => SetDetailExpandedAsync(item, false);
+
+    /// <summary>Expands the given row's detail content when it is collapsed, and collapses it otherwise.</summary>
+    public Task ToggleDetailAsync(TItem item) => SetDetailExpandedAsync(item, !IsDetailExpanded(item));
+
+    /// <summary>Expands or collapses a row's detail content. No-op without a <see cref="DetailTemplate"/>
+    /// or when the row is already in the requested state.</summary>
+    public async Task SetDetailExpandedAsync(TItem item, bool expanded)
     {
-        var key = GetKey(item);
-        if (!_expandedDetails.Add(key)) _expandedDetails.Remove(key);
+        if (!HasDetailTemplate) return;
+
+        var changed = expanded ? _expandedDetails.Add(item) : _expandedDetails.Remove(item);
+        if (!changed) return;
+
+        if (OnDetailToggle.HasDelegate)
+            await OnDetailToggle.InvokeAsync(new BitDataGridDetailEventArgs<TItem> { Item = item, Expanded = expanded });
+
+        await NotifyDetailsAsync();
+    }
+
+    /// <summary>Expands the detail content of every row of the current view (all rows matching the
+    /// active filters, not only the rendered page). No-op without a <see cref="DetailTemplate"/>.</summary>
+    public async Task ExpandAllDetailsAsync()
+    {
+        if (!HasDetailTemplate) return;
+
+        var changed = false;
+        foreach (var item in _view) changed |= _expandedDetails.Add(item);
+        if (!changed) return;
+
+        await NotifyDetailsAsync();
+    }
+
+    /// <summary>Collapses every expanded detail row.</summary>
+    public async Task CollapseAllDetailsAsync()
+    {
+        if (_expandedDetailsSet is not { Count: > 0 }) return;
+
+        _expandedDetailsSet.Clear();
+        await NotifyDetailsAsync();
+    }
+
+    private async Task NotifyDetailsAsync()
+    {
+        if (ExpandedDetailItemsChanged.HasDelegate)
+            await ExpandedDetailItemsChanged.InvokeAsync(_expandedDetails.ToList());
+
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// Applies the parent-controlled <see cref="ExpandedDetailItems"/> into the internal set. Does not
+    /// notify the parent, since the state is incoming rather than changed here.
+    /// </summary>
+    private void ApplyControlledExpandedDetails()
+    {
+        _expandedDetails.Clear();
+        if (ExpandedDetailItems is null) return;
+        foreach (var item in ExpandedDetailItems) _expandedDetails.Add(item);
     }
 
     // ---------------------------------------------------------- Editing
@@ -2237,6 +2354,10 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
             case "F2":
                 var ec = VisibleColumns[Math.Clamp(col, 0, colCount - 1)];
                 if (ColumnEditable(ec)) BeginEdit(item);
+                // Keyboard parity with the row click: when the cell has no editor to open and rows
+                // expand on click, Enter toggles the detail - otherwise a grid whose toggle column is
+                // hidden would be unreachable without a pointer.
+                else if (e.Key == "Enter" && ExpandDetailOnRowClick) await ToggleDetailAsync(item);
                 return;
             case "Escape":
                 if (_editItem is not null) await CancelEditAsync();
@@ -2873,7 +2994,13 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
 
     // ----------------------------------------------------- Layout helpers
     internal bool HasSelectColumn => SelectionMode == BitDataGridSelectionMode.Multiple;
-    internal bool HasDetailColumn => DetailTemplate is not null;
+
+    /// <summary>True when rows can render expandable detail content.</summary>
+    internal bool HasDetailTemplate => DetailTemplate is not null;
+
+    /// <summary>True when the detail rows also get the built-in toggle column. Detail content can be
+    /// expanded without it (row clicks or code), so this only governs the extra leading column.</summary>
+    internal bool HasDetailColumn => HasDetailTemplate && ShowDetailToggle;
     internal bool HasCommandColumn => Editable;
     internal bool HasReorderColumn => RowReorderEnabled;
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.razor.cs
@@ -796,6 +796,12 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
         else
         {
             ProcessClientData();
+
+            // The parent may drop rows by mutating the same Items instance in place, which leaves the
+            // reference unchanged - so OnParametersSetAsync's replaced-source prune never fires for it
+            // and the removed rows would stay selected/expanded (and strongly referenced). Pruning here
+            // covers that path too; tree sources keep their own expand state and are left alone.
+            if (!IsTreeMode) await PruneStaleRowStateAsync();
         }
         StateHasChanged();
     }
@@ -2376,8 +2382,10 @@ public partial class BitDataGrid<TItem> : ComponentBase, IAsyncDisposable
                 if (ColumnEditable(ec)) BeginEdit(item);
                 // Keyboard parity with the row click: when the cell has no editor to open and rows
                 // expand on click, Enter toggles the detail - otherwise a grid whose toggle column is
-                // hidden would be unreachable without a pointer.
-                else if (e.Key == "Enter" && ExpandDetailOnRowClick) await ToggleDetailAsync(item);
+                // hidden would be unreachable without a pointer. Gated on no edit being active for the
+                // same reason as HandleRowClickAsync: another row's cells still route here while an
+                // edit is open, and expanding a detail would shift the editors mid-edit.
+                else if (e.Key == "Enter" && ExpandDetailOnRowClick && _editItem is null) await ToggleDetailAsync(item);
                 return;
             case "Escape":
                 if (_editItem is not null) await CancelEditAsync();

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.scss
@@ -337,6 +337,18 @@ button.bit-dtg-htext {
 }
 
 /* ---------------------------------------------------------- Detail rows */
+/* The whole row toggles its detail content, so it gets the affordance of a control.
+   The reorder/select/command cells keep the default cursor: they stop the click. */
+.bit-dtg-row-expandable {
+    cursor: pointer;
+}
+
+.bit-dtg-row-expandable .bit-dtg-cell-reorder,
+.bit-dtg-row-expandable .bit-dtg-cell-select,
+.bit-dtg-row-expandable .bit-dtg-cell-command {
+    cursor: auto;
+}
+
 .bit-dtg-detail-row {
     border-bottom: 1px solid $clr-brd-ter;
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.scss
@@ -357,6 +357,12 @@ button.bit-dtg-htext {
     z-index: 1;
 }
 
+/* The inset ring is drawn over cells that a selected row paints with the primary color, so it would
+   blend into them. Switch to the selected foreground color, exactly as the focused cell does. */
+.bit-dtg-row.bit-dtg-selected[tabindex]:focus-visible {
+    outline-color: $clr-pri-text;
+}
+
 .bit-dtg-detail-row {
     border-bottom: 1px solid $clr-brd-ter;
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.scss
@@ -349,6 +349,14 @@ button.bit-dtg-htext {
     cursor: auto;
 }
 
+/* The row is focusable when it is the only detail toggle (hidden toggle column, no cell
+   navigation), so it needs the same visible focus ring the navigable cells get. */
+.bit-dtg-row[tabindex]:focus-visible {
+    outline: 2px solid $clr-pri;
+    outline-offset: -2px;
+    z-index: 1;
+}
+
 .bit-dtg-detail-row {
     border-bottom: 1px solid $clr-brd-ter;
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.ts
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGrid.ts
@@ -318,10 +318,13 @@ namespace BitBlazorUI {
     ]);
     // Keys that should stay with a self-managed control nested inside a cell. Escape is intentionally
     // excluded so it keeps bubbling to the grid as the universal "cancel edit" affordance, while the
-    // navigation keys, Enter (commit) and F2 (enter edit) are kept with the embedded control.
+    // navigation keys, Enter (commit), F2 (enter edit) and Space are kept with the embedded control.
+    // Space matters because a row acting as its own detail toggle (see BitDataGridRow) handles it on
+    // the row element: letting it bubble would type-and-toggle in an editor input, and would toggle a
+    // second time on top of the click a nested button synthesizes from Space.
     const nestedControlKeys = new Set([
         'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
-        'Home', 'End', 'PageUp', 'PageDown', 'Enter', 'F2'
+        'Home', 'End', 'PageUp', 'PageDown', 'Enter', 'F2', ' '
     ]);
     // Controls inside an editor that have their own Enter/Escape semantics and must not have those
     // keys cancelled by the grid (buttons, selects, textareas, links and contenteditable regions).
@@ -374,6 +377,14 @@ namespace BitBlazorUI {
             // Suppress the grid-owned keys here so arrow/page/home/end never scroll the viewport.
             if (target.classList?.contains('bit-dtg-cell') && target.hasAttribute('tabindex')) {
                 if (cellNavKeys.has(e.key)) e.preventDefault();
+                return;
+            }
+
+            // The row itself is the detail toggle when the toggle column is hidden and cell navigation
+            // is off (see BitDataGridRow): it is focusable and activates on Enter/Space like a button,
+            // so Space must not also scroll the page. Enter has no default worth cancelling on a div.
+            if (e.key === ' ' && target.classList?.contains('bit-dtg-row') && target.hasAttribute('tabindex')) {
+                e.preventDefault();
                 return;
             }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGridRow.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGridRow.razor
@@ -103,8 +103,11 @@
     private bool Editing => Grid.IsEditing(Item);
 
     // The row itself acts as the detail toggle, so it carries the expanded state (and the pointer
-    // affordance) that would otherwise live on the toggle button alone.
-    private bool RowExpandable => Grid.HasDetailTemplate && Grid.ExpandDetailOnRowClick;
+    // affordance) that would otherwise live on the toggle button alone. An edited row is excluded:
+    // HandleRowClickAsync refuses to toggle while an edit is open (expanding would shift the editors
+    // out from under the pointer), so advertising aria-expanded, the pointer cursor or a tab stop
+    // there would promise an interaction that cannot happen.
+    private bool RowExpandable => Grid.HasDetailTemplate && Grid.ExpandDetailOnRowClick && !Editing;
 
     // With the toggle column hidden and cell navigation off, the row is the only detail affordance and
     // nothing inside it is focusable, so an expansion that announces itself through aria-expanded would
@@ -172,7 +175,7 @@
             var c = "bit-dtg-row";
             if (Selected) c += " bit-dtg-selected";
             if (Editing) c += " bit-dtg-editing";
-            if (RowExpandable && !Editing) c += " bit-dtg-row-expandable";
+            if (RowExpandable) c += " bit-dtg-row-expandable";
             return c;
         }
     }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGridRow.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGridRow.razor
@@ -5,6 +5,7 @@
      aria-rowindex="@Grid.AriaRowIndex(Item)"
      data-ri="@(Grid.RowReorderEnabled ? Grid.RowDataIndex(Item) : null)"
      aria-selected="@(Grid.SelectionEnabled ? (Selected ? "true" : "false") : null)"
+     aria-expanded="@(RowExpandable ? (Grid.IsDetailExpanded(Item) ? "true" : "false") : null)"
      @ondragover:preventDefault="@(Grid.RowReorderEnabled && !Editing)"
      @ondrop="() => Grid.DropRowAsync(Item)">
 
@@ -27,7 +28,7 @@
     {
         specialColIndex++;
         <div class="bit-dtg-cell bit-dtg-cell-detail bit-dtg-sticky" style="@Grid.DetailStickyStyle" role="gridcell" aria-colindex="@specialColIndex" @onclick:stopPropagation="true">
-            <button type="button" class="bit-dtg-icon-btn" @onclick="() => Grid.ToggleDetail(Item)" aria-label="@Grid.Strings.ToggleDetailsLabel" aria-expanded="@Grid.IsDetailExpanded(Item)">
+            <button type="button" class="bit-dtg-icon-btn" @onclick="() => Grid.ToggleDetailAsync(Item)" aria-label="@Grid.Strings.ToggleDetailsLabel" aria-expanded="@Grid.IsDetailExpanded(Item)">
                 @(Grid.IsDetailExpanded(Item) ? "▾" : "▸")
             </button>
         </div>
@@ -83,11 +84,11 @@
     }
 </div>
 
-@if (Grid.HasDetailColumn && Grid.IsDetailExpanded(Item) && Grid.DetailTemplate is not null)
+@if (Grid.HasDetailTemplate && Grid.IsDetailExpanded(Item))
 {
     <div class="bit-dtg-detail-row" role="row">
         <div class="bit-dtg-detail-content" role="gridcell">
-            @Grid.DetailTemplate(Item)
+            @Grid.DetailTemplate?.Invoke(Item)
         </div>
     </div>
 }
@@ -98,6 +99,10 @@
 
     private bool Selected => Grid.IsRowSelected(Item);
     private bool Editing => Grid.IsEditing(Item);
+
+    // The row itself acts as the detail toggle, so it carries the expanded state (and the pointer
+    // affordance) that would otherwise live on the toggle button alone.
+    private bool RowExpandable => Grid.HasDetailTemplate && Grid.ExpandDetailOnRowClick;
 
     // Gives the row-selection checkbox an accessible name so screen readers can identify which row is
     // being selected. Uses the first visible column's value as row-specific context when available.
@@ -159,6 +164,7 @@
             var c = "bit-dtg-row";
             if (Selected) c += " bit-dtg-selected";
             if (Editing) c += " bit-dtg-editing";
+            if (RowExpandable && !Editing) c += " bit-dtg-row-expandable";
             return c;
         }
     }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGridRow.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/BitDataGridRow.razor
@@ -6,6 +6,8 @@
      data-ri="@(Grid.RowReorderEnabled ? Grid.RowDataIndex(Item) : null)"
      aria-selected="@(Grid.SelectionEnabled ? (Selected ? "true" : "false") : null)"
      aria-expanded="@(RowExpandable ? (Grid.IsDetailExpanded(Item) ? "true" : "false") : null)"
+     tabindex="@(RowKeyboardToggle ? 0 : (int?)null)"
+     @onkeydown="HandleRowKeyDown"
      @ondragover:preventDefault="@(Grid.RowReorderEnabled && !Editing)"
      @ondrop="() => Grid.DropRowAsync(Item)">
 
@@ -104,6 +106,12 @@
     // affordance) that would otherwise live on the toggle button alone.
     private bool RowExpandable => Grid.HasDetailTemplate && Grid.ExpandDetailOnRowClick;
 
+    // With the toggle column hidden and cell navigation off, the row is the only detail affordance and
+    // nothing inside it is focusable, so an expansion that announces itself through aria-expanded would
+    // be reachable by pointer only. Make the row the keyboard control in exactly that case: the toggle
+    // column is already a button, and cell navigation already routes Enter through the focused cell.
+    private bool RowKeyboardToggle => RowExpandable && !Grid.HasDetailColumn && !Grid.CellNavigation;
+
     // Gives the row-selection checkbox an accessible name so screen readers can identify which row is
     // being selected. Uses the first visible column's value as row-specific context when available.
     private string SelectRowLabel
@@ -181,6 +189,19 @@
     }
 
     private Task OnRowClick() => Grid.HandleRowClickAsync(Item);
+
+    // Keyboard activation of the row-as-toggle: Enter and Space do exactly what a click does (so the
+    // edit guard, the single-selection and the expansion all stay in one place, and aria-expanded keeps
+    // tracking the same state). Inert unless the row is the keyboard control - otherwise the focused
+    // cell or the toggle button owns these keys and would fire twice. Space's page-scroll default is
+    // cancelled by the capture-phase guard in BitDataGrid.ts, which (unlike
+    // @onkeydown:preventDefault, evaluated at render time) can decide on the key actually pressed.
+    private async Task HandleRowKeyDown(KeyboardEventArgs e)
+    {
+        if (!RowKeyboardToggle) return;
+        if (e.Key != "Enter" && e.Key != " ") return;
+        await Grid.HandleRowClickAsync(Item);
+    }
 
     // Lets keyboard users reorder rows without drag-and-drop: ArrowUp/ArrowDown move the focused row
     // one position toward the start/end, reusing the same reorder pipeline as the pointer drag path.

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/Models/BitDataGridDetailEventArgs.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/DataGrid/Models/BitDataGridDetailEventArgs.cs
@@ -1,0 +1,14 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Arguments passed to <c>OnDetailToggle</c> when a row's master-detail content is expanded or collapsed.
+/// </summary>
+/// <typeparam name="TItem">The row item type.</typeparam>
+public sealed class BitDataGridDetailEventArgs<TItem>
+{
+    /// <summary>The row whose detail content was toggled.</summary>
+    public required TItem Item { get; init; }
+
+    /// <summary>True when the detail content was expanded, false when it was collapsed.</summary>
+    public required bool Expanded { get; init; }
+}

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor
@@ -861,6 +861,7 @@
             <BitDataGrid @ref="detailGrid" TItem="Product" Items="@detailProducts" Height="430px"
                          ShowDetailToggle="false"
                          ExpandDetailOnRowClick="true"
+                         CellNavigation="true"
                          OnDetailToggle="OnDetailToggled"
                          SelectionMode="BitDataGridSelectionMode.Single"
                          KeyField="p => p.Id">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor
@@ -840,6 +840,50 @@
             </BitDataGrid>
         </DemoExample>
 
+        <DemoExample Title="Detail rows from the row &amp; from code" RazorCode="@example34RazorCode" CsharpCode="@example34CsharpCode" Id="example34">
+            <div>
+                The ▸ toggle column is not the only way into a detail row: <code>ExpandDetailOnRowClick</code>
+                expands the <code>DetailTemplate</code> from a click anywhere on the row (and
+                <kbd>Enter</kbd> on a focused cell), so <code>ShowDetailToggle="false"</code> can hide the
+                column altogether. It combines with selection - the click below both selects the row and
+                expands it. The same state is reachable from code with <code>ExpandDetailAsync</code>,
+                <code>CollapseDetailAsync</code>, <code>ToggleDetailAsync</code>,
+                <code>ExpandAllDetailsAsync</code> and <code>CollapseAllDetailsAsync</code>, or declaratively
+                by binding <code>ExpandedDetailItems</code>. Every change raises <code>OnDetailToggle</code>.
+            </div>
+            <br />
+            <BitStack Horizontal Wrap VerticalAlign="BitAlignment.Center">
+                <BitButton OnClick="ExpandAllDetails">Expand all</BitButton>
+                <BitButton OnClick="CollapseAllDetails" Variant="BitVariant.Outline">Collapse all</BitButton>
+                <BitButton OnClick="ToggleFirstDetail" Variant="BitVariant.Outline">Toggle the first row</BitButton>
+            </BitStack>
+            <br />
+            <BitDataGrid @ref="detailGrid" TItem="Product" Items="@detailProducts" Height="430px"
+                         ShowDetailToggle="false"
+                         ExpandDetailOnRowClick="true"
+                         OnDetailToggle="OnDetailToggled"
+                         SelectionMode="BitDataGridSelectionMode.Single"
+                         KeyField="p => p.Id">
+                <DetailTemplate Context="p">
+                    <BitStack Horizontal Wrap Gap="2rem">
+                        <div><strong>Supplier</strong><br />@p.Supplier</div>
+                        <div><strong>Released</strong><br />@p.ReleaseDate.ToString("D")</div>
+                        <div><strong>Inventory value</strong><br />@((p.Price * p.Stock).ToString("C2"))</div>
+                        <div><strong>Status</strong><br />@(p.Discontinued ? "Discontinued" : "Active")</div>
+                    </BitStack>
+                </DetailTemplate>
+                <Columns>
+                    <BitDataGridColumn Property="p => p.Id" Title="ID" Width="70px" Align="BitDataGridColumnAlign.Right" />
+                    <BitDataGridColumn Property="p => p.Name" Width="220px" />
+                    <BitDataGridColumn Property="p => p.Category" />
+                    <BitDataGridColumn Property="p => p.Price" Format="C2" Align="BitDataGridColumnAlign.Right" />
+                    <BitDataGridColumn Property="p => p.Stock" Align="BitDataGridColumnAlign.Right" />
+                </Columns>
+            </BitDataGrid>
+            <br />
+            <BitText>@detailStatus</BitText>
+        </DemoExample>
+
     </Examples>
 </DemoPage>
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.cs
@@ -263,6 +263,18 @@ public partial class BitDataGridDemo : AppComponentBase
     private async Task ApiPageSize50() { if (apiGrid is not null) await apiGrid.SetPageSizeAsync(50); }
     private async Task ApiRefresh() { if (apiGrid is not null) await apiGrid.RefreshAsync(); }
 
+    // example 34 - detail rows from the row & from code
+    private readonly List<Product> detailProducts = SampleData.Generate(20);
+    private BitDataGrid<Product>? detailGrid;
+    private string detailStatus = "Click any row to reveal its details.";
+
+    private void OnDetailToggled(BitDataGridDetailEventArgs<Product> args)
+        => detailStatus = $"{args.Item.Name} (#{args.Item.Id}) {(args.Expanded ? "expanded" : "collapsed")}.";
+
+    private async Task ExpandAllDetails() { if (detailGrid is not null) await detailGrid.ExpandAllDetailsAsync(); }
+    private async Task CollapseAllDetails() { if (detailGrid is not null) await detailGrid.CollapseAllDetailsAsync(); }
+    private async Task ToggleFirstDetail() { if (detailGrid is not null) await detailGrid.ToggleDetailAsync(detailProducts[0]); }
+
     // example 26 - localization
     private readonly List<Product> localizedProducts = SampleData.GeneratePersian(60);
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.params.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.params.cs
@@ -66,6 +66,11 @@ public partial class BitDataGridDemo
         new() { Name = "EmptyTemplate", Type = "RenderFragment?", DefaultValue = "null", Description = "Custom content rendered when there is no data." },
         new() { Name = "ToolbarTemplate", Type = "RenderFragment?", DefaultValue = "null", Description = "Custom content rendered in the toolbar's start area." },
         new() { Name = "DetailTemplate", Type = "RenderFragment<TItem>?", DefaultValue = "null", Description = "Expandable master-detail content rendered under a row." },
+        new() { Name = "ShowDetailToggle", Type = "bool", DefaultValue = "true", Description = "Renders the built-in expand/collapse toggle column while a DetailTemplate is set. Turn it off to drive the detail rows from row clicks (ExpandDetailOnRowClick) or from code; only the toggle column disappears, the detail rows still render." },
+        new() { Name = "ExpandDetailOnRowClick", Type = "bool", DefaultValue = "false", Description = "Expands (and collapses) a row's detail content when the row itself is clicked. Combines with SelectionMode: a click both selects the row and toggles its detail. Clicks inside the reorder/select/command cells are excluded." },
+        new() { Name = "ExpandedDetailItems", Type = "IReadOnlyList<TItem>?", DefaultValue = "null", Description = "Rows whose detail content is expanded, as a two-way bindable list. Binding it takes control of the expanded state, letting a parent expand or collapse details declaratively." },
+        new() { Name = "ExpandedDetailItemsChanged", Type = "EventCallback<IReadOnlyList<TItem>>", DefaultValue = "", Description = "Raised with the new set of expanded rows whenever a detail row is expanded or collapsed." },
+        new() { Name = "OnDetailToggle", Type = "EventCallback<BitDataGridDetailEventArgs<TItem>>", DefaultValue = "", Description = "Raised when a single row's detail content is expanded or collapsed.", LinkType = LinkType.Link, Href = "#BitDataGridDetailEventArgs" },
     ];
 
     private readonly List<ComponentParameter> componentPublicMembers =
@@ -96,6 +101,13 @@ public partial class BitDataGridDemo
         new() { Name = "CurrentPage", Type = "int", DefaultValue = "1", Description = "The 1-based current page." },
         new() { Name = "ExpandAllAsync", Type = "Task", DefaultValue = "", Description = "Expands every node in the tree. No-op outside tree mode." },
         new() { Name = "CollapseAllAsync", Type = "Task", DefaultValue = "", Description = "Collapses every node in the tree. No-op outside tree mode." },
+        new() { Name = "IsDetailExpanded", Type = "bool", DefaultValue = "", Description = "IsDetailExpanded(item) - true when the given row's DetailTemplate content is currently expanded." },
+        new() { Name = "ExpandDetailAsync", Type = "Task", DefaultValue = "", Description = "ExpandDetailAsync(item) - expands the given row's detail content. No-op without a DetailTemplate." },
+        new() { Name = "CollapseDetailAsync", Type = "Task", DefaultValue = "", Description = "CollapseDetailAsync(item) - collapses the given row's detail content." },
+        new() { Name = "ToggleDetailAsync", Type = "Task", DefaultValue = "", Description = "ToggleDetailAsync(item) - expands the given row's detail content when collapsed, and collapses it otherwise." },
+        new() { Name = "SetDetailExpandedAsync", Type = "Task", DefaultValue = "", Description = "SetDetailExpandedAsync(item, expanded) - expands or collapses a row's detail content." },
+        new() { Name = "ExpandAllDetailsAsync", Type = "Task", DefaultValue = "", Description = "Expands the detail content of every row of the current view (all rows matching the active filters, not only the rendered page)." },
+        new() { Name = "CollapseAllDetailsAsync", Type = "Task", DefaultValue = "", Description = "Collapses every expanded detail row." },
     ];
 
     private readonly List<ComponentSubClass> componentSubClasses =
@@ -183,6 +195,17 @@ public partial class BitDataGridDemo
                 new() { Name = "ColumnTitle", Type = "string", DefaultValue = "", Description = "The column's display title." },
                 new() { Name = "Value", Type = "object?", DefaultValue = "null", Description = "The raw value of the cell." },
                 new() { Name = "Mouse", Type = "MouseEventArgs", DefaultValue = "", Description = "The underlying browser mouse event." },
+            ],
+        },
+        new()
+        {
+            Id = "BitDataGridDetailEventArgs",
+            Title = "BitDataGridDetailEventArgs<TItem>",
+            Description = "Arguments raised when a row's master-detail content is expanded or collapsed.",
+            Parameters =
+            [
+                new() { Name = "Item", Type = "TItem", DefaultValue = "", Description = "The row whose detail content was toggled." },
+                new() { Name = "Expanded", Type = "bool", DefaultValue = "", Description = "True when the detail content was expanded, false when it was collapsed." },
             ],
         },
         new()

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.params.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.params.cs
@@ -106,8 +106,8 @@ public partial class BitDataGridDemo
         new() { Name = "CollapseDetailAsync", Type = "Task", DefaultValue = "", Description = "CollapseDetailAsync(item) - collapses the given row's detail content." },
         new() { Name = "ToggleDetailAsync", Type = "Task", DefaultValue = "", Description = "ToggleDetailAsync(item) - expands the given row's detail content when collapsed, and collapses it otherwise." },
         new() { Name = "SetDetailExpandedAsync", Type = "Task", DefaultValue = "", Description = "SetDetailExpandedAsync(item, expanded) - expands or collapses a row's detail content." },
-        new() { Name = "ExpandAllDetailsAsync", Type = "Task", DefaultValue = "", Description = "Expands the detail content of every row of the current view (all rows matching the active filters, not only the rendered page)." },
-        new() { Name = "CollapseAllDetailsAsync", Type = "Task", DefaultValue = "", Description = "Collapses every expanded detail row." },
+        new() { Name = "ExpandAllDetailsAsync", Type = "Task", DefaultValue = "", Description = "Expands the detail content of every row of the current view - in local mode every row matching the active filters, not only the rendered page; in server, queryable and infinite modes only the rows loaded so far. Raises OnDetailToggle once per newly expanded row." },
+        new() { Name = "CollapseAllDetailsAsync", Type = "Task", DefaultValue = "", Description = "Collapses every expanded detail row, raising OnDetailToggle once per row." },
     ];
 
     private readonly List<ComponentSubClass> componentSubClasses =

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.samples.cs
@@ -1069,4 +1069,49 @@ private List<Product> products = SampleData.Generate(30);
 // In the Excel export this span becomes a merged cell (the covered Category cell stays empty);
 // the CSV export has no merge concept and writes every column's own value.
 private int? NameSpan(Product p) => p.Discontinued ? 2 : null;" + ProductModelCode + SampleDataCode;
+
+    private readonly string example34RazorCode = @"
+<BitButton OnClick=""ExpandAllDetails"">Expand all</BitButton>
+<BitButton OnClick=""CollapseAllDetails"">Collapse all</BitButton>
+<BitButton OnClick=""ToggleFirstDetail"">Toggle the first row</BitButton>
+
+<BitDataGrid @ref=""grid"" TItem=""Product"" Items=""@products"" Height=""430px""
+             ShowDetailToggle=""false""
+             ExpandDetailOnRowClick=""true""
+             OnDetailToggle=""OnDetailToggled""
+             SelectionMode=""BitDataGridSelectionMode.Single""
+             KeyField=""p => p.Id"">
+    <DetailTemplate Context=""p"">
+        <BitStack Horizontal Wrap Gap=""2rem"">
+            <div><strong>Supplier</strong><br />@p.Supplier</div>
+            <div><strong>Released</strong><br />@p.ReleaseDate.ToString(""D"")</div>
+            <div><strong>Inventory value</strong><br />@((p.Price * p.Stock).ToString(""C2""))</div>
+            <div><strong>Status</strong><br />@(p.Discontinued ? ""Discontinued"" : ""Active"")</div>
+        </BitStack>
+    </DetailTemplate>
+    <Columns>
+        <BitDataGridColumn Property=""p => p.Id"" Title=""ID"" Width=""70px"" />
+        <BitDataGridColumn Property=""p => p.Name"" Width=""220px"" />
+        <BitDataGridColumn Property=""p => p.Category"" />
+        <BitDataGridColumn Property=""p => p.Price"" Format=""C2"" />
+        <BitDataGridColumn Property=""p => p.Stock"" />
+    </Columns>
+</BitDataGrid>
+
+<BitText>@status</BitText>";
+    private readonly string example34CsharpCode = @"
+private List<Product> products = SampleData.Generate(20);
+private BitDataGrid<Product>? grid;
+private string status = ""Click any row to reveal its details."";
+
+private void OnDetailToggled(BitDataGridDetailEventArgs<Product> args)
+    => status = $""{args.Item.Name} (#{args.Item.Id}) {(args.Expanded ? ""expanded"" : ""collapsed"")}."";
+
+private async Task ExpandAllDetails() => await grid!.ExpandAllDetailsAsync();
+private async Task CollapseAllDetails() => await grid!.CollapseAllDetailsAsync();
+private async Task ToggleFirstDetail() => await grid!.ToggleDetailAsync(products[0]);
+
+// Also available: ExpandDetailAsync(item), CollapseDetailAsync(item), SetDetailExpandedAsync(item, expanded)
+// and IsDetailExpanded(item) - or bind @bind-ExpandedDetailItems to own the expanded rows yourself.
+" + ProductModelCode + SampleDataCode;
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/DataGrid/BitDataGridDemo.razor.samples.cs
@@ -1078,6 +1078,7 @@ private int? NameSpan(Product p) => p.Discontinued ? 2 : null;" + ProductModelCo
 <BitDataGrid @ref=""grid"" TItem=""Product"" Items=""@products"" Height=""430px""
              ShowDetailToggle=""false""
              ExpandDetailOnRowClick=""true""
+             CellNavigation=""true""
              OnDetailToggle=""OnDetailToggled""
              SelectionMode=""BitDataGridSelectionMode.Single""
              KeyField=""p => p.Id"">

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
@@ -1144,6 +1144,118 @@ public class BitDataGridTests : BunitTestContext
     }
 
     [TestMethod]
+    public async Task DetailsStayExpandableWhileTheToggleColumnIsHidden()
+    {
+        var rows = CreateRows();
+        var component = RenderGrid(rows, parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ShowDetailToggle, false);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-cell-detail").Count, "the toggle column must not render");
+
+        await component.InvokeAsync(() => component.Instance.ExpandDetailAsync(rows[1]));
+
+        Assert.AreEqual("DETAIL-2", component.Find(".bit-dtg-detail-content").TextContent.Trim());
+        Assert.IsTrue(component.Instance.IsDetailExpanded(rows[1]));
+
+        await component.InvokeAsync(() => component.Instance.CollapseDetailAsync(rows[1]));
+
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+    }
+
+    [TestMethod]
+    public void RowClickTogglesDetailOnlyWhenEnabled()
+    {
+        var toggles = new List<BitDataGridDetailEventArgs<TestRow>>();
+        var component = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+        });
+
+        // Without ExpandDetailOnRowClick the row click is inert: only the toggle button expands.
+        component.Find(".bit-dtg-body > .bit-dtg-row").Click();
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+            parameters.Add(p => p.OnDetailToggle, EventCallback.Factory.Create<BitDataGridDetailEventArgs<TestRow>>(this, toggles.Add));
+        });
+
+        component.Find(".bit-dtg-body > .bit-dtg-row").Click();
+        Assert.AreEqual("DETAIL-1", component.Find(".bit-dtg-detail-content").TextContent.Trim());
+
+        component.Find(".bit-dtg-body > .bit-dtg-row").Click();
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+
+        CollectionAssert.AreEqual(new[] { true, false }, toggles.Select(t => t.Expanded).ToArray());
+        Assert.IsTrue(toggles.All(t => t.Item.Id == 1));
+    }
+
+    [TestMethod]
+    public void RowClickDoesNotToggleDetailWhileARowIsEdited()
+    {
+        var component = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.Editable, true);
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+        });
+
+        // Entering edit mode and then clicking the row must leave the editors where they are.
+        component.FindAll(".bit-dtg-cell-command button")[0].Click();
+        component.Find(".bit-dtg-body > .bit-dtg-row").Click();
+
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+    }
+
+    [TestMethod]
+    public async Task ExpandAllDetailsCoversTheWholeViewAndCollapseAllClearsIt()
+    {
+        var component = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.Pageable, true);
+            parameters.Add(p => p.PageSize, 2);
+        });
+
+        await component.InvokeAsync(() => component.Instance.ExpandAllDetailsAsync());
+
+        // Only the current page is rendered, but every row of the view is expanded - paging to the
+        // next page shows its details already open.
+        Assert.AreEqual(2, component.FindAll(".bit-dtg-detail-row").Count);
+        await component.InvokeAsync(() => component.Instance.GoToPageAsync(2));
+        Assert.AreEqual(2, component.FindAll(".bit-dtg-detail-row").Count);
+
+        await component.InvokeAsync(() => component.Instance.CollapseAllDetailsAsync());
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+    }
+
+    [TestMethod]
+    public void ExpandedDetailItemsBindingDrivesTheDetailRows()
+    {
+        var rows = CreateRows();
+        IReadOnlyList<TestRow> expanded = new List<TestRow>();
+        var component = RenderGrid(rows, parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+            parameters.Add(p => p.ExpandedDetailItems, expanded);
+            parameters.Add(p => p.ExpandedDetailItemsChanged, EventCallback.Factory.Create<IReadOnlyList<TestRow>>(this, v => expanded = v));
+        });
+
+        // Incoming state expands rows without any user interaction.
+        component.Render(parameters => parameters.Add(p => p.ExpandedDetailItems, new List<TestRow> { rows[2] }));
+        Assert.AreEqual("DETAIL-3", component.Find(".bit-dtg-detail-content").TextContent.Trim());
+
+        // Outgoing changes are reported back through the binding.
+        component.FindAll(".bit-dtg-body > .bit-dtg-row")[0].Click();
+        CollectionAssert.AreEquivalent(new[] { 3, 1 }, expanded.Select(r => r.Id).ToArray());
+    }
+
+    [TestMethod]
     public void ColumnsParameterAliasesChildContent()
     {
         var component = RenderComponent<BitDataGrid<TestRow>>(parameters =>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
@@ -1221,6 +1221,77 @@ public class BitDataGridTests : BunitTestContext
     }
 
     [TestMethod]
+    [DataRow("Enter")]
+    [DataRow(" ")]
+    public void RowIsKeyboardOperableWhenItIsTheOnlyDetailToggle(string key)
+    {
+        // Hidden toggle column + no cell navigation leaves the row as the only detail affordance, so it
+        // has to be focusable and activate on Enter/Space - otherwise the expansion is pointer-only.
+        var component = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ShowDetailToggle, false);
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+        });
+
+        var row = component.Find(".bit-dtg-body > .bit-dtg-row");
+        Assert.AreEqual("0", row.GetAttribute("tabindex"), "the row must be reachable by Tab");
+        Assert.AreEqual("false", row.GetAttribute("aria-expanded"));
+
+        row.KeyDown(key);
+        Assert.AreEqual("DETAIL-1", component.Find(".bit-dtg-detail-content").TextContent.Trim());
+        Assert.AreEqual("true", component.Find(".bit-dtg-body > .bit-dtg-row").GetAttribute("aria-expanded"));
+
+        component.Find(".bit-dtg-body > .bit-dtg-row").KeyDown(key);
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+        Assert.AreEqual("false", component.Find(".bit-dtg-body > .bit-dtg-row").GetAttribute("aria-expanded"));
+    }
+
+    [TestMethod]
+    public void RowIsNotAKeyboardToggleWhenAnotherOneExists()
+    {
+        // The toggle column is a button of its own, so the row must not double as a tab stop.
+        var withToggle = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+        });
+        Assert.IsNull(withToggle.Find(".bit-dtg-body > .bit-dtg-row").GetAttribute("tabindex"));
+
+        // Cell navigation already routes Enter through the focused cell (HandleCellKeyDownAsync).
+        var withCellNav = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ShowDetailToggle, false);
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+            parameters.Add(p => p.CellNavigation, true);
+        });
+        var navRow = withCellNav.Find(".bit-dtg-body > .bit-dtg-row");
+        Assert.IsNull(navRow.GetAttribute("tabindex"));
+
+        // ...and the row keydown stays inert there, so the cell's Enter can't toggle twice.
+        navRow.KeyDown("Enter");
+        Assert.AreEqual(0, withCellNav.FindAll(".bit-dtg-detail-row").Count);
+    }
+
+    [TestMethod]
+    public void RowKeyboardToggleDoesNotFireWhileARowIsEdited()
+    {
+        var component = RenderGrid(configure: parameters =>
+        {
+            parameters.Add(p => p.Editable, true);
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ShowDetailToggle, false);
+            parameters.Add(p => p.ExpandDetailOnRowClick, true);
+        });
+
+        component.FindAll(".bit-dtg-cell-command button")[0].Click();
+        component.Find(".bit-dtg-body > .bit-dtg-row").KeyDown("Enter");
+
+        Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count, "expanding would shift the editors mid-edit");
+    }
+
+    [TestMethod]
     public void RowClickDoesNotToggleDetailWhileARowIsEdited()
     {
         var component = RenderGrid(configure: parameters =>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
@@ -1122,6 +1122,42 @@ public class BitDataGridTests : BunitTestContext
     }
 
     [TestMethod]
+    public async Task PrunedRowsReportTheirCollapseThroughOnDetailToggle()
+    {
+        var toggles = new List<BitDataGridDetailEventArgs<TestRow>>();
+        var items = CreateRows();
+        var component = RenderGrid(items, parameters =>
+        {
+            parameters.Add(p => p.KeyField, (Func<TestRow, object>)(r => r.Id));
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.OnDetailToggle, EventCallback.Factory.Create<BitDataGridDetailEventArgs<TestRow>>(this, toggles.Add));
+        });
+
+        await component.InvokeAsync(() => component.Instance.ExpandDetailAsync(items[0]));
+        await component.InvokeAsync(() => component.Instance.ExpandDetailAsync(items[1]));
+        toggles.Clear();
+
+        // Path 1: a replaced materialized source prunes only the rows that left it.
+        component.Render(parameters => parameters.Add(p => p.Items, CreateRows().Where(r => r.Id != 1).ToList()));
+
+        CollectionAssert.AreEqual(new[] { 1 }, toggles.Select(t => t.Item.Id).ToArray(),
+            "only the removed row collapsed");
+        Assert.IsTrue(toggles.All(t => t.Expanded == false));
+
+        // Path 2: a cleared source drops every row, so everything still expanded collapses.
+        toggles.Clear();
+        component.Render(parameters => parameters.Add(p => p.Items, (IEnumerable<TestRow>?)null));
+
+        CollectionAssert.AreEqual(new[] { 2 }, toggles.Select(t => t.Item.Id).ToArray());
+        Assert.IsTrue(toggles.All(t => t.Expanded == false));
+
+        // Nothing is left expanded, so a further prune stays silent.
+        toggles.Clear();
+        component.Render(parameters => parameters.Add(p => p.Items, CreateRows()));
+        Assert.AreEqual(0, toggles.Count);
+    }
+
+    [TestMethod]
     public async Task PropertyExpressionBindsColumnLikeField()
     {
         RenderFragment columns = builder =>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
@@ -1214,9 +1214,11 @@ public class BitDataGridTests : BunitTestContext
     [TestMethod]
     public async Task ExpandAllDetailsCoversTheWholeViewAndCollapseAllClearsIt()
     {
+        var toggles = new List<BitDataGridDetailEventArgs<TestRow>>();
         var component = RenderGrid(configure: parameters =>
         {
             parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.OnDetailToggle, EventCallback.Factory.Create<BitDataGridDetailEventArgs<TestRow>>(this, toggles.Add));
             parameters.Add(p => p.Pageable, true);
             parameters.Add(p => p.PageSize, 2);
         });
@@ -1229,8 +1231,21 @@ public class BitDataGridTests : BunitTestContext
         await component.InvokeAsync(() => component.Instance.GoToPageAsync(2));
         Assert.AreEqual(2, component.FindAll(".bit-dtg-detail-row").Count);
 
+        // The bulk operation reports each row it expanded, not just the rendered page.
+        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 }, toggles.Select(t => t.Item.Id).ToArray());
+        Assert.IsTrue(toggles.All(t => t.Expanded));
+
+        toggles.Clear();
         await component.InvokeAsync(() => component.Instance.CollapseAllDetailsAsync());
         Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count);
+
+        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 }, toggles.Select(t => t.Item.Id).ToArray());
+        Assert.IsTrue(toggles.All(t => t.Expanded == false));
+
+        // Nothing left to change: a second bulk call is a no-op and raises no callback.
+        toggles.Clear();
+        await component.InvokeAsync(() => component.Instance.CollapseAllDetailsAsync());
+        Assert.AreEqual(0, toggles.Count);
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
@@ -1096,6 +1096,32 @@ public class BitDataGridTests : BunitTestContext
     }
 
     [TestMethod]
+    public async Task InPlaceItemRemovalPrunesStaleExpandedDetailsOnRefresh()
+    {
+        IReadOnlyList<TestRow>? expanded = null;
+        var items = CreateRows();
+        var component = RenderGrid(items, parameters =>
+        {
+            parameters.Add(p => p.KeyField, (Func<TestRow, object>)(r => r.Id));
+            parameters.Add(p => p.DetailTemplate, (RenderFragment<TestRow>)(r => b => b.AddContent(0, $"DETAIL-{r.Id}")));
+            parameters.Add(p => p.ExpandedDetailItemsChanged, EventCallback.Factory.Create<IReadOnlyList<TestRow>>(this, v => expanded = v));
+        });
+
+        await component.InvokeAsync(() => component.Instance.ExpandDetailAsync(items[0]));
+        await component.InvokeAsync(() => component.Instance.ExpandDetailAsync(items[1]));
+        CollectionAssert.AreEquivalent(new[] { 1, 2 }, expanded!.Select(r => r.Id).ToArray());
+
+        // The row leaves through the same list instance, so the Items reference never changes and only
+        // the explicit refresh can notice it.
+        items.RemoveAt(0);
+        await component.InvokeAsync(() => component.Instance.RefreshAsync());
+
+        CollectionAssert.AreEquivalent(new[] { 2 }, expanded!.Select(r => r.Id).ToArray(),
+            "a row removed in place must not stay expanded");
+        Assert.IsFalse(component.Instance.IsDetailExpanded(new TestRow { Id = 1 }));
+    }
+
+    [TestMethod]
     public async Task PropertyExpressionBindsColumnLikeField()
     {
         RenderFragment columns = builder =>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/DataGrid/BitDataGridTests.cs
@@ -1286,8 +1286,14 @@ public class BitDataGridTests : BunitTestContext
         });
 
         component.FindAll(".bit-dtg-cell-command button")[0].Click();
-        component.Find(".bit-dtg-body > .bit-dtg-row").KeyDown("Enter");
 
+        // The edited row must not advertise a toggle it refuses to perform.
+        var editedRow = component.Find(".bit-dtg-body > .bit-dtg-row");
+        Assert.IsNull(editedRow.GetAttribute("tabindex"));
+        Assert.IsNull(editedRow.GetAttribute("aria-expanded"));
+        Assert.IsFalse(editedRow.ClassList.Contains("bit-dtg-row-expandable"));
+
+        editedRow.KeyDown("Enter");
         Assert.AreEqual(0, component.FindAll(".bit-dtg-detail-row").Count, "expanding would shift the editors mid-edit");
     }
 


### PR DESCRIPTION
closes #12777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable DataGrid master-detail behavior.
  * Details can expand via row clicks, keyboard actions, or programmatic controls.
  * Added controlled expansion state, callbacks, and expand/collapse-all actions.
  * Added options to show or hide detail toggles while retaining functionality.
  * Added accessibility indicators and improved row interaction feedback.
* **Bug Fixes**
  * Preserved expansion across paging and refreshed data while removing stale rows.
  * Prevented expansion during editing and improved keyboard handling for nested controls.
* **Documentation**
  * Added interactive detail-row examples and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->