### PR TITLE
Update project dependencies (#12904)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     },
     "ghcr.io/devcontainers/features/node:1": { "version": "24" }
   },
-  "image": "mcr.microsoft.com/dotnet/sdk:10.0.302",
+  "image": "mcr.microsoft.com/dotnet/sdk:10.0.400",
   "postStartCommand": "dotnet workload install wasm-tools && dotnet dev-certs https --trust",
   "waitFor": "onCreateCommand",
   "customizations": {

--- a/.github/workflows/todo-sample.cd.yml
+++ b/.github/workflows/todo-sample.cd.yml
@@ -166,12 +166,13 @@ jobs:
         files: 'TodoSample/**/appsettings*json'
       env:
         ServerAddress: ${{ env.SERVER_API_ADDRESS }}
+        AdsPushVapid.PublicKey: ${{ secrets.TODO_PUBLIC_VAPIDKEY }}
         GoogleRecaptchaSiteKey: ${{ secrets.GOOGLE_RECAPTCHA_SITE_KEY }}
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        
+
     - name: Install wasm
       run:  cd src && dotnet workload install wasm-tools
 
@@ -215,12 +216,13 @@ jobs:
         files: 'TodoSample/**/appsettings*json'
       env:
         ServerAddress: ${{ env.SERVER_API_ADDRESS }}
+        AdsPushVapid.PublicKey: ${{ secrets.TODO_PUBLIC_VAPIDKEY }}
         GoogleRecaptchaSiteKey: ${{ secrets.GOOGLE_RECAPTCHA_SITE_KEY }}
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        
+
     - name: Install wasm
       run:  cd src && dotnet workload install wasm-tools
 
@@ -269,12 +271,13 @@ jobs:
         files: 'TodoSample/**/appsettings*json'
       env:
         ServerAddress: ${{ env.SERVER_API_ADDRESS }}
+        AdsPushVapid.PublicKey: ${{ secrets.TODO_PUBLIC_VAPIDKEY }}
         GoogleRecaptchaSiteKey: ${{ secrets.GOOGLE_RECAPTCHA_SITE_KEY }}
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        
+
     - name: Install wasm
       run:  cd src && dotnet workload install wasm-tools
 

--- a/src/Besql/Demo/Bit.Besql.Demo.Client/Bit.Besql.Demo.Client.csproj
+++ b/src/Besql/Demo/Bit.Besql.Demo.Client/Bit.Besql.Demo.Client.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Besql/Demo/Bit.Besql.Demo/Bit.Besql.Demo.csproj
+++ b/src/Besql/Demo/Bit.Besql.Demo/Bit.Besql.Demo.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Bit.Besql.Demo.Client\Bit.Besql.Demo.Client.csproj" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>
@@ -17,11 +17,11 @@
              and open Nuget Package Manager Console, and select `Bit.Besql.Demo.Client` project as default project
              Then run either Add-Migration MigrationName -OutputDir Data\Migrations or
              Optimize-DbContext -OutputDir Data\CompiledModel commands. -->
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tasks" Version="10.0.10">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tasks" Version="10.0.11">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Bit.BlazorUI.Demo.Server.csproj
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Bit.BlazorUI.Demo.Server.csproj
@@ -45,9 +45,9 @@
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
         <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.3" />
-        <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0" />
+        <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Shared/Bit.BlazorUI.Demo.Shared.csproj
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Shared/Bit.BlazorUI.Demo.Shared.csproj
@@ -13,10 +13,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-        <PackageReference Include="System.Text.Json" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+        <PackageReference Include="System.Text.Json" Version="10.0.11" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" ExcludeAssets="runtime">
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Bit.BlazorUI.Demo.Client.Core.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Bit.BlazorUI.Demo.Client.Core.csproj
@@ -29,10 +29,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
 
         <Using Include="System.Net.Http.Json" />
         <Using Include="System.Collections.Concurrent" />

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj
@@ -63,6 +63,8 @@
         <!-- https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets -->
         <EmccLinkOptimizationFlag>-O3</EmccLinkOptimizationFlag>
         <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+        <!-- Optimization flag for the AOT'ed assemblies bitcode, which defaults to -O2 in Release and is not covered by EmccCompileOptimizationFlag. -->
+        <WasmBitcodeCompileOptimizationFlag>-O3</WasmBitcodeCompileOptimizationFlag>
     </PropertyGroup>
 
 </Project>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Windows/Bit.BlazorUI.Demo.Client.Windows.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Windows/Bit.BlazorUI.Demo.Client.Windows.csproj
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
 
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.90" />
         <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4129.50" />
         <PackageReference Include="Velopack" Version="1.2.0" />

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
@@ -46,7 +46,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.AspNetCore.Components.WebView" Version="8.0.29" />
         <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.AspNetCore.Components.WebView" Version="9.0.18" />
-        <PackageReference Condition="'$(TargetFramework)' == 'net10.0'" Include="Microsoft.AspNetCore.Components.WebView" Version="10.0.10" />
+        <PackageReference Condition="'$(TargetFramework)' == 'net10.0'" Include="Microsoft.AspNetCore.Components.WebView" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Bit.Bmotion.Demo.Client.csproj
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Bit.Bmotion.Demo.Client.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Bit.Bmotion.Demo.Server.csproj
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Bit.Bmotion.Demo.Server.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <!-- Serves the client's _framework payload and enables WebAssembly debugging from this host. -->
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto.Client/Bit.Brouter.Samples.Auto.Client.csproj
+++ b/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto.Client/Bit.Brouter.Samples.Auto.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto.Client/Bit.Brouter.Samples.Auto.Client.csproj
+++ b/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto.Client/Bit.Brouter.Samples.Auto.Client.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto/Bit.Brouter.Samples.Auto.csproj
+++ b/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto/Bit.Brouter.Samples.Auto.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
-    <ProjectReference Include="..\Bit.Brouter.Demos.Auto.Client\Bit.Brouter.Demos.Auto.Client.csproj" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
+    <ProjectReference Include="..\Bit.Brouter.Samples.Auto.Client\Bit.Brouter.Samples.Auto.Client.csproj" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto/Bit.Brouter.Samples.Auto.csproj
+++ b/src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto/Bit.Brouter.Samples.Auto.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-    <ProjectReference Include="..\Bit.Brouter.Samples.Auto.Client\Bit.Brouter.Samples.Auto.Client.csproj" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+    <ProjectReference Include="..\Bit.Brouter.Demos.Auto.Client\Bit.Brouter.Demos.Auto.Client.csproj" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm.Client/Bit.Brouter.Samples.Wasm.Client.csproj
+++ b/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm.Client/Bit.Brouter.Samples.Wasm.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm.Client/Bit.Brouter.Samples.Wasm.Client.csproj
+++ b/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm.Client/Bit.Brouter.Samples.Wasm.Client.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm/Bit.Brouter.Samples.Wasm.csproj
+++ b/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm/Bit.Brouter.Samples.Wasm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-    <ProjectReference Include="..\Bit.Brouter.Samples.Wasm.Client\Bit.Brouter.Samples.Wasm.Client.csproj" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+    <ProjectReference Include="..\Bit.Brouter.Demos.Wasm.Client\Bit.Brouter.Demos.Wasm.Client.csproj" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm/Bit.Brouter.Samples.Wasm.csproj
+++ b/src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm/Bit.Brouter.Samples.Wasm.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
-    <ProjectReference Include="..\Bit.Brouter.Demos.Wasm.Client\Bit.Brouter.Demos.Wasm.Client.csproj" />
-    <ProjectReference Include="..\..\Core\Bit.Brouter.Demos.Core.csproj" />
+    <ProjectReference Include="..\Bit.Brouter.Samples.Wasm.Client\Bit.Brouter.Samples.Wasm.Client.csproj" />
+    <ProjectReference Include="..\..\Core\Bit.Brouter.Samples.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Bswup/Bit.Bswup.Demo/Client/Bit.Bswup.Demo.Client.csproj
+++ b/src/Bswup/Bit.Bswup.Demo/Client/Bit.Bswup.Demo.Client.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Bswup/Bit.Bswup.Demo/Server/Bit.Bswup.Demo.Server.csproj
+++ b/src/Bswup/Bit.Bswup.Demo/Server/Bit.Bswup.Demo.Server.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Bit.Bswup\Bit.Bswup.csproj" />
         <ProjectReference Include="..\Client\Bit.Bswup.Demo.Client.csproj" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
     </ItemGroup>
 
 </Project>

--- a/src/Bswup/Samples/BasicSample/Bit.Bswup.BasicSample.csproj
+++ b/src/Bswup/Samples/BasicSample/Bit.Bswup.BasicSample.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Bswup/Samples/FullSample/Client/Bit.Bswup.FullSample.Client.csproj
+++ b/src/Bswup/Samples/FullSample/Client/Bit.Bswup.FullSample.Client.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\Bit.Bswup\Bit.Bswup.csproj" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>
 

--- a/src/Bswup/Samples/FullSample/Server/Bit.Bswup.FullSample.Server.csproj
+++ b/src/Bswup/Samples/FullSample/Server/Bit.Bswup.FullSample.Server.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\Bit.Bswup\Bit.Bswup.csproj" />
         <ProjectReference Include="..\Client\Bit.Bswup.FullSample.Client.csproj" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
     </ItemGroup>
 
 </Project>

--- a/src/Butil/Bit.Butil.Demo/Client/Bit.Butil.Demo.Client.csproj
+++ b/src/Butil/Bit.Butil.Demo/Client/Bit.Butil.Demo.Client.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Butil/Bit.Butil.Demo/Server/Bit.Butil.Demo.Server.csproj
+++ b/src/Butil/Bit.Butil.Demo/Server/Bit.Butil.Demo.Server.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <!-- Serves the client's _framework payload and enables WebAssembly debugging from this host. -->
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Butil/Samples/Bit.Butil.Samples.Maui/Bit.Butil.Samples.Maui.csproj
+++ b/src/Butil/Samples/Bit.Butil.Samples.Maui/Bit.Butil.Samples.Maui.csproj
@@ -52,7 +52,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.90" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.90" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Butil/Samples/Bit.Butil.Samples.Web/Bit.Butil.Samples.Web.csproj
+++ b/src/Butil/Samples/Bit.Butil.Samples.Web/Bit.Butil.Samples.Web.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ResxTranslator/Bit.ResxTranslator/Bit.ResxTranslator.csproj
+++ b/src/ResxTranslator/Bit.ResxTranslator/Bit.ResxTranslator.csproj
@@ -16,10 +16,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.3" />
         <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.11" />
     </ItemGroup>
 
 </Project>

--- a/src/Websites/Careers/src/Bit.Websites.Careers.Client/Bit.Websites.Careers.Client.csproj
+++ b/src/Websites/Careers/src/Bit.Websites.Careers.Client/Bit.Websites.Careers.Client.csproj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
         <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>
@@ -41,7 +41,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
 
         <Using Include="System.Net.Http.Json" />
         <Using Include="System.Collections.Concurrent" />
@@ -114,6 +114,8 @@
         <!-- https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets -->
         <EmccLinkOptimizationFlag>-O3</EmccLinkOptimizationFlag>
         <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+        <!-- Optimization flag for the AOT'ed assemblies bitcode, which defaults to -O2 in Release and is not covered by EmccCompileOptimizationFlag. -->
+        <WasmBitcodeCompileOptimizationFlag>-O3</WasmBitcodeCompileOptimizationFlag>
     </PropertyGroup>
 
 </Project>

--- a/src/Websites/Careers/src/Bit.Websites.Careers.Server/Bit.Websites.Careers.Server.csproj
+++ b/src/Websites/Careers/src/Bit.Websites.Careers.Server/Bit.Websites.Careers.Server.csproj
@@ -21,9 +21,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageReference Include="AspNetCore.HealthChecks.System" Version="9.0.0" />

--- a/src/Websites/Careers/src/Bit.Websites.Careers.Shared/Bit.Websites.Careers.Shared.csproj
+++ b/src/Websites/Careers/src/Bit.Websites.Careers.Shared/Bit.Websites.Careers.Shared.csproj
@@ -14,9 +14,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-        <PackageReference Include="System.Text.Json" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+        <PackageReference Include="System.Text.Json" Version="10.0.11" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" ExcludeAssets="runtime">
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Bit.Websites.Platform.Client.csproj
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Bit.Websites.Platform.Client.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>
@@ -48,8 +48,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
 
         <Using Include="System.Net.Http.Json" />
         <Using Include="System.Collections.Concurrent" />
@@ -132,6 +132,8 @@
         <!-- https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets -->
         <EmccLinkOptimizationFlag>-O3</EmccLinkOptimizationFlag>
         <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+        <!-- Optimization flag for the AOT'ed assemblies bitcode, which defaults to -O2 in Release and is not covered by EmccCompileOptimizationFlag. -->
+        <WasmBitcodeCompileOptimizationFlag>-O3</WasmBitcodeCompileOptimizationFlag>
     </PropertyGroup>
 
 </Project>

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates02GettingStartedPage.razor
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates02GettingStartedPage.razor
@@ -1,4 +1,4 @@
-@page "/templates/getting-started"
+﻿@page "/templates/getting-started"
 @page "/templates/development-prerequisites"
 @page "/boilerplate/getting-started"
 @page "/boilerplate/development-prerequisites"
@@ -99,7 +99,7 @@
                             {
                                 <br />
                                 <BitAccordion Title="Ubuntu instructions">
-                                <CodeBox>wget https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.302/dotnet-sdk-10.0.302-linux-x64.tar.gz -O $HOME/dotnet.tar.gz
+                                <CodeBox>wget https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.400/dotnet-sdk-10.0.400-linux-x64.tar.gz -O $HOME/dotnet.tar.gz
 mkdir -p $HOME/.dotnet
 tar zxf $HOME/dotnet.tar.gz -C "$HOME/.dotnet"
 echo 'PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH' >> ~/.bashrc

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Server/Bit.Websites.Platform.Server.csproj
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Server/Bit.Websites.Platform.Server.csproj
@@ -25,11 +25,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
         <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.3" />
-        <PackageReference Include="ModelContextProtocol" Version="2.0.0" />
+        <PackageReference Include="ModelContextProtocol" Version="2.1.0" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageReference Include="AspNetCore.HealthChecks.System" Version="9.0.0" />

--- a/src/Websites/Platform/src/Bit.Websites.Platform.Shared/Bit.Websites.Platform.Shared.csproj
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Shared/Bit.Websites.Platform.Shared.csproj
@@ -14,9 +14,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-        <PackageReference Include="System.Text.Json" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+        <PackageReference Include="System.Text.Json" Version="10.0.11" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" ExcludeAssets="runtime">
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Websites/Sales/src/Bit.Websites.Sales.Client/Bit.Websites.Sales.Client.csproj
+++ b/src/Websites/Sales/src/Bit.Websites.Sales.Client/Bit.Websites.Sales.Client.csproj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
         <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>
@@ -41,7 +41,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
 
         <Using Include="System.Net.Http.Json" />
         <Using Include="System.Collections.Concurrent" />
@@ -114,6 +114,8 @@
         <!-- https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets -->
         <EmccLinkOptimizationFlag>-O3</EmccLinkOptimizationFlag>
         <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+        <!-- Optimization flag for the AOT'ed assemblies bitcode, which defaults to -O2 in Release and is not covered by EmccCompileOptimizationFlag. -->
+        <WasmBitcodeCompileOptimizationFlag>-O3</WasmBitcodeCompileOptimizationFlag>
     </PropertyGroup>
 
 </Project>

--- a/src/Websites/Sales/src/Bit.Websites.Sales.Server/Bit.Websites.Sales.Server.csproj
+++ b/src/Websites/Sales/src/Bit.Websites.Sales.Server/Bit.Websites.Sales.Server.csproj
@@ -21,9 +21,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageReference Include="AspNetCore.HealthChecks.System" Version="9.0.0" />

--- a/src/Websites/Sales/src/Bit.Websites.Sales.Shared/Bit.Websites.Sales.Shared.csproj
+++ b/src/Websites/Sales/src/Bit.Websites.Sales.Shared/Bit.Websites.Sales.Shared.csproj
@@ -14,9 +14,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-        <PackageReference Include="System.Text.Json" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+        <PackageReference Include="System.Text.Json" Version="10.0.11" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" ExcludeAssets="runtime">
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.302",
+        "version": "10.0.400",
         "rollForward": "disable"
     },
     "test": {


### PR DESCRIPTION
closes #12904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development environment and project toolchain to .NET SDK 10.0.400.
  - Refreshed Blazor, ASP.NET Core, .NET, and related platform components to version 10.0.11.
  - Updated Model Context Protocol components to version 2.1.0.

- **Performance**
  - Improved Release-build WebAssembly optimization for faster, more efficient applications.

- **Deployment**
  - Added VAPID public-key configuration to supported deployment workflows, enabling push notification setup.

- **Documentation**
  - Updated getting-started instructions to reference the latest .NET SDK version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the repository to .NET SDK 10.0.400, refreshes .NET and Model Context Protocol dependencies, enables stronger Release WebAssembly optimization, and supplies VAPID configuration in deployment workflows.
- Updates .NET packages from 10.0.10 to 10.0.11 and Model Context Protocol packages to 2.1.0.
- Aligns the development container, global SDK pin, and installation documentation on SDK 10.0.400.
- Adds the AOT bitcode `-O3` optimization setting to website and Blazor demo clients.
- Adds the public VAPID key to Todo sample deployment transformations.
- Corrects the previously broken Brouter sample project references.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously broken Brouter references now resolve to existing sample projects and the stale project names have been removed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/global.json | Pins the repository to .NET SDK 10.0.400 with roll-forward disabled. |
| .github/workflows/todo-sample.cd.yml | Adds the VAPID public key to all three Todo sample deployment configuration transformations. |
| src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj | Enables `-O3` optimization for AOT assembly bitcode in Release builds. |
| src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto.Client/Bit.Brouter.Samples.Auto.Client.csproj | Updates the WebAssembly package and now references the existing Brouter Samples Core project. |
| src/Brouter/Samples/Auto/Bit.Brouter.Samples.Auto/Bit.Brouter.Samples.Auto.csproj | Updates the server package and now references the existing Auto client and Samples Core projects. |
| src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm.Client/Bit.Brouter.Samples.Wasm.Client.csproj | Updates the WebAssembly package and now references the existing Samples Core project. |
| src/Brouter/Samples/Wasm/Bit.Brouter.Samples.Wasm/Bit.Brouter.Samples.Wasm.csproj | Updates the server package and now references the existing Wasm client and Samples Core projects. |
| src/Websites/Platform/src/Bit.Websites.Platform.Client/Pages/Templates/Templates02GettingStartedPage.razor | Updates the documented Linux SDK download to version 10.0.400. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(project references): update project ..."](https://github.com/bitfoundation/bitplatform/commit/643012d19b72a660c1e6eaf62de567e17c4f4fa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52660630)</sub>

<!-- /greptile_comment -->