### PR TITLE
Improve bit Boilerplate AI chatbot (#12891)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/09- Dependency Injection & Service Registration.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/09- Dependency Injection & Service Registration.md
@@ -196,7 +196,7 @@ Let's say you want to add a `FeedbackService` that works on all client platforms
 
 ```csharp
 // src/Client/Boilerplate.Client.Core/Services/FeedbackService.cs
-namespace Boilerplate.Client.Core.Services;
+namespace Boilerplate.Client.Core.Infrastructure.Services;
 
 public partial class FeedbackService
 {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/15- Logging, OpenTelemetry and Health Checks.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/15- Logging, OpenTelemetry and Health Checks.md
@@ -210,10 +210,16 @@ This is implemented in [`src/Server/Boilerplate.Server.Api/Infrastructure/Signal
 
 ```csharp
 /// <inheritdoc cref="SharedAppMessages.UPLOAD_DIAGNOSTIC_LOGGER_STORE"/>
-[Authorize(Policy = AppFeatures.System.ManageLogs)]
-public async Task<DiagnosticLogDto[]> GetUserSessionLogs(Guid userSessionId, [FromServices] AppDbContext dbContext)
+[HubMethodName(SharedAppMessages.GetUserSessionLogs)]
+public async Task<DiagnosticLogDto[]> GetUserSessionLogs(Guid userSessionId, [FromServices] AppDbContext dbContext, [FromServices] IAuthorizationService authorizationService)
 {
-    ...
+    var user = Context.GetHttpContext()!.User;
+
+    if ((await authorizationService.AuthorizeAsync(user, AppFeatures.System.Logs_View)).Succeeded is false)
+        throw new HubException(nameof(AppStrings.UnauthorizedException)).WithData("ConnectionId", Context.ConnectionId);
+
+    // ... resolves the session's SignalRConnectionId, scoped to the caller's tenant, then:
+    return await Clients.Client(connectionId).InvokeAsync<DiagnosticLogDto[]>(SharedAppMessages.UPLOAD_DIAGNOSTIC_LOGGER_STORE, Context.ConnectionAborted);
 }
 ```
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/22- Messaging.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/22- Messaging.md
@@ -15,13 +15,16 @@ At the heart of the Boilerplate messaging architecture is **AppMessages** - a ce
 - From JavaScript to C# code
 - From web service workers to the C# code
 
-**Location**: [`src/Shared/Infrastructure/Services/SharedAppMessages.cs`](/src/Shared/Infrastructure/Services/SharedAppMessages.cs)
-
 **Location**: [`src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs`](/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs)
+
+> **SignalR only.** `SharedAppMessages`, the SignalR channel (Channel 2) and everything below that depends on a
+> `HubConnection` exist only when the project was generated with `--signalR true`. Without it, `ClientAppMessages`
+> has no base class and Channels 1, 3, 4 and 5 are the whole picture.
 
 ### Message Structure
 
-**SharedAppMessages** (Server ↔ Client):
+**SharedAppMessages** (Server ↔ Client, `signalR` only) —
+[`src/Shared/Infrastructure/Services/SharedAppMessages.cs`](/src/Shared/Infrastructure/Services/SharedAppMessages.cs):
 
 ```csharp
 public partial class SharedAppMessages
@@ -49,7 +52,7 @@ public partial class SharedAppMessages
 **Location**: [`src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs`](/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs)
 
 ```csharp
-public partial class ClientAppMessages : SharedAppMessages
+public partial class ClientAppMessages // : SharedAppMessages, when signalR is enabled
 {    
     // Theme and culture
     public const string THEME_CHANGED = nameof(THEME_CHANGED);
@@ -62,7 +65,7 @@ public partial class ClientAppMessages : SharedAppMessages
 }
 ```
 
-**Note**: `ClientAppMessages` inherits from `SharedAppMessages`, so client-side code has access to both shared and client-only messages.
+**Note**: with SignalR enabled, `ClientAppMessages` inherits from `SharedAppMessages`, so client-side code has access to both shared and client-only messages.
 
 ---
 
@@ -92,24 +95,30 @@ PubSubService.Publish(ClientAppMessages.THEME_CHANGED, newTheme);
 **Subscribing to messages**:
 
 ```csharp
-// In component code
+// In component code. AppComponentBase exposes OnInitAsync / DisposeAsync(bool) - use those, not OnInitialized.
 private Action? unsubscribe;
 
-protected override void OnInitialized()
+protected override async Task OnInitAsync()
 {
+    await base.OnInitAsync();
+
     unsubscribe = PubSubService.Subscribe(ClientAppMessages.THEME_CHANGED, async payload =>
     {
-        currentTheme = (string)payload;
+        currentTheme = (string?)payload;
         await InvokeAsync(StateHasChanged);
     });
 }
 
-protected override void Dispose(bool disposing)
+protected override async ValueTask DisposeAsync(bool disposing)
 {
+    await base.DisposeAsync(disposing);
     unsubscribe?.Invoke();
-    base.Dispose(disposing);
 }
 ```
+
+The handler holds only a **weak** reference to its target, so a component that is collected stops receiving
+messages whether or not it unsubscribed. Call `unsubscribe` anyway: it is what removes the entry immediately, and
+the weak reference is a safety net rather than the contract.
 
 **Persistent Messages**:
 
@@ -174,8 +183,9 @@ unsubscribe = PubSubService.Subscribe(SharedAppMessages.DASHBOARD_DATA_CHANGED, 
 **Publishing from JavaScript**:
 
 ```javascript
-// From any JavaScript code
-App.publishMessage('CUSTOM_EVENT', { data: 'some data' });
+// From any JavaScript code. The payload parameter is a string - serialize anything else yourself, because the
+// interop call fails (and its promise rejects, silently) when it cannot be deserialized into string?.
+App.publishMessage('CUSTOM_EVENT', JSON.stringify({ data: 'some data' }));
 
 // Show diagnostic modal
 App.showDiagnostic(); // Publishes SHOW_DIAGNOSTIC_MODAL message
@@ -200,19 +210,22 @@ The `window.postMessage` API allows communication between different JavaScript c
 **Location**: [`src/Client/Boilerplate.Client.Core/Scripts/events.ts`](/src/Client/Boilerplate.Client.Core/Scripts/events.ts)
 
 **When to use**:
-- Communication from iframes
-- Integration with third-party scripts
-- Cross-origin messaging
+- Communication from a same-origin iframe, popup or opener
+- Integration with third-party scripts loaded into the app's own page
+
+**Same-origin only**: window messages from another origin are dropped. Do not remove that check to make a
+cross-origin integration work — it is what stops an arbitrary page that holds a handle to this window from driving
+`PubSubService`. Use a same-origin proxy page instead.
 
 **Publishing via window.postMessage**:
 
 ```javascript
-// From any JavaScript context (including iframes)
+// From a same-origin JavaScript context. The payload must be a string; see Channel 3.
 window.postMessage({ 
     key: 'PUBLISH_MESSAGE', 
     message: 'CUSTOM_EVENT', 
-    payload: { data: 'value' } 
-}, '*');
+    payload: 'value'
+}, window.location.origin);
 ```
 
 **How it works**:
@@ -222,6 +235,12 @@ window.postMessage({
 window.addEventListener('message', handleMessage);
 
 function handleMessage(e: MessageEvent) {
+    // Window messages must be same-origin. Service-worker messages (Channel 5) reach this same handler with an
+    // empty origin and are exempt, because a service worker is same-origin by registration.
+    const isFromWindow = e.currentTarget === window;
+    const isCrossOrigin = e.origin !== window.location.origin;
+    if (isFromWindow && (isCrossOrigin || !e.origin)) return;
+
     if (e.data?.key === 'PUBLISH_MESSAGE') {
         // Bridge to C# PubSubService via AppJsBridge
         App.publishMessage(e.data?.message, e.data?.payload);
@@ -260,16 +279,9 @@ self.addEventListener('notificationclick', (event) => {
 **How it works**:
 
 ```typescript
-// events.ts - Listens for service worker messages
+// events.ts - the same handler as Channel 4, also registered for service worker messages
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.addEventListener('message', handleMessage);
-}
-
-function handleMessage(e: MessageEvent) {
-    if (e.data?.key === 'PUBLISH_MESSAGE') {
-        // Bridge to C# PubSubService
-        App.publishMessage(e.data?.message, e.data?.payload);
-    }
 }
 ```
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.docs/23- Diagnostic Modal.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.docs/23- Diagnostic Modal.md
@@ -1,6 +1,6 @@
 # Stage 23: Diagnostic Modal
 
-The **Diagnostic Modal** is an incredibly powerful built-in troubleshooting tool that provides developers and support teams with comprehensive runtime information about the application. This feature is available in **all environments** (Development, Staging, and Production) and on **all platforms** (Web, Android, iOS, Windows, macOS).
+The **Diagnostic Modal** is an incredibly powerful built-in troubleshooting tool that provides developers and support teams with comprehensive runtime information about the application. The modal itself is available in **all environments** (Development, Staging, and Production) and on **all platforms** (Web, Android, iOS, Windows, macOS). Its **log list** additionally needs the `DiagnosticLogger` provider, which is registered on the client runtimes (Blazor WebAssembly, MAUI, Windows) in every environment, and on a Blazor Server host only in Development.
 
 ## What is the Diagnostic Modal?
 
@@ -50,7 +50,7 @@ A powerful log viewing and filtering system that displays logs captured by the `
 - **Text Search**: Search logs by message content, category, or state values
 - **Regular Expression Support**: Enable regex mode for advanced pattern matching
 - **Filter by Log Level**: Filter by Trace, Debug, Information, Warning, Error, Critical
-- **Filter by Category**: Multi-select dropdown showing all log categories (e.g., `Microsoft.EntityFrameworkCore`, `Boilerplate.Client.Core.Services`)
+- **Filter by Category**: Multi-select dropdown showing all log categories (e.g., `Microsoft.EntityFrameworkCore`, `Boilerplate.Client.Core.Infrastructure.Services`)
 - **Sort Order**: Toggle between ascending/descending chronological order
 
 #### Log Details View

--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -554,6 +554,7 @@
                         "src/Tests/Features/Todo/OfflineTodoTests.cs",
                         "src/Tests/Features/Urls/ODataQueryFilterTests.cs",
                         "src/Tests/Features/Diagnostics/TelemetryScopeTests.cs",
+                        "src/Tests/Features/Diagnostics/LoggingConfigurationTests.cs",
                         "src/Tests/Features/Configuration/ClientSettingsValidationTests.cs",
                         "src/Tests/Features/Identity/TrustedOriginsTests.cs",
                         "src/Tests/Features/Identity/MagicLinkSignInTests.cs",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/AGENTS.md
@@ -70,10 +70,13 @@ Before implementing any changes, you **MUST** complete the following:
 <!--#if (aspire == true)-->
 -   **Build the project**: Run `dotnet build` in src/Server/Boilerplate.Server.AppHost project directory.
 -   **Run the project**: Run `aspire start`. If needed, you may use the Playwright MCP tools to interact with the `serverweb` resource running by aspire to validate things (navigate, click, fill forms, take screenshots), and use `browser_evaluate` to run in-page JavaScript to accelerate the process (e.g. quickly locating elements, extracting data, or asserting state).
+-   **Expose the running app to remote devices**: `localhost` is unreachable from other devices, so use the public `*.devtunnels.ms` URL of the `web-dev-tunnel` resource that `aspire start` creates (read it from the aspire dashboard or the aspire MCP `list_resources` tool) instead of a `localhost` URL.
 <!--#else-->
 -   **Build the project**: Run `dotnet build` in src/Server/Boilerplate.Server.Web project directory.
 -   **Run the project**: Run `dotnet watch` in src/Server/Boilerplate.Server.Web project directory. If needed, you may use the Playwright MCP tools to interact with the running UI to validate things (navigate, click, fill forms, take screenshots), and use `browser_evaluate` to run in-page JavaScript to accelerate the process (e.g. quickly locating elements, extracting data, or asserting state).
+-   **Expose the running app to remote devices**: `localhost` is unreachable from other devices, so create a dev tunnel with the `devtunnel` CLI (`devtunnel host -p 5030 --allow-anonymous`) and use the printed public `*.devtunnels.ms` URL instead of a `localhost` URL.
 <!--#endif-->
+-   **Assume hot reload is working**: `.cs`, `.razor`, `.scss` and `.ts` changes are picked up automatically by the running app, so after an edit do NOT rebuild the project and do NOT reload/refresh the web app. Only rebuild or refresh if you can't see what you were expecting after your change.
 -   **Run tests**: Run `dotnet test` in src/Tests/Boilerplate.Tests project directory.
 -   **Add new migrations**: Run `dotnet ef migrations add <MigrationName> --output-dir Infrastructure/Data/Migrations --verbose` in src/Server/Boilerplate.Server.Api project directory.
 -   **Generate Resx C# code**: Run `dotnet build -t:PrepareResources` in src/Shared/Boilerplate.Shared project directory.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor
@@ -43,25 +43,53 @@
                                    AutoScroll
                                    Class="scr-container"
                                    ScrollbarWidth="BitScrollbarWidth.Thin">
-                    <BitStack>
+                    <BitStack Gap="0">
                         @foreach (var message in chatMessages)
                         {
-                            if (message.Role is AiChatMessageRole.User)
-                            {
-                                <BitCard Background="BitColorKind.Tertiary" Class="user-message">
-                                    <BitText Element="pre">@message.Content</BitText>
-                                </BitCard>
-                            }
-                            else
-                            {
-                                <BitMarkdownViewer Markdown="@message.Content" Pipeline="BitMarkdownPipelines.Advanced" />
-                                @if (message.Successful is false)
+                            <BitStack @key="message"
+                                      FitHeight
+                                      Gap="0"
+                                      Class="@($"message-row{(message.Role is AiChatMessageRole.User ? " user" : null)}")">
+
+                                @if (message.Role is AiChatMessageRole.User)
                                 {
-                                    <BitTag Color="BitColor.Error" Size="BitSize.Small" Style="min-height:18px">
-                                        @Localizer[nameof(AppStrings.Canceled)]
-                                    </BitTag>
+                                    <BitCard Background="BitColorKind.Tertiary" Class="user-message">
+                                        <BitText Element="pre">@message.Content</BitText>
+                                    </BitCard>
                                 }
-                            }
+                                else
+                                {
+                                    <BitMarkdownViewer Markdown="@message.Content" Pipeline="BitMarkdownPipelines.Advanced" />
+                                    @if (message.Successful is false)
+                                    {
+                                        <BitTag Color="BitColor.Error" Size="BitSize.Small" Style="min-height:18px">
+                                            @Localizer[nameof(AppStrings.Canceled)]
+                                        </BitTag>
+                                    }
+                                }
+
+                                <BitStack Horizontal FitHeight Gap="0.25rem" Class="message-actions">
+                                    @if (string.IsNullOrWhiteSpace(message.Content) is false)
+                                    {
+                                        <BitButton IconOnly
+                                                   Variant="BitVariant.Text"
+                                                   IconName="@BitIconName.Copy"
+                                                   Title="@Localizer[nameof(AppStrings.Copy)]"
+                                                   OnClick="WrapHandled(() => CopyMessage(message))" />
+
+                                        @if (isReadAloudSupported)
+                                        {
+                                            var isReading = ReferenceEquals(speakingMessage, message);
+
+                                            <BitButton IconOnly
+                                                       Variant="BitVariant.Text"
+                                                       OnClick="WrapHandled(() => ToggleReadAloud(message))"
+                                                       IconName="@(isReading ? BitIconName.CircleStopSolid : BitIconName.Volume3)"
+                                                       Title="@(isReading ? Localizer[nameof(AppStrings.AiChatPanelStopReading)] : Localizer[nameof(AppStrings.AiChatPanelReadAloud)])" />
+                                        }
+                                    }
+                                </BitStack>
+                            </BitStack>
                         }
 
                         <BitStack Alignment="BitAlignment.Center" FitHeight FillContent Class="default-prompt-container">
@@ -125,8 +153,24 @@
                                   Style="width:100%"
                                   @bind-Value="@userInput"
                                   OnEnter="WrapHandled((KeyboardEventArgs e) => HandleOnUserInputEnter(e))"
-                                  Styles="@(new() { FieldGroup = "padding:0.5rem; padding-inline-end:2.5rem", Input = "min-height:unset" })"
+                                  Styles="@(new() { FieldGroup = $"padding:0.5rem; padding-inline-end:{(isDictationSupported ? "5rem" : "2.5rem")}", Input = "min-height:unset" })"
                                   Placeholder="@(Localizer[nameof(AppStrings.AiChatPanelPlaceholder)])" />
+
+                    @* Speech-to-text. Hidden outright where the browser has no SpeechRecognition, rather than shown
+                       disabled: a control that can never become usable is noise. *@
+                    @if (isDictationSupported)
+                    {
+                        <BitButton Float
+                                   IconOnly
+                                   FloatAbsolute
+                                   FloatOffset="0.5rem"
+                                   Variant="BitVariant.Text"
+                                   Class="@($"dictate-button{(isListening ? " listening" : null)}")"
+                                   OnClick="WrapHandled(ToggleDictation)"
+                                   Color="@(isListening ? BitColor.Error : BitColor.SecondaryForeground)"
+                                   IconName="@(isListening ? BitIconName.CircleStopSolid : BitIconName.Microphone)"
+                                   Title="@(isListening ? Localizer[nameof(AppStrings.AiChatPanelStopDictation)] : Localizer[nameof(AppStrings.AiChatPanelDictate)])" />
+                    }
 
                     <BitButton Float
                                AutoLoading

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.cs
@@ -1,5 +1,6 @@
 //+:cnd:noEmit
 using System.Threading.Channels;
+using System.Text.RegularExpressions;
 using Boilerplate.Shared.Features.Chatbot;
 using Microsoft.AspNetCore.Components.Web;
 
@@ -14,13 +15,24 @@ public partial class AppAiChatPanel
     [CascadingParameter] public UserDto? CurrentUser { get; set; }
 
 
+    [AutoInject] private Clipboard clipboard = default!;
     [AutoInject] private HubConnection hubConnection = default!;
+    [AutoInject] private SpeechSynthesis speechSynthesis = default!;
+    [AutoInject] private SpeechRecognition speechRecognition = default!;
 
+
+    private bool isReadAloudSupported;
+    private bool isDictationSupported;
+    private AiChatMessage? speakingMessage;
 
     private bool isOpen;
     private bool isLoading;
     private string? userInput;
     private bool isSmallScreen;
+    private bool isListening;
+    private string? dictationPrefix;
+    private string dictationTranscript = string.Empty;
+    private IAsyncDisposable? dictationSession;
     private int responseCounter;
     private Channel<string>? channel;
     private AiChatMessage? lastAssistantMessage;
@@ -79,6 +91,7 @@ public partial class AppAiChatPanel
     protected override async Task OnAfterFirstRenderAsync()
     {
         SetDefaultValues();
+        (isDictationSupported, isReadAloudSupported) = (await speechRecognition.IsSupported(), await speechSynthesis.IsSupported());
         StateHasChanged();
         hubConnection.Reconnected += HubConnection_Reconnected;
 
@@ -102,6 +115,11 @@ public partial class AppAiChatPanel
 
     private async Task SendMessage()
     {
+        // Dictation rebuilds userInput from dictationPrefix plus the whole transcript on every result, so a recognizer
+        // still running across a send would refill the emptied box with the text that was just sent. Stopping first
+        // also lets a final transcript still in flight land before the message is taken.
+        await StopDictation();
+
         if (channel is null)
         {
             _ = StartChannel();
@@ -145,7 +163,183 @@ public partial class AppAiChatPanel
 
     private async Task HandleOnDismissPanel()
     {
+        await StopDictation();
+
+        await StopReadAloud();
+
         await StopChannel();
+    }
+
+
+    private async Task CopyMessage(AiChatMessage message)
+    {
+        if (message.Content is not { Length: > 0 } content) return;
+
+        await clipboard.WriteText(content);
+
+        SnackBarService.Info(Localizer[nameof(AppStrings.Copied)]);
+    }
+
+    private async Task ToggleReadAloud(AiChatMessage message)
+    {
+        var wasReadingThisMessage = ReferenceEquals(speakingMessage, message);
+
+        // The engine has a single queue, so whatever is being read stops first: a second press on the same message
+        // is "stop", and a press on another one replaces it rather than overlapping two answers.
+        await StopReadAloud();
+
+        if (wasReadingThisMessage || message.Content is not { Length: > 0 } content) return;
+
+        await speechSynthesis.Speak(new SpeechUtterance
+        {
+            Text = ToSpeakableText(content),
+            VoiceName = GetVoiceName(),
+            Lang = CultureInfoManager.InvariantGlobalization is false ? CultureInfoManager.DefaultCulture.Name : null
+        });
+
+        speakingMessage = message;
+
+        _ = MonitorReadAloud();
+    }
+
+    // Sample for customizing the voice name based on the platform and language. The default voice is used if this returns null.
+    private string? GetVoiceName()
+    {
+        if (CultureInfoManager.InvariantGlobalization is true || CultureInfo.CurrentUICulture.TwoLetterISOLanguageName is not "en")
+            return null;
+
+        if (TelemetryContext.Platform?.Contains("Windows", StringComparison.OrdinalIgnoreCase) is true)
+            return "Microsoft Ava Multilingual Online (Natural) - English (United States)";
+
+        return null;
+    }
+
+    /// <summary>
+    /// The synthesis API raises no completion event, so asking is the only way to stop the button claiming it is still
+    /// reading after the answer has been read out. The poll exists only while something is being read, and ends itself.
+    /// </summary>
+    private async Task MonitorReadAloud()
+    {
+        try
+        {
+            using PeriodicTimer timer = new(TimeSpan.FromMilliseconds(400));
+
+            while (speakingMessage is not null && await timer.WaitForNextTickAsync(CurrentCancellationToken))
+            {
+                if (await speechSynthesis.IsSpeaking() || await speechSynthesis.IsPending()) continue;
+
+                speakingMessage = null;
+                await InvokeAsync(StateHasChanged);
+                return;
+            }
+        }
+        catch (Exception exp) when (exp is OperationCanceledException or JSDisconnectedException)
+        {
+            // The panel closed or the circuit went away mid-poll; there is nothing left to update.
+        }
+    }
+
+    private async Task StopReadAloud()
+    {
+        if (speakingMessage is null) return;
+
+        speakingMessage = null;
+
+        await speechSynthesis.Cancel();
+    }
+
+    /// <summary>
+    /// Dictates into the message box. The transcript is written to <c>userInput</c> and goes out through the ordinary
+    /// send path, so the user reads what was heard before it is sent - a misrecognition is corrected, not delivered.
+    /// </summary>
+    private async Task ToggleDictation()
+    {
+        if (isListening)
+        {
+            await StopDictation();
+            return;
+        }
+
+        // Whatever is already typed is kept and dictation appends to it.
+        dictationPrefix = string.IsNullOrWhiteSpace(userInput) ? null : $"{userInput.TrimEnd()} ";
+        dictationTranscript = string.Empty;
+        isListening = true;
+
+        var session = await speechRecognition.Start(
+            new()
+            {
+                Lang = CultureInfoManager.InvariantGlobalization is false ? CultureInfoManager.DefaultCulture.Name : null,
+                Continuous = true,    // The user decides when a prompt is finished, not a pause in speech.
+                InterimResults = true // Streams the words into the box as they are heard, so the mic is visibly live.
+            },
+            onResult: result => _ = InvokeAsync(() => HandleDictationResult(result)),
+            onError: error => _ = InvokeAsync(() => HandleDictationError(error)),
+            onEnd: () => _ = InvokeAsync(HandleDictationEnd));
+
+        // Start is an interop round trip, so a stop pressed while it was in flight already ran: it set isListening
+        // to false and found no session to dispose. Assigning unconditionally would leave the microphone live behind
+        // a UI that says dictation is off, with the only handle able to close it overwritten by the next start.
+        if (isListening is false)
+        {
+            await session.DisposeAsync();
+            return;
+        }
+
+        dictationSession = session;
+    }
+
+    private void HandleDictationResult(SpeechRecognitionResult result)
+    {
+        if (result.IsFinal)
+        {
+            dictationTranscript += result.Transcript;
+        }
+
+        // A non-final transcript is a preview of the utterance in progress: shown, but not yet accumulated, or the
+        // engine's own revisions would be appended on top of each other.
+        userInput = $"{dictationPrefix}{dictationTranscript}{(result.IsFinal ? null : result.Transcript)}";
+
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Recognition that ends on its own - an error, or the engine simply stopping - still leaves the handle alive on
+    /// both sides, and the handle is what removes the callbacks from the scoped <c>SpeechRecognition</c> service. Going
+    /// through <see cref="StopDictation"/> is what releases them; otherwise every dictation leaves its callbacks (and
+    /// the component they capture) registered, and a late event from a finished session lands on the next one.
+    /// </summary>
+    private async Task HandleDictationError(string error)
+    {
+        await StopDictation();
+
+        // 'aborted' is what an ordinary Stop produces and 'no-speech' just means silence - neither is worth a message.
+        if (error is not ("aborted" or "no-speech"))
+        {
+            SnackBarService.Error(Localizer[nameof(AppStrings.AiChatPanelDictation)], error is "not-allowed"
+                ? Localizer[nameof(AppStrings.AiChatPanelMicrophoneBlocked)]
+                : Localizer[nameof(AppStrings.AiChatPanelDictationStopped), error]);
+        }
+
+        StateHasChanged();
+    }
+
+    /// <inheritdoc cref="HandleDictationError"/>
+    private async Task HandleDictationEnd()
+    {
+        await StopDictation();
+
+        StateHasChanged();
+    }
+
+    private async Task StopDictation()
+    {
+        isListening = false;
+
+        if (dictationSession is null) return;
+
+        var session = dictationSession;
+        dictationSession = null;
+        await session.DisposeAsync();
     }
 
     private async Task HandleOnUserInputEnter(KeyboardEventArgs e)
@@ -234,8 +428,85 @@ public partial class AppAiChatPanel
 
         hubConnection.Reconnected -= HubConnection_Reconnected;
 
+        await StopDictation();
+
+        await StopReadAloud();
+
         await StopChannel();
 
         await base.DisposeAsync(disposing);
+    }
+
+
+    [GeneratedRegex(@"(?:```|~~~)[\s\S]*?(?:```|~~~)")]
+    private static partial Regex FencedCodeRegex();
+
+    [GeneratedRegex(@"!\[[^\]]*\]\([^)]*\)")]
+    private static partial Regex MarkdownImageRegex();
+
+    [GeneratedRegex(@"\[([^\]]*)\]\([^)]*\)")]
+    private static partial Regex MarkdownLinkRegex();
+
+    [GeneratedRegex(@"<[a-z][a-z0-9+.-]*://[^>]*>|(?:https?://|www\.)\S+", RegexOptions.IgnoreCase)]
+    private static partial Regex UrlRegex();
+
+    [GeneratedRegex(@"^[ \t]{0,3}(?:>+[ \t]*|(?:#{1,6}|[-*+\u2022]|\d+[.)])[ \t]+)|[*~`]", RegexOptions.Multiline)]
+    private static partial Regex MarkdownMarkerRegex();
+
+    /// <summary>Horizontal rules and the dashes under a table header, which are a line of punctuation and nothing else.</summary>
+    [GeneratedRegex(@"^[-=:| \t]{3,}$", RegexOptions.Multiline)]
+    private static partial Regex MarkdownRuleRegex();
+
+    [GeneratedRegex(@"(?:[ \t]*\|[ \t]*)+")]
+    private static partial Regex TableCellSeparatorRegex();
+
+    /// <summary>
+    /// The dingbat and arrow blocks (U+2600-27BF, U+2B00-2BFF and friends) plus U+1F000-1FBFF as surrogate pairs,
+    /// since .NET matches one utf-16 unit at a time and \p{So} would never see an astral character. FE0F, 200D and
+    /// 20E3 are the joiners emoji sequences are built from, and are left behind when their pictograph goes.
+    /// </summary>
+    [GeneratedRegex(@"[\u2190-\u21FF\u231A-\u231B\u23E9-\u23FA\u24C2\u25AA-\u25FE\u2600-\u27BF\u2B00-\u2BFF\uFE0F\u200D\u20E3]|[\uD83C-\uD83E][\uDC00-\uDFFF]")]
+    private static partial Regex EmojiRegex();
+
+    [GeneratedRegex(@"[ \t]{2,}")]
+    private static partial Regex ExtraSpaceRegex();
+
+    /// <summary>
+    /// Answers are markdown and a synthesizer reads the syntax out loud - "star star bit platform star star" - so the
+    /// markers go and links are reduced to their label. What carries nothing once heard is dropped rather than spelled
+    /// out: code blocks, image markup, urls, and emoji - a five star rating is five spoken words in front of the number
+    /// that already says it, and a check mark becomes "check mark button" in front of every line it decorates.
+    /// </summary>
+    private static string ToSpeakableText(string markdown)
+    {
+        var text = FencedCodeRegex().Replace(markdown.ReplaceLineEndings("\n"), " ");
+        text = MarkdownImageRegex().Replace(text, string.Empty);
+        text = MarkdownLinkRegex().Replace(text, "$1");
+        text = UrlRegex().Replace(text, string.Empty);
+        text = EmojiRegex().Replace(text, string.Empty);
+        // An underscore is emphasis around a word and the joint inside an identifier both, and a space serves either:
+        // dropping it outright would hand the synthesizer "snakecasename" as one unpronounceable word.
+        text = text.Replace('_', ' ');
+        text = MarkdownMarkerRegex().Replace(text, string.Empty);
+        text = MarkdownRuleRegex().Replace(text, string.Empty);
+        text = TableCellSeparatorRegex().Replace(text, ", ");
+        text = ExtraSpaceRegex().Replace(text, " ");
+
+        // A product arrives titled, pictured and linked with the same words, so its name would be read three times over
+        // - the picture is gone by now and the two that are left are neighbouring lines. Lines emptied by the markup
+        // that was all they held go too, so the reading is not paced by pauses around nothing.
+        List<string> lines = [];
+        foreach (var line in text.Split('\n'))
+        {
+            var spoken = line.Trim(' ', '\t', ',');
+
+            if (spoken.Length is 0) continue;
+
+            if (lines.Count > 0 && string.Equals(lines[^1], spoken, StringComparison.OrdinalIgnoreCase)) continue;
+
+            lines.Add(spoken);
+        }
+
+        return string.Join('\n', lines);
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.scss
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.scss
@@ -58,6 +58,43 @@
         max-width: 100%;
     }
 
+    .message-row {
+        width: 100%;
+        align-items: flex-start;
+        padding-bottom: 0.25rem; // Separates two messages; the parent stack has no gap of its own.
+
+        &.user {
+            align-items: flex-end;
+        }
+
+        &:hover .message-actions, &:focus-within .message-actions {
+            opacity: 1;
+        }
+    }
+
+    .message-actions {
+        opacity: 0;
+        width: fit-content;
+        min-height: 1.25rem;
+        transition: opacity 0.15s ease-in-out;
+
+        button {
+            width: 1.25rem;
+            height: 1.25rem;
+            border: none;
+            background: none;
+
+            i {
+                font-size: 0.7rem;
+                color: $bit-color-foreground-secondary;
+            }
+
+            &:hover i {
+                color: $bit-color-foreground-primary;
+            }
+        }
+    }
+
     .user-message {
         align-self: end;
         padding: 0.5rem 1rem;
@@ -82,5 +119,23 @@
         left: unset;
         right: unset;
         inset-inline-end: 0.5rem;
+    }
+
+    .dictate-button {
+        left: unset;
+        right: unset;
+        inset-inline-end: 3rem;
+
+        // While the recognizer is live the button is the only feedback that the microphone is open, so it says so
+        // continuously rather than once.
+        &.listening i {
+            animation: dictate-pulse 1.2s ease-in-out infinite;
+        }
+    }
+}
+
+@keyframes dictate-pulse {
+    50% {
+        opacity: 0.4;
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/ContentSecurityPolicy.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/ContentSecurityPolicy.razor
@@ -6,6 +6,9 @@
    For Blazor Server, Auto and WebAssembly, with or without pre-rendering, it renders early enough in App.razor
 
    Warning: It's highly recommended to remove unsafe-inline, but to avoid degrading the dev experience, it's currently included.
+
+   Note: no policy is emitted in Development at all, so BuildCspString's own Development branch is inert. It is kept
+   as the record of what a Development policy would have to allow.
 *@
 
 @if (AppEnvironment.IsDevelopment() is false)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/ContentSecurityPolicy.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/ContentSecurityPolicy.razor.cs
@@ -72,6 +72,8 @@ public partial class ContentSecurityPolicy
         imgSrc.Add("https://img.shields.io");
         connectSrc.Add("https://api.github.com");
 
+        // Inert today - the component only renders the meta tag when the environment is NOT Development - and kept
+        // as the record of what a Development policy would have to allow, for whoever relaxes that guard.
         if (AppEnvironment.IsDevelopment())
         {
             connectSrc.Add("ws://localhost:* wss://localhost:*"); // Allow localhost WebSocket connections during development (hot reload / debugging)
@@ -79,7 +81,9 @@ public partial class ContentSecurityPolicy
             connectSrc.Add("https://cdn.jsdelivr.net/"); // eruda dev tools
         }
 
-        scriptSrc.Add("https://cdn.jsdelivr.net/npm/eruda"); // eruda dev tools
+        // The exact pinned url the diagnostic modal loads, not the jsdelivr host: a host-wide entry would let any
+        // package on that CDN execute here. Keep it in sync with erudaUrl in Scripts/App.ts.
+        scriptSrc.Add("https://cdn.jsdelivr.net/npm/eruda@3.4.3/eruda.min.js"); // eruda dev tools
 
         // Construct the final CSP string
         CspContent = $"default-src {string.Join(" ", ownOrigins)}; " + // Fallback for all directives.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.Utils.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.Utils.cs
@@ -6,6 +6,9 @@ public partial class AppDiagnosticModal
 {
     [AutoInject] private Cookie cookie = default!;
     [AutoInject] private AuthManager authManager = default!;
+    [AutoInject] private LocalStorage localStorage = default!;
+    [AutoInject] private CacheStorage cacheStorage = default!;
+    [AutoInject] private SessionStorage sessionStorage = default!;
     [AutoInject] private IStorageService storageService = default!;
     [AutoInject] private IUserController userController = default!;
     [AutoInject] private IAppUpdateService appUpdateService = default!;
@@ -133,9 +136,16 @@ public partial class AppDiagnosticModal
             logger.LogWarning(exp, "Failed to sign out during ClearAppStorage.");
         }
 
-        await storageService.Clear(); // Blazor Hybrid stores key/value pairs outside webview's storage.
+        try
+        {
+            await storageService.Clear(); // Blazor Hybrid stores key/value pairs outside webview's storage.
+        }
+        catch (Exception exp)
+        {
+            logger.LogWarning(exp, "Failed to clear the storage service during ClearAppStorage.");
+        }
 
-        await JSRuntime.ClearWebStorages();
+        await ClearWebStorages();
 
         //#if (offlineDb == true)
         try
@@ -158,6 +168,46 @@ public partial class AppDiagnosticModal
         else
         {
             NavigationManager.Refresh(forceReload: true);
+        }
+    }
+
+    /// <summary>
+    /// Clears the browser / web view storages of this origin.
+    /// </summary>
+    private async Task ClearWebStorages()
+    {
+        await Attempt(nameof(CacheStorage), async () =>
+        {
+            if (await cacheStorage.IsSupported() is false) return;
+
+            foreach (var cacheName in await cacheStorage.Keys())
+            {
+                await cacheStorage.Delete(cacheName);
+            }
+        });
+
+        await Attempt(nameof(LocalStorage), localStorage.Clear);
+
+        await Attempt(nameof(SessionStorage), sessionStorage.Clear);
+
+        await Attempt(nameof(Cookie), async () =>
+        {
+            foreach (var item in await cookie.GetAll())
+            {
+                await cookie.Remove(new ButilCookie { Name = item.Name, Path = "/" });
+            }
+        });
+
+        async Task Attempt(string storageName, Func<Task> clear)
+        {
+            try
+            {
+                await clear();
+            }
+            catch (Exception exp)
+            {
+                logger.LogWarning(exp, "Failed to clear {Storage} during ClearAppStorage.", storageName);
+            }
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.cs
@@ -36,6 +36,11 @@ public partial class AppDiagnosticModal
     private bool isDescendingSort = true;
     private List<Action> unsubscribers = [];
     private IEnumerable<string>? filterCategoryValues;
+    private readonly HashSet<string> seenCategories = [];
+    /// <summary>
+    /// Logs fetched from another device for inspection. Null means the modal is showing this device's own store.
+    /// </summary>
+    private DiagnosticLogDto[]? inspectedLogs;
     private DiagnosticLogDto[] allLogs = default!;
     private BitDropdownItem<string>[] allCategoryItems = [];
     private DiagnosticLogDto[] filteredLogs = default!;
@@ -50,10 +55,12 @@ public partial class AppDiagnosticModal
     {
         await base.OnInitAsync();
 
-        unsubscribers.Add(PubSubService.Subscribe(ClientAppMessages.SHOW_DIAGNOSTIC_MODAL, async _ =>
+        unsubscribers.Add(PubSubService.Subscribe(ClientAppMessages.SHOW_DIAGNOSTIC_MODAL, async payload =>
         {
             isOpen = true;
-            ReloadLogs();
+            // A payload means someone else's logs were fetched for inspection (UsersPage). Without one the modal
+            // shows this device's own store.
+            SetLogSource(payload as DiagnosticLogDto[]);
             await InvokeAsync(StateHasChanged);
         }));
 
@@ -122,7 +129,28 @@ public partial class AppDiagnosticModal
 
     private async Task ClearLogs()
     {
-        DiagnosticLogger.Store.Clear();
+        if (inspectedLogs is null)
+        {
+            DiagnosticLogger.ClearStore();
+        }
+        else
+        {
+            inspectedLogs = [];
+        }
+
+        ReloadLogs();
+    }
+
+    /// <summary>
+    /// Switches between this device's own log store (<paramref name="logs"/> null) and a set of logs fetched for
+    /// inspection. The category filter is reset on every switch, because the two sets do not share categories.
+    /// </summary>
+    private void SetLogSource(DiagnosticLogDto[]? logs)
+    {
+        inspectedLogs = logs;
+        seenCategories.Clear();
+        filterCategoryValues = null;
+
         ReloadLogs();
     }
 
@@ -136,7 +164,10 @@ public partial class AppDiagnosticModal
                                    .Order()
                                    .ToArray();
 
-        filterCategoryValues ??= [.. allCategories];
+        // Every category not seen before joins the selection. Latching the filter on the first load would silently
+        // hide whatever arrives later - including the exception the error boundary opened this modal to show - while
+        // still honouring a category the user has deliberately deselected.
+        filterCategoryValues = [.. (filterCategoryValues ?? []).Concat(allCategories.Where(seenCategories.Add))];
 
         allCategoryItems = [.. allCategories.Select(c => new BitDropdownItem<string>() { Text = c, Value = c })];
 
@@ -145,7 +176,7 @@ public partial class AppDiagnosticModal
 
     private void ReloadLogs()
     {
-        LoadLogs([.. DiagnosticLogger.Store]);
+        LoadLogs(inspectedLogs ?? [.. DiagnosticLogger.Store]);
     }
 
     private void FilterLogs()

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AccentColorSwitcher.razor
@@ -8,7 +8,7 @@
 
             <BitButton Title="@name"
                        aria-pressed="@(isActive ? "true" : "false")"
-                       AriaLabel="@Localizer["Apply the {0} accent color", name]"
+                       AriaLabel="@Localizer[nameof(AppStrings.AccentColorApply), name]"
                        Class="@($"accent-swatch{(isActive ? " accent-swatch--active" : null)}")"
                        Style="@($"--swatch-color:{hex}")"
                        OnClick="WrapHandled(() => accentColorService.ApplyAsync(hex))" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor.cs
@@ -119,8 +119,11 @@ public partial class AppMenu
     //#if (multitenant == true)
     private void AuthManager_AuthenticationStateChanged(Task<AuthenticationState> task)
     {
-        showTenants = false; // This would help refreshing the list of tenants, so they would get loaded again the next time user opens the tenant menu.
-        StateHasChanged();
+        _ = InvokeAsync(() =>
+        {
+            showTenants = false; // This would help refreshing the list of tenants, so they would get loaded again the next time user opens the tenant menu.
+            StateHasChanged();
+        });
     }
     //#endif
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Home/HomePage.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Home/HomePage.razor
@@ -38,12 +38,14 @@
         @*#endif*@
 
         @*#if (module == "Sales")*@
+        @*#if (signalR == true)*@
         <BitSearchBox ReadOnly
                       Underlined
                       ShowSearchButton
                       Style="width:80%"
                       Color="BitColor.Secondary"
                       @onclick="HandleOnSearchBoxClick" />
+        @*#endif*@
 
         <ProductsCarousel />
         <br />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Home/HomePage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Home/HomePage.razor.cs
@@ -71,7 +71,7 @@ public partial class HomePage
         }
     }
     //#endif
-    //#if(module == "Sales")
+    //#if (module == "Sales" && signalR == true)
     private async Task HandleOnSearchBoxClick()
     {
         PubSubService.Publish(ClientAppMessages.SEARCH_PRODUCTS);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/UsersPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/UsersPage.razor.cs
@@ -190,13 +190,7 @@ public partial class UsersPage
     {
         var logs = await hubConnection.InvokeAsync<DiagnosticLogDto[]>(SharedAppMessages.GetUserSessionLogs, userSessionId);
 
-        DiagnosticLogger.Store.Clear();
-        foreach (var log in logs)
-        {
-            DiagnosticLogger.Store.Enqueue(log);
-        }
-
-        PubSubService.Publish(ClientAppMessages.SHOW_DIAGNOSTIC_MODAL);
+        PubSubService.Publish(ClientAppMessages.SHOW_DIAGNOSTIC_MODAL, logs);
     }
     //#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs
@@ -80,45 +80,30 @@ public partial class PasswordlessTab
         }
         catch (Exception ex)
         {
-            // Regardless of whether the user actively cancelled the operation, it timed out, or the passkey is no
-            // longer valid, the browser throws the same generic error, so we cannot distinguish the root cause.
-            // The local flag is deliberately NOT cleared here: it used to be cleared in a `finally`, which meant a
-            // cancelled ceremony flipped the UI to "not configured" while the server-side credential was untouched
-            // and passwordless sign-in still worked - the UI asserted a security state the server did not hold.
+            // we can safely ignore the exception thrown here since it mostly because of a timeout or user cancelling the native ui.
+            // In case passkey is no longer valid, the browser would show a message dialog itself.
             ExceptionHandler.Handle(ex, ExceptionDisplayKind.None);
-            SnackBarService.Warning(Localizer[nameof(AppStrings.DisablePasswordlessFailedMessage)]);
             return;
         }
+        finally
+        {
+            // Regardless of whether the user actively cancelled the operation, it has timed out or the passkey is no longer valid,
+            // the browser throws the same generic error.
+            // As a result, we cannot reliably distinguish the root cause of the failure.
+            // To allow the user to attempt configuration again, we must clear the stored user ID here.
+            await webAuthnService.RemoveWebAuthnConfiguredUserId(User.Id);
+            isConfigured = false;
+        }
 
-        // Proof of possession. A failed assertion does not return a value here - fido2.MakeAssertionAsync
-        // throws on the server - so reaching the next line means verification passed. The server also consumes
-        // the challenge at this point, so this assertion cannot be replayed for sign-in.
         await identityController
             .WithQueryIf(AppPlatform.IsBlazorHybrid, "origin", localHttpServer.Origin)
             .VerifyWebAuthAssertion(assertion, CurrentCancellationToken);
 
-        try
-        {
-            await userController
-                .WithQueryIf(AppPlatform.IsBlazorHybrid, "origin", localHttpServer.Origin)
-                .DeleteWebAuthnCredential(assertion, CurrentCancellationToken);
+        await userController
+            .WithQueryIf(AppPlatform.IsBlazorHybrid, "origin", localHttpServer.Origin)
+            .DeleteWebAuthnCredential(assertion, CurrentCancellationToken);
 
-            SnackBarService.Success(Localizer[nameof(AppStrings.DisablePasswordlessSucsessMessage)]);
-        }
-        catch (ResourceNotFoundException)
-        {
-            // The server has no such credential - the row was removed out of band (table wiped etc).
-            // The local flag is the ONLY thing left claiming a passkey
-            // exists, so clearing it here is the whole point: otherwise the user is stuck with a toggle that
-            // says "configured" and can never be turned off.
-            SnackBarService.Warning(Localizer[nameof(AppStrings.PasswordlessAlreadyRemovedMessage)]);
-        }
-
-        // Reached on success and on "already gone" - both mean the server holds no credential for this user.
-        // NOT reached when the ceremony itself failed or was cancelled, which is the case that used to lie to the
-        // user by reporting a revocation that never happened.
-        await webAuthnService.RemoveWebAuthnConfiguredUserId(User.Id);
-        isConfigured = false;
+        SnackBarService.Success(Localizer[nameof(AppStrings.DisablePasswordlessSucsessMessage)]);
     }
 
     protected override async Task OnAfterFirstRenderAsync()

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/UpgradeAccountSection.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/UpgradeAccountSection.razor
@@ -1,3 +1,4 @@
+@*+:cnd:noEmit*@
 @inherits AppComponentBase
 
 <section>
@@ -25,11 +26,13 @@
             }
         }
 
+        @*#if (signalR == true)*@
         @if (showTroubleButton)
         {
             <BitButton OnClick="WrapHandled(HandleAdTrouble)">
                 @Localizer[nameof(AppStrings.UpgradeAdHaveTrouble)]
             </BitButton>
         }
+        @*#endif*@
     </BitStack>
 </section>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/UpgradeAccountSection.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/UpgradeAccountSection.razor.cs
@@ -1,3 +1,4 @@
+//+:cnd:noEmit
 namespace Boilerplate.Client.Core.Components.Pages.Settings;
 
 public partial class UpgradeAccountSection
@@ -9,14 +10,17 @@ public partial class UpgradeAccountSection
 
     private bool adIsReady;
     private bool adIsShown;
-    private bool showTroubleButton;
     private AdWatchResult? watchResult = null;
+    //#if (signalR == true)
+    private bool showTroubleButton;
+    //#endif
 
 
     protected override async Task OnAfterFirstRenderAsync()
     {
         await base.OnAfterFirstRenderAsync();
 
+        //#if (signalR == true)
         _ = Task.Delay(5000).ContinueWith(_ =>
         {
             if (adIsReady) return;
@@ -24,11 +28,14 @@ public partial class UpgradeAccountSection
             showTroubleButton = true;
             InvokeAsync(StateHasChanged);
         });
+        //#endif
 
         await adsService.Init(clientCoreSettings.AdUnitPath);
 
         adIsReady = true;
+        //#if (signalR == true)
         showTroubleButton = false;
+        //#endif
 
         StateHasChanged();
     }
@@ -38,6 +45,7 @@ public partial class UpgradeAccountSection
     {
         if (adIsReady is false || adIsShown) return;
 
+        //#if (signalR == true)
         _ = Task.Delay(3000).ContinueWith(_ =>
         {
             if (watchResult is not null || adIsShown) return;
@@ -45,11 +53,14 @@ public partial class UpgradeAccountSection
             showTroubleButton = true;
             InvokeAsync(StateHasChanged);
         });
+        //#endif
 
         watchResult = await adsService.Watch();
 
         adIsShown = true;
+        //#if (signalR == true)
         showTroubleButton = false;
+        //#endif
 
         StateHasChanged();
 
@@ -63,9 +74,11 @@ public partial class UpgradeAccountSection
         }
     }
 
+    //#if (signalR == true)
     private async Task HandleAdTrouble()
     {
         logger.LogWarning("User having trouble with ads");
         PubSubService.Publish(ClientAppMessages.AD_HAVE_TROUBLE);
     }
+    //#endif
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Data/Migrations/20260119232453_Initial.Designer.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Data/Migrations/20260119232453_Initial.Designer.cs
@@ -17,7 +17,7 @@ partial class Initial
     protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "10.0.10");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.11");
 
         modelBuilder.Entity("Boilerplate.Shared.Dtos.Todo.TodoItemDto", b =>
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Data/Migrations/AppOfflineDbContextModelSnapshot.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Data/Migrations/AppOfflineDbContextModelSnapshot.cs
@@ -14,7 +14,7 @@ partial class AppOfflineDbContextModelSnapshot : ModelSnapshot
     protected override void BuildModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "10.0.10");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.11");
 
         modelBuilder.Entity("Boilerplate.Shared.Dtos.Todo.TodoItemDto", b =>
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IJSRuntimeExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/IJSRuntimeExtensions.cs
@@ -1,8 +1,4 @@
 //+:cnd:noEmit
-//#if (notification == true)
-using Boilerplate.Shared.Features.PushNotification;
-//#endif
-
 namespace Microsoft.JSInterop;
 
 public static partial class IJSRuntimeExtensions
@@ -26,27 +22,12 @@ public static partial class IJSRuntimeExtensions
         }
         //#endif
 
-        //#if (notification == true)
-        public async ValueTask<PushNotificationSubscriptionDto> GetPushNotificationSubscription(string vapidPublicKey)
-        {
-            return await jsRuntime.InvokeAsync<PushNotificationSubscriptionDto>("App.getPushNotificationSubscription", vapidPublicKey);
-        }
-        //#endif
-
         /// <summary>
         /// The return value would be false during pre-rendering
         /// </summary>
         public bool IsInitialized()
         {
             return jsRuntime is not null && jsRuntime.IsRuntimeInvalid() is false;
-        }
-
-        /// <summary>
-        /// Clears web browser / web view storages
-        /// </summary>
-        public async Task ClearWebStorages()
-        {
-            await jsRuntime.InvokeVoidAsync("App.clearWebStorages");
         }
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/ClientAppMessages.cs
@@ -42,7 +42,7 @@ public partial class ClientAppMessages
     /// </summary>
     public const string SHOW_DIAGNOSTIC_MODAL = nameof(SHOW_DIAGNOSTIC_MODAL);
 
-    //#if(module == "Sales")
+    //#if (module == "Sales" && signalR == true)
     /// <summary>
     /// A publisher that sends this message announces that the subscriber should open the AI chat panel with product search prompt.
     /// When a user taps on search bar, this message is published to open the AI chat panel with product search prompt.
@@ -50,7 +50,7 @@ public partial class ClientAppMessages
     public const string SEARCH_PRODUCTS = nameof(SEARCH_PRODUCTS);
     //#endif
 
-    //#if(ads == true)
+    //#if (ads == true && signalR == true)
     /// <summary>
     /// A publisher that sends this message announces that the subscriber should open the AI chat panel with ad help prompt.
     /// When a user has trouble with ads, this message is published to open the AI chat panel with ad help prompt.

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/DiagnosticLog/DiagnosticLogger.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/DiagnosticLog/DiagnosticLogger.cs
@@ -4,7 +4,14 @@ namespace Boilerplate.Client.Core.Infrastructure.Services.DiagnosticLog;
 
 public partial class DiagnosticLogger(TimeProvider timeProvider) : ILogger
 {
-    public static ConcurrentQueue<DiagnosticLogDto> Store { get; } = [];
+    private static readonly ConcurrentQueue<DiagnosticLogDto> store = [];
+
+    public static IReadOnlyCollection<DiagnosticLogDto> Store => store;
+
+    /// <summary>
+    /// Discards this device's buffer. Called when the signed-in user changes, and by the diagnostic modal.
+    /// </summary>
+    public static void ClearStore() => store.Clear();
 
     private readonly AsyncLocal<IDictionary<string, object?>?> currentState = new();
 
@@ -38,12 +45,12 @@ public partial class DiagnosticLogger(TimeProvider timeProvider) : ILogger
 
         var message = formatter(state, exception);
 
-        if (Store.Count >= 1_000)
+        if (store.Count >= 1_000)
         {
-            Store.TryDequeue(out var _);
+            store.TryDequeue(out var _);
         }
 
-        Store.Enqueue(new()
+        store.Enqueue(new()
         {
             CreatedOn = timeProvider.GetUtcNow(),
             Level = logLevel,

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/PubSubService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/PubSubService.cs
@@ -3,7 +3,7 @@ namespace Boilerplate.Client.Core.Infrastructure.Services;
 /// <summary>
 /// Service for Publish/Subscribe pattern.
 /// You could publish messages within blazor components, pages outside blazor components (Like MAUI Xaml pages), JavaScript
-/// codes using window.postMessage or even from server side using SignalR (<see cref="SharedAppMessages.SESSION_REVOKED"/> as example.
+/// codes using window.postMessage, or - when SignalR is enabled - from the server side (<c>SESSION_REVOKED</c> as example).
 /// </summary>
 public partial class PubSubService
 {
@@ -21,14 +21,17 @@ public partial class PubSubService
     /// Serializes "queue a persistent message" against "register a handler and drain the queue". Without it the
     /// two can interleave so that Publish finds no handler, Subscribe drains an empty queue, and Publish then
     /// enqueues a message the handler that just arrived will never be given.
+    /// It is also the only lock guarding the inner <see cref="List{T}"/> of <see cref="handlers"/>: the dictionary
+    /// is concurrent, the lists inside it are not, and publishers run off the renderer's thread (SignalR callbacks,
+    /// and the faulted-task continuation below) while unsubscribes run on it.
     /// </summary>
-    private readonly Lock persistentMessagesLock = new();
+    private readonly Lock handlersLock = new();
 
     public void Publish(string message, object? payload = null, bool persistent = false)
     {
         if (TryDeliver(message, payload) || persistent is false) return;
 
-        lock (persistentMessagesLock)
+        lock (handlersLock)
         {
             // Re-attempt under the lock: a Subscribe that completed while we were deciding has a live handler
             // now. Nothing was delivered above, so this cannot deliver twice.
@@ -42,15 +45,23 @@ public partial class PubSubService
     {
         var delivered = false;
 
-        if (handlers.TryGetValue(message, out var weakHandlers))
+        if (handlers.TryGetValue(message, out var weakHandlers) is false) return delivered;
+
+        WeakHandler[] snapshot;
+
+        lock (handlersLock)
         {
-            foreach (var weakHandler in weakHandlers.ToArray())
+            snapshot = [.. weakHandlers];
+        }
+
+        // Dispatched outside the lock on purpose: a handler that blocks must not stall every other Publish and
+        // Subscribe on this instance.
+        foreach (var weakHandler in snapshot)
+        {
+            if (weakHandler.Invoke(payload) is Task handlerTask)
             {
-                if (weakHandler.Invoke(payload) is Task handlerTask)
-                {
-                    delivered = true;
-                    handlerTask.ContinueWith(HandleException, TaskContinuationOptions.OnlyOnFaulted);
-                }
+                delivered = true;
+                handlerTask.ContinueWith(HandleException, TaskContinuationOptions.OnlyOnFaulted);
             }
         }
 
@@ -62,7 +73,7 @@ public partial class PubSubService
         var weakHandler = new WeakHandler(handler);
         var weakHandlers = handlers.GetOrAdd(message, _ => []);
 
-        lock (persistentMessagesLock)
+        lock (handlersLock)
         {
             weakHandlers.Add(weakHandler);
 
@@ -92,13 +103,34 @@ public partial class PubSubService
 
         return () =>
         {
-            var removedHandlersCount = weakHandlers.RemoveAll(wh => wh.Matches(handler));
+            lock (handlersLock)
+            {
+                weakHandlers.RemoveAll(wh => wh.Matches(handler));
+            }
         };
     }
 
     private void HandleException(Task t)
     {
-        serviceProvider.GetRequiredService<ClientExceptionHandlerBase>().Handle(t.Exception!);
+        // The AggregateException a faulted Task carries is not what the handler threw, and every type test in
+        // ClientExceptionHandlerBase (KnownException, TransientException, UnauthorizedException) is written against
+        // the real exception. Handing over the wrapper turns an expected KnownException into a Critical log and a
+        // blocking modal showing "unknown error".
+        var exception = t.Exception is { InnerExceptions.Count: 1 } aggregateException
+            ? aggregateException.InnerExceptions[0]
+            : (Exception)t.Exception!;
+
+        try
+        {
+            serviceProvider.GetRequiredService<ClientExceptionHandlerBase>().Handle(exception);
+        }
+        catch (Exception)
+        {
+            // This is the terminal observer of the handler's exception: nothing awaits this continuation, so letting
+            // it fault would destroy the exception it was called to report. Reaching here means the scope that owns
+            // the exception handler is already gone (a torn-down Blazor Server circuit), and nothing scoped survives
+            // to report either exception.
+        }
     }
 
     private class WeakHandler

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/SnackBarService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/SnackBarService.cs
@@ -10,7 +10,8 @@ public partial class SnackBarService
         pubSubService.Publish(ClientAppMessages.SHOW_SNACK, (title, body, color), persistent: true);
     }
 
-    public void Error(string title, string body = "") => Show(title, body, BitColor.Error);
+    public void Info(string title, string body = "") => Show(title, body, BitColor.Info);
     public void Success(string title, string body = "") => Show(title, body, BitColor.Success);
     public void Warning(string title, string body = "") => Show(title, body, BitColor.Warning);
+    public void Error(string title, string body = "") => Show(title, body, BitColor.Error);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/App.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/App.ts
@@ -20,54 +20,37 @@ export class App {
         return Intl.DateTimeFormat().resolvedOptions().timeZone;
     }
 
-    public static openDevTools() {
-        const allScripts = Array.from(document.scripts).map(s => s.src);
-        const scriptAppended = allScripts.find(as => as.includes('npm/eruda'));
+    private static readonly erudaUrl = 'https://cdn.jsdelivr.net/npm/eruda@3.4.3/eruda.min.js';
+    private static readonly erudaIntegrity = 'sha384-F7xQBvh3l6dG/mMD6QPIeVmXtzWT4Ce3ZDu8ysPuzMWMx9bFOIMGnRPUhLuQipss';
+    private static readonly erudaScriptId = 'app-eruda-script';
 
-        if (scriptAppended) {
-            (window as any).eruda.show();
+    public static openDevTools() {
+        const eruda = (window as any).eruda;
+
+        if (eruda) {
+            eruda.show();
             return;
         }
 
+        // window.eruda only exists once the CDN script has run, so a second press while the first request is still
+        // in flight would append a second copy and init it twice. The element is the marker for that in-flight load.
+        if (document.getElementById(App.erudaScriptId)) return;
+
         const script = document.createElement('script');
-        script.src = "https://cdn.jsdelivr.net/npm/eruda";
-        document.body.append(script);
-        script.onload = function () {
+        script.id = App.erudaScriptId;
+        script.src = App.erudaUrl;
+        script.integrity = App.erudaIntegrity;
+        script.crossOrigin = 'anonymous';
+        script.onload = () => {
             (window as any).eruda.init();
             (window as any).eruda.show();
-        }
-    }
-
-    //#if (notification == true)
-    public static async getPushNotificationSubscription(vapidPublicKey: string) {
-        const registration = await navigator.serviceWorker.ready;
-        if (!registration) return null;
-
-        const pushManager = registration.pushManager;
-        if (!pushManager) return null;
-
-        let subscription = await pushManager.getSubscription();
-
-        if (!subscription) {
-            subscription = await pushManager.subscribe({
-                userVisibleOnly: true,
-                applicationServerKey: vapidPublicKey
-            });
-        }
-
-        const pushChannel = subscription.toJSON();
-        const p256dh = pushChannel.keys!['p256dh'];
-        const auth = pushChannel.keys!['auth'];
-
-        return {
-            deviceId: `${p256dh}-${auth}`,
-            platform: 'browser',
-            p256dh: p256dh,
-            auth: auth,
-            endpoint: pushChannel.endpoint
         };
-    };
-    //#endif
+        script.onerror = () => {
+            script.remove();
+            console.error(`Failed to load the dev tools from ${App.erudaUrl}.`);
+        };
+        document.body.append(script);
+    }
 
     /* Checks for and applies updates if available.
        Called by `WebAppUpdateService.cs` when the user clicks the app version in `AppShell.razor`
@@ -86,17 +69,6 @@ export class App {
         bswupProgress.config({ autoReload });
 
         bswup.checkForUpdate();
-    }
-
-    /* Clears web browser / web view storages */
-    public static async clearWebStorages() {
-        await Promise.all([
-            ...await caches.keys().then(k => k.map(caches.delete.bind(caches))),
-            ...await indexedDB.databases().then(d => d.map(db => indexedDB.deleteDatabase(db.name!))),
-            localStorage.clear(),
-            sessionStorage.clear(),
-            document.cookie.split(';').forEach(c => document.cookie = c.split('=')[0].trim() + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/')
-        ]);
     }
 }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/bswup.ts
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Scripts/bswup.ts
@@ -9,13 +9,19 @@ import { App } from './App';
     bswup.skipWaiting(); // Use new service worker if available.
 
     // Detects if the app was in the background for over 2 minutes. Since setInterval usually pauses in the background on modern browsers and runs immediately upon resuming,
-    // a lastRunInForeground older than 2 minutes indicates the app was likely not focused.
+    // a lastTimeAppWasInForeground older than 2 minutes indicates the app was likely not focused.
     let counter = 0;
     let lastTimeAppWasInForeground = new Date().getTime();
 
     setInterval(() => {
         const now = new Date().getTime();
-        const resuming = now - lastTimeAppWasInForeground > 60 * 2 * 1000;
+        const isVisible = document.visibilityState === 'visible';
+
+        // Only a tick that can see the page counts as a resume. Without that conjunct the condition stays true for
+        // every subsequent tick of a long background period, turning a once-per-resume update check into a
+        // once-per-second one on a device whose screen is off - and it also skips the reload path (autoReload) that
+        // resuming exists to trigger, because the page is not there to reload.
+        const resuming = isVisible && now - lastTimeAppWasInForeground > 60 * 2 * 1000;
 
         counter++;
         if (counter % 60 === 0 /*Every 60 seconds*/ || resuming) {
@@ -23,7 +29,7 @@ import { App } from './App';
             App.tryUpdatePwa(resuming);
         }
 
-        if (document.visibilityState === 'visible') {
+        if (isVisible) {
             lastTimeAppWasInForeground = now;
         }
     }, 1000);

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Android/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round"></application>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
 </manifest>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/MacCatalyst/Info.plist
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/MacCatalyst/Info.plist
@@ -28,6 +28,10 @@
         </array>
         <key>NSCameraUsageDescription</key>
         <string>This app uses camera for uploading profile photo using FileUpload component</string>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>This app uses the microphone to dictate your message in the AI chat panel</string>
+        <key>NSSpeechRecognitionUsageDescription</key>
+        <string>This app converts your dictated message into text in the AI chat panel</string>
         <key>UISupportedInterfaceOrientations</key>
         <array>
             <string>UIInterfaceOrientationPortrait</string>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/Windows/Package.appxmanifest
@@ -42,6 +42,7 @@
 
     <Capabilities>
         <rescap:Capability Name="runFullTrust" />
+        <DeviceCapability Name="microphone" />
     </Capabilities>
 
 </Package>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/iOS/Info.plist
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Platforms/iOS/Info.plist
@@ -17,6 +17,10 @@
     </array>
     <key>NSCameraUsageDescription</key>
     <string>This app uses camera for uploading profile photo using FileUpload component</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app uses the microphone to dictate your message in the AI chat panel</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>This app converts your dictated message into text in the AI chat panel</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Boilerplate.Client.Web.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Boilerplate.Client.Web.csproj
@@ -65,6 +65,8 @@
         <!-- https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets -->
         <EmccLinkOptimizationFlag>-O3</EmccLinkOptimizationFlag>
         <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+        <!-- Optimization flag for the AOT'ed assemblies bitcode, which defaults to -O2 in Release and is not covered by EmccCompileOptimizationFlag. -->
+        <WasmBitcodeCompileOptimizationFlag>-O3</WasmBitcodeCompileOptimizationFlag>
     </PropertyGroup>
 
     <!--

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebPushNotificationService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebPushNotificationService.cs
@@ -5,20 +5,63 @@ namespace Boilerplate.Client.Web.Infrastructure.Services;
 
 public partial class WebPushNotificationService : PushNotificationServiceBase
 {
+    [AutoInject] private Push push = default!;
     [AutoInject] private Notification notification = default!;
-    [AutoInject] private readonly IJSRuntime jSRuntime = default!;
+    [AutoInject] private ServiceWorker serviceWorker = default!;
     [AutoInject] private readonly ClientWebSettings clientWebSettings = default!;
 
     public override async Task<PushNotificationSubscriptionDto?> GetSubscription(CancellationToken cancellationToken)
     {
-        var subscription = await jSRuntime.GetPushNotificationSubscription(clientWebSettings.AdsPushVapid!.PublicKey);
+        await WaitForActiveServiceWorker(cancellationToken);
 
-        if (subscription is null)
+        var subscription = await push.GetSubscription();
+
+        if (subscription.IsActive is false)
         {
-            Logger.LogError("Could not retrieve push notification subscription"); // Browser's incognito mode etc.
+            subscription = await push.Subscribe(clientWebSettings.AdsPushVapid!.PublicKey);
         }
 
-        return subscription;
+        if (subscription.IsActive is false)
+        {
+            // Browser's incognito mode, a denied notification permission, or a service worker that is not
+            // registered yet. Returning null skips this round; the next auth-state propagation tries again.
+            Logger.LogError("Could not retrieve push notification subscription");
+            return null;
+        }
+
+        return new()
+        {
+            DeviceId = $"{subscription.P256dh}-{subscription.Auth}",
+            Platform = "browser",
+            P256dh = subscription.P256dh,
+            Auth = subscription.Auth,
+            Endpoint = subscription.Endpoint
+        };
+    }
+
+    /// <summary>
+    /// A push subscription is owned by the service worker registration, and <see cref="Push"/> reads that registration
+    /// through <c>navigator.serviceWorker.getRegistration()</c>, which answers immediately - on a first visit it
+    /// answers before the worker has activated. Asking then reports "not subscribed" for a browser that is merely a
+    /// moment early, and nothing retries until the auth state changes again.
+    /// <para>
+    /// This waits for an activated worker rather than using <c>navigator.serviceWorker.ready</c>, whose promise simply
+    /// never settles when no worker is ever registered (pwa turned off, unsupported browser). Giving up after the
+    /// timeout lets the caller report the genuine "no subscription" case instead of hanging on it.
+    /// </para>
+    /// </summary>
+    private async Task WaitForActiveServiceWorker(CancellationToken cancellationToken)
+    {
+        if (await serviceWorker.IsSupported() is false) return;
+
+        var giveUpAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
+
+        while (DateTimeOffset.UtcNow < giveUpAt)
+        {
+            if ((await serviceWorker.GetRegistration()).ActiveState is "activated") return;
+
+            await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+        }
     }
 
     public override async Task<bool> IsAvailable(CancellationToken cancellationToken) => string.IsNullOrEmpty(clientWebSettings.AdsPushVapid?.PublicKey) is false && await notification.IsNotificationAvailable();

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/web-interop-app.html
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/wwwroot/web-interop-app.html
@@ -10,8 +10,8 @@ state and avoid restarting Blazor upon returning from External Sign-in, the Popu
 after authentication. Using app.js, it can notify the main Window via window.opener.postMessage({ key: 'PUBLISH_MESSAGE', ... }),
 allowing the main Window to resume its operations.
 
-When publishing Client.Web (BlazorWebAssembly Standalone) and Server.Api, there won't be any WebInteropAppEndpoint,
-in this case, uncomment the Route attribute below to make this component accessible via /web-interop-app route. -->
+This page is plain static HTML served from the web app's own origin (wwwroot), at PageUrls.WebInteropApp
+(/web-interop-app.html). Client.Windows and Client.Maui link this same file rather than copying it. -->
 
 <html>
 <head>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -14,27 +14,27 @@
         <PackageVersion Include="Bit.SourceGenerators" Version="10.6.0-pre-01" />
         <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3" />
         <PackageVersion Include="Fido2.AspNet" Version="4.0.1" />
-        <PackageVersion Include="HtmlSanitizer" Version="9.1.982" />
+        <PackageVersion Include="HtmlSanitizer" Version="9.2.995" />
         <PackageVersion Include="libphonenumber-csharp" Version="9.0.36" />
         <PackageVersion Include="Meziantou.Framework.Win32.Jobs" Version="4.0.0" />
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" />
         <PackageVersion Include="Asp.Versioning.Mvc" Version="10.2.1" />
         <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.2.1" />
         <PackageVersion Include="EmbedIO" Version="3.5.2" />
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
         <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
         <PackageVersion Include="AspNetCore.HealthChecks.System" Version="9.0.0" />
         <PackageVersion Include="AspNetCore.HealthChecks.Hangfire" Version="9.0.0" />
         <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.11" />
         <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.90" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.90" />
@@ -52,11 +52,11 @@
         <PackageVersion Include="Plugin.Maui.AppRating" Version="1.3.0" />
         <PackageVersion Include="Scalar.AspNetCore" Version="2.16.18" />
         <PackageVersion Include="Velopack" Version="1.2.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="10.0.11" />
         <!--/+:msbuild-conditional:noEmit -->
         <PackageVersion Condition="'$(signalR)' == 'true' OR '$(signalR)' == ''" Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
         <PackageVersion Condition=" '$(aspire)' == 'true' OR '$(aspire)' == '' " Include="Aspire.Hosting.Maui" Version="13.4.6-preview.1.26319.6" />
@@ -92,7 +92,7 @@
         <PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.1.2" />
         <PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="Bit.Besql" Version="10.6.0-pre-01" />
         <PackageVersion Condition=" '$(offlineDb)' == 'true' OR '$(offlineDb)' == ''" Include="CommunityToolkit.Datasync.Client" Version="10.1.2" />
-        <PackageVersion Condition=" '$(signalR)' == 'true' OR '$(signalR)' == ''" Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+        <PackageVersion Condition=" '$(signalR)' == 'true' OR '$(signalR)' == ''" Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
         <PackageVersion Condition=" '$(signalR)' == 'true' OR '$(signalR)' == ''" Include="Microsoft.Azure.SignalR" Version="1.33.1" />
         <PackageVersion Condition=" ('$(signalR)' == 'true' OR '$(signalR)' == '') OR ('$(database)' == 'PostgreSQL' OR '$(database)' == '') OR ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Microsoft.Extensions.AI" Version="10.8.3" />
         <PackageVersion Condition=" ('$(signalR)' == 'true' OR '$(signalR)' == '') OR ('$(database)' == 'PostgreSQL' OR '$(database)' == '') OR ('$(database)' == 'SqlServer' OR '$(database)' == '') " Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
@@ -103,20 +103,20 @@
         <PackageVersion Condition=" ('$(database)' == 'PostgreSQL' OR '$(database)' == '') " Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
         <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
         <PackageVersion Condition=" '$(appInsights)' == 'true' OR '$(appInsights)' == '' " Include="BlazorApplicationInsights" Version="3.3.0" />
-        <PackageVersion Condition=" '$(database)' == 'SqlServer' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+        <PackageVersion Condition=" '$(database)' == 'SqlServer' OR '$(database)' == '' " Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
         <PackageVersion Condition=" '$(database)' == 'PostgreSQL' OR '$(database)' == '' " Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
         <PackageVersion Condition=" '$(database)' == 'MySql' OR '$(database)' == '' " Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
         <PackageVersion Condition=" '$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '' " Include="FluentStorage.Azure.Blobs" Version="8.0.10" />
         <PackageVersion Condition=" '$(filesStorage)' == 'S3' OR '$(filesStorage)' == '' " Include="FluentStorage.AWS" Version="8.0.10" />
-        <PackageVersion Condition=" '$(filesStorage)' == 'S3' OR '$(filesStorage)' == '' " Include="AWSSDK.Core" Version="4.0.100.9" />
+        <PackageVersion Condition=" '$(filesStorage)' == 'S3' OR '$(filesStorage)' == '' " Include="AWSSDK.Core" Version="4.0.101" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Aspire.Hosting.Redis" Version="13.4.6" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Aspire.Hosting.Azure.Redis" Version="13.4.6" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Aspire.StackExchange.Redis" Version="13.4.6" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.6.0" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="DistributedLock.Redis" Version="1.1.1" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Hangfire.Redis.StackExchange" Version="1.12.0" />
-        <PackageVersion Condition=" ('$(redis)' == 'true' OR '$(redis)' == '') AND ('$(signalR)' == 'true' OR '$(signalR)' == '')" Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.10" />
-        <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
+        <PackageVersion Condition=" ('$(redis)' == 'true' OR '$(redis)' == '') AND ('$(signalR)' == 'true' OR '$(signalR)' == '')" Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.11" />
+        <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.11" />
         <PackageVersion Condition="'$(redis)' == 'true' OR '$(redis)' == ''" Include="ZiggyCreatures.FusionCache.Locking.Distributed.Redis" Version="2.6.0" />
         <PackageVersion Condition=" '$(advancedTests)' == 'true' OR '$(advancedTests)' == '' " Include="Otp.NET" Version="1.4.1" />
         <!--/-:msbuild-conditional:noEmit -->
@@ -125,31 +125,31 @@
         <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.16.0" />
         <PackageVersion Include="FluentEmail.Smtp" Version="3.0.2" />
         <PackageVersion Include="FluentStorage" Version="8.0.16" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
         <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.5.0" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
         <PackageVersion Include="Microsoft.Identity.Web" Version="4.14.2" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.11" />
         <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="10.0.0" />
         <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
         <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
         <PackageVersion Include="Twilio" Version="7.14.9" />
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-        <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.11" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
         <PackageVersion Include="System.Text.Json" Version="10.0.0" />
         <PackageVersion Include="FakeItEasy" Version="9.0.1" />
         <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
-        <PackageVersion Include="Microsoft.Playwright.MSTest.v4" Version="1.61.0" />
+        <PackageVersion Include="Microsoft.Playwright.MSTest.v4" Version="1.62.0" />
         <PackageVersion Include="bunit" Version="2.9.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache.AspNetCore.OutputCaching" Version="2.6.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.6.0" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/.config/dotnet-tools.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.10",
+      "version": "10.0.11",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Properties/launchSettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/Properties/launchSettings.json
@@ -10,7 +10,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "dotnetRunMessages": true,
-            "applicationUrl": "http://*:5031"
+            "applicationUrl": "http://localhost:5031;http://*:5031"
         },
         "WSL": {
             "commandName": "WSL2",
@@ -18,7 +18,7 @@
             "launchUrl": "scalar",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "ASPNETCORE_URLS": "http://*:5031"
+                "ASPNETCORE_URLS": "http://localhost:5031;http://*:5031"
             }
         },
         "Docker": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
@@ -154,7 +154,7 @@ public static class WebApplicationExtensions
                     // 6. Permissions-Policy
                     // "Disables" sensitive hardware/API access to reduce the attack surface.
                     // Example: If building an E-Commerce or Delivery app, remove 'payment' or 'geolocation' from this list.
-                    headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), display-capture=()";
+                    headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=(self), payment=(), usb=(), display-capture=()";
 
                     // 7. Cross-Origin-Resource-Policy (CORP)
                     // Set to 'cross-origin' to explicitly allow resources (images, fonts, etc.) to be loaded by

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/.config/dotnet-tools.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.10",
+      "version": "10.0.11",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Components/App.razor
@@ -21,7 +21,7 @@
 }
 
 <!DOCTYPE html>
-<html bit-theme-system bit-theme-persist bit-theme-view-transition>
+<html bit-theme-system bit-theme-persist bit-theme-persist-cookie bit-theme-view-transition>
 
 <head>
     <ContentSecurityPolicy />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Properties/launchSettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Properties/launchSettings.json
@@ -9,7 +9,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "dotnetRunMessages": true,
-            "applicationUrl": "http://*:5030"
+            "applicationUrl": "http://localhost:5030;http://*:5030"
         },
         //#if (api == "Integrated")
         "Boilerplate.Server.Web-Scalar": {
@@ -20,7 +20,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "dotnetRunMessages": true,
-            "applicationUrl": "http://*:5030"
+            "applicationUrl": "http://localhost:5030;http://*:5030"
         },
         //#endif
         "Boilerplate.Server.Web-BlazorWebAssembly": {
@@ -32,7 +32,7 @@
             },
             "dotnetRunMessages": true,
             "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-            "applicationUrl": "http://*:5030"
+            "applicationUrl": "http://localhost:5030;http://*:5030"
         },
         "WSL": {
             "commandName": "WSL2",
@@ -40,7 +40,7 @@
             "launchUrl": "http://localhost:5030/",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "ASPNETCORE_URLS": "http://*:5030"
+                "ASPNETCORE_URLS": "http://localhost:5030;http://*:5030"
             }
         },
         "Docker": {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
@@ -1135,17 +1135,14 @@
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>تم تعطيل تسجيل الدخول بدون كلمة مرور بنجاح</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>تعذّر التحقق من مفتاح المرور الخاص بك، لذلك لم تتم إزالته. يرجى المحاولة مرة أخرى.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>لم يعد مفتاح المرور هذا موجودًا على الخادم؛ تمت إزالته من هذا الجهاز.</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>مسح</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>إرسال</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>تطبيق لون التمييز {0}</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>ملغى</value>
@@ -1153,6 +1150,27 @@
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>لوحة الدردشة بالذكاء الاصطناعي</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>أملِ رسالتك</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>إيقاف الإملاء</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>الإملاء</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>تم حظر الوصول إلى الميكروفون. اسمح به لهذا الموقع لكي تتمكن من الإملاء.</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>توقف الإملاء: {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>القراءة بصوت عالٍ</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>إيقاف القراءة</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>مرحبًا{0}! أنا هنا لجعل تجربة التطبيق رائعة! هل لديك سؤال أو تحتاج مساعدة؟</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
@@ -1135,17 +1135,14 @@ Nach Erreichen von {0} haben zusätzliche Anmeldungen reduzierte Funktionen.</va
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>Passwortlose Anmeldung erfolgreich deaktiviert</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>Ihr Passkey konnte nicht überprüft werden und wurde daher nicht entfernt. Bitte versuchen Sie es erneut.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>Dieser Passkey existiert nicht mehr auf dem Server; er wurde von diesem Gerät entfernt.</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>Löschen</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>Senden</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>Akzentfarbe {0} anwenden</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>Abgebrochen</value>
@@ -1153,6 +1150,27 @@ Nach Erreichen von {0} haben zusätzliche Anmeldungen reduzierte Funktionen.</va
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>AI-Chat-Panel</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>Nachricht diktieren</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>Diktat beenden</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>Diktat</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>Der Zugriff auf das Mikrofon ist blockiert. Erlauben Sie ihn für diese Website, um zu diktieren.</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>Diktat beendet: {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>Vorlesen</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>Vorlesen beenden</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>Hallo{0}! Ich bin hier, um Ihr App-Erlebnis fantastisch zu machen! Haben Sie eine Frage oder brauchen Sie Hilfe?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
@@ -1135,17 +1135,14 @@ Después de alcanzar {0}, los inicios de sesión adicionales tendrán funciones 
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>Inicio de sesión sin contraseña deshabilitado exitosamente</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>No se pudo verificar tu clave de acceso, por lo que no se eliminó. Inténtalo de nuevo.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>Esta clave de acceso ya no existe en el servidor; se ha eliminado de este dispositivo.</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>Limpiar</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>Enviar</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>Aplicar el color de acento {0}</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>Cancelado</value>
@@ -1153,6 +1150,27 @@ Después de alcanzar {0}, los inicios de sesión adicionales tendrán funciones 
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>Panel de chat con IA</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>Dicta tu mensaje</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>Detener el dictado</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>Dictado</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>El acceso al micrófono está bloqueado. Permítelo para este sitio para poder dictar.</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>Dictado detenido: {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>Leer en voz alta</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>Detener la lectura</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>¡Saludos{0}! Estoy aquí para hacer que tu experiencia en la app sea genial. ¿Tienes una pregunta o necesitas ayuda?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
@@ -1135,17 +1135,14 @@
     <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>ورود بی رمز با موفقیت غیرفعال شد</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>کلید عبور شما تأیید نشد، بنابراین حذف نشد. لطفاً دوباره تلاش کنید.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>این کلید عبور دیگر روی سرور وجود ندارد؛ از این دستگاه حذف شد.</value>
-  </data>
     <data name="Clear" xml:space="preserve">
     <value>پاک کردن</value>
   </data>
     <data name="Send" xml:space="preserve">
     <value>ارسال</value>
+  </data>
+    <data name="AccentColorApply" xml:space="preserve">
+    <value>اعمال رنگ تأکیدی {0}</value>
   </data>
     <data name="Canceled" xml:space="preserve">
     <value>لغو شده</value>
@@ -1153,6 +1150,27 @@
     <!--#if (signalR == true) -->
     <data name="AiChatPanelTitle" xml:space="preserve">
     <value>پنل هوش مصنوعی</value>
+  </data>
+    <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>پیام خود را بگویید</value>
+  </data>
+    <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>توقف گفتار</value>
+  </data>
+    <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>تبدیل گفتار به متن</value>
+  </data>
+    <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>دسترسی به میکروفن مسدود است. برای این سایت اجازه دهید تا بتوانید گفتار خود را وارد کنید.</value>
+  </data>
+    <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>تبدیل گفتار به متن متوقف شد: {0}</value>
+  </data>
+    <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>خواندن با صدای بلند</value>
+  </data>
+    <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>توقف خواندن</value>
   </data>
     <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>سلام{0}! من اینجا هستم تا تجربه اپلیکیشن شما رو فوق‌العاده کنم! سؤالی دارید یا به کمک نیاز دارید؟</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
@@ -1135,17 +1135,14 @@ Après avoir atteint {0}, les connexions supplémentaires auront des fonctions r
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>Connexion sans mot de passe désactivée avec succès</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>Votre clé d'accès n'a pas pu être vérifiée, elle n'a donc pas été supprimée. Veuillez réessayer.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>Cette clé d'accès n'existe plus sur le serveur ; elle a été supprimée de cet appareil.</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>Effacer</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>Envoyer</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>Appliquer la couleur d'accentuation {0}</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>Annulé</value>
@@ -1153,6 +1150,27 @@ Après avoir atteint {0}, les connexions supplémentaires auront des fonctions r
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>Panneau de chat IA</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>Dicter votre message</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>Arrêter la dictée</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>Dictée</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>L'accès au microphone est bloqué. Autorisez-le pour ce site afin de pouvoir dicter.</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>Dictée interrompue : {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>Lire à voix haute</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>Arrêter la lecture</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>Salutations{0}! Je suis là pour rendre votre expérience d'application géniale ! Une question ou besoin d'aide ?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
@@ -1135,17 +1135,14 @@
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>पासवर्डरहित साइन-इन सफलतापूर्वक अक्षम</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>आपकी पासकी सत्यापित नहीं हो सकी, इसलिए इसे हटाया नहीं गया। कृपया पुनः प्रयास करें।</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>यह पासकी अब सर्वर पर मौजूद नहीं है; इसे इस डिवाइस से हटा दिया गया है।</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>साफ़ करें</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>भेजें</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>{0} एक्सेंट रंग लागू करें</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>रद्द</value>
@@ -1153,6 +1150,27 @@
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>एआई चैट पैनल</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>अपना संदेश बोलें</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>श्रुतलेख रोकें</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>श्रुतलेख</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>माइक्रोफ़ोन का उपयोग अवरुद्ध है। बोलकर लिखने के लिए इस साइट को अनुमति दें।</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>श्रुतलेख रुक गया: {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>ज़ोर से पढ़ें</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>पढ़ना रोकें</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>नमस्ते{0}! मैं यहां आपके ऐप अनुभव को शानदार बनाने के लिए हूं! कोई प्रश्न है या मदद चाहिए?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
@@ -1135,17 +1135,14 @@ Na het bereiken van {0} zullen extra aanmeldingen verminderde functies hebben.</
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>Wachtwoordloze aanmelding succesvol uitgeschakeld</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>Je toegangssleutel kon niet worden geverifieerd en is daarom niet verwijderd. Probeer het opnieuw.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>Deze toegangssleutel bestaat niet meer op de server; hij is van dit apparaat verwijderd.</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>Wissen</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>Verzenden</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>De accentkleur {0} toepassen</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>Geannuleerd</value>
@@ -1153,6 +1150,27 @@ Na het bereiken van {0} zullen extra aanmeldingen verminderde functies hebben.</
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>AI-chatpaneel</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>Uw bericht dicteren</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>Dicteren stoppen</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>Dicteren</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>Toegang tot de microfoon is geblokkeerd. Sta deze toe voor deze site om te kunnen dicteren.</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>Dicteren gestopt: {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>Voorlezen</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>Voorlezen stoppen</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>Hallo{0}! Ik ben hier om je app-ervaring geweldig te maken! Heb je een vraag of heb je hulp nodig?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -1135,17 +1135,14 @@ After reaching {0}, extra sign-ins will have reduced functions.</value>
     <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>Passwordless sign-in disabled successfully</value>
   </data>
-    <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>Could not verify your passkey, so it was not removed. Please try again.</value>
-  </data>
-    <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>This passkey no longer exists on the server; it has been removed from this device.</value>
-  </data>
     <data name="Clear" xml:space="preserve">
     <value>Clear</value>
   </data>
     <data name="Send" xml:space="preserve">
     <value>Send</value>
+  </data>
+    <data name="AccentColorApply" xml:space="preserve">
+    <value>Apply the {0} accent color</value>
   </data>
     <data name="Canceled" xml:space="preserve">
     <value>Canceled</value>
@@ -1153,6 +1150,27 @@ After reaching {0}, extra sign-ins will have reduced functions.</value>
     <!--#if (signalR == true) -->
     <data name="AiChatPanelTitle" xml:space="preserve">
     <value>AI chat panel</value>
+  </data>
+    <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>Dictate your message</value>
+  </data>
+    <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>Stop dictation</value>
+  </data>
+    <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>Dictation</value>
+  </data>
+    <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>Microphone access is blocked. Allow it for this site to dictate.</value>
+  </data>
+    <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>Dictation stopped: {0}</value>
+  </data>
+    <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>Read aloud</value>
+  </data>
+    <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>Stop reading</value>
   </data>
     <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>Greetings{0}! I'm here to make your app experience awesome! Got a question or need a hand?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
@@ -1135,17 +1135,14 @@ Efter att ha nått {0} kommer extra inloggningar att ha reducerade funktioner.</
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>Lösenordslös inloggning har inaktiverats</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>Din nyckel kunde inte verifieras och togs därför inte bort. Försök igen.</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>Den här nyckeln finns inte längre på servern; den har tagits bort från den här enheten.</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>Rensa</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>Skicka</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>Använd accentfärgen {0}</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>Avbrutet</value>
@@ -1153,6 +1150,27 @@ Efter att ha nått {0} kommer extra inloggningar att ha reducerade funktioner.</
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>AI-chattpanel</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>Diktera ditt meddelande</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>Sluta diktera</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>Diktering</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>Åtkomsten till mikrofonen är blockerad. Tillåt den för den här webbplatsen för att kunna diktera.</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>Dikteringen stoppades: {0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>Läs upp</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>Sluta läsa upp</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>Hej{0}! Jag är här för att göra din app-upplevelse fantastisk! Har du en fråga eller behöver du hjälp?</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
@@ -1135,17 +1135,14 @@
   <data name="DisablePasswordlessSucsessMessage" xml:space="preserve">
     <value>无密码登录禁用成功</value>
   </data>
-  <data name="DisablePasswordlessFailedMessage" xml:space="preserve">
-    <value>无法验证您的通行密钥，因此未将其移除。请重试。</value>
-  </data>
-  <data name="PasswordlessAlreadyRemovedMessage" xml:space="preserve">
-    <value>该通行密钥在服务器上已不存在；已从此设备中移除。</value>
-  </data>
   <data name="Clear" xml:space="preserve">
     <value>清除</value>
   </data>
   <data name="Send" xml:space="preserve">
     <value>发送</value>
+  </data>
+  <data name="AccentColorApply" xml:space="preserve">
+    <value>应用 {0} 强调色</value>
   </data>
   <data name="Canceled" xml:space="preserve">
     <value>已取消</value>
@@ -1153,6 +1150,27 @@
   <!--#if (signalR == true) -->
   <data name="AiChatPanelTitle" xml:space="preserve">
     <value>AI 聊天面板</value>
+  </data>
+  <data name="AiChatPanelDictate" xml:space="preserve">
+    <value>口述你的消息</value>
+  </data>
+  <data name="AiChatPanelStopDictation" xml:space="preserve">
+    <value>停止口述</value>
+  </data>
+  <data name="AiChatPanelDictation" xml:space="preserve">
+    <value>语音输入</value>
+  </data>
+  <data name="AiChatPanelMicrophoneBlocked" xml:space="preserve">
+    <value>麦克风访问已被阻止。请为本站点允许访问后再进行口述。</value>
+  </data>
+  <data name="AiChatPanelDictationStopped" xml:space="preserve">
+    <value>语音输入已停止：{0}</value>
+  </data>
+  <data name="AiChatPanelReadAloud" xml:space="preserve">
+    <value>朗读</value>
+  </data>
+  <data name="AiChatPanelStopReading" xml:space="preserve">
+    <value>停止朗读</value>
   </data>
   <data name="AiChatPanelInitialResponse" xml:space="preserve">
     <value>您好{0}！我是来让您的应用体验更棒的！有问题或需要帮助吗？</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/appsettings.json
@@ -8,7 +8,7 @@
         "LogLevel": {
             "Default": "Warning",
             "Microsoft.Hosting.Lifetime": "Information",
-            "Boilerplate.Client.Core.Services.AuthManager": "Information",
+            "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
             "Microsoft.EntityFrameworkCore.Database.Command": "Information",
             "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
         },
@@ -18,7 +18,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information"
             }
         },
@@ -35,7 +35,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information",
                 "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
             }
@@ -46,7 +46,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information",
                 "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
             }
@@ -56,7 +56,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information",
                 "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
             }
@@ -66,7 +66,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information"
             }
         },
@@ -75,7 +75,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information",
                 "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
             }
@@ -85,7 +85,7 @@
             "LogLevel": {
                 "Default": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
-                "Boilerplate.Client.Core.Services.AuthManager": "Information",
+                "Boilerplate.Client.Core.Infrastructure.Services.AuthManager": "Information",
                 "Microsoft.EntityFrameworkCore.Database.Command": "Information",
                 "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
             }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Diagnostics/LoggingConfigurationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/Diagnostics/LoggingConfigurationTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+
+namespace Boilerplate.Tests.Features.Diagnostics;
+
+/// <summary>
+/// A logging category in <c>appsettings.json</c> is matched against a record's category with
+/// <c>category.StartsWith(rule.CategoryName)</c>, so a key naming a type or namespace that no longer exists matches
+/// nothing at all and the provider silently falls back to its section's <c>Default</c>. Nothing reports it: the
+/// configuration binds, the app starts, and the only symptom is that the records the entry was written to keep are
+/// missing from production telemetry.
+/// <para>
+/// This has already happened once. The move to the feature-based <c>Infrastructure/</c> layout left eight provider
+/// sections pointing at <c>Boilerplate.Client.Core.Services.AuthManager</c>, so the token-refresh log the entries
+/// exist for was dropped from Sentry, Application Insights, OpenTelemetry, Console, EventLog and EventSource in
+/// Production.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("UnitTest")]
+public class LoggingConfigurationTests
+{
+    [ClassInitialize]
+    public static void EnsureAppAssembliesLoaded(TestContext _)
+    {
+        Assembly.Load("Boilerplate.Shared");
+        Assembly.Load("Boilerplate.Client.Core");
+        Assembly.Load("Boilerplate.Client.Web");
+    }
+
+    [TestMethod]
+    public void EveryConfiguredLogCategory_Should_NameATypeOrNamespaceThatStillExists()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddClientConfigurations(clientEntryAssemblyName: "Boilerplate.Client.Web")
+            .Build();
+
+        var appTypeNames = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => assembly.GetName().Name?.StartsWith("Boilerplate", StringComparison.Ordinal) is true)
+            .SelectMany(assembly => assembly.GetTypes())
+            .Select(type => type.FullName)
+            .OfType<string>()
+            .ToArray();
+
+        // Only the app's own categories are checkable: a framework category such as Microsoft.EntityFrameworkCore
+        // names types this assembly does not necessarily load.
+        var appCategories = CollectLogCategories(configuration.GetSection("Logging"))
+            .Where(category => category.StartsWith("Boilerplate", StringComparison.Ordinal))
+            .Distinct()
+            .ToArray();
+
+        Assert.IsNotEmpty(appCategories, "No app-owned logging categories were found, so this guard is checking nothing - has the configuration layout moved?");
+
+        var danglingCategories = appCategories
+            .Where(category => appTypeNames.Any(typeName => typeName == category || typeName.StartsWith($"{category}.", StringComparison.Ordinal)) is false)
+            .ToArray();
+
+        Assert.IsEmpty(danglingCategories,
+            $"These logging categories match no type or namespace in the app, so their level never applies and the provider falls back to its Default: {string.Join(", ", danglingCategories)}");
+    }
+
+    /// <summary>
+    /// Walks the whole <c>Logging</c> section, because a category can sit under the root <c>LogLevel</c> or under any
+    /// provider alias's own <c>LogLevel</c> - and the same stale key is typically copied into every one of them.
+    /// </summary>
+    private static IEnumerable<string> CollectLogCategories(IConfigurationSection loggingSection)
+    {
+        foreach (var section in loggingSection.GetChildren())
+        {
+            if (section.Key is "LogLevel")
+            {
+                foreach (var category in section.GetChildren())
+                {
+                    yield return category.Key;
+                }
+            }
+            else
+            {
+                foreach (var category in CollectLogCategories(section))
+                {
+                    yield return category;
+                }
+            }
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/PubSub/PubSubServiceTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/PubSub/PubSubServiceTests.cs
@@ -203,6 +203,113 @@ public class PubSubServiceTests
         Assert.AreEqual(0, counter.Value);
     }
 
+    /// <summary>
+    /// The handlers of one message live in a plain <c>List&lt;WeakHandler&gt;</c> inside a ConcurrentDictionary - the
+    /// dictionary is concurrent, the list is not. Publishers genuinely run off the renderer's thread (SignalR
+    /// callbacks and the faulted-task continuation), while unsubscribes run on it during component disposal, so
+    /// <c>ToArray</c> could observe the torn state <c>RemoveAll</c> leaves behind between its <c>Array.Clear</c> and
+    /// its <c>_size</c> assignment - a null entry, dereferenced one line later.
+    /// </summary>
+    [TestMethod]
+    public async Task Subscribe_Should_NotLoseHandlers_WhenItRunsConcurrentlyWithUnsubscribe()
+    {
+        const int handlerCount = 2_000;
+
+        var pubSub = CreatePubSubService();
+
+        // Subscribed up front and unsubscribed on the racing thread. RemoveAll compacts the list in place, so it is
+        // the mutation that can overwrite what Add is writing at the same moment.
+        var doomedTargets = Enumerable.Range(0, handlerCount).Select(_ => new SubscriberTarget(new StrongBox<int>(0))).ToArray();
+        var unsubscribes = doomedTargets.Select(target => pubSub.Subscribe(Message, target.HandleAsync)).ToArray();
+
+        var survivingTargets = Enumerable.Range(0, handlerCount).Select(_ => new SubscriberTarget(new StrongBox<int>(0))).ToArray();
+
+        using var start = new Barrier(2);
+
+        var subscriber = Task.Run(() =>
+        {
+            start.SignalAndWait();
+            foreach (var target in survivingTargets)
+            {
+                pubSub.Subscribe(Message, target.HandleAsync);
+            }
+        });
+
+        var unsubscriber = Task.Run(() =>
+        {
+            start.SignalAndWait();
+            foreach (var unsubscribe in unsubscribes)
+            {
+                unsubscribe();
+            }
+        });
+
+        await Task.WhenAll(subscriber, unsubscriber);
+
+        pubSub.Publish(Message);
+
+        // Every surviving subscription must have been invoked exactly once. Fewer means the handler list lost an
+        // entry: Add and RemoveAll were interleaving on a plain List<T> that only Add was holding a lock for.
+        Assert.AreEqual(handlerCount, survivingTargets.Count(target => target.Counter.Value == 1),
+            "Subscriptions were lost to a concurrent unsubscribe, so a component that subscribed successfully never receives its messages.");
+        Assert.AreEqual(0, doomedTargets.Count(target => target.Counter.Value != 0),
+            "An unsubscribed handler was still invoked.");
+    }
+
+    /// <summary>
+    /// A faulted handler task is routed to <c>ClientExceptionHandlerBase</c> through a <c>ContinueWith</c> that nobody
+    /// awaits, so the continuation is the terminal observer of that exception. If resolving the handler throws - the
+    /// service provider here is a bare fake, which is exactly what a torn-down Blazor Server circuit scope behaves
+    /// like - the continuation must not fault in turn and take the original exception down with it.
+    /// </summary>
+    [TestMethod]
+    public async Task AFaultedHandler_Should_NotProduceAnUnobservedTaskException_WhenTheExceptionHandlerCannotBeResolved()
+    {
+        var pubSub = CreatePubSubService();
+        var unobserved = new List<Exception>();
+
+        void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e) => unobserved.Add(e.Exception);
+
+        TaskScheduler.UnobservedTaskException += OnUnobserved;
+        try
+        {
+            RunFaultingPublish(pubSub);
+
+            // The continuation runs on the thread pool; give it a turn, then force the finalizers that raise
+            // UnobservedTaskException for any task that faulted without being observed.
+            await Task.Delay(200);
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(200);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= OnUnobserved;
+        }
+
+        Assert.IsEmpty(unobserved,
+            "The faulted-handler continuation threw while resolving the exception handler, which destroys the exception it exists to report.");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RunFaultingPublish(PubSubService pubSub)
+    {
+        var target = new FaultingSubscriberTarget();
+        _ = pubSub.Subscribe(Message, target.HandleAsync);
+        pubSub.Publish(Message);
+        GC.KeepAlive(target);
+    }
+
+    private sealed class FaultingSubscriberTarget
+    {
+        public async Task HandleAsync(object? payload)
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("handler blew up");
+        }
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference SubscribeAndForget(PubSubService pubSub, StrongBox<int> counter)
     {
@@ -223,6 +330,8 @@ public class PubSubServiceTests
 
     private sealed class SubscriberTarget(StrongBox<int> counter)
     {
+        public StrongBox<int> Counter { get; } = counter;
+
         public Task HandleAsync(object? payload)
         {
             counter.Value++;

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ServerWeb/SecurityHeadersTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/ServerWeb/SecurityHeadersTests.cs
@@ -1,0 +1,93 @@
+//+:cnd:noEmit
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Boilerplate.Tests.Features.ServerWeb;
+
+/// <summary>
+/// Pins the parts of <c>UseSecurityHeaders</c> (<c>Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs</c>)
+/// that a shipped feature depends on, as opposed to the ones that are pure hardening and can be tightened freely.
+/// <para>
+/// The middleware only runs outside Development, so these tests host it on their own minimal app rather than through
+/// <see cref="AppTestServer"/>: that one is Development by construction, and the production branch it would have to
+/// take also turns on <c>UseHttpsRedirection</c>, which would answer every plain-http assertion with a 307.
+/// </para>
+/// </summary>
+[TestClass, TestCategory("IntegrationTest")]
+public class SecurityHeadersTests
+{
+    /// <summary>
+    /// <c>Permissions-Policy</c> lists the features this origin may even ask for, and an empty allowlist -
+    /// <c>microphone=()</c> - denies the origin itself, not just third parties. The AI chat panel dictates into the
+    /// message box, so it needs <c>microphone=(self)</c>.
+    /// <para>
+    /// This gets a test because the failure is invisible everywhere it would plausibly be looked for: the header is
+    /// only sent outside Development, Chrome on Android gates <c>SpeechRecognition</c> on this feature while Chrome on
+    /// desktop does not, and the browser reports the refusal as the same generic <c>not-allowed</c> that a user
+    /// declining the microphone prompt produces. So tightening it back to <c>()</c> breaks dictation on phones, in
+    /// production only, with an error message that blames the user.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task PermissionsPolicy_Should_LetThisOriginUseTheMicrophone()
+    {
+        var permissionsPolicy = await ReadPermissionsPolicy();
+
+        Assert.Contains("microphone=(self)", permissionsPolicy,
+            $"Dictation in the AI chat panel needs this origin to be allowed to request the microphone. Header: {permissionsPolicy}");
+    }
+
+    /// <summary>
+    /// Non-vacuity, and the reason the assertion above is not merely "the header mentions the microphone": everything
+    /// the template does not use stays denied. Without this, relaxing the whole header would keep the test above green
+    /// while quietly widening the attack surface.
+    /// </summary>
+    [TestMethod]
+    public async Task PermissionsPolicy_Should_StillDenyTheFeaturesNothingUses()
+    {
+        var permissionsPolicy = await ReadPermissionsPolicy();
+
+        foreach (var feature in (string[])["geolocation", "camera", "payment", "usb", "display-capture"])
+        {
+            Assert.Contains($"{feature}=()", permissionsPolicy,
+                $"Nothing in the template uses {feature}, so it should stay denied. Header: {permissionsPolicy}");
+        }
+    }
+
+    /// <summary>
+    /// Hosts <c>UseSecurityHeaders</c> on its own, in Production, and returns the <c>Permissions-Policy</c> it wrote.
+    /// </summary>
+    private async Task<string> ReadPermissionsPolicy()
+    {
+        var address = $"http://127.0.0.1:{Random.Shared.Next(20000, 30000)}";
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseUrls(address);
+        builder.Logging.ClearProviders();
+
+        await using var app = builder.Build();
+
+        app.UseSecurityHeaders();
+        app.MapGet("/", () => "ok");
+
+        await app.StartAsync(TestContext.CancellationToken);
+
+        try
+        {
+            using var httpClient = new HttpClient { BaseAddress = new Uri(address) };
+            using var response = await httpClient.GetAsync("/", TestContext.CancellationToken);
+
+            Assert.IsTrue(response.Headers.TryGetValues("Permissions-Policy", out var values),
+                "UseSecurityHeaders should write a Permissions-Policy header; without one these tests assert nothing.");
+
+            return string.Join(", ", values!);
+        }
+        finally
+        {
+            await app.StopAsync(TestContext.CancellationToken);
+        }
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}


### PR DESCRIPTION
closes #12891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added copy, read-aloud, and speech-to-text controls to AI chat.
  - Diagnostic tools can display logs retrieved from another device.
  - Improved clearing of cached files, browser storage, and cookies.
  - Search and advertising controls now appear only when supported.
- **Bug Fixes**
  - Prevented unnecessary PWA reload attempts while the app remains in the background.
  - Improved messaging reliability and error handling.
  - Pinned the diagnostic developer-tools script for safer loading.
- **Localization**
  - Added translations for AI chat voice controls and accent-color actions across supported languages.
- **Documentation**
  - Updated guidance for diagnostics, messaging, authorization, and service registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the Boilerplate AI chat with copy, read-aloud, and dictation controls while improving diagnostics, messaging, storage cleanup, platform configuration, localization, and documentation.
- Adds speech synthesis and recognition lifecycle handling to the AI chat panel.
- Adds remote diagnostic-log inspection and broader browser-storage cleanup.
- Updates messaging, CSP, PWA, platform manifests, resources, tests, and template guidance.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because rapid stop-and-restart interaction can leave an obsolete dictation startup competing with the current speech-recognition session.

The previously reported restart race remains: pending starts are distinguished only by the shared isListening flag, which a newer start can restore before an older interop call completes, allowing the obsolete invocation to publish its independent session.

**Files Needing Attention:** src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.cs | Adds copy, speech synthesis, speech recognition, and markdown-to-speech processing, with the previously reported restart race still present. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.cs | Adds support for switching between local diagnostic logs and logs fetched from another device while maintaining category filters. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Diagnostic/AppDiagnosticModal.razor.Utils.cs | Expands app-storage cleanup across cache, local storage, session storage, cookies, and hybrid storage with isolated error handling. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/PubSubService.cs | Improves publication and subscription behavior for application messages and is accompanied by focused tests. |
| src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Settings/Account/PasswordlessTab.razor.cs | Revises client-side passwordless configuration cleanup around the disable flow. |

</details>

<sub>Reviews (11): Last reviewed commit: ["improve bit Boilerplate AI chatbot (#128..."](https://github.com/bitfoundation/bitplatform/commit/8caace00bdc93c8adb7e7aed26519cc1692819f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52368649)</sub>

<!-- /greptile_comment -->