### PR TITLE
Improve bit Boilerplate http delegating handlers (#12887)

### DIFF
--- a/.github/workflows/bit.full.ci.yml
+++ b/.github/workflows/bit.full.ci.yml
@@ -252,18 +252,9 @@ jobs:
         path: ./TestSqlServer/src/Tests/TestResults
         retention-days: 14
 
-    - name: Run UI tests (InvariantGlobalization)
-      id: test-mssql-invariantglobalization
-      working-directory: TestSqlServer/src/Tests
-      run: WebAppRender__BlazorMode=BlazorWebAssembly WebAppRender__PrerenderEnabled=true ResponseCaching__EnableOutputCaching=true dotnet test -p:InvariantGlobalization=true --filter "TestCategory=UITest&TestCategory!=Localization"
-
-    - name: Upload InvariantGlobalization test results on failure
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: ${{ !cancelled() && steps.test-mssql-invariantglobalization.outcome == 'failure' }}
-      with:
-        name: sqlserver-tests-invariantglobalization
-        path: ./TestSqlServer/src/Tests/TestResults
-        retention-days: 14
+    # This job deliberately has no InvariantGlobalization run: Microsoft.Data.SqlClient throws
+    # "Globalization Invariant Mode is not supported." out of SqlConnection.Open, so the whole assembly aborts in
+    # its initializer before a single browser starts. The PostgreSQL job above covers that configuration.
 
 
   build-boilerplate-configurations:

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/14- Response Caching System.md
@@ -399,8 +399,10 @@ The `CacheDelegatingHandler` (located in `/src/Client/Boilerplate.Client.Core/In
 ```csharp
 protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 {
-    var cacheKey = $"{request.Method}-{request.RequestUri}";
     var useCache = AppEnvironment.IsDevelopment() is false && AppPlatform.IsBlazorHybridOrBrowser;
+    // Identity and culture are in the key because this cache outlives the user session, and because the token and
+    // Accept-Language are attached by handlers below this one. See BuildCacheKey.
+    var cacheKey = useCache ? await BuildCacheKey(request) : string.Empty;
 
     // Try to get from cache
     if (useCache && memoryCache.TryGetValue(cacheKey, out ResponseMemoryCacheItems? cachedResponse))
@@ -423,9 +425,16 @@ protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage 
         {
             Content = responseContent,
             StatusCode = response.StatusCode,
-            ResponseHeaders = response.Headers.ToDictionary(),
-            ContentHeaders = response.Content.Headers.ToDictionary()
-        }, maxAge);
+            ResponseHeaders = response.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()),
+            ContentHeaders = response.Content.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()),
+            LogScopeData = logScopeData.ToDictionary()
+        }, options: new()
+        {
+            // Size is not optional here: AppMemoryCache's 4 KB fallback does not apply to an options object, and the
+            // budget in the table below is only byte-accurate because this is the response's real length.
+            Size = responseContent.Length,
+            AbsoluteExpirationRelativeToNow = maxAge
+        });
     }
 
     return response;
@@ -454,6 +463,14 @@ This creates an exceptionally smooth user experience because the app feels nativ
 **Important Notes:**
 - **Client In-Memory Cache** is cleared when the app is closed (doesn't persist across sessions)
 - **Browser HTTP cache** persists even after closing the browser, but it's asynchronous (shows loading briefly)
+
+> **Neither private cache is per-user.** "One app session" and "one browser profile" both span however many people
+> sign in on that device: signing out and switching tenant are in-app navigations, so they do not restart the runtime,
+> and the browser cache outlives the process entirely. The in-memory cache therefore keys on the caller's identity and
+> culture as well as the URL (see `BuildCacheKey`), and a response the server filtered by the caller's tenant claim is
+> not given a client `max-age` at all (see `AppResponseCachePolicy`) - because the browser's cache keys on the URL and
+> nothing the server sends can add a dimension to it. `UserAgnostic` does not help here: it gates the two *shared*
+> caches, which is a different question from whether a *private* cache may hold the response.
 - The combination of both provides the best user experience:
   - Instant loads during the current session (Client In-Memory Cache)
   - Fast loads on return visits (browser cache)
@@ -478,7 +495,8 @@ When a user makes a request, it flows through these layers in order:
 │  1. Client In-Memory Cache Check (CacheDelegatingHandler)   │
 │     - Fastest (microseconds - SYNCHRONOUS)                   │
 │     - No loading indicators, spinners, or shimmers           │
-│     - Only works during current app session                  │
+│     - Lives as long as the app process, across user sessions │
+│     - Keyed by identity + culture + method + URI              │
 │     - Not purgeable                                          │
 └─────────────────────────────────────────────────────────────┘
         │ MISS                          │ HIT

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/21- .NET MAUI - Blazor Hybrid.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/21- .NET MAUI - Blazor Hybrid.md
@@ -359,8 +359,8 @@ public partial class MauiStorageService : IStorageService
 ```
 
 **Usage**: Store user preferences, authentication tokens, and other data that should persist across app restarts.
-`persistent: false` is how "don't remember me" is honoured, so the two stores must not both hold the same key -
-`IStorageServiceContractTests` pins that for all four implementations.
+`persistent: false` is how "don't remember me" is honoured, so the two stores must not both hold the same key, and
+`IsPersistent` must answer from the persistent store - `AuthManager` re-derives the choice from it on every refresh.
 
 ### MauiExternalNavigationService
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/21- .NET MAUI - Blazor Hybrid.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/21- .NET MAUI - Blazor Hybrid.md
@@ -332,26 +332,35 @@ Implements `IStorageService` using MAUI's `Preferences` API in [`MauiStorageServ
 ```csharp
 public partial class MauiStorageService : IStorageService
 {
+    private readonly Dictionary<string, string?> tempStorage = [];
+
     public async ValueTask<string?> GetItem(string key)
     {
-        return Preferences.Get(key, null);
+        tempStorage.TryGetValue(key, out string? value);
+        return Preferences.Get(key, value); // The temp value is the DEFAULT: a persisted entry wins.
     }
-    
+
     public async ValueTask SetItem(string key, string? value, bool persistent = true)
     {
+        // A key lives in exactly one of the two stores, so each write evicts the other copy. Without that, the
+        // superseded value stays where GetItem still reads it - and Preferences wins there.
         if (persistent)
         {
+            tempStorage.Remove(key);
             Preferences.Set(key, value); // Persisted to disk
         }
         else
         {
-            tempStorage[key] = value; // In-memory only
+            Preferences.Remove(key);
+            tempStorage[key] = value; // In-memory only, dies with the process
         }
     }
 }
 ```
 
 **Usage**: Store user preferences, authentication tokens, and other data that should persist across app restarts.
+`persistent: false` is how "don't remember me" is honoured, so the two stores must not both hold the same key -
+`IStorageServiceContractTests` pins that for all four implementations.
 
 ### MauiExternalNavigationService
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -547,6 +547,7 @@
                     "exclude": [
                         "src/Tests/Features/ServerWeb/**",
                         "src/Tests/Features/Identity/AuthManagerRefreshCoordinationTests.cs",
+                        "src/Tests/Features/Identity/AuthManagerTokenPersistenceTests.cs",
                         "src/Tests/Infrastructure/Components/BitOtpInputUtils.cs",
                         "src/Tests/Features/Todo/OfflineTodoTests.cs",
                         "src/Tests/Features/Identity/TrustedOriginsTests.cs",
@@ -622,7 +623,9 @@
                     // Tenant is the only `long Version` entity that exists without a module or signalR.
                     "condition": "(advancedTests != true || multitenant != true)",
                     "exclude": [
-                        "src/Tests/Features/Data/ConcurrencyTokenTests.cs"
+                        "src/Tests/Features/Data/ConcurrencyTokenTests.cs",
+                        // The rule it pins - a tenant filtered body gets no client max-age - only exists under multitenant.
+                        "src/Tests/Features/Caching/ResponseCachePolicyClientCacheTests.cs"
                     ]
                 },
                 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -548,6 +548,8 @@
                         "src/Tests/Features/ServerWeb/**",
                         "src/Tests/Features/Identity/AuthManagerRefreshCoordinationTests.cs",
                         "src/Tests/Features/Identity/AuthManagerTokenPersistenceTests.cs",
+                        "src/Tests/Features/Identity/AccessTokenParsingTests.cs",
+                        "src/Tests/Features/Identity/IStorageServiceContractTests.cs",
                         "src/Tests/Infrastructure/Components/BitOtpInputUtils.cs",
                         "src/Tests/Features/Todo/OfflineTodoTests.cs",
                         "src/Tests/Features/Identity/TrustedOriginsTests.cs",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/ForceUpdateSnackBar.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/ForceUpdateSnackBar.razor
@@ -1,6 +1,6 @@
 @inherits AppComponentBase
 
-<BitSnackBar @ref="bitSnackBar" AutoDismiss="false" Persistent>
+<BitSnackBar @ref="bitSnackBar" AutoDismiss="false" Persistent Class="force-update-snack-bar">
     <TitleTemplate>
         <BitStack FitHeight>
             <BitText Typography="BitTypography.H5">

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs
@@ -54,8 +54,8 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
 
         rememberMe ??= await storageService.IsPersistent("refresh_token");
 
-        await storageService.SetItem("access_token", response!.AccessToken);
         await storageService.SetItem("refresh_token", response!.RefreshToken, rememberMe is true);
+        await storageService.SetItem("access_token", response!.AccessToken, rememberMe is true);
 
         NotifyAuthenticationStateChanged(Task.FromResult(await GetAuthenticationStateAsync()));
     }
@@ -158,7 +158,7 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
                         //#endif
                     }, default);
                     await StoreTokens(refreshTokenResponse);
-                    currentTsc.SetResult(refreshTokenResponse.AccessToken!);
+                    currentTsc.TrySetResult(refreshTokenResponse.AccessToken!);
                 }
                 catch (Exception exp)
                 {
@@ -176,7 +176,7 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
                         await ClearTokens();
                     }
 
-                    currentTsc.SetResult(null);
+                    currentTsc.TrySetResult(null);
                 }
             }
             finally
@@ -187,6 +187,9 @@ public partial class AuthManager : AuthenticationStateProvider, IAsyncDisposable
                 {
                     accessTokenTsc = null;
                 }
+
+                currentTsc.TrySetResult(null);
+
                 semaphore.Release();
             }
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IAuthTokenProvider.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IAuthTokenProvider.cs
@@ -42,6 +42,9 @@ public interface IAuthTokenProvider
     {
         var parsedClaims = DeserializeAccessToken(accessToken);
 
+        if (parsedClaims is null)
+            return null;
+
         if (validateExpiry)
         {
             if (parsedClaims.TryGetValue("exp", out var exp) is false ||
@@ -82,7 +85,7 @@ public interface IAuthTokenProvider
         return claims;
     }
 
-    private static Dictionary<string, JsonElement> DeserializeAccessToken(string accessToken)
+    private static Dictionary<string, JsonElement>? DeserializeAccessToken(string accessToken)
     {
         // Split the token to get the payload
         string base64UrlPayload = accessToken.Split('.')[1];
@@ -94,7 +97,7 @@ public interface IAuthTokenProvider
         string jsonPayload = Encoding.UTF8.GetString(Convert.FromBase64String(base64Payload));
 
         // Deserialize the JSON string to a dictionary
-        var claims = JsonSerializer.Deserialize(jsonPayload, AppJsonContext.Default.Options.GetTypeInfo<Dictionary<string, JsonElement>>())!;
+        var claims = JsonSerializer.Deserialize(jsonPayload, AppJsonContext.Default.Options.GetTypeInfo<Dictionary<string, JsonElement>>());
 
         return claims;
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IAuthTokenProvider.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IAuthTokenProvider.cs
@@ -17,7 +17,16 @@ public interface IAuthTokenProvider
         if (string.IsNullOrEmpty(accessToken) is true)
             return Anonymous();
 
-        var claims = ReadClaims(accessToken, validateExpiry);
+        IEnumerable<Claim>? claims;
+
+        try
+        {
+            claims = ReadClaims(accessToken, validateExpiry);
+        }
+        catch (Exception exp) when (exp is FormatException or JsonException or IndexOutOfRangeException or ArgumentException)
+        {
+            return Anonymous();
+        }
 
         if (claims is null)
             return Anonymous();
@@ -33,10 +42,11 @@ public interface IAuthTokenProvider
     {
         var parsedClaims = DeserializeAccessToken(accessToken);
 
-        if (validateExpiry && long.TryParse(parsedClaims["exp"].ToString(), out var expSeconds))
+        if (validateExpiry)
         {
-            var expirationDate = DateTimeOffset.FromUnixTimeSeconds(expSeconds);
-            if (expirationDate <= TimeProvider.GetUtcNow())
+            if (parsedClaims.TryGetValue("exp", out var exp) is false ||
+                long.TryParse(exp.ToString(), out var expSeconds) is false ||
+                DateTimeOffset.FromUnixTimeSeconds(expSeconds) <= TimeProvider.GetUtcNow())
                 return null;
         }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
@@ -77,7 +77,7 @@ internal class CacheDelegatingHandler(IMemoryCache memoryCache, IAuthTokenProvid
         if (user.IsAuthenticated())
         {
             //#if (multitenant == true)
-            identity = FormattableString.Invariant($"{identity}-{user.GetTenantId()}");
+            identity = FormattableString.Invariant($"{user.GetUserId()}-{user.GetTenantId()}");
             //#else
             identity = user.GetUserId().ToString();
             //#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs
@@ -1,9 +1,10 @@
+//+:cnd:noEmit
 using System.Net;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Boilerplate.Client.Core.Infrastructure.Services.HttpMessageHandlers;
 
-internal class CacheDelegatingHandler(IMemoryCache memoryCache, HttpMessageHandler handler)
+internal class CacheDelegatingHandler(IMemoryCache memoryCache, IAuthTokenProvider tokenProvider, HttpMessageHandler handler)
     : DelegatingHandler(handler)
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -14,7 +15,7 @@ internal class CacheDelegatingHandler(IMemoryCache memoryCache, HttpMessageHandl
 
         try
         {
-            var cacheKey = $"{request.Method}-{request.RequestUri}";
+            var cacheKey = useCache ? await BuildCacheKey(request) : string.Empty;
 
             if (useCache && memoryCache.TryGetValue(cacheKey, out ResponseMemoryCacheItems? cachedResponse))
             {
@@ -65,6 +66,26 @@ internal class CacheDelegatingHandler(IMemoryCache memoryCache, HttpMessageHandl
         {
             logScopeData["MemoryCacheStatus"] = memoryCacheStatus;
         }
+    }
+
+    private async Task<string> BuildCacheKey(HttpRequestMessage request)
+    {
+        var user = IAuthTokenProvider.ParseAccessToken(await tokenProvider.GetAccessToken(), validateExpiry: false);
+
+        var identity = "anonymous";
+
+        if (user.IsAuthenticated())
+        {
+            //#if (multitenant == true)
+            identity = FormattableString.Invariant($"{identity}-{user.GetTenantId()}");
+            //#else
+            identity = user.GetUserId().ToString();
+            //#endif
+        }
+
+        var culture = CultureInfoManager.InvariantGlobalization ? string.Empty : CultureInfo.CurrentUICulture.Name;
+
+        return FormattableString.Invariant($"{identity}-{culture}-{request.Method}-{request.RequestUri}");
     }
 
     public class ResponseMemoryCacheItems

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/ExceptionDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/ExceptionDelegatingHandler.cs
@@ -19,11 +19,13 @@ public partial class ExceptionDelegatingHandler(PubSubService pubSubService,
 
         string? requestIdValue = null;
 
+        HttpResponseMessage? response = null;
+
         try
         {
             try
             {
-                var response = await base.SendAsync(request, cancellationToken);
+                response = await base.SendAsync(request, cancellationToken);
 
                 if (response.Headers.TryGetValues("Request-Id", out var requestId))
                 {
@@ -82,6 +84,7 @@ public partial class ExceptionDelegatingHandler(PubSubService pubSubService,
         }
         catch (Exception exp)
         {
+            response?.Dispose(); // Only ever reached on a failure; the success path returns from the inner try.
             exp.WithData("RequestId", requestIdValue ?? "?"); // Connect the exception to its corresponding request id, if one exists.
             throw;
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/RetryDelegatingHandler.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/RetryDelegatingHandler.cs
@@ -1,3 +1,5 @@
+using System.Runtime.ExceptionServices;
+
 namespace Boilerplate.Client.Core.Infrastructure.Services.HttpMessageHandlers;
 
 public partial class RetryDelegatingHandler(HttpMessageHandler handler)
@@ -10,7 +12,7 @@ public partial class RetryDelegatingHandler(HttpMessageHandler handler)
         const int maxRetries = 3;
         var delays = GetDelaySequence(scaleFirstTry: TimeSpan.FromSeconds(3)).Take(maxRetries - 1).ToArray();
 
-        Exception? lastExp = null;
+        ExceptionDispatchInfo? lastExp = null;
 
         for (int attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -35,7 +37,11 @@ public partial class RetryDelegatingHandler(HttpMessageHandler handler)
                 if (exp is KnownException and not TransientException)
                     throw;
 
-                lastExp = exp;
+                // Captured rather than stored, because `throw lastExp` at the end would reset the stack trace to that
+                // line - discarding where the failure actually came from, on the one path whose whole purpose is to
+                // report an unrecoverable network failure. The retry loop is disabled in Development, so the mangled
+                // trace only ever existed in telemetry from released clients.
+                lastExp = ExceptionDispatchInfo.Capture(exp);
 
                 // Only wait if there are retries left
                 if (attempt < maxRetries - 1)
@@ -46,7 +52,8 @@ public partial class RetryDelegatingHandler(HttpMessageHandler handler)
             }
         }
 
-        throw lastExp!;
+        lastExp!.Throw();
+        throw null; // Unreachable: Throw() above never returns, but the compiler cannot know that.
     }
 
     /// <summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiStorageService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiStorageService.cs
@@ -1,5 +1,8 @@
 // [mirror] IStorageService semantics - persistent vs temp storage - keep in sync with:
 // - src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsStorageService.cs
+// - src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebStorageService.cs
+// - src/Tests/Infrastructure/Services/TestStorageService.cs
+// IStorageServiceContractTests pins the behaviour all four must share.
 
 namespace Boilerplate.Client.Maui.Infrastructure.Services;
 
@@ -26,16 +29,18 @@ public partial class MauiStorageService : IStorageService
 
     public async ValueTask SetItem(string key, string? value, bool persistent = true)
     {
+        // A key lives in exactly one of the two stores. Writing to one without removing it from the other would leave
+        // the previous value where GetItem still reads it - and since Preferences wins there (it is the value, the temp
+        // entry is only the default), a temporary write would be shadowed by the persistent value it supersedes.
         if (persistent)
         {
+            tempStorage.Remove(key);
             Preferences.Set(key, value);
         }
         else
         {
-            if (tempStorage.TryAdd(key, value) is false)
-            {
-                tempStorage[key] = value;
-            }
+            Preferences.Remove(key);
+            tempStorage[key] = value;
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebStorageService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebStorageService.cs
@@ -1,3 +1,9 @@
+// [mirror] IStorageService semantics - persistent vs temp storage - keep in sync with:
+// - src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiStorageService.cs
+// - src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsStorageService.cs
+// - src/Tests/Infrastructure/Services/TestStorageService.cs
+// IStorageServiceContractTests pins the behaviour all four must share.
+
 using Bit.Butil;
 
 namespace Boilerplate.Client.Web.Infrastructure.Services;
@@ -30,12 +36,17 @@ public partial class WebStorageService : IStorageService
 
     public async ValueTask SetItem(string key, string? value, bool persistent = true)
     {
+        // A key lives in exactly one of the two stores. Writing to one without removing it from the other would leave
+        // the previous value where GetItem still reads it - and since Preferences wins there (it is the value, the temp
+        // entry is only the default), a temporary write would be shadowed by the persistent value it supersedes.
         if (persistent)
         {
+            await sessionStorage.RemoveItem(key);
             await localStorage.SetItem(key, value);
         }
         else
         {
+            await localStorage.RemoveItem(key);
             await sessionStorage.SetItem(key, value);
         }
     }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsStorageService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsStorageService.cs
@@ -1,5 +1,8 @@
 // [mirror] IStorageService semantics - persistent vs temp storage - keep in sync with:
 // - src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiStorageService.cs
+// - src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebStorageService.cs
+// - src/Tests/Infrastructure/Services/TestStorageService.cs
+// IStorageServiceContractTests pins the behaviour all four must share.
 
 using System.IO.IsolatedStorage;
 
@@ -12,7 +15,9 @@ public partial class WindowsStorageService : IStorageService
 
     public async ValueTask<bool> IsPersistent(string key)
     {
-        return string.IsNullOrEmpty(await GetItem(key)) is false;
+        persistentStorage ??= await Restore();
+
+        return persistentStorage.ContainsKey(key);
     }
 
     public async ValueTask<string?> GetItem(string key)
@@ -39,15 +44,24 @@ public partial class WindowsStorageService : IStorageService
 
     public async ValueTask SetItem(string key, string? value, bool persistent = true)
     {
+        persistentStorage ??= await Restore();
+
+        // A key lives in exactly one of the two stores. Writing to one without removing it from the other would leave
+        // the previous value where GetItem still reads it - and since Preferences wins there (it is the value, the temp
+        // entry is only the default), a temporary write would be shadowed by the persistent value it supersedes.
         if (persistent)
         {
-            persistentStorage ??= await Restore();
+            tempStorage.Remove(key);
             persistentStorage[key] = value;
             await Save(persistentStorage);
         }
         else
         {
             tempStorage[key] = value;
+            if (persistentStorage.Remove(key))
+            {
+                await Save(persistentStorage);
+            }
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Build.props
@@ -41,6 +41,8 @@
         <WasmFingerprintAssets>false</WasmFingerprintAssets>
         <StaticWebAssetsFingerprintContent>false</StaticWebAssetsFingerprintContent>
         <StaticWebAssetFingerprintingEnabled>false</StaticWebAssetFingerprintingEnabled>
+
+        <DefaultItemExcludes>$(DefaultItemExcludes);**/App_Data/**</DefaultItemExcludes>
     </PropertyGroup>
     <!--/+:msbuild-conditional:noEmit -->
 
@@ -79,8 +81,6 @@
 
         <PackageReference Include="Bit.CodeAnalyzers" />
         <PackageReference Include="Bit.SourceGenerators" />
-
-        <Watch Remove="*.scss" />
     </ItemGroup>
 
     <!--

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
@@ -106,22 +106,25 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
 
         if (context.HttpContext.User.IsAuthenticated() && responseCacheAtt.UserAgnostic is false)
         {
-            // See UserAgnostic's comment.
+            // See UserAgnostic's comment. The private caches are no more per-user than the shared ones: one browser
+            // profile and one running app each span every user who signs in on that device, and both key on the URL.
+            // So a body that depends on who asked for it may not carry a client max-age either.
             edgeCacheTtl = -1;
             outputCacheTtl = -1;
+            clientCacheTtl = -1;
         }
 
         //#if (multitenant == true)
         if (currentTenantId is not null)
         {
-            // The Tenant rule above gives the output cache a tenant dimension, but VaryByValues is an output cache
-            // concept: it never becomes a response header, so no cache outside this process can see it. The two
-            // private caches - the browser's own HTTP cache and the client's CacheDelegatingHandler - key on the URL,
-            // which for an authenticated caller is identical across tenants. A max-age would therefore let the
-            // browser replay this tenant's rows to whoever signs in next on the same profile, and it survives a
-            // restart. Anonymous callers are unaffected: their tenant comes from the host, so it is already in the
-            // URL - which is the traffic the client cache exists for.
+            // The Tenant rule above is a VaryByValues entry, and that is an output cache concept: it never becomes a
+            // response header, so the output cache is the only cache that can see it. Every other cache keys on the
+            // URL, which for an authenticated caller is identical across tenants - a CDN would hand tenant A's body
+            // to tenant B, and the browser's own cache would replay it to whoever signs in next on that profile,
+            // across a restart. Anonymous callers are unaffected: their tenant comes from the host, so it is already
+            // in the URL, and that is the traffic these caches exist for.
             clientCacheTtl = -1;
+            edgeCacheTtl = -1;
         }
         //#endif
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs
@@ -70,9 +70,10 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
         // and tenant scoped entities are filtered by that tenant (See AppDbContext.ConfigureTenantAwareEntity). Without this
         // rule two users of different tenants on the same host would share a single entry, so a UserAgnostic endpoint like
         // ProductViewController would serve one tenant's rows to another.
-        if (context.HttpContext.User.GetTenantId() is Guid currentTenantId)
+        var currentTenantId = context.HttpContext.User.GetTenantId();
+        if (currentTenantId is not null)
         {
-            context.CacheVaryByRules.VaryByValues.Add("Tenant", currentTenantId.ToString());
+            context.CacheVaryByRules.VaryByValues.Add("Tenant", currentTenantId.Value.ToString());
         }
         //#endif
 
@@ -109,6 +110,20 @@ public class AppResponseCachePolicy(IHostEnvironment env, ServerSharedSettings s
             edgeCacheTtl = -1;
             outputCacheTtl = -1;
         }
+
+        //#if (multitenant == true)
+        if (currentTenantId is not null)
+        {
+            // The Tenant rule above gives the output cache a tenant dimension, but VaryByValues is an output cache
+            // concept: it never becomes a response header, so no cache outside this process can see it. The two
+            // private caches - the browser's own HTTP cache and the client's CacheDelegatingHandler - key on the URL,
+            // which for an authenticated caller is identical across tenants. A max-age would therefore let the
+            // browser replay this tenant's rows to whoever signs in next on the same profile, and it survives a
+            // restart. Anonymous callers are unaffected: their tenant comes from the host, so it is already in the
+            // URL - which is the traffic the client cache exists for.
+            clientCacheTtl = -1;
+        }
+        //#endif
 
         if (context.HttpContext.IsBlazorPageContext() && CultureInfoManager.InvariantGlobalization is false)
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Attributes/AppResponseCacheAttribute.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Attributes/AppResponseCacheAttribute.cs
@@ -21,13 +21,12 @@ public class AppResponseCacheAttribute : Attribute
     public int SharedMaxAge { get; set; } = -1;
 
     /// <summary>
-    /// If the current request is authenticated, the pre-rendered HTML response might include the user's name, 
-    /// or the JSON content of API calls might be based on the user's roles or tenant. 
-    /// Storing such a response in the browser's private cache is generally not an issue, 
-    /// but caching the response on a CDN's edge or in the output cache of ASP.NET Core 
-    /// could result in serving that response to other users. 
-    /// 
-    /// If you are certain that your page or API is not affected by the user, 
+    /// If the current request is authenticated, the pre-rendered HTML response might include the user's name,
+    /// or the JSON content of API calls might be based on the user's roles or tenant.
+    /// Caching such a response on a CDN's edge or in the output cache of ASP.NET Core
+    /// could result in serving that response to other users.
+    ///
+    /// If you are certain that your page or API is not affected by the user,
     /// you can set this property to true to cache those responses and improve performance.
     /// </summary>
     public bool UserAgnostic { get; set; }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Services/AppMemoryCache.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Services/AppMemoryCache.cs
@@ -17,6 +17,11 @@ namespace Boilerplate.Shared.Infrastructure.Services;
 /// (https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/1190) - are charged
 /// <see cref="EstimatedEntrySizeInBytes"/> instead. That's deliberately an over-estimate: charging an entry too much
 /// only means fewer of them fit, while charging too little lets the cache outgrow the limit it exists to enforce.
+///
+/// The fallback covers a caller that sets no size. It does NOT cover one that passes a MemoryCacheEntryOptions
+/// without a Size: SetOptions assigns every field unconditionally, so it overwrites the default with null and, because
+/// a SizeLimit is configured, the write then throws out of Set. A caller passing an options object must set Size
+/// itself - which is what CacheDelegatingHandler does.
 /// </summary>
 public class AppMemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory loggerFactory) : IMemoryCache
 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ResponseCachePolicyClientCacheTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ResponseCachePolicyClientCacheTests.cs
@@ -1,0 +1,91 @@
+//+:cnd:noEmit
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Boilerplate.Server.Shared;
+using Microsoft.AspNetCore.OutputCaching;
+using Boilerplate.Server.Shared.Infrastructure.Services;
+
+namespace Boilerplate.Tests.Features.Caching;
+
+/// <summary>
+/// <c>AppResponseCachePolicy</c> gives the output cache a tenant dimension through <c>VaryByValues["Tenant"]</c>. That
+/// covers the shared caches and nothing else: <c>VaryByValues</c> never becomes a response header, so the two
+/// <b>private</b> caches - the browser's own HTTP cache and the client's <c>CacheDelegatingHandler</c> - cannot see
+/// it. They key on the URL, which for an authenticated caller is identical whatever tenant they are in. So a
+/// <c>max-age</c> on a tenant filtered body lets a browser replay one tenant's rows to whoever signs in next on that
+/// profile, and the browser's cache outlives the process - which is why this has to be fixed on the server.
+/// <para>
+/// This is a plain unit test rather than an integration one because <c>AppTestServer</c> hard-codes
+/// <c>EnvironmentName = Development</c>, and the policy zeroes every client ttl in Development. No test that boots the
+/// real server can observe a client <c>max-age</c> at all, so the rule under test would be invisible to it.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest"), TestCategory("Caching")]
+public partial class ResponseCachePolicyClientCacheTests
+{
+    private const int MaxAgeSeconds = 300;
+
+    /// <summary>
+    /// The control. An anonymous caller resolves its tenant from the host, so the tenant is already part of the URL
+    /// every private cache keys on, and the carve-out must not touch it - that traffic is what the client cache
+    /// exists for. If this fails, the rule stopped being a carve-out and became a blanket pessimisation.
+    /// </summary>
+    [TestMethod]
+    public async Task AnAnonymousCaller_Should_KeepTheClientMaxAge()
+    {
+        var httpContext = await RunPolicy(tenantId: null);
+
+        Assert.AreEqual(TimeSpan.FromSeconds(MaxAgeSeconds), httpContext.Response.GetTypedHeaders().CacheControl?.MaxAge);
+    }
+
+    [TestMethod]
+    public async Task ACallerWhoseTenantCameFromAClaim_Should_NotGetAClientMaxAge()
+    {
+        var httpContext = await RunPolicy(tenantId: Guid.NewGuid());
+
+        Assert.IsNull(httpContext.Response.GetTypedHeaders().CacheControl?.MaxAge,
+            "A response the server filtered by the caller's tenant claim must not be storable in a URL keyed private " +
+            "cache, or the next person to use this browser profile is served this tenant's rows.");
+
+        Assert.Contains("Client:-1", httpContext.Response.Headers["App-Cache-Response"].ToString());
+    }
+
+    /// <summary>
+    /// Drives the real policy against a request shaped like <c>ProductViewController.Get</c> - the endpoint the defect
+    /// was found on: <c>UserAgnostic</c> (so the authenticated downgrade for the shared caches does not fire) with a
+    /// five minute <c>MaxAge</c>, outside Development (which would zero every client ttl on its own).
+    /// </summary>
+    private static async Task<HttpContext> RunPolicy(Guid? tenantId)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new("localhost");
+        httpContext.Request.Path = "/api/v1/ProductView/Get/1";
+
+        httpContext.SetEndpoint(new Endpoint(
+            requestDelegate: null,
+            new EndpointMetadataCollection(new AppResponseCacheAttribute { MaxAge = MaxAgeSeconds, UserAgnostic = true }),
+            displayName: nameof(ResponseCachePolicyClientCacheTests)));
+
+        if (tenantId is not null)
+        {
+            httpContext.User = new(new ClaimsIdentity(
+                [new Claim(AppClaimTypes.TENANT_ID, tenantId.Value.ToString())], authenticationType: "Bearer"));
+        }
+
+        var policy = new AppResponseCachePolicy(new ProductionEnvironment(), new ServerSharedSettings());
+
+        await policy.CacheRequestAsync(new OutputCacheContext { HttpContext = httpContext }, CancellationToken.None);
+
+        return httpContext;
+    }
+
+    private sealed class ProductionEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = nameof(ResponseCachePolicyClientCacheTests);
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ResponseCachePolicyClientCacheTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ResponseCachePolicyClientCacheTests.cs
@@ -48,7 +48,35 @@ public partial class ResponseCachePolicyClientCacheTests
             "A response the server filtered by the caller's tenant claim must not be storable in a URL keyed private " +
             "cache, or the next person to use this browser profile is served this tenant's rows.");
 
-        Assert.Contains("Client:-1", httpContext.Response.Headers["App-Cache-Response"].ToString());
+        Assert.IsNull(httpContext.Response.GetTypedHeaders().CacheControl?.SharedMaxAge,
+            "Nor in the CDN edge: the Tenant dimension is a VaryByValues entry, which never becomes a response " +
+            "header, so an edge keyed on the URL would hand this tenant's rows to the next one.");
+
+        var decision = httpContext.Response.Headers["App-Cache-Response"].ToString();
+        Assert.Contains("Client:-1", decision);
+        Assert.Contains("Edge:-1", decision);
+        // The output cache is the one cache that CAN see the Tenant dimension, so it stays enabled - otherwise this
+        // rule would be a blanket pessimisation rather than a carve-out.
+        Assert.DoesNotContain("Output:-1", decision);
+    }
+
+    /// <summary>
+    /// The same reasoning one step out: <c>UserAgnostic = false</c> declares that the body depends on the caller, and
+    /// the two private caches are no more per-user than the shared ones - one browser profile and one running app each
+    /// span every user who signs in on that device. No shipped endpoint sets that combination today; this pins the
+    /// decision surface the attribute's own documentation points template consumers at.
+    /// </summary>
+    [TestMethod]
+    public async Task AnAuthenticatedCallerOfANonUserAgnosticEndpoint_Should_NotGetAClientMaxAge()
+    {
+        var httpContext = await RunPolicy(tenantId: null, authenticated: true, userAgnostic: false);
+
+        Assert.IsNull(httpContext.Response.GetTypedHeaders().CacheControl?.MaxAge);
+
+        var decision = httpContext.Response.Headers["App-Cache-Response"].ToString();
+        Assert.Contains("Client:-1", decision);
+        Assert.Contains("Edge:-1", decision);
+        Assert.Contains("Output:-1", decision);
     }
 
     /// <summary>
@@ -56,7 +84,7 @@ public partial class ResponseCachePolicyClientCacheTests
     /// was found on: <c>UserAgnostic</c> (so the authenticated downgrade for the shared caches does not fire) with a
     /// five minute <c>MaxAge</c>, outside Development (which would zero every client ttl on its own).
     /// </summary>
-    private static async Task<HttpContext> RunPolicy(Guid? tenantId)
+    private static async Task<HttpContext> RunPolicy(Guid? tenantId, bool authenticated = false, bool userAgnostic = true)
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Scheme = "https";
@@ -65,13 +93,13 @@ public partial class ResponseCachePolicyClientCacheTests
 
         httpContext.SetEndpoint(new Endpoint(
             requestDelegate: null,
-            new EndpointMetadataCollection(new AppResponseCacheAttribute { MaxAge = MaxAgeSeconds, UserAgnostic = true }),
+            new EndpointMetadataCollection(new AppResponseCacheAttribute { MaxAge = MaxAgeSeconds, UserAgnostic = userAgnostic }),
             displayName: nameof(ResponseCachePolicyClientCacheTests)));
 
-        if (tenantId is not null)
+        if (tenantId is not null || authenticated)
         {
-            httpContext.User = new(new ClaimsIdentity(
-                [new Claim(AppClaimTypes.TENANT_ID, tenantId.Value.ToString())], authenticationType: "Bearer"));
+            Claim[] claims = tenantId is null ? [] : [new Claim(AppClaimTypes.TENANT_ID, tenantId.Value.ToString())];
+            httpContext.User = new(new ClaimsIdentity(claims, authenticationType: "Bearer"));
         }
 
         var policy = new AppResponseCachePolicy(new ProductionEnvironment(), new ServerSharedSettings());

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AiChatPanelThemeUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Chatbot/AiChatPanelThemeUITests.cs
@@ -87,13 +87,11 @@ public partial class AiChatPanelThemeUITests : AppPageTest
         await SendChatMessage(panel, "please switch the app theme", chatClient);
 
         // The payoff: the browser's own theme attribute, changed by nothing but the chatbot.
-        await Expect(htmlElement).ToHaveAttributeAsync("bit-theme", requestedTheme,
-            new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+        await Expect(htmlElement).ToHaveAttributeAsync("bit-theme", requestedTheme);
 
         // The answer written after the tool ran reaches the panel, which proves the second half of the round trip -
         // the tool result went back to the model and its prose was streamed to the user.
-        await Expect(panel.GetByText(finalAnswer))
-            .ToBeVisibleAsync(new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+        await Expect(panel.GetByText(finalAnswer)).ToBeVisibleAsync();
 
         // The tool really executed on the server rather than the theme changing by some other route: its return
         // value was fed back into the conversation. SetApplicationTheme returns "Theme changed to X successfully"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Culture/CultureSelectionUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Culture/CultureSelectionUITests.cs
@@ -54,6 +54,12 @@ public partial class CultureSelectionUITests : AppPageTest
         // Pick Persian. This writes the culture cookie and force-reloads the page (See CultureService.ChangeCulture).
         await Page.GetByText(faDisplayName, new() { Exact = true }).ClickAsync();
 
+        // Wait for the reloaded page to finish booting before touching the menu again. With pre-rendering on, the
+        // Persian markup is on screen while the app is still downloading, and a click landing on that not-yet-interactive
+        // DOM is simply lost - the menu never opens and the assertion below waits out its whole timeout. The text
+        // assertions in between would not have caught it: they are satisfied by the pre-rendered html.
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
         // After the reload the home message is now in Persian and the English one is gone.
         await Expect(Page.GetByText(faHomeMessage)).ToBeVisibleAsync();
         await Expect(Page.GetByText(defaultHomeMessage)).ToBeHiddenAsync();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ForceUpdate/ForceUpdateUITests.cs
@@ -40,7 +40,12 @@ public partial class ForceUpdateUITests : AppPageTest
 
         // The rejected request publishes the persistent FORCE_UPDATE message, so the force update panel shows up with its
         // title and body (See ForceUpdateSnackBar.razor) instead of the OTP panel the request would otherwise reveal.
-        await Expect(Page.GetByText(AppStrings.ForceUpdateTitle)).ToBeVisibleAsync();
-        await Expect(Page.GetByText(AppStrings.ForceUpdateBody)).ToBeVisibleAsync();
+        // Scoped to that panel: ClientNotSupportedException's own message IS AppStrings.ForceUpdateTitle, so whenever the
+        // rethrown exception also reaches AppSnackBar the page carries a second element with the very same text, and an
+        // unscoped locator then fails with a strict mode violation instead of finding the panel.
+        var forceUpdatePanel = Page.Locator(".force-update-snack-bar");
+
+        await Expect(forceUpdatePanel.GetByText(AppStrings.ForceUpdateTitle)).ToBeVisibleAsync();
+        await Expect(forceUpdatePanel.GetByText(AppStrings.ForceUpdateBody)).ToBeVisibleAsync();
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AccessTokenParsingTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AccessTokenParsingTests.cs
@@ -1,0 +1,100 @@
+//+:cnd:noEmit
+using System.Text;
+
+namespace Boilerplate.Tests.Features.Identity;
+
+/// <summary>
+/// <c>IAuthTokenProvider.ParseAccessToken</c> has to be total. The value it is handed is not always one the app
+/// minted: on the web client it comes from browser storage, and on Server.Web <c>ServerSideAuthTokenProvider</c>
+/// returns the request's own <c>access_token</c> cookie verbatim during pre-rendering. Its callers include
+/// <c>AuthDelegatingHandler</c>, whose catch filter only covers <c>ForbiddenException</c> and
+/// <c>UnauthorizedException</c>, so anything else it throws surfaces as a generic error dialog - or, during
+/// server-side rendering, somewhere worse.
+/// </summary>
+[TestClass, TestCategory("UnitTest"), TestCategory("Identity")]
+public partial class AccessTokenParsingTests
+{
+    /// <summary>
+    /// The payload <c>null</c> is the one malformed shape that does not throw on the way in: it deserializes to a
+    /// null dictionary, which then throws <see cref="NullReferenceException"/> on first use - a type the guard in
+    /// <c>ParseAccessToken</c> does not catch, because every other malformed input fails as a
+    /// <c>FormatException</c> or a <c>JsonException</c> first.
+    /// </summary>
+    [TestMethod]
+    // "bnVsbA" is base64url for the four characters `null`.
+    [DataRow("header.bnVsbA.signature", DisplayName = "payload is the JSON literal null")]
+    [DataRow("not-a-jwt", DisplayName = "no dots at all")]
+    [DataRow("header..signature", DisplayName = "empty payload")]
+    [DataRow("header.!!!not-base64!!!.signature", DisplayName = "payload is not base64")]
+    [DataRow("header.eyJhIjox.signature", DisplayName = "payload is truncated json")]
+    [DataRow("header.WyJhbiIsImFycmF5Il0.signature", DisplayName = "payload is a json array, not an object")]
+    public void AMalformedAccessToken_Should_ParseAsAnonymous(string accessToken)
+    {
+        foreach (var validateExpiry in new[] { true, false })
+        {
+            var user = IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry);
+
+            Assert.IsFalse(user.IsAuthenticated(),
+                $"'{accessToken}' (validateExpiry: {validateExpiry}) must yield an anonymous principal, not throw and " +
+                $"not authenticate.");
+        }
+    }
+
+    /// <summary>
+    /// The control. Without it every assertion above would pass against a method that returned
+    /// <c>Anonymous()</c> unconditionally.
+    /// </summary>
+    [TestMethod]
+    public void AWellFormedAccessToken_Should_StillParse()
+    {
+        var user = IAuthTokenProvider.ParseAccessToken(BuildToken(expiresOn: DateTimeOffset.UtcNow.AddMinutes(5)), validateExpiry: true);
+
+        Assert.IsTrue(user.IsAuthenticated());
+        Assert.AreEqual("the-user", user.FindFirst("name")?.Value);
+    }
+
+    /// <summary>
+    /// Expiry has to fail closed. The check used to be skipped entirely when <c>exp</c> could not be read, which
+    /// would have turned an unreadable claim into a session that never expires on the client - and
+    /// <c>AuthDelegatingHandler</c> and <c>GetFreshAccessToken</c> both treat "still valid" as permission to keep
+    /// using the token without refreshing it.
+    /// </summary>
+    [TestMethod]
+    [DataRow("\"not-a-number\"", DisplayName = "exp is a string")]
+    [DataRow("null", DisplayName = "exp is null")]
+    [DataRow("absent", DisplayName = "exp is missing entirely")]
+    public void AnUnreadableExpiry_Should_CountAsExpired(string rawExp)
+    {
+        var payload = rawExp is "absent"
+            ? """{"name":"the-user"}"""
+            : $$"""{"name":"the-user","exp":{{rawExp}}}""";
+
+        var accessToken = $"header.{ToBase64Url(payload)}.signature";
+
+        Assert.IsFalse(IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: true).IsAuthenticated(),
+            "A token whose expiry cannot be read must be treated as expired, never as valid forever.");
+
+        // ...while the caller that deliberately ignores expiry (GetAuthenticationStateAsync, so the app can render
+        // before it has refreshed) still gets the claims.
+        Assert.IsTrue(IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: false).IsAuthenticated());
+    }
+
+    [TestMethod]
+    public void AnExpiredAccessToken_Should_ParseAsAnonymous_OnlyWhenExpiryIsValidated()
+    {
+        var accessToken = BuildToken(expiresOn: DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        Assert.IsFalse(IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: true).IsAuthenticated());
+        Assert.IsTrue(IAuthTokenProvider.ParseAccessToken(accessToken, validateExpiry: false).IsAuthenticated());
+    }
+
+    private static string BuildToken(DateTimeOffset expiresOn)
+    {
+        return $"header.{ToBase64Url($$"""{"name":"the-user","exp":{{expiresOn.ToUnixTimeSeconds()}}}""")}.signature";
+    }
+
+    private static string ToBase64Url(string json)
+    {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(json)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AccountSelfServiceSecurityTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AccountSelfServiceSecurityTests.cs
@@ -222,10 +222,12 @@ public class AccountSelfServiceSecurityTests
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var normalizedEmail = email.ToUpperInvariant();
 
-        return await dbContext.Set<User>()
+        var state = await dbContext.Set<User>()
             .Where(u => u.NormalizedEmail == normalizedEmail)
-            .Select(u => ValueTuple.Create(u.EmailConfirmed, u.SecurityStamp))
+            .Select(u => new { u.EmailConfirmed, u.SecurityStamp })
             .SingleAsync(TestContext.CancellationToken);
+
+        return (state.EmailConfirmed, state.SecurityStamp);
     }
 
     public TestContext TestContext { get; set; } = default!;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AuthManagerRefreshCoordinationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AuthManagerRefreshCoordinationTests.cs
@@ -124,4 +124,70 @@ public partial class AuthManagerRefreshCoordinationTests
 
         Assert.HasCount(1, refreshRequests, "Two overlapping plain refreshes must share a single request.");
     }
+
+    /// <summary>
+    /// The third part of the contract, and the one that has no visible failure until it happens: the Task
+    /// <c>RefreshToken</c> hands back must <b>always</b> complete.
+    /// <para>
+    /// It is produced by a <c>TaskCompletionSource</c> that the fire-and-forget implementation completes, and that used
+    /// to happen on two statements deep inside an inner try - while three awaits sat outside it, the first of them a
+    /// storage read that is JS interop on the web client. Anything thrown there left the source uncompleted on a task
+    /// nobody observes, and since <c>RefreshToken</c> takes no <c>CancellationToken</c>, every awaiter then waited
+    /// forever: <c>AuthDelegatingHandler</c> in the middle of an HTTP request, the SignalR access token provider, a
+    /// tenant switch. The user's only way out was reloading the app.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task AFailureInsideTheRefresh_Should_StillCompleteTheAwaitingCallers()
+    {
+        await using var server = new AppTestServer();
+        await server.Build(configureTestServices: services =>
+        {
+            services.AddIntegrationApiOnlyTestsServices();
+            services.RemoveAll<IStorageService>();
+            services.AddScoped<IStorageService, ThrowsWhenTheRefreshTokenIsRead>();
+        }).Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var authManager = scope.ServiceProvider.GetRequiredService<AuthManager>();
+
+        // Two callers, because the second joins the first's shared source rather than starting its own - so a source
+        // that is never completed strands both, which is the shape the defect takes in the app.
+        var first = authManager.RefreshToken(requestedBy: "first");
+        var second = authManager.RefreshToken(requestedBy: "second");
+
+        // Any timeout at all is the assertion: unfixed, this waits forever rather than a few seconds.
+        var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(30), TestContext.CancellationToken);
+
+        Assert.IsNull(results[0], "A refresh that could not run reports failure by returning null.");
+        Assert.IsNull(results[1]);
+
+        // The manager has to be usable afterwards: the finally still clears the shared field and releases the
+        // semaphore, so a later refresh is not blocked by the failed one.
+        Assert.IsNull(await authManager.RefreshToken(requestedBy: "after").WaitAsync(TimeSpan.FromSeconds(30), TestContext.CancellationToken));
+    }
+
+    /// <summary>
+    /// Reproduces the one real thrower on that path: reading the refresh token is JS interop on the web client, which
+    /// throws when the circuit is being torn down or the call times out. Everything else behaves normally, so the test
+    /// fails for this reason and no other.
+    /// </summary>
+    private sealed class ThrowsWhenTheRefreshTokenIsRead : IStorageService
+    {
+        private readonly TestStorageService inner = new();
+
+        public ValueTask<string?> GetItem(string key)
+        {
+            if (key is "refresh_token")
+                throw new InvalidOperationException("JavaScript interop calls cannot be issued at this time.");
+
+            return inner.GetItem(key);
+        }
+
+        public ValueTask<bool> IsPersistent(string key) => inner.IsPersistent(key);
+        public ValueTask RemoveItem(string key) => inner.RemoveItem(key);
+        public ValueTask SetItem(string key, string? value, bool persistent = true) => inner.SetItem(key, value, persistent);
+        public ValueTask Clear() => inner.Clear();
+    }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AuthManagerTokenPersistenceTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AuthManagerTokenPersistenceTests.cs
@@ -68,41 +68,4 @@ public partial class AuthManagerTokenPersistenceTests
         }
     }
 
-    /// <summary>
-    /// The other half of the storage contract, and the one no shipped implementation used to honour: a key belongs to
-    /// exactly one of the two stores. A write that leaves the superseded copy behind is not merely untidy - every
-    /// implementation's <c>GetItem</c> prefers one store over the other, so the stale copy WINS the next read. On the
-    /// web client that means a sign-in with "Remember me" unchecked writes its refresh token where nothing will read
-    /// it, while the previous session's token in localStorage keeps being used - so the user carries on as the
-    /// account they just replaced.
-    /// </summary>
-    [TestMethod]
-    public async Task AWriteToOneStore_Should_EvictTheKeyFromTheOther()
-    {
-        await using var server = new AppTestServer();
-        await server.Build(configureTestServices: services => services.AddIntegrationApiOnlyTestsServices())
-                    .Start(TestContext.CancellationToken);
-
-        await using var scope = server.WebApp.Services.CreateAsyncScope();
-        var storageService = scope.ServiceProvider.GetRequiredService<IStorageService>();
-
-        await storageService.SetItem("refresh_token", "remembered", persistent: true);
-        Assert.IsTrue(await storageService.IsPersistent("refresh_token"));
-
-        await storageService.SetItem("refresh_token", "not-remembered", persistent: false);
-
-        Assert.AreEqual("not-remembered", await storageService.GetItem("refresh_token"),
-            "The persistent copy shadowed the value that was just written, so the app would keep using the superseded token.");
-        Assert.IsFalse(await storageService.IsPersistent("refresh_token"),
-            "A key written to temporary storage must not still report as persistent - AuthManager.StoreTokens derives " +
-            "'Remember me' from that answer on every refresh, so a wrong one re-promotes the session.");
-
-        await storageService.SetItem("refresh_token", "remembered-again", persistent: true);
-
-        Assert.AreEqual("remembered-again", await storageService.GetItem("refresh_token"));
-        Assert.IsTrue(await storageService.IsPersistent("refresh_token"));
-
-        await storageService.RemoveItem("refresh_token");
-        Assert.IsNull(await storageService.GetItem("refresh_token"), "RemoveItem has to clear both stores.");
-    }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AuthManagerTokenPersistenceTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/AuthManagerTokenPersistenceTests.cs
@@ -1,0 +1,108 @@
+//+:cnd:noEmit
+namespace Boilerplate.Tests.Features.Identity;
+
+/// <summary>
+/// "Remember me" decides one thing: whether this sign-in survives the app being closed. That decision has to hold for
+/// <b>both</b> tokens and it has to survive a refresh, because a refresh is what happens minutes into every session -
+/// <c>AuthManager.StoreTokens</c> is called again with no <c>rememberMe</c> argument and re-derives it from storage.
+/// <para>
+/// Two defects lived in exactly that gap. The access token was stored persistently regardless of the user's choice,
+/// so a "don't remember me" session left it behind - and <c>GetAuthenticationStateAsync</c> parses a leftover access
+/// token <b>without validating expiry</b>, so the app kept rendering the previous user's name, e-mail and roles with
+/// no path back to anonymous. Separately, the storage implementations answered "is this key persistent?" from
+/// whichever store happened to hold it rather than from the persistent one, so the first refresh silently promoted a
+/// session the user asked not to remember.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest"), TestCategory("Identity")]
+public partial class AuthManagerTokenPersistenceTests
+{
+    public TestContext TestContext { get; set; } = default!;
+
+    /// <summary>
+    /// Drives the real sequence - sign in, then refresh - and asserts the persistence of both tokens at both points.
+    /// The refresh is the half that matters: at sign-in <c>rememberMe</c> is passed explicitly, so only the second
+    /// check can catch a session being promoted behind the user's back.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task BothTokens_Should_KeepTheRememberMeTheUserChose_AcrossARefresh(bool rememberMe)
+    {
+        await using var server = new AppTestServer();
+        await server.Build(configureTestServices: services => services.AddIntegrationApiOnlyTestsServices())
+                    .Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+
+        var authManager = scope.ServiceProvider.GetRequiredService<AuthManager>();
+        var storageService = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        var requiresTwoFactor = await authManager.SignIn(new()
+        {
+            Email = TestData.DefaultTestEmail,
+            Password = TestData.DefaultTestPassword,
+            RememberMe = rememberMe
+        }, TestContext.CancellationToken);
+
+        Assert.IsFalse(requiresTwoFactor, $"'{TestData.DefaultTestEmail}' is not expected to have two factor authentication enabled.");
+
+        await AssertPersistence("right after signing in");
+
+        // A real refresh against the real endpoint, which is what re-enters StoreTokens with no rememberMe argument.
+        var refreshedAccessToken = await authManager.RefreshToken(requestedBy: nameof(BothTokens_Should_KeepTheRememberMeTheUserChose_AcrossARefresh));
+
+        Assert.IsFalse(string.IsNullOrEmpty(refreshedAccessToken),
+            "The refresh did not succeed, so the assertions below would be about a session that never got a second pair of tokens.");
+
+        await AssertPersistence("after a refresh");
+
+        async Task AssertPersistence(string when)
+        {
+            Assert.AreEqual(rememberMe, await storageService.IsPersistent("refresh_token"),
+                $"The refresh token's persistence {when} does not match the user's 'Remember me' choice.");
+
+            Assert.AreEqual(rememberMe, await storageService.IsPersistent("access_token"),
+                $"The access token's persistence {when} does not match the user's 'Remember me' choice. It used to be " +
+                $"stored persistently regardless, which left a signed-out browser rendering the previous user's identity.");
+        }
+    }
+
+    /// <summary>
+    /// The other half of the storage contract, and the one no shipped implementation used to honour: a key belongs to
+    /// exactly one of the two stores. A write that leaves the superseded copy behind is not merely untidy - every
+    /// implementation's <c>GetItem</c> prefers one store over the other, so the stale copy WINS the next read. On the
+    /// web client that means a sign-in with "Remember me" unchecked writes its refresh token where nothing will read
+    /// it, while the previous session's token in localStorage keeps being used - so the user carries on as the
+    /// account they just replaced.
+    /// </summary>
+    [TestMethod]
+    public async Task AWriteToOneStore_Should_EvictTheKeyFromTheOther()
+    {
+        await using var server = new AppTestServer();
+        await server.Build(configureTestServices: services => services.AddIntegrationApiOnlyTestsServices())
+                    .Start(TestContext.CancellationToken);
+
+        await using var scope = server.WebApp.Services.CreateAsyncScope();
+        var storageService = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        await storageService.SetItem("refresh_token", "remembered", persistent: true);
+        Assert.IsTrue(await storageService.IsPersistent("refresh_token"));
+
+        await storageService.SetItem("refresh_token", "not-remembered", persistent: false);
+
+        Assert.AreEqual("not-remembered", await storageService.GetItem("refresh_token"),
+            "The persistent copy shadowed the value that was just written, so the app would keep using the superseded token.");
+        Assert.IsFalse(await storageService.IsPersistent("refresh_token"),
+            "A key written to temporary storage must not still report as persistent - AuthManager.StoreTokens derives " +
+            "'Remember me' from that answer on every refresh, so a wrong one re-promotes the session.");
+
+        await storageService.SetItem("refresh_token", "remembered-again", persistent: true);
+
+        Assert.AreEqual("remembered-again", await storageService.GetItem("refresh_token"));
+        Assert.IsTrue(await storageService.IsPersistent("refresh_token"));
+
+        await storageService.RemoveItem("refresh_token");
+        Assert.IsNull(await storageService.GetItem("refresh_token"), "RemoveItem has to clear both stores.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/ExternalIdentityTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/ExternalIdentityTests.cs
@@ -51,8 +51,6 @@ public partial class ExternalIdentityTests : AppPageTest
         {
             await Page.GetByTitle(AppStrings.KeycloakSignInButtonText).ClickAsync();
         });
-        keycloakLogin.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
-
         // Keycloak's standard username/password login form uses these stable element ids.
         await keycloakLogin.Locator("#username").FillAsync(RealmUserName);
         await keycloakLogin.Locator("#password").FillAsync(RealmPassword);
@@ -61,8 +59,7 @@ public partial class ExternalIdentityTests : AppPageTest
         // With valid credentials (this realm user has no required actions and the client needs no consent), Keycloak
         // redirects the popup back to the server's external sign-in callback, which hands the result to the opener window
         // through the web-interop page and closes the popup. The main page then completes the sign-in and redirects home.
-        await Expect(Page).ToHaveURLAsync(serverAddress.ToString(),
-            new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+        await Expect(Page).ToHaveURLAsync(serverAddress.ToString());
 
         // Keycloak users are created with their username as the full name (See IdentityController.ExternalSignInCallback),
         // so the header persona shows "alice" and the Sign in button is gone.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IStorageServiceContractTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IStorageServiceContractTests.cs
@@ -1,0 +1,111 @@
+//+:cnd:noEmit
+namespace Boilerplate.Tests.Features.Identity;
+
+/// <summary>
+/// The contract every <see cref="IStorageService"/> has to honour, written once so the four implementations have
+/// something to be in sync <b>with</b> rather than only a <c>[mirror]</c> comment saying they should be.
+/// <para>
+/// It exists because <c>AuthManager.StoreTokens</c> re-derives the user's "Remember me" choice from
+/// <see cref="IStorageService.IsPersistent"/> on every refresh, so the two questions "which store is this key in?"
+/// and "which value does a read return?" decide whether a session the user asked not to remember survives - and all
+/// three shipped implementations answered at least one of them wrongly.
+/// </para>
+/// <para>
+/// ⚠ <b>Only the test double is exercised here, and that is a real gap, not an oversight.</b>
+/// <c>MauiStorageService</c> and <c>WindowsStorageService</c> live in projects this one does not reference and cannot:
+/// Client.Maui needs the MAUI workloads and Client.Windows is <c>net10.0-windows</c>, so referencing either would
+/// retarget the test project and break the Linux CI job. <c>WebStorageService</c> is reachable as a type but its
+/// stores are <c>localStorage</c> and <c>sessionStorage</c> behind JS interop, so it needs a browser. What this class
+/// buys is a single, executable statement of the contract that a reader can diff the three by hand against; what it
+/// does not buy is a guard that fails when one of them drifts.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest"), TestCategory("Identity")]
+public partial class IStorageServiceContractTests
+{
+    private const string Key = "refresh_token";
+
+    private static IEnumerable<object[]> Implementations()
+    {
+        yield return [new TestStorageService()];
+    }
+
+    /// <summary>
+    /// A key lives in exactly one of the two stores. A write that leaves the superseded copy behind is not merely
+    /// untidy: every implementation's <c>GetItem</c> prefers one store over the other, so the stale copy WINS the
+    /// next read. On the web client that meant a sign-in with "Remember me" unchecked wrote its refresh token where
+    /// nothing would read it, while the previous session's token in localStorage kept being used - so the user
+    /// carried on as the account they had just replaced.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(Implementations))]
+    public async Task AWriteToOneStore_Should_EvictTheKeyFromTheOther(IStorageService storageService)
+    {
+        await storageService.SetItem(Key, "remembered", persistent: true);
+        Assert.IsTrue(await storageService.IsPersistent(Key));
+
+        await storageService.SetItem(Key, "not-remembered", persistent: false);
+
+        Assert.AreEqual("not-remembered", await storageService.GetItem(Key),
+            "The persistent copy shadowed the value that was just written, so the app would keep using the superseded token.");
+        Assert.IsFalse(await storageService.IsPersistent(Key),
+            "A key written to temporary storage must not still report as persistent - AuthManager.StoreTokens derives " +
+            "'Remember me' from that answer on every refresh, so a wrong one re-promotes the session.");
+
+        await storageService.SetItem(Key, "remembered-again", persistent: true);
+
+        Assert.AreEqual("remembered-again", await storageService.GetItem(Key));
+        Assert.IsTrue(await storageService.IsPersistent(Key));
+    }
+
+    /// <summary>
+    /// <c>IsPersistent</c> answers "is this key in the persistent store", not "does this key have a value anywhere".
+    /// The Windows implementation delegated to <c>GetItem</c>, which reads temporary storage first, so a
+    /// remember-me-off refresh token reported as persistent and was promoted to a 14 day on-disk credential.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(Implementations))]
+    public async Task IsPersistent_Should_AnswerFromThePersistentStoreAlone(IStorageService storageService)
+    {
+        Assert.IsFalse(await storageService.IsPersistent(Key), "An absent key is not persistent.");
+
+        await storageService.SetItem(Key, "temporary", persistent: false);
+
+        Assert.AreEqual("temporary", await storageService.GetItem(Key), "The value has to be readable to begin with.");
+        Assert.IsFalse(await storageService.IsPersistent(Key));
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(Implementations))]
+    public async Task RemoveItem_Should_ClearBothStores(IStorageService storageService)
+    {
+        await storageService.SetItem(Key, "remembered", persistent: true);
+        await storageService.RemoveItem(Key);
+        Assert.IsNull(await storageService.GetItem(Key));
+
+        await storageService.SetItem(Key, "temporary", persistent: false);
+        await storageService.RemoveItem(Key);
+        Assert.IsNull(await storageService.GetItem(Key));
+
+        Assert.IsFalse(await storageService.IsPersistent(Key));
+    }
+
+    /// <summary>
+    /// <c>AuthManager.ClearTokens</c> removes a key that may be in either store, and <c>StoreTokens</c> can be handed
+    /// a null refresh token, so neither a missing key nor a null value may throw.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(Implementations))]
+    public async Task AMissingKeyAndANullValue_Should_BeTolerated(IStorageService storageService)
+    {
+        Assert.IsNull(await storageService.GetItem("never-written"));
+        await storageService.RemoveItem("never-written");
+
+        await storageService.SetItem(Key, null, persistent: true);
+        Assert.IsNull(await storageService.GetItem(Key));
+
+        await storageService.Clear();
+        Assert.IsNull(await storageService.GetItem(Key));
+        Assert.IsFalse(await storageService.IsPersistent(Key));
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkSignInUtils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/MagicLinkSignInUtils.cs
@@ -35,7 +35,10 @@ public static class MagicLinkSignInUtils
     /// </summary>
     public static async Task RequestMagicLinkAndOtpOnCurrentPanel(IPage page, string email)
     {
-        await page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillAsync(email);
+        // Filled through FillEnsuringStable because with pre-rendering on, this panel is on screen before the app is
+        // interactive: a value typed into the pre-rendered input is discarded when hydration swaps that subtree out, and
+        // the send button - which only enables once the debounced e-mail is committed - then stays disabled for good.
+        await page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillEnsuringStable(email);
 
         // The button stays disabled until the debounced e-mail value is committed, so Playwright waits for it to enable.
         await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.SendMagicLinkButtonText }).ClickAsync();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/PrivilegedSessionTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/PrivilegedSessionTests.cs
@@ -44,19 +44,15 @@ public partial class PrivilegedSessionTests : AppPageTest
         // right afterwards - the server-side UserSession persists regardless, keeping its privileged slot taken.
         for (var device = 0; device < maxPrivilegedSessions - 1; device++)
         {
-            await using var deviceContext = await Browser.NewContextAsync(ContextOptions());
-            await SetBlazorWebAssemblyServerAddress(serverAddress, deviceContext);
+            await using var deviceContext = await NewBrowserContext(serverAddress);
             var devicePage = await deviceContext.NewPageAsync();
-            devicePage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
             await MagicLinkSignInUtils.SignInAgainViaMagicLinkOtp(devicePage, server, email, TestContext.CancellationToken);
         }
 
         // The final sign-in (a fourth isolated browser): all the allowed privileged sessions already exist, so this
         // newest session is NOT privileged. Keep its browser open to inspect the session's own state below.
-        await using var newestContext = await Browser.NewContextAsync(ContextOptions());
-        await SetBlazorWebAssemblyServerAddress(serverAddress, newestContext);
+        await using var newestContext = await NewBrowserContext(serverAddress);
         var newestPage = await newestContext.NewPageAsync();
-        newestPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
         await MagicLinkSignInUtils.SignInAgainViaMagicLinkOtp(newestPage, server, email, TestContext.CancellationToken);
 
         // From the newest session, open the Settings > Sessions page.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/RefreshTokenRotationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/RefreshTokenRotationTests.cs
@@ -234,10 +234,12 @@ public partial class RefreshTokenRotationTests
         await using var scope = server.WebApp.Services.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-        return await dbContext.UserSessions
+        var timestamps = await dbContext.UserSessions
             .Where(us => us.Id == sessionId)
-            .Select(us => ValueTuple.Create(us.StartedOn, us.RenewedOn))
+            .Select(us => new { us.StartedOn, us.RenewedOn })
             .SingleAsync();
+
+        return (timestamps.StartedOn, timestamps.RenewedOn);
     }
 
     private static async Task<bool> SessionExists(AppTestServer server, Guid sessionId)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/UserGroupFeatureManagementUITests.cs
@@ -54,10 +54,8 @@ public partial class UserGroupFeatureManagementUITests : AppPageTest
         await SetUserGroupRolesManageFeature(Page, server, userGroupName, granted: true, elevationIsRequired: true);
 
         // ---- Browser 2: the group's member, in her own isolated browser context ----
-        await using var memberContext = await Browser.NewContextAsync(ContextOptions());
-        await SetBlazorWebAssemblyServerAddress(serverAddress, memberContext);
+        await using var memberContext = await NewBrowserContext(serverAddress);
         var memberPage = await memberContext.NewPageAsync();
-        memberPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
 
         // Her first sign-in happens after the grant, so her token carries the group's freshly added feature and she
         // can reach the Manage roles page.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/SignalR/ProfileRealtimeUpdateUITests.cs
@@ -36,10 +36,8 @@ public partial class ProfileRealtimeUpdateUITests : AppPageTest
         await MagicLinkSignInUtils.SignInViaMagicLinkOtp(Page, server, email, TestContext.CancellationToken);
 
         // ---- Browser B: a second session of the same user, in its own isolated browser context. ----
-        await using var otherContext = await Browser.NewContextAsync(ContextOptions());
-        await SetBlazorWebAssemblyServerAddress(serverAddress, otherContext);
+        await using var otherContext = await NewBrowserContext(serverAddress);
         var otherPage = await otherContext.NewPageAsync();
-        otherPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
 
         // The account is already confirmed now, so this repeat sign-in receives a plain OTP and opens a brand-new session.
         await MagicLinkSignInUtils.SignInAgainViaMagicLinkOtp(otherPage, server, email, TestContext.CancellationToken);
@@ -68,8 +66,7 @@ public partial class ProfileRealtimeUpdateUITests : AppPageTest
 
         // ---- Browser B: without any reload, its header persona reflects the new full name, pushed to it over SignalR. ----
         // The persona shows the user's DisplayName, which is FullName once it is set (See UserDto.DisplayName).
-        await Expect(otherPage.Locator(".bit-prs.persona").First)
-            .ToContainTextAsync(newFullName, new() { Timeout = (float)TimeSpan.FromSeconds(30).TotalMilliseconds });
+        await Expect(otherPage.Locator(".bit-prs.persona").First).ToContainTextAsync(newFullName);
     }
 
     /// <summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/TenantInvitationUITests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Tenants/TenantInvitationUITests.cs
@@ -40,10 +40,8 @@ public partial class TenantInvitationUITests : AppPageTest
         await InviteUserToCurrentTenant(Page, server, invitedEmail);
 
         // ---- Browser 2: the invited user, in her own isolated browser context ----
-        await using var invitedContext = await Browser.NewContextAsync(ContextOptions());
-        await SetBlazorWebAssemblyServerAddress(serverAddress, invitedContext);
+        await using var invitedContext = await NewBrowserContext(serverAddress);
         var invitedPage = await invitedContext.NewPageAsync();
-        invitedPage.SetDefaultTimeout((float)TimeSpan.FromSeconds(30).TotalMilliseconds);
 
         // The account the invitation just created signs in for the very first time with the magic link OTP, exactly the
         // way a self-registered user would (the same flow as MagicLinkSignInTests). Getting signed in proves that a user
@@ -105,7 +103,7 @@ public partial class TenantInvitationUITests : AppPageTest
         // The create and the rename forms share the same "tenant name" placeholder; the create one comes first in the DOM.
         // Expanding the create section resets its form (See ManageMyTenantsPage.OnSectionExpand); that async re-render can
         // wipe a value filled too eagerly, so fill and confirm it stuck before submitting.
-        await FillEnsuringStable(page.GetByPlaceholder(AppStrings.EnterTenantName).First, tenantName);
+        await page.GetByPlaceholder(AppStrings.EnterTenantName).First.FillEnsuringStable(tenantName);
         await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Save, Exact = true }).First.ClickAsync();
 
         // Creating a tenant needs elevated access: an elevated token is e-mailed (and dev-logged) and the OTP prompt appears.
@@ -129,7 +127,8 @@ public partial class TenantInvitationUITests : AppPageTest
         var inviteHeaderPrefix = AppStrings.InviteUserToTenant.Replace("{0}", "").Trim();
         await page.GetByText(inviteHeaderPrefix).First.ClickAsync();
 
-        await page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillAsync(email);
+        // Expanding this section resets its form the same way the create one does, so the value has to be confirmed.
+        await page.GetByPlaceholder(AppStrings.EmailPlaceholder).FillEnsuringStable(email);
         await page.GetByRole(AriaRole.Button, new() { Name = AppStrings.Invite, Exact = true }).ClickAsync();
 
         // Inviting also needs elevated access, but she is still elevated from creating the tenant, so no new prompt shows.
@@ -210,24 +209,4 @@ public partial class TenantInvitationUITests : AppPageTest
         await Expect(page).ToHaveTitleAsync(accessible ? AppStrings.DashboardPageTitle : AppStrings.NotAuthorizedPageTitle);
     }
     //#endif
-
-    /// <summary>
-    /// Fills a text field and makes sure the value survives, retrying if an async re-render (e.g. a form that resets
-    /// itself when its accordion section finishes expanding) wipes a value that was filled a moment too early.
-    /// </summary>
-    private static async Task FillEnsuringStable(ILocator field, string value)
-    {
-        for (var attempt = 0; attempt < 5; attempt++)
-        {
-            await field.FillAsync(value);
-
-            // Give any pending reset a moment to land, then confirm our value is still there.
-            await field.Page.WaitForTimeoutAsync((float)TimeSpan.FromMilliseconds(500).TotalMilliseconds);
-
-            if (await field.InputValueAsync() == value)
-                return;
-        }
-
-        throw new InvalidOperationException($"Could not keep the field filled with '{value}'.");
-    }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
@@ -53,6 +53,9 @@ public class AppPageTest : PageTest
     public override BrowserNewContextOptions ContextOptions()
     {
         var options = base.ContextOptions();
+
+        options.IgnoreHTTPSErrors = true;
+
         return TestContext.TestRunCount > 1 ? options.EnableVideoRecording(TestContext) : options;
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
@@ -4,10 +4,37 @@ namespace Boilerplate.Tests.Infrastructure;
 
 public class AppPageTest : PageTest
 {
+    /// <summary>
+    /// How long anything in this suite waits before giving up. Set on the context rather than the page so that pages
+    /// this test opens later - the external sign-in popup, for one - are as patient as the first one.
+    /// </summary>
+    private static readonly TimeSpan defaultTimeout = TimeSpan.FromMinutes(1);
+
     [TestInitialize]
     public async Task PageTimeoutSetup()
     {
-        Page.SetDefaultTimeout((float)TimeSpan.FromMinutes(1).TotalMilliseconds);
+        Context.SetDefaultTimeout((float)defaultTimeout.TotalMilliseconds);
+        Assertions.SetDefaultExpectTimeout((float)defaultTimeout.TotalMilliseconds);
+    }
+
+    /// <summary>
+    /// Opens a second browser - an isolated context, i.e. its own storage and its own session - already carrying this
+    /// suite's timeout and pointed at <paramref name="serverAddress"/>. The caller owns the context and disposes it.
+    /// <para>
+    /// Both of those are easy to forget and neither fails loudly: a context left on Playwright's own 30 second default
+    /// simply gives up sooner than the first browser on the very same step, and one that never had the server address
+    /// injected talks to whatever the app was built against.
+    /// </para>
+    /// </summary>
+    protected async Task<IBrowserContext> NewBrowserContext(Uri serverAddress)
+    {
+        var context = await Browser.NewContextAsync(ContextOptions());
+
+        context.SetDefaultTimeout((float)defaultTimeout.TotalMilliseconds);
+
+        await SetBlazorWebAssemblyServerAddress(serverAddress, context);
+
+        return context;
     }
 
     /// <summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/PlaywrightLocatorExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/PlaywrightLocatorExtensions.cs
@@ -1,0 +1,40 @@
+namespace Microsoft.Playwright;
+
+public static class PlaywrightLocatorExtensions
+{
+    extension(ILocator field)
+    {
+        /// <summary>
+        /// Fills <paramref name="field"/> and keeps filling it until the value is still there a moment later.
+        /// <para>
+        /// A plain <c>FillAsync</c> writes into whatever input is on screen right now, and there are two routine ways
+        /// for the app to throw that away immediately afterwards: a component that resets its form as it renders (See
+        /// <c>ManageMyTenantsPage.OnSectionExpand</c>), and - with pre-rendering on - hydration replacing the whole
+        /// pre-rendered subtree with a freshly rendered, empty one. Either leaves the value gone and any button gated on
+        /// it disabled forever, which reads as a hang on the NEXT step rather than as a failure to fill.
+        /// </para>
+        /// <para>
+        /// Deliberately not a fixed number of attempts: on a loaded CI runner a WebAssembly boot can take longer than
+        /// any attempt count worth hard-coding, so this waits against a deadline instead.
+        /// </para>
+        /// </summary>
+        public async Task FillEnsuringStable(string value)
+        {
+            var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+
+            while (true)
+            {
+                await field.FillAsync(value);
+
+                // Give any pending reset / hydration a moment to land, then confirm our value survived it.
+                await field.Page.WaitForTimeoutAsync((float)TimeSpan.FromMilliseconds(500).TotalMilliseconds);
+
+                if (await field.InputValueAsync() == value)
+                    return;
+
+                if (DateTimeOffset.UtcNow >= deadline)
+                    throw new InvalidOperationException($"Could not keep the field filled with '{value}'; something keeps resetting it.");
+            }
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/TestServiceCollectionExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Extensions/TestServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static class TestServiceCollectionExtensions
             // "stats could not be loaded" branch (no NullReferenceException) without hitting the real API.
             // GetGitHubStats is skipped during pre-rendering and its failures are swallowed by the page, so it needs no setup.
             A.CallTo(() => statisticsController.GetNugetStats(A<string>._, A<CancellationToken>._))
-                .Returns(Task.FromResult<NugetStatsDto>(null!));
+                .ReturnsLazily(() => NoNugetStats());
 
             services.RemoveAll<IStatisticsController>();
             services.AddScoped(_ => statisticsController);
@@ -35,5 +35,19 @@ public static class TestServiceCollectionExtensions
 
             return services;
         }
+    }
+
+    /// <summary>
+    /// Yields before returning, so the home page's <c>OnInitAsync</c> does not complete inside the first render pass -
+    /// which is what the real controller (an http call to nuget.org) does, and what makes the page stream. A
+    /// synchronously completed task renders the whole page in one pass and leaves the response with no
+    /// <c>blazor-ssr</c> block at all, so every assertion about streaming would silently be asserting about nothing.
+    /// That is configuration dependent: with the Sales module the home page also awaits the product sections and
+    /// streams either way, while with Admin / no module the statistics call is the only async work on the page.
+    /// </summary>
+    private static async Task<NugetStatsDto> NoNugetStats()
+    {
+        await Task.Yield();
+        return null!;
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Services/TestStorageService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/Services/TestStorageService.cs
@@ -1,32 +1,58 @@
+// [mirror] IStorageService semantics - persistent vs temp storage - keep in sync with:
+// - src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiStorageService.cs
+// - src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsStorageService.cs
+// - src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebStorageService.cs
+// IStorageServiceContractTests pins the behaviour all four must share.
+
 namespace Boilerplate.Tests.Infrastructure.Services;
 
 /// <summary>
 /// In UI tests, browser will uses its own storage, but for api tests, we need to fake the storage.
+/// <para>
+/// It models the two stores the shipped implementations have, because <c>AuthManager.StoreTokens</c> asks
+/// <see cref="IsPersistent"/> which of them a key is in and decides "remember me" from the answer. A single-store fake
+/// that hard-coded <c>IsPersistent =&gt; false</c> made that line a constant under test, so no test could reach the
+/// contract the shipped clients have to honour.
+/// </para>
 /// </summary>
 public partial class TestStorageService : IStorageService
 {
     private readonly Dictionary<string, string?> tempStorage = [];
+    private readonly Dictionary<string, string?> persistentStorage = [];
 
     public async ValueTask<string?> GetItem(string key)
     {
-        tempStorage.TryGetValue(key, out string? value);
-        return value;
+        if (persistentStorage.TryGetValue(key, out string? persistentValue))
+            return persistentValue;
+
+        tempStorage.TryGetValue(key, out string? tempValue);
+        return tempValue;
     }
 
     public async ValueTask<bool> IsPersistent(string key)
     {
-        return false;
+        return persistentStorage.ContainsKey(key);
     }
 
     public async ValueTask RemoveItem(string key)
     {
         tempStorage.Remove(key);
+        persistentStorage.Remove(key);
     }
 
     public async ValueTask SetItem(string key, string? value, bool persistent = true)
     {
-        if (tempStorage.TryAdd(key, value) is false)
+        // A key lives in exactly one of the two stores. Writing to one without removing it from the other would leave
+        // the previous value where GetItem still reads it - and since Preferences wins there (it is the value, the temp
+        // entry is only the default), a temporary write would be shadowed by the persistent value it supersedes.
+        if (persistent)
         {
+            tempStorage.Remove(key);
+            persistentStorage[key] = value;
+        }
+        else
+        {
+            persistentStorage.Remove(key);
             tempStorage[key] = value;
         }
     }
@@ -34,5 +60,6 @@ public partial class TestStorageService : IStorageService
     public async ValueTask Clear()
     {
         tempStorage.Clear();
+        persistentStorage.Clear();
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/MSTestSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/MSTestSettings.cs
@@ -1,1 +1,1 @@
-[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 3)]
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 2)]


### PR DESCRIPTION
closes #12887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved response caching with identity- and culture-aware keys, preserved headers, and expiration based on cache directives.
  - Improved storage consistency across temporary and persistent storage.
  - Added safer authentication token handling and refresh coordination.

- **Bug Fixes**
  - Tenant-specific responses are no longer retained in client caches.
  - Improved error and retry handling.
  - Enhanced force-update notification targeting and token parsing resilience.

- **Documentation**
  - Clarified caching, storage, and authentication behavior across supported platforms.

- **Tests**
  - Added coverage for caching, token persistence, refresh failures, storage behavior, and UI reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR strengthens the boilerplate HTTP handlers, authentication-token lifecycle, storage consistency, and response-cache isolation.
- Keys client response-cache entries by identity, tenant, culture, method, and URI while preventing tenant-dependent responses from entering URL-only caches.
- Coordinates refresh completion more defensively and preserves the selected token-persistence mode across refreshes.
- Aligns temporary and persistent storage semantics across Web, MAUI, Windows, and test implementations.
- Adds focused caching, authentication, storage-contract, and UI reliability coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/HttpMessageHandlers/CacheDelegatingHandler.cs | Adds identity-, tenant-, and culture-aware client cache keys and preserves cached response metadata. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Services/AppResponseCachePolicy.cs | Prevents authenticated tenant-dependent responses from receiving client or edge cache lifetimes while retaining tenant-aware output caching. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/AuthManager.cs | Applies remember-me consistently to both tokens and guarantees refresh waiters are completed without throwing on duplicate completion. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IAuthTokenProvider.cs | Makes malformed-token parsing return an anonymous principal and treats missing or unreadable expiry claims as invalid. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebStorageService.cs | Enforces exclusive ownership of each key by either local or session storage. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiStorageService.cs | Evicts superseded temporary or persistent values when changing a key’s storage mode. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsStorageService.cs | Aligns persistence detection and cross-store transitions with the shared storage contract. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Identity/IStorageServiceContractTests.cs | Defines and verifies cross-store eviction, persistence detection, removal, and null-value behavior. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Caching/ResponseCachePolicyClientCacheTests.cs | Verifies that tenant- and user-dependent responses are excluded from URL-only private and edge caches. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix"](https://github.com/bitfoundation/bitplatform/commit/eaf33ccb42bb58156fe5ac25b9ae6584602666cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52208403)</sub>

<!-- /greptile_comment -->