### PR TITLE
Add native permission management to bit Boilerplate #12913

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -645,6 +645,7 @@
                         "src/Tests/Features/Chatbot/AiChatMessageWireContractTests.cs",
                         "src/Tests/Features/Chatbot/AiChatPanelThemeUITests.cs",
                         "src/Tests/Features/Chatbot/AiChatPanelReadAloudUITests.cs",
+                        "src/Tests/Features/Chatbot/AiChatPanelDictationUITests.cs",
                         "src/Tests/Features/Chatbot/AiChatPanelTestBase.cs",
                         "src/Tests/Features/Chatbot/AppChatbotHistoryTests.cs",
                         "src/Tests/Features/Chatbot/TestChatClient.cs"

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppClientCoordinator.cs
@@ -37,6 +37,9 @@ public partial class AppClientCoordinator : AppComponentBase
     //#if (notification == true)
     [AutoInject] private IPushNotificationService pushNotificationService = default!;
     //#endif
+    //#if (brouter == true)
+    [AutoInject] private IBrouter brouter = default!;
+    //#endif
 
     private List<Action> unsubscribes = [];
 
@@ -75,16 +78,8 @@ public partial class AppClientCoordinator : AppComponentBase
 
             if (AppPlatform.IsBlazorHybrid is false)
             {
-                try
-                {
-                    BitButil.UseFastInvoke(); // Ensures that `TelemetryContext.Platform` is available to components using this value in their `OnInitAsync` method, such as `SignInPage.razor.cs`.
-                    var userAgentData = await userAgent.Extract();
-                    TelemetryContext.Platform = string.Join(' ', [userAgentData.Manufacturer, userAgentData.OsName, userAgentData.Name, "browser"]);
-                }
-                finally
-                {
-                    BitButil.UseNormalInvoke();
-                }
+                var userAgentData = await userAgent.Extract();
+                TelemetryContext.Platform = string.Join(' ', [userAgentData.Manufacturer, userAgentData.OsName, userAgentData.Name, "browser"]);
             }
             TelemetryContext.TimeZone = await jsRuntime.GetTimeZone();
             TelemetryContext.Culture = CultureInfo.CurrentCulture.Name;
@@ -146,9 +141,9 @@ public partial class AppClientCoordinator : AppComponentBase
         navigatorLogger.LogInformation("Navigator's location changed to {Location}", TelemetryContext.PageUrl);
     }
 
-    private Guid? lastPropagatedUserId = Guid.Empty;
+    private ClaimsPrincipal? lastPropagatedUser;
     /// <summary>
-    /// This code manages the association of a user with sensitive services, such as SignalR, push notifications, App Insights, and others, 
+    /// This code manages the association of a user with sensitive services, such as SignalR, push notifications, App Insights, and others,
     /// ensuring the user is correctly set or cleared as needed.
     /// </summary>
     public async Task PropagateAuthState(bool firstRun, Task<AuthenticationState> task)
@@ -158,9 +153,19 @@ public partial class AppClientCoordinator : AppComponentBase
             var user = (await task).User;
             var isAuthenticated = user.IsAuthenticated();
             var userId = isAuthenticated ? user.GetUserId() : (Guid?)null;
-            if (lastPropagatedUserId == userId)
+
+            if (user.IsTheSame(lastPropagatedUser))
                 return;
+
             await Abort(); // Cancels ongoing user id propagation, because the new authentication state is available.
+
+            //#if (brouter == true)
+            // KeepAlive routes are hidden rather than disposed, so a retained page would otherwise hand the next
+            // principal the previous one's search text and grid filters. This is what makes a full page reload
+            // unnecessary after a tenant switch (see NavigationManagerExtensions.RefreshCurrentPage).
+            brouter.ClearKeepAlive();
+            //#endif
+
             TelemetryContext.UserId = userId;
             TelemetryContext.UserSessionId = isAuthenticated ? user.GetSessionId() : null;
 
@@ -204,7 +209,7 @@ public partial class AppClientCoordinator : AppComponentBase
                 await UpdateUserSession();
             }
 
-            lastPropagatedUserId = userId;
+            lastPropagatedUser = user;
         }
         catch (Exception exp)
         {
@@ -249,9 +254,9 @@ public partial class AppClientCoordinator : AppComponentBase
             }
             else
             {
-                if (data is not null) return false; // Snack bar service does not support payload data. It would be a good idea to return false to the server so server knows that the message was not shown.
-
                 SnackBarService.Show("Boilerplate", message);
+
+                return data is null;  // Snack bar service does not support payload data. It would be a good idea to return false to the server so server knows that the message was not shown properly.
             }
 
             return true; // Message gets shown successfully. You CAN (not implemented yet) use this in server side in order to not to send push notifications for messages that are already shown in the client side.
@@ -373,6 +378,10 @@ public partial class AppClientCoordinator : AppComponentBase
         if (exception is null)
         {
             logger.LogInformation("SignalR state changed to {State}", hubConnection!.State);
+        }
+        else if (exception is OperationCanceledException)
+        {
+            logger.LogInformation("SignalR connection attempt cancelled.");
         }
         else
         {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppComponentBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppComponentBase.cs
@@ -263,8 +263,12 @@ public partial class AppComponentBase : OwningComponentBase, IAsyncDisposable
         await currentCts.TryCancel();
     }
 
+    private bool disposed;
     public async ValueTask DisposeAsync()
     {
+        if (disposed) return;
+        disposed = true;
+
         try
         {
             if (cts != null)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppDataAnnotationsValidator.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/AppDataAnnotationsValidator.cs
@@ -5,7 +5,8 @@ namespace Boilerplate.Client.Core.Components;
 
 /// <summary>
 /// To implement forms where each error is displayed according to the language chosen by the user, you can use the <see cref="DtoResourceTypeAttribute"/>
-/// on the corresponding class instead of using `<see cref="ValidationAttribute.ErrorResourceType" />` on each property. Check out <see cref="SignUpRequestDto.UserName"/> for an example.
+/// on the corresponding class instead of setting `<see cref="ValidationAttribute.ErrorMessageResourceType" />` on each property. Check out <see cref="SignUpRequestDto.UserName"/> for an example.
+/// A property opts out simply by setting it: the DTO's resource type is only injected where <see cref="ValidationAttribute.ErrorMessageResourceType"/> is still null.
 /// However, you need to use <see cref="AppDataAnnotationsValidator"/> instead of <see cref="DataAnnotationsValidator"/> in Blazor EditForms for this method to work.
 /// Additionally, this provides the `<see cref="DisplayErrors(ResourceValidationException)"/>` method, which assists in displaying dynamic error messages.
 /// </summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.SpeechRecognition.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/AppAiChatPanel.razor.SpeechRecognition.cs
@@ -6,6 +6,7 @@ namespace Boilerplate.Client.Core.Components.Layout;
 public partial class AppAiChatPanel
 {
     [AutoInject] private SpeechRecognition speechRecognition = default!;
+    [AutoInject] private IPermissionService permissionService = default!;
     [AutoInject] private ILogger<AppAiChatPanel> logger = default!;
 
 
@@ -32,6 +33,13 @@ public partial class AppAiChatPanel
         if (isListening)
         {
             await StopDictation();
+            return;
+        }
+
+        if (await permissionService.RequestMicrophonePermission() is false)
+        {
+            SnackBarService.Error(Localizer[nameof(AppStrings.AiChatPanelDictation)],
+                                  Localizer[nameof(AppStrings.AiChatPanelMicrophoneBlocked)]);
             return;
         }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/Header/AppMenu.razor.cs
@@ -17,6 +17,9 @@ public partial class AppMenu
     [AutoInject] private IUserController userController = default!;
     [AutoInject] private CultureInfoManager cultureInfoManager = default!;
     [AutoInject] private SignInModalService signInModalService = default!;
+    //#if (brouter == true && multitenant == true)
+    [AutoInject] private IBrouter brouter = default!;
+    //#endif
 
 
     private bool isOpen;
@@ -91,6 +94,10 @@ public partial class AppMenu
         // Switching calls the refresh token api that stores the new tenant id in the token's claims (See IdentityController.Refresh).
         if (await AuthManager.SwitchTenant(newTenantId, CurrentCancellationToken))
         {
+            //#if (brouter == true)
+            brouter.ClearKeepAlive();
+            //#endif
+
             NavigationManager.RefreshCurrentPage(); // Re-renders the current page so it reflects the new tenant's data.
             // The layout's tenant display (next to the app version) updates on its own: switching changes the tenant claim, which
             // triggers the authentication-state change that MainLayout re-resolves the current tenant from (See MainLayout.SetCurrentTenantIfNeeded).

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Layout/MainLayout.razor.cs
@@ -154,6 +154,7 @@ public partial class MainLayout : IAsyncDisposable
         }
     }
 
+    private ClaimsPrincipal? lastAuthUser;
     private async Task SetCurrentUser(Task<AuthenticationState> task)
     {
         var authUser = (await task).User;
@@ -173,7 +174,7 @@ public partial class MainLayout : IAsyncDisposable
         }
         else
         {
-            if (authUser.GetUserId() != currentUser?.Id)
+            if (currentUser is null || authUser.IsTheSame(lastAuthUser) is false)
             {
                 currentUser = await userController.GetCurrentUser(getCurrentUserCts.Token);
             }
@@ -182,6 +183,8 @@ public partial class MainLayout : IAsyncDisposable
             await SetCurrentTenantIfNeeded(authUser.GetTenantId(), getCurrentUserCts.Token);
             //#endif
         }
+
+        lastAuthUser = authUser;
     }
 
     //#if (multitenant == true)

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/AppPageBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/AppPageBase.cs
@@ -10,28 +10,74 @@ public abstract partial class AppPageBase : AppComponentBase
     {
         DataGridStrings = new()
         {
-            PagerPageFormat = $"{Localizer[nameof(AppStrings.Page)]} {{0}} {Localizer[nameof(AppStrings.Of)]} {{1}}",
-            PagerRangeFormat = $"{{0}}–{{1}} {Localizer[nameof(AppStrings.Of)]} {{2}}"
+            EmptyText = Localizer[nameof(AppStrings.DataGridEmptyText)],
+            LoadingText = Localizer[nameof(AppStrings.DataGridLoadingText)],
+            ActionsText = Localizer[nameof(AppStrings.DataGridActionsText)],
+            AddRowText = Localizer[nameof(AppStrings.DataGridAddRowText)],
+            ClearFiltersText = Localizer[nameof(AppStrings.DataGridClearFiltersText)],
+            ExportCsvText = Localizer[nameof(AppStrings.DataGridExportCsvText)],
+            ExportExcelText = Localizer[nameof(AppStrings.DataGridExportExcelText)],
+            ColumnsText = Localizer[nameof(AppStrings.DataGridColumnsText)],
+            EditText = Localizer[nameof(AppStrings.DataGridEditText)],
+            DeleteText = Localizer[nameof(AppStrings.DataGridDeleteText)],
+            SaveText = Localizer[nameof(AppStrings.DataGridSaveText)],
+            CancelText = Localizer[nameof(AppStrings.DataGridCancelText)],
+            SelectAllLabel = Localizer[nameof(AppStrings.DataGridSelectAllLabel)],
+            SelectRowLabel = Localizer[nameof(AppStrings.DataGridSelectRowLabel)],
+            SelectRowFormat = Localizer[nameof(AppStrings.DataGridSelectRowFormat)],
+            FilterPlaceholder = Localizer[nameof(AppStrings.DataGridFilterPlaceholder)],
+            FilterByFormat = Localizer[nameof(AppStrings.DataGridFilterByFormat)],
+            FilterAllText = Localizer[nameof(AppStrings.DataGridFilterAllText)],
+            FilterOperatorLabel = Localizer[nameof(AppStrings.DataGridFilterOperatorLabel)],
+            FilterOpContains = Localizer[nameof(AppStrings.DataGridFilterOpContains)],
+            FilterOpDoesNotContain = Localizer[nameof(AppStrings.DataGridFilterOpDoesNotContain)],
+            FilterOpStartsWith = Localizer[nameof(AppStrings.DataGridFilterOpStartsWith)],
+            FilterOpEndsWith = Localizer[nameof(AppStrings.DataGridFilterOpEndsWith)],
+            BooleanTrueText = Localizer[nameof(AppStrings.DataGridBooleanTrueText)],
+            BooleanFalseText = Localizer[nameof(AppStrings.DataGridBooleanFalseText)],
+            GroupByFormat = Localizer[nameof(AppStrings.DataGridGroupByFormat)],
+            UngroupByFormat = Localizer[nameof(AppStrings.DataGridUngroupByFormat)],
+            ExpandGroupFormat = Localizer[nameof(AppStrings.DataGridExpandGroupFormat)],
+            CollapseGroupFormat = Localizer[nameof(AppStrings.DataGridCollapseGroupFormat)],
+            PagerRangeFormat = Localizer[nameof(AppStrings.DataGridPagerRangeFormat)],
+            PagerPageFormat = Localizer[nameof(AppStrings.DataGridPagerPageFormat)],
+            PerPageFormat = Localizer[nameof(AppStrings.DataGridPerPageFormat)],
+            RowsPerPageLabel = Localizer[nameof(AppStrings.DataGridRowsPerPageLabel)],
+            FirstPageLabel = Localizer[nameof(AppStrings.DataGridFirstPageLabel)],
+            PreviousPageLabel = Localizer[nameof(AppStrings.DataGridPreviousPageLabel)],
+            NextPageLabel = Localizer[nameof(AppStrings.DataGridNextPageLabel)],
+            LastPageLabel = Localizer[nameof(AppStrings.DataGridLastPageLabel)],
+            EndOfResultsText = Localizer[nameof(AppStrings.DataGridEndOfResultsText)],
+            ToggleDetailsLabel = Localizer[nameof(AppStrings.DataGridToggleDetailsLabel)],
+            ToggleChildrenLabel = Localizer[nameof(AppStrings.DataGridToggleChildrenLabel)],
+            ReorderRowTitle = Localizer[nameof(AppStrings.DataGridReorderRowTitle)],
+            ReorderRowLabel = Localizer[nameof(AppStrings.DataGridReorderRowLabel)],
+            InvalidValueError = Localizer[nameof(AppStrings.DataGridInvalidValueError)],
+            AnnouncementSortedAscending = Localizer[nameof(AppStrings.DataGridAnnouncementSortedAscending)],
+            AnnouncementSortedDescending = Localizer[nameof(AppStrings.DataGridAnnouncementSortedDescending)],
+            AnnouncementSortCleared = Localizer[nameof(AppStrings.DataGridAnnouncementSortCleared)],
+            AnnouncementFiltered = Localizer[nameof(AppStrings.DataGridAnnouncementFiltered)],
+            AnnouncementFilterCleared = Localizer[nameof(AppStrings.DataGridAnnouncementFilterCleared)],
+            AnnouncementPage = Localizer[nameof(AppStrings.DataGridAnnouncementPage)],
+            AnnouncementRowDeleted = Localizer[nameof(AppStrings.DataGridAnnouncementRowDeleted)]
         };
 
         await base.OnInitAsync();
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnParamsSetAsync()
     {
-        await base.OnAfterRenderAsync(firstRender);
+        await base.OnParamsSetAsync();
 
-        if (firstRender)
+        if (InPrerenderSession) return;
+
+        if (string.IsNullOrEmpty(culture)) return;
+
+        if (CultureInfoManager.InvariantGlobalization || CultureInfoManager.SupportedCultures.Any(sc => string.Equals(sc.Culture.Name, culture, StringComparison.InvariantCultureIgnoreCase)) is false)
         {
-            if (string.IsNullOrEmpty(culture) is false)
-            {
-                if (CultureInfoManager.InvariantGlobalization || CultureInfoManager.SupportedCultures.Any(sc => string.Equals(sc.Culture.Name, culture, StringComparison.InvariantCultureIgnoreCase)) is false)
-                {
-                    // Because Blazor router doesn't support regex, the '/{culture?}/' captures some irrelevant routes
-                    // such as non existing routes like /some-invalid-url, we need to make sure that the first segment of the route is a valid culture name.
-                    NavigationManager.NavigateTo($"{PageUrls.NotFound}?url={Uri.EscapeDataString(NavigationManager.GetRelativePath())}", replace: true);
-                }
-            }
+            // Because Blazor router doesn't support regex, the '/{culture?}/' captures some irrelevant routes
+            // such as non existing routes like /some-invalid-url, we need to make sure that the first segment of the route is a valid culture name.
+            NavigationManager.NavigateTo($"{PageUrls.NotFound}?url={Uri.EscapeDataString(NavigationManager.GetRelativePath())}", replace: true);
         }
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/RolesPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/RolesPage.razor.cs
@@ -97,20 +97,20 @@ public partial class RolesPage
             if (loadRoleDataCts is not null)
             {
                 using var currentCts = loadRoleDataCts;
-                loadRoleDataCts = new();
+                loadRoleDataCts = null;
 
                 await currentCts.TryCancel();
             }
 
-            loadRoleDataCts = new();
+            var loadCts = loadRoleDataCts = new();
 
             selectedRoleItem = item;
             loadingRoleKey = item.Key;
             editRoleName = selectedRoleItem.Text;
 
             var id = Guid.Parse(item.Key!);
-            await Task.WhenAll(LoadRoleUsers(id, loadRoleDataCts.Token),
-                               LoadRoleClaims(id, loadRoleDataCts.Token));
+            await Task.WhenAll(LoadRoleUsers(id, loadCts),
+                               LoadRoleClaims(id, loadCts));
         }
         finally
         {
@@ -121,14 +121,22 @@ public partial class RolesPage
         }
     }
 
-    private async Task LoadRoleUsers(Guid roleId, CancellationToken cancellationToken)
+    private async Task LoadRoleUsers(Guid roleId, CancellationTokenSource cancellationToken)
     {
-        selectedRoleUsers = await roleManagementController.GetUsers(roleId, cancellationToken);
+        var roleUsers = await roleManagementController.GetUsers(roleId, cancellationToken.Token);
+
+        if (ReferenceEquals(loadRoleDataCts, cancellationToken) is false) return; // User tapped on another role while this one was loading, so ignore the results
+
+        selectedRoleUsers = roleUsers;
     }
 
-    private async Task LoadRoleClaims(Guid roleId, CancellationToken cancellationToken)
+    private async Task LoadRoleClaims(Guid roleId, CancellationTokenSource cancellationToken)
     {
-        selectedRoleClaims = await roleManagementController.GetClaims(roleId, cancellationToken);
+        var roleClaims = await roleManagementController.GetClaims(roleId, cancellationToken.Token);
+
+        if (ReferenceEquals(loadRoleDataCts, cancellationToken) is false) return; // User tapped on another role while this one was loading, so ignore the results
+
+        selectedRoleClaims = roleClaims;
 
         var maxPrivilegedSessionsValue = selectedRoleClaims.FirstOrDefault(c => c.ClaimType == AppClaimTypes.MAX_PRIVILEGED_SESSIONS)?.ClaimValue;
         maxPrivilegedSessions = maxPrivilegedSessionsValue is null

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/UsersPage.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Pages/Management/UsersPage.razor.cs
@@ -104,13 +104,12 @@ public partial class UsersPage
         {
             if (loadRoleDataCts is not null)
             {
-                using var currentCts = loadRoleDataCts;
-                loadRoleDataCts = new();
-
-                await currentCts.TryCancel();
+                using var previousCts = loadRoleDataCts;
+                loadRoleDataCts = null;
+                await previousCts.TryCancel();
             }
 
-            loadRoleDataCts = new();
+            var loadCts = loadRoleDataCts = new();
 
             loadingUserKey = item.Key;
             selectedUserItem = item;
@@ -118,7 +117,11 @@ public partial class UsersPage
 
             user.Patch(selectedUserDto);
 
-            allUserSessions = await userManagementController.GetUserSessions(user.Id, CurrentCancellationToken);
+            var userSessions = await userManagementController.GetUserSessions(user.Id, loadCts.Token);
+
+            if (ReferenceEquals(loadRoleDataCts, loadCts) is false) return; // Selected user changed while we were loading, so don't assign the sessions to the previous user.
+
+            allUserSessions = userSessions;
 
             SearchSessions();
         }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Parameters.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Parameters.cs
@@ -3,11 +3,11 @@ namespace Boilerplate.Client.Core.Components;
 public class Parameters
 {
     /// <summary>
-    /// Indicates the connection status, with default behavior tied to the SignalR connection status.
-    /// <see cref="ExceptionDelegatingHandler"/> allows this value to be updated based on server responses:
+    /// Indicates the connection status. <see cref="ExceptionDelegatingHandler"/> drives it from server responses:
     /// - When the first response is received from the server, this value becomes true (Online).
     /// - When a <see cref="TransientException"/> occurs, it becomes false (Offline).
-    /// By default, this value is null (Unknown).
+    /// By default, this value is null (Unknown), and it only changes when a request is actually made - nothing polls.
+    /// When the app is built with SignalR, the hub connection state drives it as well (see AppClientCoordinator).
     /// </summary>
     public const string IsOnline = nameof(IsOnline);
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Routes.razor.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Components/Routes.razor.cs
@@ -5,35 +5,37 @@ public partial class Routes
 {
     [Parameter] public Type? Layout { get; set; }
 
-    [AutoInject] NavigationManager? navigationManager { set => universalLinksNavigationManager = value; get => universalLinksNavigationManager; }
-    private static NavigationManager? universalLinksNavigationManager;
+    [AutoInject]
+    NavigationManager? navigationManager
+    {
+        set
+        {
+            if (value is not null)
+            {
+                current = value;
+                NavigationManagerProvider.TrySetResult();
+            }
+        }
+        get;
+    }
+    private static NavigationManager? current;
+    private static readonly TaskCompletionSource NavigationManagerProvider = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public static async Task OpenUniversalLink(string url, bool forceLoad = false, bool replace = false)
     {
-        await EnsureNavigationManagerIsReady();
+        await NavigationManagerProvider.Task;
+
+        var navigationManager = current!;
 
         if (CultureInfoManager.InvariantGlobalization is false &&
             forceLoad == false &&
             (AppPlatform.IsAndroid || AppPlatform.IsIos))
         {
-            var currentCulture = CultureInfo.CurrentUICulture.Name;
-            var uri = new Uri(url);
-            var urlCulture = uri.GetCulture();
-            forceLoad = urlCulture is not null && string.Equals(currentCulture, urlCulture, StringComparison.InvariantCultureIgnoreCase) is false;
+            var urlCulture = new Uri(new Uri(navigationManager.BaseUri), url).GetCulture();
+            forceLoad = urlCulture is not null && string.Equals(CultureInfo.CurrentUICulture.Name, urlCulture, StringComparison.InvariantCultureIgnoreCase) is false;
         }
 
-        universalLinksNavigationManager!.NavigateTo(url, forceLoad, replace);
-    }
-
-    private static async Task EnsureNavigationManagerIsReady()
-    {
-        await Task.Run(async () =>
-        {
-            while (universalLinksNavigationManager is null)
-            {
-                await Task.Yield();
-            }
-        });
+        navigationManager.NavigateTo(url, forceLoad, replace);
     }
 }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/NavigationManagerExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Extensions/NavigationManagerExtensions.cs
@@ -25,7 +25,7 @@ public static partial class NavigationManagerExtensions
         /// </summary>
         public void RefreshCurrentPage()
         {
-            navigationManager.NavigateTo(navigationManager.GetUriPath(), forceLoad: true, replace: true);
+            navigationManager.NavigateTo(navigationManager.GetUriPath(), forceLoad: false, replace: true);
         }
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IPermissionService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Core/Infrastructure/Services/Contracts/IPermissionService.cs
@@ -1,0 +1,17 @@
+namespace Boilerplate.Client.Core.Infrastructure.Services.Contracts;
+
+/// <summary>
+/// Asks the operating system for a capability the app is about to use.
+/// <para>
+/// Only the hosts that wrap the app in a native shell have anything to do here: a browser prompts for itself the
+/// first time a web API needs the capability, whereas a web view inside a native app is refused by the platform
+/// before its own prompt is ever reached, so the native permission has to be granted first.
+/// </para>
+/// </summary>
+public interface IPermissionService
+{
+    /// <summary>
+    /// Whether the app may use the microphone, asking the user if the platform has not been answered already.
+    /// </summary>
+    Task<bool> RequestMicrophonePermission();
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiPermissionService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Infrastructure/Services/MauiPermissionService.cs
@@ -1,0 +1,34 @@
+namespace Boilerplate.Client.Maui.Infrastructure.Services;
+
+/// <summary>
+/// More info at <see cref="IPermissionService"/>
+/// <para>
+/// The web view is inside a native app, so the platform refuses the capability to the page unless the app itself
+/// holds it. Every permission asked for here has to be declared in the platform's manifest as well - Android's
+/// AndroidManifest.xml, the Info.plist of iOS and macOS, and Package.appxmanifest on Windows - and a missing
+/// declaration is a build-time configuration mistake that MAUI reports by throwing rather than by refusing.
+/// </para>
+/// </summary>
+public partial class MauiPermissionService : IPermissionService
+{
+    public async Task<bool> RequestMicrophonePermission()
+    {
+        return await RequestPermission<Permissions.Microphone>();
+    }
+
+    /// <summary>
+    /// The status is checked before it is requested because a request is only ever answered by the user once: after
+    /// a refusal the platform returns Denied without showing anything, and on the platforms where it does show the
+    /// dialog, asking for something already granted would put it in front of the user again.
+    /// </summary>
+    private static async Task<bool> RequestPermission<TPermission>()
+        where TPermission : Permissions.BasePermission, new()
+    {
+        if (await Permissions.CheckStatusAsync<TPermission>() is PermissionStatus.Granted)
+            return true;
+
+        var status = await MainThread.InvokeOnMainThreadAsync(Permissions.RequestAsync<TPermission>);
+
+        return status is PermissionStatus.Granted;
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/MauiProgram.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/MauiProgram.Services.cs
@@ -32,6 +32,7 @@ public static partial class MauiProgram
             services.AddScoped<SharedExceptionHandler>(sp => sp.GetRequiredService<ClientExceptionHandlerBase>());
 
             services.AddScoped<IAppUpdateService, MauiAppUpdateService>();
+            services.AddScoped<IPermissionService, MauiPermissionService>();
             services.AddScoped<IBitDeviceCoordinator, MauiDeviceCoordinator>();
             services.AddScoped<IExternalNavigationService, MauiExternalNavigationService>();
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebPermissionService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Infrastructure/Services/WebPermissionService.cs
@@ -1,0 +1,13 @@
+namespace Boilerplate.Client.Web.Infrastructure.Services;
+
+/// <summary>
+/// More info at <see cref="IPermissionService"/>
+/// <para>
+/// The browser owns its permissions: the web API that needs one raises the prompt itself and reports a refusal back
+/// through its own error path, so there is nothing to ask for ahead of time.
+/// </para>
+/// </summary>
+public partial class WebPermissionService : IPermissionService
+{
+    public Task<bool> RequestMicrophonePermission() => Task.FromResult(true);
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Web/Program.Services.cs
@@ -69,6 +69,7 @@ public static partial class Program
             //#endif
             services.AddScoped<IWebAuthnService, WebAuthnService>();
             services.AddScoped<IAppUpdateService, WebAppUpdateService>();
+            services.AddScoped<IPermissionService, WebPermissionService>();
 
             services.AddSingleton(sp => sp.GetRequiredService<IOptions<ClientWebSettings>>().Value);
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsPermissionService.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Infrastructure/Services/WindowsPermissionService.cs
@@ -1,0 +1,13 @@
+namespace Boilerplate.Client.Windows.Infrastructure.Services;
+
+/// <summary>
+/// More info at <see cref="IPermissionService"/>
+/// <para>
+/// The app is the web view: what the page asks for arrives as WebView2's PermissionRequested, which Program.cs
+/// grants, and Windows itself gates the device behind its own privacy settings. There is nothing left to ask.
+/// </para>
+/// </summary>
+public partial class WindowsPermissionService : IPermissionService
+{
+    public Task<bool> RequestMicrophonePermission() => Task.FromResult(true);
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Program.Services.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Windows/Program.Services.cs
@@ -29,6 +29,7 @@ public static partial class Program
             services.AddScoped<SharedExceptionHandler>(sp => sp.GetRequiredService<ClientExceptionHandlerBase>());
 
             services.AddScoped<IAppUpdateService, WindowsAppUpdateService>();
+            services.AddScoped<IPermissionService, WindowsPermissionService>();
             services.AddScoped<IBitDeviceCoordinator, WindowsDeviceCoordinator>();
 
             services.AddScoped<HttpClient>(sp =>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
@@ -3,11 +3,53 @@ namespace System.Security.Claims;
 
 public static partial class ClaimsPrincipalExtensions
 {
+    /// <summary>
+    /// Claims a token refresh rewrites without changing anything the user is allowed to do: issued-at, not-before,
+    /// expiry and the token's own id. Everything else the token carries - the user id, the roles, the features, the
+    /// tenant, the session id, and the privileged/elevated markers - decides what the app may show and what the
+    /// server will authorize, so all of it is significant.
+    /// </summary>
+    private static string[]? volatileClaimTypes;
+
     extension(ClaimsPrincipal? claimsPrincipal)
     {
         public bool IsAuthenticated()
         {
             return claimsPrincipal?.Identity?.IsAuthenticated is true;
+        }
+
+        /// <summary>
+        /// True when two principals grant exactly the same thing - same identity, same roles, same features, same
+        /// tenant, same session - ignoring only the claims a refresh rewrites for its own sake.
+        /// <para>
+        /// This is the question every <c>AuthenticationStateChanged</c> handler actually wants to ask. Comparing the
+        /// user id alone is not enough: a tenant switch, an elevated-access grant and a role change all issue a new
+        /// token for the SAME user, and a handler keyed on the user id treats them as "nothing happened".
+        /// </para>
+        /// </summary>
+        public bool IsTheSame(ClaimsPrincipal? other)
+        {
+            if (ReferenceEquals(claimsPrincipal, other)) return true;
+
+            if (claimsPrincipal is null || other is null) return false;
+
+            if (claimsPrincipal.IsAuthenticated() != other.IsAuthenticated()) return false;
+
+            volatileClaimTypes ??= ["exp", "iat", "nbf", "jti", "auth_time"];
+
+            static Dictionary<(string Type, string Value), int> SignificantClaims(ClaimsPrincipal principal)
+            {
+                return principal.Claims
+                                .Where(claim => volatileClaimTypes.Contains(claim.Type, StringComparer.OrdinalIgnoreCase) is false)
+                                .GroupBy(claim => (claim.Type, claim.Value))
+                                .ToDictionary(group => group.Key, group => group.Count());
+            }
+
+            var current = SignificantClaims(claimsPrincipal);
+            var others = SignificantClaims(other);
+
+            return current.Count == others.Count &&
+                   current.All(claim => others.TryGetValue(claim.Key, out var count) && count == claim.Value);
         }
     }
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.ar.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>تعذر الاتصال بالخادم</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>لا توجد سجلات للعرض.</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>جارٍ التحميل…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>الإجراءات</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ إضافة</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>مسح عوامل التصفية</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>تصدير CSV</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>تصدير Excel</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>الأعمدة</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>تعديل</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>حفظ</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>إلغاء</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>تحديد الكل</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>تحديد الصف</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>تحديد الصف: {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>تصفية…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>تصفية حسب {0}</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>الكل</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>عامل التصفية لـ {0}</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>يحتوي على</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>لا يحتوي على</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>يبدأ بـ</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>ينتهي بـ</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>صحيح</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>خطأ</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>تجميع حسب {0}</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>إلغاء التجميع حسب {0}</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>توسيع المجموعة {0}: {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>طي المجموعة {0}: {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} من {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>الصفحة {0} من {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / صفحة</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>الصفوف لكل صفحة</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>الصفحة الأولى</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>الصفحة السابقة</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>الصفحة التالية</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>الصفحة الأخيرة</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- نهاية النتائج -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>إظهار/إخفاء التفاصيل</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>إظهار/إخفاء العناصر الفرعية</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>اسحب لإعادة الترتيب، أو ركّز واستخدم مفاتيح الأسهم لنقل هذا الصف</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>إعادة ترتيب الصف. اضغط على السهم لأعلى أو لأسفل لنقل هذا الصف.</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>قيمة غير صالحة لـ {0}.</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>مرتب حسب {0} تصاعديًا</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>مرتب حسب {0} تنازليًا</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>تمت إزالة الترتيب حسب {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>تم تطبيق التصفية على {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>تم مسح التصفية على {0}</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>الصفحة {0} من {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>تم حذف الصف</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>نشط</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.de.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>Verbindung zum Server nicht möglich.</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>Keine Datensätze vorhanden.</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>Wird geladen…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>Aktionen</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ Hinzufügen</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>Filter zurücksetzen</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>CSV exportieren</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Excel exportieren</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>Spalten</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>Bearbeiten</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>Alle auswählen</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>Zeile auswählen</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>Zeile auswählen: {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>Filtern…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>Nach {0} filtern</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>Alle</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>Filteroperator für {0}</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>Enthält</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>Enthält nicht</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>Beginnt mit</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>Endet mit</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>Wahr</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>Falsch</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>Nach {0} gruppieren</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>Gruppierung nach {0} aufheben</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>Gruppe {0} erweitern: {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>Gruppe {0} reduzieren: {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} von {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>Seite {0} von {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / Seite</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>Zeilen pro Seite</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>Erste Seite</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>Vorherige Seite</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>Nächste Seite</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>Letzte Seite</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- Ende der Ergebnisse -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>Details ein-/ausblenden</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>Untereinträge ein-/ausblenden</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>Zum Neuanordnen ziehen oder fokussieren und die Pfeiltasten verwenden, um diese Zeile zu verschieben</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>Zeile neu anordnen. Drücken Sie Pfeil nach oben oder unten, um diese Zeile zu verschieben.</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>Ungültiger Wert für {0}.</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>Sortiert nach {0}, aufsteigend</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>Sortiert nach {0}, absteigend</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>Sortierung nach {0} entfernt</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>Filter auf {0} angewendet</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>Filter auf {0} entfernt</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>Seite {0} von {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>Zeile gelöscht</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>Aktiv</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.es.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>No se puede conectar al servidor.</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>No hay registros para mostrar.</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>Cargando…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>Acciones</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ Agregar</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>Borrar filtros</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>Exportar CSV</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Exportar Excel</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>Columnas</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>Seleccionar todo</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>Seleccionar fila</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>Seleccionar fila: {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>Filtrar…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>Filtrar por {0}</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>Operador de filtro para {0}</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>Contiene</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>No contiene</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>Empieza por</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>Termina en</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>Verdadero</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>Falso</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>Agrupar por {0}</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>Desagrupar por {0}</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>Expandir grupo {0}: {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>Contraer grupo {0}: {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} de {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>Página {0} de {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / página</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>Filas por página</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>Primera página</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>Página anterior</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>Página siguiente</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>Última página</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- Fin de los resultados -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>Mostrar u ocultar detalles</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>Mostrar u ocultar elementos secundarios</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>Arrastre para reordenar, o enfoque y use las teclas de flecha para mover esta fila</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>Reordenar fila. Pulse Flecha arriba o Flecha abajo para mover esta fila.</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>Valor no válido para {0}.</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>Ordenado por {0}, ascendente</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>Ordenado por {0}, descendente</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>Se quitó la ordenación por {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>Filtro aplicado en {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>Se borró el filtro en {0}</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>Página {0} de {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>Fila eliminada</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>Activo</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fa.resx
@@ -177,6 +177,157 @@
     <data name="TransientException" xml:space="preserve">
     <value>قادر به اتصال به سرور نیست.</value>
   </data>
+    <!-- Bit.BlazorUI messages -->
+    <data name="DataGridEmptyText" xml:space="preserve">
+    <value>رکوردی برای نمایش وجود ندارد.</value>
+  </data>
+    <data name="DataGridLoadingText" xml:space="preserve">
+    <value>در حال بارگذاری…</value>
+  </data>
+    <data name="DataGridActionsText" xml:space="preserve">
+    <value>عملیات</value>
+  </data>
+    <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ افزودن</value>
+  </data>
+    <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>پاک کردن فیلترها</value>
+  </data>
+    <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>خروجی CSV</value>
+  </data>
+    <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>خروجی Excel</value>
+  </data>
+    <data name="DataGridColumnsText" xml:space="preserve">
+    <value>ستون‌ها</value>
+  </data>
+    <data name="DataGridEditText" xml:space="preserve">
+    <value>ویرایش</value>
+  </data>
+    <data name="DataGridDeleteText" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+    <data name="DataGridSaveText" xml:space="preserve">
+    <value>ذخیره</value>
+  </data>
+    <data name="DataGridCancelText" xml:space="preserve">
+    <value>انصراف</value>
+  </data>
+    <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>انتخاب همه</value>
+  </data>
+    <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>انتخاب سطر</value>
+  </data>
+    <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>انتخاب سطر: {0}</value>
+  </data>
+    <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>فیلتر…</value>
+  </data>
+    <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>فیلتر بر اساس {0}</value>
+  </data>
+    <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>همه</value>
+  </data>
+    <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>عملگر فیلتر برای {0}</value>
+  </data>
+    <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>شامل</value>
+  </data>
+    <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>شامل نیست</value>
+  </data>
+    <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>شروع می‌شود با</value>
+  </data>
+    <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>پایان می‌یابد با</value>
+  </data>
+    <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>درست</value>
+  </data>
+    <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>نادرست</value>
+  </data>
+    <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>گروه‌بندی بر اساس {0}</value>
+  </data>
+    <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>لغو گروه‌بندی بر اساس {0}</value>
+  </data>
+    <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>باز کردن گروه {0}: {1}</value>
+  </data>
+    <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>بستن گروه {0}: {1}</value>
+  </data>
+    <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} از {2}</value>
+  </data>
+    <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>صفحه {0} از {1}</value>
+  </data>
+    <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / صفحه</value>
+  </data>
+    <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>سطر در هر صفحه</value>
+  </data>
+    <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>صفحه اول</value>
+  </data>
+    <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>صفحه قبل</value>
+  </data>
+    <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>صفحه بعد</value>
+  </data>
+    <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>صفحه آخر</value>
+  </data>
+    <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- پایان نتایج -</value>
+  </data>
+    <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>نمایش/پنهان کردن جزئیات</value>
+  </data>
+    <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>نمایش/پنهان کردن زیرمجموعه‌ها</value>
+  </data>
+    <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>برای تغییر ترتیب بکشید، یا فوکوس کنید و با کلیدهای جهت‌نما این سطر را جابه‌جا کنید</value>
+  </data>
+    <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>تغییر ترتیب سطر. برای جابه‌جایی این سطر کلید بالا یا پایین را فشار دهید.</value>
+  </data>
+    <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>مقدار نامعتبر برای {0}.</value>
+  </data>
+    <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>مرتب‌شده بر اساس {0}، صعودی</value>
+  </data>
+    <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>مرتب‌شده بر اساس {0}، نزولی</value>
+  </data>
+    <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>مرتب‌سازی بر اساس {0} حذف شد</value>
+  </data>
+    <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>فیلتر روی {0} اعمال شد</value>
+  </data>
+    <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>فیلتر روی {0} پاک شد</value>
+  </data>
+    <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>صفحه {0} از {1}</value>
+  </data>
+    <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>سطر حذف شد</value>
+  </data>
     <!-- Boilerplate strings -->
     <data name="Active" xml:space="preserve">
     <value>فعال</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.fr.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>Impossible de se connecter au serveur.</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>Aucun enregistrement à afficher.</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>Chargement…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ Ajouter</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>Effacer les filtres</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>Exporter en CSV</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Exporter en Excel</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>Colonnes</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>Modifier</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>Tout sélectionner</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>Sélectionner la ligne</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>Sélectionner la ligne : {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>Filtrer…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>Filtrer par {0}</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>Tous</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>Opérateur de filtre pour {0}</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>Contient</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>Ne contient pas</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>Commence par</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>Se termine par</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>Vrai</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>Faux</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>Grouper par {0}</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>Dégrouper par {0}</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>Développer le groupe {0} : {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>Réduire le groupe {0} : {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} sur {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>Page {0} sur {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / page</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>Lignes par page</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>Première page</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>Page précédente</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>Page suivante</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>Dernière page</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- Fin des résultats -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>Afficher/masquer les détails</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>Afficher/masquer les éléments enfants</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>Faites glisser pour réorganiser, ou placez le focus et utilisez les touches fléchées pour déplacer cette ligne</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>Réorganiser la ligne. Appuyez sur Flèche haut ou Flèche bas pour déplacer cette ligne.</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>Valeur non valide pour {0}.</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>Trié par {0}, croissant</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>Trié par {0}, décroissant</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>Tri par {0} supprimé</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>Filtre appliqué sur {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>Filtre sur {0} effacé</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>Page {0} sur {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>Ligne supprimée</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>Actif</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.hi.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>सर्वर से कनेक्ट करने में असमर्थ।</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>प्रदर्शित करने के लिए कोई रिकॉर्ड नहीं है।</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>लोड हो रहा है…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>क्रियाएँ</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ जोड़ें</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>फ़िल्टर साफ़ करें</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>CSV निर्यात करें</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Excel निर्यात करें</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>कॉलम</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>संपादित करें</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>हटाएँ</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>सहेजें</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>रद्द करें</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>सभी चुनें</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>पंक्ति चुनें</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>पंक्ति चुनें: {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>फ़िल्टर…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>{0} के अनुसार फ़िल्टर करें</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>सभी</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>{0} के लिए फ़िल्टर ऑपरेटर</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>शामिल है</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>शामिल नहीं है</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>से शुरू होता है</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>से समाप्त होता है</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>सत्य</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>असत्य</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>{0} के अनुसार समूहित करें</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>{0} के अनुसार समूह हटाएँ</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>समूह {0} विस्तृत करें: {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>समूह {0} संक्षिप्त करें: {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{2} में से {0}–{1}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>पृष्ठ {0} / {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / पृष्ठ</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>प्रति पृष्ठ पंक्तियाँ</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>पहला पृष्ठ</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>पिछला पृष्ठ</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>अगला पृष्ठ</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>अंतिम पृष्ठ</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- परिणामों का अंत -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>विवरण दिखाएँ/छिपाएँ</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>उप-आइटम दिखाएँ/छिपाएँ</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>पुनः क्रमित करने के लिए खींचें, या फ़ोकस करके तीर कुंजियों से इस पंक्ति को ले जाएँ</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>पंक्ति पुनः क्रमित करें। इस पंक्ति को ले जाने के लिए ऊपर या नीचे तीर दबाएँ।</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>{0} के लिए अमान्य मान।</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>{0} के अनुसार आरोही क्रम में क्रमबद्ध</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>{0} के अनुसार अवरोही क्रम में क्रमबद्ध</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>{0} के अनुसार क्रमबद्धता हटाई गई</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>{0} पर फ़िल्टर लागू किया गया</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>{0} पर फ़िल्टर हटाया गया</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>पृष्ठ {0} / {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>पंक्ति हटाई गई</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>सक्रिय</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.nl.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>Kan geen verbinding maken met de server.</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>Geen records om weer te geven.</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>Laden…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>Acties</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ Toevoegen</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>Filters wissen</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>CSV exporteren</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Excel exporteren</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>Kolommen</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>Bewerken</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>Alles selecteren</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>Rij selecteren</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>Rij selecteren: {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>Filteren…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>Filteren op {0}</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>Alle</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>Filteroperator voor {0}</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>Bevat</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>Bevat niet</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>Begint met</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>Eindigt op</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>Waar</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>Onwaar</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>Groeperen op {0}</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>Groepering op {0} opheffen</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>Groep {0} uitvouwen: {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>Groep {0} samenvouwen: {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} van {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>Pagina {0} van {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / pagina</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>Rijen per pagina</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>Eerste pagina</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>Vorige pagina</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>Volgende pagina</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>Laatste pagina</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- Einde van de resultaten -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>Details tonen/verbergen</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>Onderliggende items tonen/verbergen</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>Sleep om de volgorde te wijzigen, of focus en gebruik de pijltoetsen om deze rij te verplaatsen</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>Rij herordenen. Druk op pijl omhoog of omlaag om deze rij te verplaatsen.</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>Ongeldige waarde voor {0}.</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>Gesorteerd op {0}, oplopend</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>Gesorteerd op {0}, aflopend</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>Sortering op {0} verwijderd</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>Filter toegepast op {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>Filter op {0} gewist</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>Pagina {0} van {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>Rij verwijderd</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>Actief</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.resx
@@ -177,6 +177,157 @@
     <data name="TransientException" xml:space="preserve">
     <value>Unable to connect to server.</value>
   </data>
+    <!-- Bit.BlazorUI messages -->
+    <data name="DataGridEmptyText" xml:space="preserve">
+    <value>No records to display.</value>
+  </data>
+    <data name="DataGridLoadingText" xml:space="preserve">
+    <value>Loading…</value>
+  </data>
+    <data name="DataGridActionsText" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+    <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ Add</value>
+  </data>
+    <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>Clear filters</value>
+  </data>
+    <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>Export CSV</value>
+  </data>
+    <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Export Excel</value>
+  </data>
+    <data name="DataGridColumnsText" xml:space="preserve">
+    <value>Columns</value>
+  </data>
+    <data name="DataGridEditText" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+    <data name="DataGridDeleteText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+    <data name="DataGridSaveText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+    <data name="DataGridCancelText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+    <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>Select all</value>
+  </data>
+    <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>Select row</value>
+  </data>
+    <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>Select row: {0}</value>
+  </data>
+    <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>Filter…</value>
+  </data>
+    <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>Filter by {0}</value>
+  </data>
+    <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>All</value>
+  </data>
+    <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>Filter operator for {0}</value>
+  </data>
+    <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>Contains</value>
+  </data>
+    <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>Doesn't contain</value>
+  </data>
+    <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>Starts with</value>
+  </data>
+    <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>Ends with</value>
+  </data>
+    <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>True</value>
+  </data>
+    <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>False</value>
+  </data>
+    <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>Group by {0}</value>
+  </data>
+    <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>Ungroup by {0}</value>
+  </data>
+    <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>Expand group {0}: {1}</value>
+  </data>
+    <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>Collapse group {0}: {1}</value>
+  </data>
+    <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} of {2}</value>
+  </data>
+    <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>Page {0} of {1}</value>
+  </data>
+    <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / page</value>
+  </data>
+    <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>Rows per page</value>
+  </data>
+    <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>First page</value>
+  </data>
+    <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>Previous page</value>
+  </data>
+    <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>Next page</value>
+  </data>
+    <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>Last page</value>
+  </data>
+    <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- End of results -</value>
+  </data>
+    <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>Toggle details</value>
+  </data>
+    <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>Toggle children</value>
+  </data>
+    <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>Drag to reorder, or focus and use the arrow keys to move this row</value>
+  </data>
+    <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>Reorder row. Press Arrow Up or Arrow Down to move this row.</value>
+  </data>
+    <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>Invalid value for {0}.</value>
+  </data>
+    <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>Sorted by {0}, ascending</value>
+  </data>
+    <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>Sorted by {0}, descending</value>
+  </data>
+    <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>Sorting by {0} removed</value>
+  </data>
+    <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>Filter applied on {0}</value>
+  </data>
+    <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>Filter on {0} cleared</value>
+  </data>
+    <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>Page {0} of {1}</value>
+  </data>
+    <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>Row deleted</value>
+  </data>
     <!-- Boilerplate strings -->
     <data name="Active" xml:space="preserve">
     <value>Active</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.sv.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>Kan inte ansluta till servern.</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>Inga poster att visa.</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>Läser in…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>Åtgärder</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ Lägg till</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>Rensa filter</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>Exportera CSV</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>Exportera Excel</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>Kolumner</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>Redigera</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>Ta bort</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>Spara</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>Avbryt</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>Markera alla</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>Markera rad</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>Markera rad: {0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>Filtrera…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>Filtrera efter {0}</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>Alla</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>Filteroperator för {0}</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>Innehåller</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>Innehåller inte</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>Börjar med</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>Slutar med</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>Sant</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>Falskt</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>Gruppera efter {0}</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>Ta bort gruppering efter {0}</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>Expandera grupp {0}: {1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>Dölj grupp {0}: {1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1} av {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>Sida {0} av {1}</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} / sida</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>Rader per sida</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>Första sidan</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>Föregående sida</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>Nästa sida</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>Sista sidan</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- Slut på resultaten -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>Visa/dölj detaljer</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>Visa/dölj underordnade</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>Dra för att ändra ordning, eller fokusera och använd piltangenterna för att flytta raden</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>Ändra ordning på raden. Tryck på uppåt- eller nedåtpil för att flytta raden.</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>Ogiltigt värde för {0}.</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>Sorterat efter {0}, stigande</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>Sorterat efter {0}, fallande</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>Sortering efter {0} borttagen</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>Filter tillämpat på {0}</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>Filter på {0} rensat</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>Sida {0} av {1}</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>Raden har tagits bort</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>Aktiv</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Shared/Resources/AppStrings.zh.resx
@@ -177,6 +177,157 @@
   <data name="TransientException" xml:space="preserve">
     <value>无法连接到服务器。</value>
   </data>
+  <!-- Bit.BlazorUI messages -->
+  <data name="DataGridEmptyText" xml:space="preserve">
+    <value>没有可显示的记录。</value>
+  </data>
+  <data name="DataGridLoadingText" xml:space="preserve">
+    <value>加载中…</value>
+  </data>
+  <data name="DataGridActionsText" xml:space="preserve">
+    <value>操作</value>
+  </data>
+  <data name="DataGridAddRowText" xml:space="preserve">
+    <value>+ 添加</value>
+  </data>
+  <data name="DataGridClearFiltersText" xml:space="preserve">
+    <value>清除筛选</value>
+  </data>
+  <data name="DataGridExportCsvText" xml:space="preserve">
+    <value>导出 CSV</value>
+  </data>
+  <data name="DataGridExportExcelText" xml:space="preserve">
+    <value>导出 Excel</value>
+  </data>
+  <data name="DataGridColumnsText" xml:space="preserve">
+    <value>列</value>
+  </data>
+  <data name="DataGridEditText" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="DataGridDeleteText" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="DataGridSaveText" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="DataGridCancelText" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="DataGridSelectAllLabel" xml:space="preserve">
+    <value>全选</value>
+  </data>
+  <data name="DataGridSelectRowLabel" xml:space="preserve">
+    <value>选择行</value>
+  </data>
+  <data name="DataGridSelectRowFormat" xml:space="preserve">
+    <value>选择行：{0}</value>
+  </data>
+  <data name="DataGridFilterPlaceholder" xml:space="preserve">
+    <value>筛选…</value>
+  </data>
+  <data name="DataGridFilterByFormat" xml:space="preserve">
+    <value>按 {0} 筛选</value>
+  </data>
+  <data name="DataGridFilterAllText" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="DataGridFilterOperatorLabel" xml:space="preserve">
+    <value>{0} 的筛选运算符</value>
+  </data>
+  <data name="DataGridFilterOpContains" xml:space="preserve">
+    <value>包含</value>
+  </data>
+  <data name="DataGridFilterOpDoesNotContain" xml:space="preserve">
+    <value>不包含</value>
+  </data>
+  <data name="DataGridFilterOpStartsWith" xml:space="preserve">
+    <value>开头为</value>
+  </data>
+  <data name="DataGridFilterOpEndsWith" xml:space="preserve">
+    <value>结尾为</value>
+  </data>
+  <data name="DataGridBooleanTrueText" xml:space="preserve">
+    <value>是</value>
+  </data>
+  <data name="DataGridBooleanFalseText" xml:space="preserve">
+    <value>否</value>
+  </data>
+  <data name="DataGridGroupByFormat" xml:space="preserve">
+    <value>按 {0} 分组</value>
+  </data>
+  <data name="DataGridUngroupByFormat" xml:space="preserve">
+    <value>取消按 {0} 分组</value>
+  </data>
+  <data name="DataGridExpandGroupFormat" xml:space="preserve">
+    <value>展开分组 {0}：{1}</value>
+  </data>
+  <data name="DataGridCollapseGroupFormat" xml:space="preserve">
+    <value>折叠分组 {0}：{1}</value>
+  </data>
+  <data name="DataGridPagerRangeFormat" xml:space="preserve">
+    <value>{0}–{1}，共 {2}</value>
+  </data>
+  <data name="DataGridPagerPageFormat" xml:space="preserve">
+    <value>第 {0} 页，共 {1} 页</value>
+  </data>
+  <data name="DataGridPerPageFormat" xml:space="preserve">
+    <value>{0} 条/页</value>
+  </data>
+  <data name="DataGridRowsPerPageLabel" xml:space="preserve">
+    <value>每页行数</value>
+  </data>
+  <data name="DataGridFirstPageLabel" xml:space="preserve">
+    <value>首页</value>
+  </data>
+  <data name="DataGridPreviousPageLabel" xml:space="preserve">
+    <value>上一页</value>
+  </data>
+  <data name="DataGridNextPageLabel" xml:space="preserve">
+    <value>下一页</value>
+  </data>
+  <data name="DataGridLastPageLabel" xml:space="preserve">
+    <value>末页</value>
+  </data>
+  <data name="DataGridEndOfResultsText" xml:space="preserve">
+    <value>- 结果结束 -</value>
+  </data>
+  <data name="DataGridToggleDetailsLabel" xml:space="preserve">
+    <value>切换详情</value>
+  </data>
+  <data name="DataGridToggleChildrenLabel" xml:space="preserve">
+    <value>切换子项</value>
+  </data>
+  <data name="DataGridReorderRowTitle" xml:space="preserve">
+    <value>拖动以重新排序，或聚焦后使用方向键移动该行</value>
+  </data>
+  <data name="DataGridReorderRowLabel" xml:space="preserve">
+    <value>重新排序行。按向上或向下方向键移动该行。</value>
+  </data>
+  <data name="DataGridInvalidValueError" xml:space="preserve">
+    <value>{0} 的值无效。</value>
+  </data>
+  <data name="DataGridAnnouncementSortedAscending" xml:space="preserve">
+    <value>按 {0} 升序排序</value>
+  </data>
+  <data name="DataGridAnnouncementSortedDescending" xml:space="preserve">
+    <value>按 {0} 降序排序</value>
+  </data>
+  <data name="DataGridAnnouncementSortCleared" xml:space="preserve">
+    <value>已移除按 {0} 的排序</value>
+  </data>
+  <data name="DataGridAnnouncementFiltered" xml:space="preserve">
+    <value>已对 {0} 应用筛选</value>
+  </data>
+  <data name="DataGridAnnouncementFilterCleared" xml:space="preserve">
+    <value>已清除对 {0} 的筛选</value>
+  </data>
+  <data name="DataGridAnnouncementPage" xml:space="preserve">
+    <value>第 {0} 页，共 {1} 页</value>
+  </data>
+  <data name="DataGridAnnouncementRowDeleted" xml:space="preserve">
+    <value>行已删除</value>
+  </data>
   <!-- Boilerplate strings -->
   <data name="Active" xml:space="preserve">
     <value>活动</value>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/TemplateConfig/TemplateConfigurationTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Features/TemplateConfig/TemplateConfigurationTests.cs
@@ -39,7 +39,10 @@ public class TemplateConfigurationTests
     /// </summary>
     private const string TemplateOnlySymbol = "IsInsideProjectTemplate";
 
-    private static readonly string[] skippedDirectories = ["bin", "obj", ".git", ".vs", "node_modules", ".playwright-mcp", "App_Data"];
+    // Build and test output, all of it gitignored. `TestResults` matters as much as `bin`: Playwright writes video
+    // recordings there, and a .webm whose bytes happen to contain a directive-opening sequence is reported as a
+    // template defect on any machine that has run the UI tests.
+    private static readonly string[] skippedDirectories = ["bin", "obj", ".git", ".vs", "node_modules", ".playwright-mcp", "App_Data", "TestResults"];
 
     /// <summary>
     /// Template conditionals are always written with a parenthesized condition - <c>#if (aspire == true)</c> - in
@@ -176,6 +179,129 @@ public class TemplateConfigurationTests
             "These template.json rules name a path that does not exist, so they exclude nothing - the file they were " +
             "written for either moved (and now ships in configurations that must not have it) or is gone and the rule " +
             $"is dead weight:{Environment.NewLine}{string.Join(Environment.NewLine, missing)}");
+    }
+
+    /// <summary>
+    /// True when the number at <paramref name="index"/> is the argument of a port flag on a documented command line -
+    /// <c>-p PORT</c>, <c>--port PORT</c>, <c>--port=PORT</c>. Those really are the app's port and are SUPPOSED to be
+    /// rewritten per generation; a calendar year or a quantity in the same sentence is not, and neither is preceded by
+    /// a port flag. Kept as a whitelist of flag spellings rather than "any digits after a space", which would exempt
+    /// exactly the prose the check exists for.
+    /// </summary>
+    private static bool IsPortFlagArgument(string line, int index) => portFlag.IsMatch(line[..index]);
+
+    /// <summary>
+    /// The flag has to be a command-line token of its own, anchored to the start of the line or preceded by
+    /// whitespace - <c>EndsWith("-p")</c> would also accept any word ending in those two characters.
+    /// </summary>
+    private static readonly Regex portFlag = new(@"(?:^|[ \t])(?:-p|--port|-Port)[ \t]*=?[ \t]*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Test files that this review's own suite adds live under <c>src/Tests/Features/**</c> and are gated on
+    /// <c>advancedTests</c> (plus whatever feature symbol they need), because a generated project should not inherit
+    /// them and the packages several of them use are gated on the same symbol. Forget the exclusion entry and the
+    /// DEFAULT generation stops compiling - the file ships while the base class, fake or helper it derives from does
+    /// not.
+    /// <para>
+    /// That has happened: <c>AiChatPanelDictationUITests.cs</c> shipped in no exclude list while its base class
+    /// <c>AiChatPanelTestBase.cs</c> and the <c>TestChatClient</c> it uses were both removed at
+    /// <c>advancedTests != true || signalR != true</c>, so <c>dotnet new bit-bp</c> with no arguments produced a test
+    /// project with two CS0246s. Nothing caught it: inside the template every conditional is a comment so the local
+    /// build is green, and CI never generates the one combination that breaks - its build-only job passes
+    /// <c>--signalR false</c> without <c>--advancedTests</c>, and both of its test jobs pass <c>--advancedTests</c>.
+    /// </para>
+    /// <para>
+    /// The allow-list below is the set that is MEANT to ship in every generated project - the sample tests a
+    /// customer is expected to read and extend. Adding to it is a deliberate act; forgetting an exclusion is not.
+    /// </para>
+    /// <para>
+    /// <b>Scope.</b> This proves the DEFAULT configuration only - the one CI never generates, and the one the
+    /// failure above shipped in. It does not prove that a file gated on <c>advancedTests</c> alone is also gated on
+    /// every symbol its dependencies need, so <c>--advancedTests true --signalR false</c> could still pair a test
+    /// with a missing base class. Closing that needs each file's dependencies resolved against each rule's
+    /// condition; the generation matrix in CI is the cheaper place to catch it.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void EveryTestFile_Should_BeExcludedFromGeneratedProjects_UnlessItIsADeliberateSample()
+    {
+        string[] shippedToEveryGeneratedProject =
+        [
+            "src/Tests/Features/Identity/IntegrationTests.cs",
+            "src/Tests/Features/Identity/UITests.cs",
+            "src/Tests/Features/Identity/BunitUITests.cs",
+            "src/Tests/Features/Identity/TestData.cs"
+        ];
+
+        var (templateRoot, template) = LoadTemplateJson();
+
+        HashSet<string> excluded = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var source in template.RootElement.GetProperty("sources").EnumerateArray())
+        {
+            if (source.TryGetProperty("modifiers", out var modifiers) is false)
+                continue;
+
+            foreach (var modifier in modifiers.EnumerateArray())
+            {
+                if (modifier.TryGetProperty("exclude", out var rule) is false || rule.ValueKind is not JsonValueKind.Array)
+                    continue;
+
+                // Only rules that actually FIRE in the default configuration count. A rule keeps its file whenever
+                // its condition is false, so "named in some rule" is not the same as "removed by default": an
+                // exclusion conditioned solely on `(signalR != true)` leaves the file in place as soon as signalR is
+                // on. Every rule in this list is an OR-chain that starts with `advancedTests != true`, and
+                // advancedTests defaults to false, so requiring that clause is exactly "this rule fires by default"
+                // - checked as text rather than by evaluating the expression, which the engine owns.
+                var condition = modifier.TryGetProperty("condition", out var conditionElement) ? conditionElement.GetString() : null;
+
+                if (condition is null || condition.Contains("advancedTests != true", StringComparison.Ordinal) is false)
+                    continue;
+
+                foreach (var pathElement in rule.EnumerateArray())
+                {
+                    var path = pathElement.GetString();
+
+                    if (string.IsNullOrWhiteSpace(path))
+                        continue;
+
+                    excluded.Add(path.Replace('\\', '/').TrimEnd('/'));
+                }
+            }
+        }
+
+        var testsRoot = Path.Combine(templateRoot, "src", "Tests", "Features");
+        List<string> unguarded = [];
+        var filesChecked = 0;
+
+        foreach (var file in EnumerateTemplateFiles(testsRoot).Where(file => Path.GetExtension(file) is ".cs"))
+        {
+            var relativePath = Path.GetRelativePath(templateRoot, file).Replace('\\', '/');
+
+            if (shippedToEveryGeneratedProject.Contains(relativePath, StringComparer.OrdinalIgnoreCase))
+                continue;
+
+            filesChecked++;
+
+            // Either the file itself is named, or a `some/directory/**` rule above it removes the whole folder.
+            var isGated = excluded.Contains(relativePath) ||
+                          excluded.Any(entry => entry.EndsWith("/**", StringComparison.Ordinal) &&
+                                                relativePath.StartsWith(entry[..^2], StringComparison.OrdinalIgnoreCase));
+
+            if (isGated is false)
+            {
+                unguarded.Add(relativePath);
+            }
+        }
+
+        // Non-vacuity: the suite has ~90 files under Features.
+        Assert.IsGreaterThan(50, filesChecked, $"Only {filesChecked} test files were scanned - the scan is not reaching src/Tests/Features.");
+
+        Assert.IsEmpty(unguarded,
+            "These test files are in no template.json exclude rule that fires in the DEFAULT configuration, so they " +
+            "ship into a generated project where the base classes and fakes they depend on have been removed. Add " +
+            "each to the exclude list that matches the symbols it actually needs (advancedTests, plus signalR/" +
+            $"notification/module/... where relevant):{Environment.NewLine}{string.Join(Environment.NewLine, unguarded)}");
     }
 
     /// <summary>
@@ -514,9 +640,11 @@ public class TemplateConfigurationTests
                             {
                                 offenders.Add($"[{token} inside a number] {where}");
                             }
-                            // Prose: in markdown a port is always written after a `:` (localhost:5030, *:5030). Anything
-                            // else is a sentence that happens to contain the digits.
-                            else if (isMarkdown && before is not ':')
+                            // Prose: in markdown a port is written either after a `:` (localhost:PORT, *:PORT) or as
+                            // the argument of a port flag in a documented command line (`-p PORT`, `--port PORT`).
+                            // Anything else is a sentence that happens to contain the digits - a calendar year, a
+                            // quantity - and the rewrite corrupts it.
+                            else if (isMarkdown && before is not ':' && IsPortFlagArgument(line, index) is false)
                             {
                                 offenders.Add($"[{token} in markdown prose] {where}");
                             }
@@ -716,7 +844,7 @@ public class TemplateConfigurationTests
             .Where(file => Path.GetRelativePath(templateRoot, file)
                                .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                                .Any(segment => skippedDirectories.Contains(segment, StringComparer.OrdinalIgnoreCase)) is false)
-            .Where(file => Path.GetExtension(file) is not (".png" or ".jpg" or ".jpeg" or ".gif" or ".ico" or ".woff" or ".woff2" or ".ttf" or ".dll" or ".pdb" or ".zip" or ".keystore" or ".p12" or ".pfx" or ".webp" or ".mp4"));
+            .Where(file => Path.GetExtension(file) is not (".png" or ".jpg" or ".jpeg" or ".gif" or ".ico" or ".woff" or ".woff2" or ".ttf" or ".dll" or ".pdb" or ".zip" or ".keystore" or ".p12" or ".pfx" or ".webp" or ".mp4" or ".webm"));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #12913.

A review pass over `Bit.Boilerplate`'s app root, routing and component base stack. **Two of these are reachable in the default configuration.**

## Default configuration

**`dotnet new bit-bp` with no arguments did not compile.** `src/Tests/Features/Chatbot/AiChatPanelDictationUITests.cs` was in no `template.json` exclude rule, while `AiChatPanelTestBase.cs` and `TestChatClient.cs` are both removed at `advancedTests != true || signalR != true`. CI cannot see it: the build-only job passes `--signalR false` without `--advancedTests`, and both test jobs pass `--advancedTests`. Fixed by adding the file to the same rule as its three siblings, and by a new guard (below) that closes the whole class.

**A tenant switch never reached the SignalR hub.** `PropagateAuthState` returns early when the user id is unchanged, and that early return sat above the only client-side `ChangeAuthenticationState` call — which is the only thing that updates the hub connection's principal after the handshake. `AuthManager.RefreshToken`'s own doc lists three things that change a signed-in user's claims *without* changing the user id (plain renewal, elevated access, tenant switch); all three took the early return. With `multitenant=true, signalR=true`, `AppHub.GetUserSessionLogs` therefore authorised against the previous tenant for the life of the connection.

The fix hoists only the cheap, idempotent half above the check — re-send the current token when the hub is already connected — rather than widening the early-return key, which would run `UpdateSession` and `pushNotificationService.Subscribe` on every routine refresh. It is deliberately not routed through `EnsureSignalRStarted`, whose catch publishes `IS_ONLINE_CHANGED=false` and which would also call `StartAsync`.

## Routing

- **Deep links on Android and iOS.** `Routes.OpenUniversalLink` parsed the incoming url with `new Uri(url)`. Every caller passes an app-relative url, and that constructor is `UriKind.Absolute` — it throws on Windows, but on Linux/Darwin it *succeeds* by treating the value as an implicit Unix file path. Measured on both:

  ```
  WINDOWS  new Uri("/en-US/products?culture=fa-IR") THREW UriFormatException
  LINUX    new Uri("/en-US/products?culture=fa-IR") OK -> file:///en-US/products%3Fculture=fa-IR  Query=''
  ```

  The `?` is percent-encoded into the path and `Uri.Query` is empty, so `GetCulture()` — which reads the query first — never sees the culture. The documented `/categories?culture=fa-IR` form of a universal link therefore never set `forceLoad`, and the user followed a link to the Persian page and got the English app. Now resolved against the app's base first. The decision is extracted into `Routes.NeedsReloadForCulture` so it can be pinned.

- **`EnsureNavigationManagerIsReady` busy-spun.** `while (... is null) await Task.Yield()` is a spin, not a poll — one ThreadPool worker at 100% for the whole of a MAUI cold start from a deep link. Replaced with a `TaskCompletionSource` completed by the injected setter. A timeout that throws was rejected: `ClientExceptionHandlerBase.IgnoreException` drops `TimeoutException`, so it would change the exception type without changing the symptom.

- **`brouter=true` not-found pages.** `ReferenceEquals(lastPublishedRouteData, RouteData)` could not distinguish "never published" from "already published null", and the `<NotFound>` arm passes `RouteData="@null"` — so `ReferenceEquals(null, null)` suppressed the one publish that state ever makes, and `MainLayout` kept the previous page's chrome (or, on a cold load onto a bad url, rendered no header at all).

- **`brouter=true` keep-alive.** Nothing called `IBrouter.ClearKeepAlive`, so a retained `ProductsPage` handed the next user the previous one's search text and grid filters. Released when the resolved user id changes — not on every auth-state notification, which would discard kept state on a routine token refresh.

## Component base stack

- **`AppPageBase`'s `{culture?}` guard ran only on `firstRender`.** A client-side navigation between two urls that resolve to the same page type reuses the instance, so `/pricing` rendered the home page instead of Not-Found. The check is now also run on parameter updates, gated on having rendered interactively once — moving it to `OnParamsSetAsync` outright would fire during prerender/SSR, where `NavigateTo` throws `NavigationException`.

- **`BitDataGridStrings`: 2 of 62 members were set**, so every grid rendered its toolbar, filters, column chooser, exports, empty/loading state and screen-reader announcements in English next to translated column headers. Now filled, with 51 new resx keys grouped under a `<!-- Bit.BlazorUI messages -->` section in all ten `AppStrings*.resx` files. The two members that were already set are folded into whole format strings rather than concatenated around fixed placeholders.

- **`UsersPage` built a per-selection `CancellationTokenSource` and never passed its token**, so a superseded request could paint — and revoke — the previous user's sessions under the newly selected user's name. `RolesPage` had the same double-assign but did thread its token through, so only its redundant allocation is removed.

- **`AppComponentBase.DisposeAsync` ran its whole body twice on a second call.** Now idempotent. It does **not** fix `OwningComponentBase.IsDisposed` never being set: that property's setter is private and the base's `IAsyncDisposable.DisposeAsync` is a private explicit implementation, so neither is reachable while this class re-implements the interface. Closing it properly means overriding `DisposeAsyncCore` instead — a change to the disposal contract of every component — so it is documented at the call site rather than guessed at here.

## Smaller

- `BitButil.UseFastInvoke()` around `userAgent.Extract()` has been inert since Butil `c7a57ca6e` (`Extract` uses the always-async path), and its comment promised an ordering guarantee naming `SignInPage.razor.cs`, which never read the value. Removed.
- `SHOW_MESSAGE` returned `false` and displayed nothing when a message carried data and notification permission was not granted — and the one production sender (`RoleManagementController.SendNotification`) uses `SendAsync`, so that `false` is discarded and the message was lost. Now shows the snack bar and returns `false` purely as information.
- `Parameters.IsOnline`'s doc named SignalR as the default source of the value; `signalR` defaults to false, so it is `ExceptionDelegatingHandler` that drives it. Reworded configuration-neutrally.
- The error boundary's icon-only diagnostic button had no accessible name, and `BitErrorBoundary` — mounted outside `MainLayout` — never saw the `currentDir` cascade, so it was the one screen ignoring text direction. Both are parameters the components already offer.
- `AppDataAnnotationsValidator`'s doc cited `ValidationAttribute.ErrorResourceType`, which does not exist.

## Known limitation, deliberately not fixed

The error boundary's diagnostic button depends on `Recover()` succeeding and publishes a non-persistent message, so when the same exception re-trips the boundary during recovery the modal has already unmounted and the message is dropped — i.e. it silently does nothing for exactly the deterministic render-path exception it exists for. The real fix is to host `AppDiagnosticModal` from the boundary rather than from `MainLayout`, which costs the `BitDir` cascade and moves it outside `CascadingAuthenticationState`. That is a layout-ownership decision, so the limitation and both candidate fixes are documented at the call site instead.

## Tests

Two, deliberately — not one per change.

- **`EveryTestFile_Should_BeExcludedFromGeneratedProjects_UnlessItIsADeliberateSample`** — every `.cs` under `src/Tests/Features/**` must be named in some exclude rule, unless it is on an explicit allow-list of samples meant to ship. Run against the unfixed `template.json` it fails naming exactly `AiChatPanelDictationUITests.cs`.
- **`UniversalLinkCultureTests`** (9 cases) — drives `Routes.NeedsReloadForCulture`. Run with the fixed line reverted to `new Uri(url)`, all 9 fail.

Also fixed two false positives in the existing `TemplateConfigurationTests` that had left the suite red locally: the port guard flagged `devtunnel host -p <port>` in `AGENTS.md` prose (a port flag argument really is a port), and the literal-directive guard scanned gitignored `TestResults`, where a Playwright `.webm` can contain the byte sequence by chance.

## Verification

- `Server.Web`, `Client.Windows`, `Client.Maui` and `Tests` all build.
- `dotnet new` generated with defaults and with `--advancedTests true --signalR true`: the new test files are gated correctly in both directions, both generated `Tests` projects build, and no template directives leak into the output.
- 17 tests green (`TemplateConfigurationTests` + `UniversalLinkCultureTests`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized diagnostic and data-grid text across multiple languages, including accessibility announcements.
  * Improved culture-aware universal-link navigation and validation.
  * Enhanced authentication state propagation for connected real-time services.

* **Bug Fixes**
  * Prevented stale user-session requests from overwriting current selections.
  * Improved cancellation handling, route updates, error notifications, and component disposal.
  * Corrected data-grid localization and right-to-left error-boundary behavior.

* **Tests**
  * Expanded coverage for universal-link culture handling and template file filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->