### PR TITLE
Make build process of BlazorUI projects faster (#12853)

### DIFF
--- a/.github/workflows/bit.ci.BlazorUI.yml
+++ b/.github/workflows/bit.ci.BlazorUI.yml
@@ -51,8 +51,10 @@ jobs:
       continue-on-error: true # Error MSB4057, not all csproj files have InstallNodejsDependencies target.
       run: dotnet build src/BlazorUI/Bit.BlazorUI.slnx -t:InstallNodejsDependencies -m:1 -f net10.0
 
+    # BuildAllTfms=true opts back into net9.0 and net8.0, which the Debug configuration skips so that local
+    # inner-loop builds only compile the TFM the demo and the tests actually run on.
     - name: dotnet build
-      run: dotnet build src/BlazorUI/Bit.BlazorUI.slnx
+      run: dotnet build src/BlazorUI/Bit.BlazorUI.slnx -p:BuildAllTfms=true
 
     - name: Test
-      run: cd src/BlazorUI/Tests/Bit.BlazorUI.Tests && dotnet test --no-build --verbosity normal
+      run: cd src/BlazorUI/Tests/Bit.BlazorUI.Tests && dotnet test --no-build --verbosity normal -p:BuildAllTfms=true

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Bit.BlazorUI.Assets.csproj
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Bit.BlazorUI.Assets.csproj
@@ -4,6 +4,8 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- See the note in Bit.BlazorUI.csproj: Debug builds only the TFM the demo and tests run on. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ResolveStaticWebAssetsInputsDependsOn Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Bit.BlazorUI.Extras.csproj
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Bit.BlazorUI.Extras.csproj
@@ -4,6 +4,8 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- See the note in Bit.BlazorUI.csproj: Debug builds only the TFM the demo and tests run on. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ResolveStaticWebAssetsInputsDependsOn Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/BlazorUI/Bit.BlazorUI.Icons/Bit.BlazorUI.Icons.csproj
+++ b/src/BlazorUI/Bit.BlazorUI.Icons/Bit.BlazorUI.Icons.csproj
@@ -4,6 +4,8 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- See the note in Bit.BlazorUI.csproj: Debug builds only the TFM the demo and tests run on. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <RootNamespace>Bit.BlazorUI</RootNamespace>
         <WarningLevel>0</WarningLevel>
         <ResolveStaticWebAssetsInputsDependsOn Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/BlazorUI/Bit.BlazorUI.Legacy/Bit.BlazorUI.Legacy.csproj
+++ b/src/BlazorUI/Bit.BlazorUI.Legacy/Bit.BlazorUI.Legacy.csproj
@@ -4,6 +4,8 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- See the note in Bit.BlazorUI.csproj: Debug builds only the TFM the demo and tests run on. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ResolveStaticWebAssetsInputsDependsOn Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/BlazorUI/Bit.BlazorUI/Bit.BlazorUI.csproj
+++ b/src/BlazorUI/Bit.BlazorUI/Bit.BlazorUI.csproj
@@ -4,6 +4,10 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- The demo and the tests only run on the latest TFM, so compiling net9.0 and net8.0 on every Debug
+             build triples the inner-loop work for output nothing consumes. Release (pack, CI) still builds
+             all three; pass -p:BuildAllTfms=true to get them in Debug too. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ResolveStaticWebAssetsInputsDependsOn Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/BlazorUI/Demo/Directory.Build.props
+++ b/src/BlazorUI/Demo/Directory.Build.props
@@ -25,6 +25,11 @@
         <DefineConstants Condition="  $(TargetFramework.Contains('-mac')) ">$(DefineConstants);Mac</DefineConstants>
 
         <HotReloadAutoRestart>true</HotReloadAutoRestart>
+
+        <!-- Bit.CodeAnalyzers runs over every demo page and adds ~25% to the inner-loop compile, for
+             diagnostics that are warnings-only here. The IDE still surfaces them live (that is
+             RunAnalyzersDuringLiveAnalysis, untouched) and Release builds still run them. -->
+        <RunAnalyzersDuringBuild Condition=" '$(Configuration)' == 'Debug' ">false</RunAnalyzersDuringBuild>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/BlazorUI/Demo/README.md
+++ b/src/BlazorUI/Demo/README.md
@@ -20,7 +20,7 @@ Two things keep the Debug inner loop small, and both are off in Release so that
 packing and CI still see the full picture:
 
 - **One target framework.** `Bit.BlazorUI`, `.Assets`, `.Extras`, `.Icons`,
-  `.Legacy` and `Bit.BlazorUI.Tests` multi-target `net10.0;net9.0;net8.0`, but the
+  `.Legacy` and the test projects multi-target `net10.0;net9.0;net8.0`, but the
   demo and the tests only ever run on `net10.0`, so Debug compiles that one alone.
   Pass `-p:BuildAllTfms=true` to compile all three locally; CI already does.
 - **No analyzers during build.** `Bit.CodeAnalyzers` runs over every demo page and

--- a/src/BlazorUI/Demo/README.md
+++ b/src/BlazorUI/Demo/README.md
@@ -13,3 +13,26 @@ build with the WASM client included, e.g.:
 That flag alone both bundles the WASM client and boots the app as Blazor
 WebAssembly in Debug (it defines `INCLUDE_WASM`, which `AppRenderMode.WasmEnabled`
 reads).
+
+## Build speed
+
+Two things keep the Debug inner loop small, and both are off in Release so that
+packing and CI still see the full picture:
+
+- **One target framework.** `Bit.BlazorUI`, `.Assets`, `.Extras`, `.Icons`,
+  `.Legacy` and `Bit.BlazorUI.Tests` multi-target `net10.0;net9.0;net8.0`, but the
+  demo and the tests only ever run on `net10.0`, so Debug compiles that one alone.
+  Pass `-p:BuildAllTfms=true` to compile all three locally; CI already does.
+- **No analyzers during build.** `Bit.CodeAnalyzers` runs over every demo page and
+  its findings are warnings only, so `RunAnalyzersDuringBuild` is off in Debug (see
+  `Directory.Build.props`). The IDE still reports them live, and Release builds
+  still run them.
+
+Beyond that:
+
+- Open `Bit.BlazorUI.Web.slnf`, not `Bit.BlazorUI.slnx`. The full solution pulls in
+  the MAUI and Windows clients, which add four platform target frameworks nothing
+  in the web demo needs.
+- Prefer `dotnet watch --project Bit.BlazorUI.Demo.Server` over rebuilding: most
+  `.razor` and `.cs` edits apply through hot reload with no build at all, and scss
+  edits never need one (the in-app compiler handles them - see `ScssCompilerService`).

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
@@ -4,6 +4,9 @@
     
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- Matches the referenced Bit.BlazorUI projects: Debug builds/runs the tests on the latest TFM
+             only, CI passes -p:BuildAllTfms=true to cover net9.0 and net8.0 as well. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <LangVersion>14.0</LangVersion>
         <Nullable>enable</Nullable>

--- a/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance.TestHost/Bit.BlazorUI.Tests.Performance.TestHost.csproj
+++ b/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance.TestHost/Bit.BlazorUI.Tests.Performance.TestHost.csproj
@@ -2,6 +2,10 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- Matches the referenced Bit.BlazorUI projects: Debug builds the latest TFM only, CI passes
+             -p:BuildAllTfms=true to cover net9.0 and net8.0 as well. Without this the net9.0/net8.0
+             TFMs of this host would reference a Debug Bit.BlazorUI that only builds net10.0. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>preview</LangVersion>

--- a/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance/Bit.BlazorUI.Tests.Performance.csproj
+++ b/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance/Bit.BlazorUI.Tests.Performance.csproj
@@ -4,6 +4,9 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+        <!-- Matches the test host it drives: Debug builds the latest TFM only, CI passes
+             -p:BuildAllTfms=true to cover net9.0 and net8.0 as well. -->
+        <TargetFrameworks Condition=" '$(Configuration)' == 'Debug' And '$(BuildAllTfms)' != 'true' ">net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <LangVersion>14.0</LangVersion>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
closes #12853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Debug builds are faster by default, compiling only the primary target framework.
  - Build-time analyzers are disabled during Debug builds while live IDE analysis remains available.

- **Build & Testing**
  - Release builds and explicitly enabled full builds continue validating all supported .NET target frameworks.
  - Automated builds and tests now cover the complete supported framework set.

- **Documentation**
  - Added guidance for faster development workflows, including solution filters and `dotnet watch`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->