### PR TITLE
Add accent color switcher to Boilerplate (#12885)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs
@@ -33,6 +33,7 @@ public partial class AppClientCoordinator : AppComponentBase
     [AutoInject] private ILogger<AuthManager> authLogger = default!;
     [AutoInject] private ILogger<Navigator> navigatorLogger = default!;
     [AutoInject] private ILogger<AppClientCoordinator> logger = default!;
+    [AutoInject] private AppAccentColorService accentColorService = default!;
     //#if (notification == true)
     [AutoInject] private IPushNotificationService pushNotificationService = default!;
     //#endif
@@ -100,6 +101,8 @@ public partial class AppClientCoordinator : AppComponentBase
                 }
             });
             //#endif
+
+            await accentColorService.InitializeAsync(); // Restores the persisted accent (main theme) color, if any.
 
             NavigationManager.LocationChanged += NavigationManager_LocationChanged;
             AuthManager.AuthenticationStateChanged += AuthenticationStateChanged;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor
@@ -1,0 +1,17 @@
+@inherits AppComponentBase
+
+<div class="accent-switcher">
+    <BitStack Horizontal VerticalAlign="BitAlignment.Center" Gap="0.5rem">
+        @foreach (var (name, hex) in AppAccentColorService.Presets)
+        {
+            var isActive = accentColorService.ActiveAccent == hex;
+
+            <BitButton Title="@name"
+                       aria-pressed="@(isActive ? "true" : "false")"
+                       AriaLabel="@Localizer["Apply the {0} accent color", name]"
+                       Class="@($"accent-swatch{(isActive ? " accent-swatch--active" : null)}")"
+                       Style="@($"--swatch-color:{hex}")"
+                       OnClick="WrapHandled(() => accentColorService.ApplyAsync(hex))" />
+        }
+    </BitStack>
+</div>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor.cs
@@ -1,0 +1,33 @@
+namespace Boilerplate.Client.Core.Components.Layout.Header;
+
+/// <summary>
+/// The accent color swatches: one brand color fed to <see cref="BitThemeFactory"/> re-themes the
+/// whole app live. The accent itself is owned by <see cref="AppAccentColorService"/> - this only
+/// renders it and hands clicks over.
+/// </summary>
+public partial class AccentColorSwitcher
+{
+    [AutoInject] private AppAccentColorService accentColorService = default!;
+
+    private Action? unsubscribe;
+
+    protected override async Task OnInitAsync()
+    {
+        await base.OnInitAsync();
+
+        // Subscribed this early - rather than after the first render - so the restore that
+        // AppClientCoordinator kicks off cannot land in the gap between rendering the swatches and
+        // listening for the accent they mark.
+        unsubscribe = PubSubService.Subscribe(ClientAppMessages.ACCENT_COLOR_CHANGED, async _ =>
+        {
+            await InvokeAsync(StateHasChanged);
+        });
+    }
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        unsubscribe?.Invoke();
+
+        await base.DisposeAsync(disposing);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor.scss
@@ -1,0 +1,37 @@
+@import '../../../Styles/abstracts/_bit-css-variables.scss';
+
+.accent-switcher {
+    width: 100%;
+    padding: 0 8px;
+}
+
+::deep .accent-swatch {
+    padding: 0;
+    width: 20px;
+    height: 20px;
+    min-width: 20px;
+    min-height: 20px;
+    border-radius: 50%;
+    background-color: var(--swatch-color);
+    border: 1px solid $bit-color-border-secondary;
+    transition: transform $bit-motion-duration $bit-motion-easing;
+
+    &:hover,
+    &:active {
+        background-color: var(--swatch-color);
+    }
+
+    &:hover {
+        transform: scale(1.15);
+    }
+
+    &:focus-visible {
+        outline: 2px solid $bit-color-primary;
+        outline-offset: 2px;
+    }
+
+    &.accent-swatch--active {
+        outline: 2px solid var(--swatch-color);
+        outline-offset: 2px;
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor
@@ -110,6 +110,8 @@
                             <BitToggle OnChange="ToggleTheme" Value="CurrentTheme == AppThemeType.Light" ValueChanged="v => { }" />
                         </BitStack>
 
+                        <AccentColorSwitcher />
+
                         <AuthorizeView>
                             <BitActionButton FullWidth
                                              Color="BitColor.Error"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IClientCoreServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IClientCoreServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static partial class IClientCoreServiceCollectionExtensions
 
             services.AddScoped<ThemeService>();
             services.AddScoped<CultureService>();
+            services.AddScoped<AppAccentColorService>();
             services.AddScoped<LazyAssemblyLoader>();
             services.AddScoped<SignInModalService>();
             services.AddScoped<IAuthTokenProvider, ClientSideAuthTokenProvider>();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppAccentColorService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppAccentColorService.cs
@@ -1,0 +1,313 @@
+using System.Collections.Concurrent;
+
+namespace Boilerplate.Client.Core.Infrastructure.Services;
+
+/// <summary>
+/// Owns the app's accent (main theme) color: the applied theme overlay, the storage + cookie copies
+/// that survive a refresh, and the re-derivation a dark/light switch needs.
+/// </summary>
+/// <remarks>
+/// The accent applies to the whole app, so it lives in a service rather than in the component that
+/// renders the swatches: a component could not restore the accent after a refresh that lands on
+/// another page, nor keep it in step with a theme toggle made while it is not rendered.
+/// </remarks>
+public partial class AppAccentColorService : IDisposable
+{
+    private const string StorageKey = "AccentColor";
+
+    /// <summary>
+    /// The cookie mirroring <see cref="StorageKey"/>. localStorage is unreachable while the server
+    /// prerenders, so the accent is written to a cookie as well and the server paints the accented
+    /// palette into the first response - see <see cref="BuildPrerenderCss"/>.
+    /// </summary>
+    public const string CookieName = "app-accent-color";
+
+    // ~400 days, the upper bound modern browsers clamp persistent cookies to.
+    private const int CookieMaxAgeSeconds = 34560000;
+
+    /// <summary>
+    /// Id of the <c>&lt;style&gt;</c> element carrying <see cref="BuildPrerenderCss"/> in the
+    /// server-rendered document (see Server.Web's App.razor). The element is never removed; the
+    /// inline overlay <see cref="ApplyAsync"/> writes always outranks it.
+    /// </summary>
+    public const string PrerenderStyleElementId = "app-prerender-accent";
+
+    /// <summary>
+    /// The accents the switcher offers, and the only values <see cref="ApplyAsync"/> honors: a
+    /// persisted value is attacker-editable (it is just a localStorage entry / cookie), so it is
+    /// matched against this list rather than handed to <see cref="BitThemeFactory"/> as-is.
+    /// </summary>
+    public static readonly (string Name, string Hex)[] Presets =
+    [
+        ("Blue", BitAccentColorPresets.Blue),
+        ("Purple", BitAccentColorPresets.Purple),
+        ("Green", BitAccentColorPresets.Green),
+        ("Orange", BitAccentColorPresets.Orange),
+        ("Teal", BitAccentColorPresets.Teal),
+        ("Rose", BitAccentColorPresets.Rose),
+    ];
+
+    /// <summary>Rendered <see cref="BuildPrerenderCss"/> output, keyed by accent hex.</summary>
+    private static readonly ConcurrentDictionary<string, string> prerenderCss = new(StringComparer.Ordinal);
+
+    [AutoInject] private Cookie cookie = default!;
+    [AutoInject] private PubSubService pubSubService = default!;
+    [AutoInject] private IStorageService storageService = default!;
+    [AutoInject] private BitThemeManager bitThemeManager = default!;
+    [AutoInject] private BitThemeNotifications bitThemeNotifications = default!;
+    [AutoInject] private ILogger<AppAccentColorService> logger = default!;
+
+    private bool initialized;
+
+    /// <summary>
+    /// True once an inline overlay has been applied in this session. From then on every dark/light
+    /// switch (and a switch back to <see cref="BitAccentColorPresets.Blue"/>) must re-apply a full
+    /// seeded theme, because the packaged stylesheet alone no longer describes what is on screen.
+    /// </summary>
+    private bool overlayApplied;
+
+    /// <summary>
+    /// The accent currently applied. <see cref="BitAccentColorPresets.Blue"/> is the packaged
+    /// palette's own primary, i.e. "no override".
+    /// </summary>
+    public string ActiveAccent { get; private set; } = BitAccentColorPresets.Blue;
+
+    /// <summary>
+    /// Restores the persisted accent and applies it. Reading the stores needs an interactive
+    /// session, so this is called from AppClientCoordinator once prerendering is over. Safe to call
+    /// repeatedly - only the first call does the work. Never throws: losing the accent is not a
+    /// reason to take app startup down.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        if (initialized) return;
+        initialized = true;
+
+        try
+        {
+            // Subscribed here rather than in the constructor because attaching the handler kicks off
+            // the JS notifier registration, which can only succeed once the client is live.
+            bitThemeNotifications.ThemeChanged += OnThemeChanged;
+
+            // Storage first, cookie second: they are written together, so they only diverge when one
+            // of them is unavailable or was cleared alone. Either one on its own restores the accent.
+            var fromStorage = NormalizeAccent(await TryReadStorageAsync());
+            var stored = fromStorage;
+
+            if (AppPlatform.IsBlazorHybrid is false)
+            {
+                stored ??= NormalizeAccent(await TryReadCookieAsync());
+            }
+
+            if (stored is null) return; // Nothing persisted: the packaged palette is already correct.
+
+            ActiveAccent = stored;
+
+            // Rewrite both stores from whichever one answered, so a divergence (e.g. the cookie's
+            // absolute ~400-day cap expiring, or storage cleared alone) does not keep the server
+            // prerendering the packaged Blue while the client repaints the accent on every load.
+            await PersistAsync(stored, rewriteStorage: fromStorage is null);
+
+            if (stored == BitAccentColorPresets.Blue) return; // The packaged palette's own primary; nothing to override.
+
+            await ApplyForThemeAsync(stored, await bitThemeManager.GetCurrentThemeAsync());
+
+            pubSubService.Publish(ClientAppMessages.ACCENT_COLOR_CHANGED, stored);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Restoring the persisted accent color failed.");
+        }
+    }
+
+    /// <summary>
+    /// Applies <paramref name="hex"/> as the accent and persists it. Values outside
+    /// <see cref="Presets"/> are ignored.
+    /// </summary>
+    public async Task ApplyAsync(string hex)
+    {
+        if (Presets.Any(p => p.Hex == hex) is false) return;
+
+        ActiveAccent = hex;
+
+        await PersistAsync(hex, rewriteStorage: true);
+
+        if (hex == BitAccentColorPresets.Blue && overlayApplied is false)
+        {
+            // No overlay and no prerendered accent rule can be in the document, so the packaged
+            // palette is already showing - skip pushing ~200 custom properties for a no-op.
+        }
+        else
+        {
+            await ApplyForThemeAsync(hex, await bitThemeManager.GetCurrentThemeAsync());
+        }
+
+        pubSubService.Publish(ClientAppMessages.ACCENT_COLOR_CHANGED, hex);
+    }
+
+    /// <summary>
+    /// The stylesheet the server emits so a prerendered page paints <paramref name="accentHex"/>
+    /// immediately, instead of the packaged palette that the client would then have to repaint.
+    /// Returns <see langword="null"/> when there is nothing to override - no stored accent, an
+    /// unrecognized one, or Blue, which is the packaged palette's own primary.
+    /// </summary>
+    /// <remarks>
+    /// Both schemes are emitted, each scoped to the <c>bit-theme</c> attribute the library's inline
+    /// head script resolves before first paint, so the server does not have to know (and, while
+    /// following the OS, cannot know) whether the visitor lands on dark or light.
+    /// <para>
+    /// The doubled <c>:root:root</c> is there for specificity: the packaged palette declares the
+    /// same tokens at <c>:root[bit-theme=…]</c>, and outranking it lets this block sit anywhere in
+    /// the document instead of having to come after every stylesheet link.
+    /// </para>
+    /// </remarks>
+    public static string? BuildPrerenderCss(string? accentHex)
+    {
+        var hex = NormalizeAccent(accentHex);
+
+        if (hex is null || hex == BitAccentColorPresets.Blue) return null;
+
+        // Deriving a palette from a seed is real work (OKLCH conversions over ~200 tokens) and there
+        // are only six of them, so the rendered CSS is built once per accent rather than per request.
+        return prerenderCss.GetOrAdd(hex, static hex =>
+        {
+            return $":root:root[bit-theme$=dark]{{{Declarations(BitThemeFactory.CreateDarkThemeFromSeed(hex))}}}" +
+                   $":root:root:not([bit-theme$=dark]){{{Declarations(BitThemeFactory.CreateLightThemeFromSeed(hex))}}}";
+
+            static string Declarations(BitTheme theme)
+            {
+                return string.Concat(BitThemeUtilities.ToCssVariables(theme).Select(v => $"{v.Key}:{v.Value};"));
+            }
+        });
+    }
+
+    /// <summary>
+    /// Matches a value from any of the (attacker-editable) stores against <see cref="Presets"/>,
+    /// returning the canonical hex or <see langword="null"/>. Nothing outside the presets is ever
+    /// handed to <see cref="BitThemeFactory"/> or written into the document.
+    /// </summary>
+    private static string? NormalizeAccent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        var candidate = value.Trim();
+
+        foreach (var (_, hex) in Presets)
+        {
+            if (string.Equals(hex, candidate, StringComparison.OrdinalIgnoreCase)) return hex;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Writes the accent to storage and (on web) mirrors it into the cookie the server prerender
+    /// reads. Each write is tolerated to fail on its own: the pick still applies for this session
+    /// and is restored on the next load from whichever store did take it.
+    /// </summary>
+    private async Task PersistAsync(string hex, bool rewriteStorage)
+    {
+        if (rewriteStorage)
+        {
+            try
+            {
+                await storageService.SetItem(StorageKey, hex, persistent: true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Persisting the accent color to storage failed.");
+            }
+        }
+
+        if (AppPlatform.IsBlazorHybrid) return; // No server prerender to inform.
+
+        try
+        {
+            await cookie.Set(new()
+            {
+                Name = CookieName,
+                Value = hex,
+                MaxAge = CookieMaxAgeSeconds,
+                Path = "/",
+                SameSite = SameSite.Strict,
+                Secure = AppEnvironment.IsDevelopment() is false
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Persisting the accent color cookie failed.");
+        }
+    }
+
+    private async Task<string?> TryReadStorageAsync()
+    {
+        try
+        {
+            return await storageService.GetItem(StorageKey);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Reading the persisted accent color from storage failed.");
+            return null;
+        }
+    }
+
+    private async Task<string?> TryReadCookieAsync()
+    {
+        try
+        {
+            return await cookie.GetValue(CookieName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Reading the persisted accent color cookie failed.");
+            return null;
+        }
+    }
+
+    private async Task ApplyForThemeAsync(string hex, string? themeName)
+    {
+        // The whole-theme factory rather than the accent-only one, so the surfaces, text, strokes
+        // and status colors all move with the brand color instead of an accent changing under a
+        // fixed gray page. Applied even for Blue (which reproduces the packaged palette exactly)
+        // because an earlier overlay or the server's prerendered accent rule may still be painting
+        // another color - inline custom properties are the one thing that outranks both.
+        var isDark = themeName?.Contains("dark", StringComparison.OrdinalIgnoreCase) is true;
+        var theme = isDark ? BitThemeFactory.CreateDarkThemeFromSeed(hex) : BitThemeFactory.CreateLightThemeFromSeed(hex);
+
+        await bitThemeManager.ApplyBitThemeAsync(theme);
+
+        overlayApplied = true;
+    }
+
+    // Re-derives the accent overlay for the new scheme, otherwise a light-scheme primary would
+    // linger on the dark palette (and vice versa).
+    private void OnThemeChanged(object? sender, BitThemeChangedEventArgs e)
+    {
+        if (overlayApplied is false) return;
+
+        _ = ReapplyForThemeAsync(e.NewTheme);
+    }
+
+    // The event accessor cannot await, so this is fire-and-forget and has to swallow its own
+    // failures: the notification is raised from the JS interop callback, where an unobserved fault
+    // would surface far from anything that could report it.
+    private async Task ReapplyForThemeAsync(string? themeName)
+    {
+        try
+        {
+            await ApplyForThemeAsync(ActiveAccent, themeName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Re-applying the {Accent} accent color for the new theme failed.", ActiveAccent);
+        }
+    }
+
+    public void Dispose()
+    {
+        bitThemeNotifications.ThemeChanged -= OnThemeChanged;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppAccentColorService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppAccentColorService.cs
@@ -60,6 +60,20 @@ public partial class AppAccentColorService : IDisposable
     private bool initialized;
 
     /// <summary>
+    /// Serializes the persist + theme-lookup + apply sequence of an accent transition, so
+    /// overlapping restore / pick / scheme-switch work cannot land out of order and leave a stale
+    /// palette as the final applied state.
+    /// </summary>
+    private readonly SemaphoreSlim transitionGate = new(1, 1);
+
+    /// <summary>
+    /// Monotonic stamp of the latest requested transition. A transition that finds a newer stamp
+    /// once it holds <see cref="transitionGate"/> abandons itself: the newer request is already
+    /// queued behind it and will apply the up-to-date accent and scheme.
+    /// </summary>
+    private int transitionVersion;
+
+    /// <summary>
     /// True once an inline overlay has been applied in this session. From then on every dark/light
     /// switch (and a switch back to <see cref="BitAccentColorPresets.Blue"/>) must re-apply a full
     /// seeded theme, because the packaged stylesheet alone no longer describes what is on screen.
@@ -89,28 +103,41 @@ public partial class AppAccentColorService : IDisposable
             // the JS notifier registration, which can only succeed once the client is live.
             bitThemeNotifications.ThemeChanged += OnThemeChanged;
 
-            // Storage first, cookie second: they are written together, so they only diverge when one
-            // of them is unavailable or was cleared alone. Either one on its own restores the accent.
-            var fromStorage = NormalizeAccent(await TryReadStorageAsync());
-            var stored = fromStorage;
+            var version = ++transitionVersion;
 
-            if (AppPlatform.IsBlazorHybrid is false)
-            {
-                stored ??= NormalizeAccent(await TryReadCookieAsync());
-            }
+            // Both stores are read (they are written together, so they only diverge when one of
+            // them was unavailable or cleared alone): storage is authoritative, and the cookie both
+            // backfills a cleared storage and reveals what the server prerendered.
+            var fromStorage = NormalizeAccent(await TryReadStorageAsync());
+            var fromCookie = AppPlatform.IsBlazorHybrid ? null : NormalizeAccent(await TryReadCookieAsync());
+
+            var stored = fromStorage ?? fromCookie;
 
             if (stored is null) return; // Nothing persisted: the packaged palette is already correct.
 
-            ActiveAccent = stored;
+            await transitionGate.WaitAsync();
+            try
+            {
+                if (version != transitionVersion) return; // The user already picked an accent; this restore is stale.
 
-            // Rewrite both stores from whichever one answered, so a divergence (e.g. the cookie's
-            // absolute ~400-day cap expiring, or storage cleared alone) does not keep the server
-            // prerendering the packaged Blue while the client repaints the accent on every load.
-            await PersistAsync(stored, rewriteStorage: fromStorage is null);
+                ActiveAccent = stored;
 
-            if (stored == BitAccentColorPresets.Blue) return; // The packaged palette's own primary; nothing to override.
+                // Rewrite both stores from whichever one answered, so a divergence (e.g. the cookie's
+                // absolute ~400-day cap expiring, or storage cleared alone) does not keep the server
+                // prerendering the packaged Blue while the client repaints the accent on every load.
+                await PersistAsync(stored, rewriteStorage: fromStorage is null);
 
-            await ApplyForThemeAsync(stored, await bitThemeManager.GetCurrentThemeAsync());
+                // Blue is the packaged palette's own primary, so normally there is nothing to
+                // override - unless the stores diverged and the server prerendered another accent
+                // from the cookie, which the seeded Blue theme must then overwrite.
+                if (stored == BitAccentColorPresets.Blue && (fromCookie is null || fromCookie == BitAccentColorPresets.Blue)) return;
+
+                await ApplyForThemeAsync(stored, await bitThemeManager.GetCurrentThemeAsync());
+            }
+            finally
+            {
+                transitionGate.Release();
+            }
 
             pubSubService.Publish(ClientAppMessages.ACCENT_COLOR_CHANGED, stored);
         }
@@ -128,18 +155,30 @@ public partial class AppAccentColorService : IDisposable
     {
         if (Presets.Any(p => p.Hex == hex) is false) return;
 
+        var version = ++transitionVersion;
+
         ActiveAccent = hex;
 
-        await PersistAsync(hex, rewriteStorage: true);
+        await transitionGate.WaitAsync();
+        try
+        {
+            if (version != transitionVersion) return; // A newer pick supersedes this one.
 
-        if (hex == BitAccentColorPresets.Blue && overlayApplied is false)
-        {
-            // No overlay and no prerendered accent rule can be in the document, so the packaged
-            // palette is already showing - skip pushing ~200 custom properties for a no-op.
+            await PersistAsync(hex, rewriteStorage: true);
+
+            if (hex == BitAccentColorPresets.Blue && overlayApplied is false)
+            {
+                // No overlay and no prerendered accent rule can be in the document, so the packaged
+                // palette is already showing - skip pushing ~200 custom properties for a no-op.
+            }
+            else
+            {
+                await ApplyForThemeAsync(hex, await bitThemeManager.GetCurrentThemeAsync());
+            }
         }
-        else
+        finally
         {
-            await ApplyForThemeAsync(hex, await bitThemeManager.GetCurrentThemeAsync());
+            transitionGate.Release();
         }
 
         pubSubService.Publish(ClientAppMessages.ACCENT_COLOR_CHANGED, hex);
@@ -296,7 +335,19 @@ public partial class AppAccentColorService : IDisposable
     {
         try
         {
-            await ApplyForThemeAsync(ActiveAccent, themeName);
+            var version = ++transitionVersion;
+
+            await transitionGate.WaitAsync();
+            try
+            {
+                if (version != transitionVersion) return; // The newer transition re-reads the current theme itself.
+
+                await ApplyForThemeAsync(ActiveAccent, themeName);
+            }
+            finally
+            {
+                transitionGate.Release();
+            }
         }
         catch (Exception ex)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs
@@ -71,6 +71,12 @@ public partial class ClientAppMessages
     public const string THEME_CHANGED = nameof(THEME_CHANGED);
 
     /// <summary>
+    /// A publisher that publishes this message notifies that the app's accent (main theme) color has changed.
+    /// The payload is the new accent's hex value (See <see cref="AppAccentColorService"/>).
+    /// </summary>
+    public const string ACCENT_COLOR_CHANGED = nameof(ACCENT_COLOR_CHANGED);
+
+    /// <summary>
     /// A publisher that publishes this message notifies that the app culture has changed.
     /// </summary>
     public const string CULTURE_CHANGED = nameof(CULTURE_CHANGED);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/AccentColorPrerenderStyle.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/AccentColorPrerenderStyle.razor
@@ -1,0 +1,4 @@
+@if (accentCss is not null)
+{
+    <style id="@AppAccentColorService.PrerenderStyleElementId">@((MarkupString)accentCss)</style>
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/AccentColorPrerenderStyle.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/AccentColorPrerenderStyle.razor.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Boilerplate.Server.Web.Components;
+
+/// <summary>
+/// Paints the visitor's persisted accent (main theme) color into the first response, so the
+/// prerendered page does not flash the packaged palette before the client applies the accent.
+/// Renders nothing unless a non-default accent is stored - see <see cref="AppAccentColorService.BuildPrerenderCss"/>.
+/// </summary>
+public partial class AccentColorPrerenderStyle
+{
+    [CascadingParameter] public HttpContext HttpContext { get; set; } = default!;
+
+    private string? accentCss;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        accentCss = AppAccentColorService.BuildPrerenderCss(HttpContext.Request.Cookies[AppAccentColorService.CookieName]);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
@@ -55,6 +55,17 @@
     @*#endif*@
     <Link rel="apple-touch-icon" sizes="512x512" Href="images/icons/bit-icon-512.png" />
     <Link rel="manifest" Href="manifest.json" />
+
+    @{
+        // Paints the visitor's persisted accent (main theme) color into the first response, so the
+        // prerendered page does not flash the packaged palette before the client applies the accent.
+        // Null unless a non-default accent is stored - see AppAccentColorService.BuildPrerenderCss.
+        var accentCss = AppAccentColorService.BuildPrerenderCss(HttpContext.Request.Cookies[AppAccentColorService.CookieName]);
+    }
+    @if (accentCss is not null)
+    {
+        <style id="@AppAccentColorService.PrerenderStyleElementId">@((MarkupString)accentCss)</style>
+    }
 </head>
 
 <body class="@BitCss.Class.Color.Background.Primary.Main @BitCss.Class.Color.Foreground.Primary.Main bit-blazor-web">

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
@@ -56,16 +56,7 @@
     <Link rel="apple-touch-icon" sizes="512x512" Href="images/icons/bit-icon-512.png" />
     <Link rel="manifest" Href="manifest.json" />
 
-    @{
-        // Paints the visitor's persisted accent (main theme) color into the first response, so the
-        // prerendered page does not flash the packaged palette before the client applies the accent.
-        // Null unless a non-default accent is stored - see AppAccentColorService.BuildPrerenderCss.
-        var accentCss = AppAccentColorService.BuildPrerenderCss(HttpContext.Request.Cookies[AppAccentColorService.CookieName]);
-    }
-    @if (accentCss is not null)
-    {
-        <style id="@AppAccentColorService.PrerenderStyleElementId">@((MarkupString)accentCss)</style>
-    }
+    <AccentColorPrerenderStyle />
 </head>
 
 <body class="@BitCss.Class.Color.Background.Primary.Main @BitCss.Class.Color.Foreground.Primary.Main bit-blazor-web">


### PR DESCRIPTION
closes #12885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accent color switcher to the application menu with accessible preset color choices.
  * Accent color preferences now persist across sessions and apply consistently in light and dark themes.
  * Added active-state indicators, hover effects, focus styling, and smooth color transitions.
  * Preserved the selected accent color during initial page loading to reduce visual flicker.
  * Accent color changes now update throughout the application without interrupting navigation or authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a persisted accent-color switcher, dynamic light and dark theme generation, and server-rendered accent CSS to reduce first-paint flicker.
- Adds selectable accent swatches to the application menu.
- Persists and restores the accent through local storage and a cookie.
- Reapplies generated palettes when the light or dark theme changes.
- Emits the persisted palette during server prerendering.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because restoring a persisted accent can leave the menu showing Blue as active while another palette is applied.

AppClientCoordinator initializes one component-owned AppAccentColorService instance, while AccentColorSwitcher reads another scoped instance whose ActiveAccent remains Blue, so persisted non-blue selections are represented incorrectly after refresh.

**Files Needing Attention:** src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IClientCoreServiceCollectionExtensions.cs, src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs, src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AppAccentColorService.cs | Implements accent persistence, serialized theme transitions, palette generation, and theme-change handling. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IClientCoreServiceCollectionExtensions.cs | Registers the accent service as scoped, which leaves its state split between separately owned component scopes. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor | Renders accessible accent swatches but derives active state from a service instance that is not the one restored by the coordinator. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/AccentColorPrerenderStyle.razor.cs | Reads the validated accent cookie and generates the corresponding prerendered palette. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor | Adds the accent prerender style component to the document head. |

</details>

<sub>Reviews (3): Last reviewed commit: ["resolve review comments"](https://github.com/bitfoundation/bitplatform/commit/e882c2a6d604e3d5ad371680ab706960ef7cfd68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52138696)</sub>

**Context used:**

- Context used - src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.m... ([source](https://github.com/bitfoundation/bitplatform/blob/develop/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md))

<!-- /greptile_comment -->