### PR TITLE
Fix non-ascii number issue in markdown components (#12841)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockGrammar.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockGrammar.cs
@@ -27,7 +27,12 @@ internal static partial class BitMarkdownBlockGrammar
     [GeneratedRegex(@"^ {0,3}([-+*])(?:([ \t]+)(.*))?$")]
     public static partial Regex Bullet();
 
-    [GeneratedRegex(@"^ {0,3}(\d{1,9})([.)])(?:([ \t]+)(.*))?$")]
+    // The digits are matched as [0-9] rather than \d on purpose: CommonMark defines an
+    // ordered list marker as ASCII digits only, while .NET's \d also matches every other
+    // Unicode decimal digit (Arabic-Indic "۱", Devanagari "१", fullwidth "１", ...). Those
+    // must stay paragraph text, and letting them match here also fed a non-ASCII number
+    // to int.Parse in the list parser, which threw a FormatException.
+    [GeneratedRegex(@"^ {0,3}([0-9]{1,9})([.)])(?:([ \t]+)(.*))?$")]
     public static partial Regex Ordered();
 
     [GeneratedRegex(@"^ {0,3}(=+|-+)\s*$")]

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownListParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownListParser.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Bit.BlazorUI;
@@ -33,7 +34,14 @@ public sealed class BitMarkdownListParser : BitMarkdownBlockParser
         if (ordered)
         {
             var fm = BitMarkdownBlockGrammar.Ordered().Match(first);
-            startNum = int.Parse(fm.Groups[1].Value);
+            // The grammar guarantees 1-9 ASCII digits here; parse defensively (and
+            // culture-independently) so a malformed marker degrades to a "1." list
+            // instead of throwing out of the component's parse.
+            if (int.TryParse(fm.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed) is false)
+            {
+                parsed = 1;
+            }
+            startNum = parsed;
             markerChar = fm.Groups[2].Value[0];
         }
         else

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -429,6 +429,45 @@ public class BitMarkdownViewerTests : BunitTestContext
         Assert.DoesNotContain("\u202E", component.Markup);
     }
 
+    [TestMethod,
+        DataRow("۱."),          // Extended Arabic-Indic (Persian) digit one
+        DataRow("١."),          // Arabic-Indic digit one
+        DataRow("१."),          // Devanagari digit one
+        DataRow("１."),          // Fullwidth digit one
+        DataRow("۱) item"),
+        DataRow("۱. item")]
+    public void BitMarkdownViewerShouldNotTreatNonAsciiDigitsAsOrderedListMarkers(string markdown)
+    {
+        // .NET's \d matches every Unicode decimal digit, so these lines used to be taken
+        // for ordered list markers and then fed to int.Parse, which throws (only ASCII
+        // digits parse). CommonMark restricts the marker to ASCII digits, so they must
+        // render as ordinary paragraph text.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+        });
+
+        var markup = component.Markup;
+
+        Assert.DoesNotContain("<ol", markup);
+        Assert.Contains(markdown[..1], markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldStillRenderAsciiOrderedLists()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "3. three\n4. four");
+        });
+
+        var markup = component.Markup;
+
+        Assert.Contains("<ol", markup);
+        Assert.Contains("start=\"3\"", markup);
+        Assert.AreEqual(2, component.FindAll(".bit-mdv ol li").Count);
+    }
+
     [TestMethod]
     public void BitMarkdownViewerShouldRespectMaxLength()
     {


### PR DESCRIPTION
closes #12841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown ordered-list parsing to recognize only ASCII numeric markers.
  * Non-ASCII digit prefixes now render as regular paragraph text instead of ordered lists.
  * Malformed list markers no longer cause errors and safely default to starting at 1.
  * Valid ASCII ordered lists continue to preserve their correct starting number and item count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->