### PR TITLE
Add MCP server infrastructure to Brouter website (#12937)

### DIFF
--- a/src/Brouter/Bit.Brouter.Demo/Client/DocsCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Client/DocsCatalog.cs
@@ -1,10 +1,14 @@
+using Bit.Brouter.Demo.Client.Pages;
+
 namespace Bit.Brouter.Demo.Client;
 
 /// <summary>
 /// One documentation page: <paramref name="Slug"/> is the path under /docs (empty for the
-/// /docs index itself), <paramref name="Keywords"/> feeds the header search box.
+/// /docs index itself), <paramref name="Keywords"/> feeds the header search box, and
+/// <paramref name="PageType"/> is the component AppRouter renders for the slug - which is what
+/// lets the MCP server render a page's documentation on demand.
 /// </summary>
-public record DocsPageInfo(string Slug, string Title, string Description, string Keywords)
+public record DocsPageInfo(string Slug, string Title, string Description, string Keywords, Type PageType)
 {
     public string Url => Slug.Length == 0 ? "/docs" : $"/docs/{Slug}";
 }
@@ -24,86 +28,114 @@ public static class DocsCatalog
         [
             new("", "Overview",
                 "What Brouter is, the problems it solves, and a map of every feature area.",
-                "overview introduction about features map"),
+                "overview introduction about features map",
+                typeof(DocsOverviewPage)),
             new("getting-started", "Getting started",
                 "Install the packages, register the services, and declare your first routes.",
-                "install setup nuget package AddBitBrouterServices quick start program.cs"),
+                "install setup nuget package AddBitBrouterServices quick start program.cs",
+                typeof(GettingStartedPage)),
             new("navigation-pipeline", "How a navigation works",
                 "The ordered pipeline behind every navigation: what runs before the URL moves, what runs after, and what each step can do about it.",
-                "pipeline order phases decide commit preventive supersession cancel redirect fail closed revalidation preload concepts"),
+                "pipeline order phases decide commit preventive supersession cancel redirect fail closed revalidation preload concepts",
+                typeof(PipelinePage)),
         ]),
         new("Routing",
         [
             new("route-templates", "Route templates",
                 "The full template grammar: literals, typed parameters, optionals, defaults, complex segments, catch-alls and specificity.",
-                "template syntax segment literal optional default catch-all wildcard complex specificity precedence"),
+                "template syntax segment literal optional default catch-all wildcard complex specificity precedence",
+                typeof(TemplatesPage)),
             new("constraints", "Constraints",
                 "18 built-in type and validation constraints, chaining rules, and custom constraints - tested interactively.",
-                "constraint int guid datetime alpha regex min max range length custom register"),
+                "constraint int guid datetime alpha regex min max range length custom register",
+                typeof(ConstraintsPage)),
             new("route-parameters", "Route parameters",
                 "How URL values reach components: [Parameter] binding, the cascaded parameter bag, and query-string binding.",
-                "parameter binding SupplyParameterFromQuery BrouterParameter BrouterQuery query string typed cascade"),
+                "parameter binding SupplyParameterFromQuery BrouterParameter BrouterQuery query string typed cascade",
+                typeof(ParametersPage)),
             new("nested-routes", "Nested routes & outlets",
                 "Route trees where parents render persistent layout and children fill outlets - named views and pathless groups included.",
-                "nested outlet BrouterOutlet BrouterView named views pathless group index route layout"),
+                "nested outlet BrouterOutlet BrouterView named views pathless group index route layout",
+                typeof(OutletsPage)),
             new("page-discovery", "@page discovery",
                 "Scan assemblies for @page / [Route] components so routes stay colocated with their pages.",
-                "attribute route discovery AppAssembly AdditionalAssemblies @page [Route] razor class library lazy assembly"),
+                "attribute route discovery AppAssembly AdditionalAssemblies @page [Route] razor class library lazy assembly",
+                typeof(PageDiscoveryPage)),
         ]),
         new("Navigation",
         [
             new("navigation", "Navigation & history",
                 "Programmatic navigation with awaited outcomes, history entry state, query updates, named routes and BrouterLink.",
-                "navigate NavigateAsync outcome back forward history state NavigateWithQuery named routes relative BrouterLink"),
+                "navigate NavigateAsync outcome back forward history state NavigateWithQuery named routes relative BrouterLink",
+                typeof(NavigationPage)),
             new("guards", "Guards & navigation locks",
                 "Enter guards, preventive leave guards, component-level locks with custom dialogs, redirects and global hooks.",
-                "guard leave guard lock OnDeactivating OnRenavigating cancel redirect unsaved changes hooks OnNavigating"),
+                "guard leave guard lock OnDeactivating OnRenavigating cancel redirect unsaved changes hooks OnNavigating",
+                typeof(GuardsPage)),
             new("scroll-and-focus", "Scroll & focus",
                 "Scroll-to-top, fragment scrolling, scroll restoration on Back/Forward, and accessible focus management.",
-                "scroll restore fragment anchor hash focus accessibility FocusOnNavigateSelector a11y"),
+                "scroll restore fragment anchor hash focus accessibility FocusOnNavigateSelector a11y",
+                typeof(ScrollFocusPage)),
         ]),
         new("Data",
         [
             new("data-loading", "Data loading",
                 "Route loaders with stale-while-revalidate caching, revalidation, preloading, deferred data and error boundaries.",
-                "loader cache StaleTime revalidate preload Intent Viewport deferred BrouterAwait ErrorContent retry"),
+                "loader cache StaleTime revalidate preload Intent Viewport deferred BrouterAwait ErrorContent retry",
+                typeof(LoadersPage)),
         ]),
         new("User experience",
         [
             new("view-transitions", "View transitions",
                 "Direction-aware page animations and shared-element morphs via the browser View Transitions API.",
-                "view transition animation morph shared element startViewTransition reduced motion"),
+                "view transition animation morph shared element startViewTransition reduced motion",
+                typeof(TransitionsPage)),
             new("lifecycle", "Lifecycle & keep-alive",
                 "Activation, renavigation and deactivation callbacks, plus keep-alive retention with per-parameter instances.",
-                "lifecycle OnActivated OnDeactivated OnRenavigated keep-alive KeepAlive KeepAliveMax retention LRU"),
+                "lifecycle OnActivated OnDeactivated OnRenavigated keep-alive KeepAlive KeepAliveMax retention LRU",
+                typeof(LifecycleOverviewPage)),
         ]),
         new("Tooling & adoption",
         [
             new("typed-routes", "Typed routes (generator)",
                 "The Bit.Brouter.Generators source generator: compile-time-safe URL builders from your route declarations.",
-                "generator source generator BrouterRoutes typed url builder compile-time Names"),
+                "generator source generator BrouterRoutes typed url builder compile-time Names",
+                typeof(GeneratorPage)),
             new("migration", "Migrating from the built-in Router",
                 "Drop-in migration: the Found template, zero-template authorization, layouts, and the parameter mapping table.",
-                "migration built-in router Found RouteView AuthorizeRouteView authorization layout NotFound Navigating"),
+                "migration built-in router Found RouteView AuthorizeRouteView authorization layout NotFound Navigating",
+                typeof(MigrationPage)),
             new("performance", "Performance & scalability",
                 "What routes cost, how matching scales, prerender state bridging, and guidance for very large apps.",
-                "performance benchmark memory startup scalability prerender PersistLoaderState SSR"),
+                "performance benchmark memory startup scalability prerender PersistLoaderState SSR",
+                typeof(PerformancePage)),
         ]),
         new("Reference",
         [
             new("api", "API reference",
                 "Every component parameter, service member, option and value type, with defaults.",
-                "api reference parameters options BrouterOptions IBrouter Broute BrouterLink enums types defaults lookup"),
+                "api reference parameters options BrouterOptions IBrouter Broute BrouterLink enums types defaults lookup",
+                typeof(ApiPage)),
             new("recipes", "Recipes",
                 "Task-oriented solutions: protected areas, unsaved changes, revalidation, query state, breadcrumbs, keep-alive lists.",
-                "recipes cookbook patterns how-to examples auth login unsaved changes breadcrumbs paging filters localization"),
+                "recipes cookbook patterns how-to examples auth login unsaved changes breadcrumbs paging filters localization",
+                typeof(RecipesPage)),
             new("faq", "FAQ & troubleshooting",
                 "Adoption questions, and the symptoms you might hit afterwards - each with the reason behind it.",
-                "faq troubleshooting problem error not matching 404 ambiguous null parameter cache stale animation help"),
+                "faq troubleshooting problem error not matching 404 ambiguous null parameter cache stale animation help",
+                typeof(FaqPage)),
         ]),
     ];
 
     public static readonly DocsPageInfo[] AllPages = Sections.SelectMany(s => s.Pages).ToArray();
+
+    /// <summary>Finds the catalog entry for a slug ("" for the overview), or null when there is none.</summary>
+    public static DocsPageInfo? FindBySlug(string? slug)
+    {
+        var trimmed = (slug ?? string.Empty).Trim('/');
+
+        return AllPages.FirstOrDefault(p => string.Equals(p.Slug, trimmed, StringComparison.OrdinalIgnoreCase));
+    }
 
     /// <summary>Finds the catalog entry matching a /docs path, or null for non-docs URLs.</summary>
     public static DocsPageInfo? FindByPath(string path)

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/GeneratorPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/GeneratorPage.razor
@@ -180,7 +180,18 @@ brouter.NavigateToName(<span class="k">BrouterRoutes.Names</span>.Counter, <span
             ("BrouterRoutes.Posts(\"2026/07/hello world\")", BrouterRoutes.Posts("2026/07/hello world")),
         ];
 
-        _resolvedUrl = brouter.ResolveUrl(BrouterRoutes.Names.Counter, new Dictionary<string, object?> { ["init"] = 7 });
+        try
+        {
+            _resolvedUrl = brouter.ResolveUrl(BrouterRoutes.Names.Counter, new Dictionary<string, object?> { ["init"] = 7 });
+        }
+        catch (InvalidOperationException)
+        {
+            // Name resolution needs a mounted <Brouter> to hold the route table, and this page is
+            // also rendered on its own by the MCP server (GetBrouterDocsPage) to serve its text.
+            // The generated builder needs nothing and produces the identical URL, so the card still
+            // shows the real value rather than taking the whole page down.
+            _resolvedUrl = BrouterRoutes.Counter(7);
+        }
     }
 
     private void NavigateByName()

--- a/src/Brouter/Bit.Brouter.Demo/Server/Bit.Brouter.Demo.Server.csproj
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Bit.Brouter.Demo.Server.csproj
@@ -41,12 +41,19 @@
             <LogicalName>BrouterSource/Demo/Server/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
         </EmbeddedResource>
 
-        <!-- The minimal hosting samples - one per Blazor render mode. Samples\Core is left out on
-             purpose: it is a smaller copy of this demo's pages, and the demo itself is embedded above. -->
+        <!-- The minimal hosting samples - one per Blazor render mode. The rest of Samples\Core is
+             left out on purpose: it is a smaller copy of this demo's pages, and the demo itself is
+             embedded above. Its service registration is the exception - it is the shared method the
+             two containers of a Web App both call, which is exactly what the setup guide has to show. -->
         <EmbeddedResource Include="..\..\Samples\**\*.razor;..\..\Samples\**\Program.cs;..\..\Samples\**\*.csproj"
-                          Exclude="..\..\Samples\Core\**;..\..\Samples\**\bin\**;..\..\Samples\**\obj\**">
+                          Exclude="..\..\Samples\Core\*.razor;..\..\Samples\Core\Pages\**;..\..\Samples\Core\Shared\**;..\..\Samples\**\bin\**;..\..\Samples\**\obj\**">
             <LogicalName>BrouterSource/Sample/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
         </EmbeddedResource>
+
+        <!-- Named outright: %(RecursiveDir) only captures what a '**' matched, so a glob with a fixed
+             folder prefix would flatten this file to the Sample/ root. -->
+        <EmbeddedResource Include="..\..\Samples\Core\Extensions\IServiceCollectionExtensions.cs"
+                          LogicalName="BrouterSource/Sample/Core/Extensions/IServiceCollectionExtensions.cs" />
     </ItemGroup>
 
 </Project>

--- a/src/Brouter/Bit.Brouter.Demo/Server/Bit.Brouter.Demo.Server.csproj
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Bit.Brouter.Demo.Server.csproj
@@ -11,10 +11,42 @@
     <ItemGroup>
         <!-- Serves the client's _framework payload and enables WebAssembly debugging from this host. -->
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+        <!-- The MCP server (see Controllers/McpController.cs), mapped at /mcp. -->
+        <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
+        <!-- Flattens the rendered HTML of a docs page into the Markdown an MCP client reads. -->
+        <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Client\Bit.Brouter.Demo.Client.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Microsoft.AspNetCore.Mvc" />
+        <Using Include="Microsoft.Extensions.Options" />
+    </ItemGroup>
+
+    <!-- Text the MCP server hands out. It is embedded rather than read from disk so the tools keep
+         working from a published deployment, where none of these files exist next to the app.
+         LogicalName is set explicitly because the resource name IS the path an MCP client asks for. -->
+    <ItemGroup>
+        <EmbeddedResource Include="..\..\README.md" LogicalName="BrouterDocs/README.md" />
+
+        <EmbeddedResource Include="..\Client\**\*.razor;..\Client\**\*.cs;..\Client\**\*.css;..\Client\**\*.js"
+                          Exclude="..\Client\bin\**;..\Client\obj\**">
+            <LogicalName>BrouterSource/Demo/Client/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+        </EmbeddedResource>
+
+        <EmbeddedResource Include="Program.cs;Components\**\*.razor">
+            <LogicalName>BrouterSource/Demo/Server/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+        </EmbeddedResource>
+
+        <!-- The minimal hosting samples - one per Blazor render mode. Samples\Core is left out on
+             purpose: it is a smaller copy of this demo's pages, and the demo itself is embedded above. -->
+        <EmbeddedResource Include="..\..\Samples\**\*.razor;..\..\Samples\**\Program.cs;..\..\Samples\**\*.csproj"
+                          Exclude="..\..\Samples\Core\**;..\..\Samples\**\bin\**;..\..\Samples\**\obj\**">
+            <LogicalName>BrouterSource/Sample/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+        </EmbeddedResource>
     </ItemGroup>
 
 </Project>

--- a/src/Brouter/Bit.Brouter.Demo/Server/Bit.Brouter.Demo.Server.csproj
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Bit.Brouter.Demo.Server.csproj
@@ -37,8 +37,12 @@
             <LogicalName>BrouterSource/Demo/Client/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
         </EmbeddedResource>
 
-        <EmbeddedResource Include="Program.cs;Components\**\*.razor">
-            <LogicalName>BrouterSource/Demo/Server/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+        <EmbeddedResource Include="Program.cs" LogicalName="BrouterSource/Demo/Server/Program.cs" />
+
+        <!-- The Components\ prefix is written out: %(RecursiveDir) only captures what the '**'
+             matched, so it starts at Pages\ and would drop the folder the components live in. -->
+        <EmbeddedResource Include="Components\**\*.razor">
+            <LogicalName>BrouterSource/Demo/Server/Components/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
         </EmbeddedResource>
 
         <!-- The minimal hosting samples - one per Blazor render mode. The rest of Samples\Core is

--- a/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpController.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpController.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Reflection;
+using System.Collections.Concurrent;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 using Bit.Brouter.Demo.Client;
@@ -28,6 +30,14 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
     // context window; the ones in this demo land far below the cap.
     private const int MaxDocumentLength = 40_000;
 
+    // The rendered Markdown of every docs page served so far, keyed by slug.
+    private static readonly ConcurrentDictionary<string, string> _renderedPages = new(StringComparer.Ordinal);
+
+    private static readonly string BrouterVersion =
+        typeof(BrouterLink).Assembly.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(BrouterLink).Assembly.GetName().Version?.ToString()
+        ?? "unknown";
+
     [HttpGet]
     [McpServerTool(Name = nameof(GetBrouterOverview))]
     [Description("Start here. Explains what Bit.Brouter is, how to install and register it, shows a minimal working router, and lists which of the other Brouter tools to call for what.")]
@@ -39,15 +49,23 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
         var firstSection = readme.IndexOf("\n## ", StringComparison.Ordinal);
         builder.AppendLine(firstSection > 0 ? readme[..firstSection].Trim() : readme).AppendLine();
 
-        builder.AppendLine(BrouterSourceCatalog.GetGuideSection("Install")).AppendLine();
-        builder.AppendLine(BrouterSourceCatalog.GetGuideSection("Quick start")).AppendLine();
-        builder.AppendLine(BrouterSourceCatalog.GetGuideSection("Features")).AppendLine();
+        // Which build the answers come from: every tool below reflects THIS assembly, not a remembered version.
+        builder.AppendLine($"_These tools answer from Bit.Brouter {BrouterVersion}, loaded in this server._").AppendLine();
+
+        AppendGuideSection(builder, "Install");
+        AppendGuideSection(builder, "Quick start");
+        AppendGuideSection(builder, "Features");
 
         builder.AppendLine("""
             ---
 
             ## Which tool to call
 
+            - `SearchBrouter` - **the default entry point.** One query across the guide, the docs pages, every public
+              type and member, the constraints and the demo's sources; each hit carries the exact follow-up call.
+              Reach for it whenever you do not already know the section, slug or type name you want.
+            - `GetBrouterSetupGuide` - the complete wiring for one Blazor render mode ('server', 'wasm', 'auto',
+              'standalone-wasm'), as the real files of a working project. Start here when adding Brouter to an app.
             - `GetBrouterGuideSections` / `GetBrouterGuideSection` - the library's own reference guide, one topic at a
               time, with copy-pasteable code. The fastest route to a working implementation of a specific feature
               (guards, loaders, keep-alive, view transitions, typed routes, migration, ...).
@@ -58,8 +76,11 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
               Call this before writing code against a member you are not sure about.
             - `GetBrouterRouteConstraints` - every constraint usable in a route template, with a passing and a failing
               example for each.
-            - `InspectBrouterRouteTemplate` - parse a route template with Brouter's own parser before you ship it: it
-              reports the parameters, the constraints, the specificity, and the exact error for an invalid template.
+            - `InspectBrouterRouteTemplate` / `AnalyzeBrouterRouteTable` - check a template, or a whole set of them,
+              with Brouter's own parser before you ship it: parameters, constraints, specificity ranking, ambiguous
+              pairs, and the exact error for an invalid template.
+            - `GetBrouterTypedRoutes` - what the optional source generator emits: compile-time-safe URL builders and
+              route-name constants, shown from a real project.
             - `GetBrouterSourceFiles` / `GetBrouterSourceFile` - real, working source: the whole route table of this
               site (`Demo/Client/AppRouter.razor`), every demo page behind it, and the minimal hosting samples for
               each Blazor render mode (`Sample/Wasm/...`, `Sample/Server/...`, `Sample/Auto/...`).
@@ -76,6 +97,33 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
             """);
 
         return builder.ToString();
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(SearchBrouter))]
+    [Description("Searches everything known about Bit.Brouter at once - the reference guide, the documentation pages, every public type and member, the route constraints and the demo's source files - and returns the best matches, each with the exact follow-up tool call that returns its full text. Use this first whenever you do not already know which section, page or type holds the answer. Example queries: 'block navigation unsaved changes', 'cache loader data', 'keep component alive', 'query string binding'.")]
+    public BrouterSearchHitDto[] SearchBrouter(string query, int limit = 12)
+    {
+        return BrouterSearchIndex.Search(query, limit);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterSetupGuide))]
+    [Description("Gets the complete wiring needed to add Bit.Brouter to a Blazor app in one render mode, as the real files of a working project: 'server' (Blazor Web App, InteractiveServer), 'wasm' (InteractiveWebAssembly), 'auto' (InteractiveAuto) or 'standalone-wasm'. Call this before writing any setup code - which DI container registers the services and where the catch-all host page lives differ per render mode.")]
+    public string GetBrouterSetupGuide(string renderMode)
+    {
+        return BrouterSetupGuide.Get(renderMode)
+            ?? $"'{renderMode}' is not a known render mode. Use one of: {string.Join(", ", BrouterSetupGuide.RenderModes)}.";
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterTypedRoutes))]
+    [Description("Explains the optional Bit.Brouter.Generators source generator and shows its real output: the compile-time-safe URL builders and route-name constants it emitted for this documentation site's own route table. Call it when asked for typed/compile-safe URLs or BrouterRoutes.")]
+    public object GetBrouterTypedRoutes()
+    {
+        return (object?)BrouterTypedRoutesCatalog.TypedRoutes
+            ?? "The typed-route generator did not run for this build, so there is no generated output to show. " +
+               "Call GetBrouterGuideSection(heading: \"Typed routes (source generator)\") for how it works.";
     }
 
     [HttpGet]
@@ -111,6 +159,10 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
             return $"No documentation page has the slug '{slug}'. Available slugs: {slugs}.";
         }
 
+        // Rendering a page and flattening it costs far more than serving it; the pages are static,
+        // so the first caller pays for it and everyone after reads the same Markdown.
+        if (_renderedPages.TryGetValue(page.Slug, out var cached)) return cached;
+
         // The page is rendered by the same component the site serves, so the documentation an agent
         // reads is the documentation a human reads - there is no second copy that could go stale.
         var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
@@ -121,7 +173,11 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
         });
 
         // The page renders its own <h1>, so only its source is prepended here.
-        return Truncate($"Bit.Brouter documentation page: {page.Url}\n\n{html.ToMarkdown()}");
+        var markdown = Truncate($"Bit.Brouter documentation page: {page.Url}\n\n{html.ToMarkdown()}");
+
+        _renderedPages[page.Slug] = markdown;
+
+        return markdown;
     }
 
     [HttpGet]
@@ -160,20 +216,23 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
     [HttpGet]
     [McpServerTool(Name = nameof(GetBrouterApiDetails))]
     [Description("Gets the full reference of one Bit.Brouter type: its Blazor parameters with types and default values, its properties, methods, events or enum values, each with its documentation. Call it before using a member you are unsure about, e.g. 'Broute', 'Brouter', 'BrouterLink', 'IBrouter', 'BrouterOptions', 'BrouterNavigationContext'.")]
-    public object GetBrouterApiDetails(string typeName)
+    public BrouterApiDetailsResultDto GetBrouterApiDetails(string typeName)
     {
         var details = BrouterApiCatalog.GetTypeDetails(typeName);
 
-        if (details is not null) return details;
+        if (details is not null) return new BrouterApiDetailsResultDto { Details = details };
 
         var candidates = BrouterApiCatalog.Types
             .Where(t => t.Name.Contains(typeName ?? string.Empty, StringComparison.OrdinalIgnoreCase))
             .Select(t => t.Name)
             .ToArray();
 
-        return candidates.Length > 0
-            ? $"Bit.Brouter has no public type called '{typeName}'. Did you mean: {string.Join(", ", candidates)}?"
-            : $"Bit.Brouter has no public type called '{typeName}'. Call GetBrouterApiList for the full list.";
+        return new BrouterApiDetailsResultDto
+        {
+            Message = candidates.Length > 0
+                ? $"Bit.Brouter has no public type called '{typeName}'. Did you mean: {string.Join(", ", candidates)}?"
+                : $"Bit.Brouter has no public type called '{typeName}'. Call GetBrouterApiList for the full list."
+        };
     }
 
     [HttpGet]
@@ -188,7 +247,9 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
             Rule = constraint.Rule,
             PassExample = constraint.PassExample,
             FailExample = constraint.FailExample,
-            TryUrl = $"/c/{constraint.Kind}/{constraint.PassExample}"
+            // The example is one path segment: escaped, so a value carrying a slash, a space or a
+            // '#' still produces the URL that exercises the constraint rather than a different one.
+            TryUrl = $"/c/{constraint.Kind}/{Uri.EscapeDataString(constraint.PassExample)}"
         })];
     }
 
@@ -200,6 +261,16 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
         // The app's own constraint registry, so custom constraints registered in
         // AddBitBrouterServices (this demo registers "slug") resolve exactly as they do at runtime.
         return BrouterTemplateInspector.Inspect(template, brouterOptions.Value.Constraints);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(AnalyzeBrouterRouteTable))]
+    [Description("Parses a whole set of route templates together and reports how they relate: the order in which the router prefers them when several match the same URL (by specificity), any templates that are indistinguishable - Brouter throws at registration for those - and the exact error for each invalid one. Pass the templates separated by newlines, commas or semicolons. Use it after adding routes to an existing table.")]
+    public BrouterRouteTableAnalysisDto AnalyzeBrouterRouteTable(string templates)
+    {
+        var parts = (templates ?? string.Empty).Split(['\n', '\r', ',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return BrouterTemplateInspector.Analyze(parts, brouterOptions.Value.Constraints);
     }
 
     [HttpGet]
@@ -231,6 +302,18 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
         }
 
         return Truncate(content);
+    }
+
+    /// <summary>
+    /// A renamed README heading must not silently leave a blank gap in the overview - the agent is
+    /// told where the text went instead.
+    /// </summary>
+    private static void AppendGuideSection(StringBuilder builder, string heading)
+    {
+        builder.AppendLine(BrouterSourceCatalog.GetGuideSection(heading)
+                           ?? $"_The guide's \"{heading}\" section was not found in this build. " +
+                              $"Call GetBrouterGuideSections for the sections it does have._")
+               .AppendLine();
     }
 
     private static string Truncate(string text)

--- a/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpController.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpController.cs
@@ -165,15 +165,13 @@ public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> b
 
         // The page is rendered by the same component the site serves, so the documentation an agent
         // reads is the documentation a human reads - there is no second copy that could go stale.
-        var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
-        {
-            var component = await htmlRenderer.RenderComponentAsync(page.PageType);
+        var (rendered, error) = await DocsPageRenderer.TryRenderMarkdownAsync(htmlRenderer, page);
 
-            return component.ToHtmlString();
-        });
+        // Not cached: a page that failed to render is a bug to be fixed, not a stale answer to keep.
+        if (rendered is null) return DocsPageRenderer.Unavailable(page, error);
 
         // The page renders its own <h1>, so only its source is prepended here.
-        var markdown = Truncate($"Bit.Brouter documentation page: {page.Url}\n\n{html.ToMarkdown()}");
+        var markdown = Truncate($"Bit.Brouter documentation page: {page.Url}\n\n{rendered}");
 
         _renderedPages[page.Slug] = markdown;
 

--- a/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpController.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpController.cs
@@ -1,0 +1,242 @@
+using System.Text;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using Bit.Brouter.Demo.Client;
+using Bit.Brouter.Demo.Server.Dtos;
+using Bit.Brouter.Demo.Server.Services;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Bit.Brouter.Demo.Server.Controllers;
+
+/// <summary>
+/// The Brouter MCP server: the tools an AI agent calls to build features with Bit.Brouter without
+/// guessing at its API.
+/// <para>
+/// Every tool answers from the shipped library or from this site's own content - the XML
+/// documentation compiled into Bit.Brouter, the README, the docs pages rendered by the very router
+/// they describe, and the demo's source files - so an agent gets what the current version actually
+/// does rather than a snapshot someone wrote down. The same methods are exposed as plain HTTP GET
+/// endpoints under /api/mcp/..., which makes each of them inspectable from a browser.
+/// </para>
+/// </summary>
+[ApiController]
+[McpServerToolType]
+[Route("api/[controller]/[action]")]
+public class McpController(HtmlRenderer htmlRenderer, IOptions<BrouterOptions> brouterOptions) : ControllerBase
+{
+    // The docs pages are rich enough that a couple of them would otherwise dominate a client's
+    // context window; the ones in this demo land far below the cap.
+    private const int MaxDocumentLength = 40_000;
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterOverview))]
+    [Description("Start here. Explains what Bit.Brouter is, how to install and register it, shows a minimal working router, and lists which of the other Brouter tools to call for what.")]
+    public string GetBrouterOverview()
+    {
+        var builder = new StringBuilder();
+
+        var readme = BrouterSourceCatalog.Readme;
+        var firstSection = readme.IndexOf("\n## ", StringComparison.Ordinal);
+        builder.AppendLine(firstSection > 0 ? readme[..firstSection].Trim() : readme).AppendLine();
+
+        builder.AppendLine(BrouterSourceCatalog.GetGuideSection("Install")).AppendLine();
+        builder.AppendLine(BrouterSourceCatalog.GetGuideSection("Quick start")).AppendLine();
+        builder.AppendLine(BrouterSourceCatalog.GetGuideSection("Features")).AppendLine();
+
+        builder.AppendLine("""
+            ---
+
+            ## Which tool to call
+
+            - `GetBrouterGuideSections` / `GetBrouterGuideSection` - the library's own reference guide, one topic at a
+              time, with copy-pasteable code. The fastest route to a working implementation of a specific feature
+              (guards, loaders, keep-alive, view transitions, typed routes, migration, ...).
+            - `GetBrouterDocsList` / `GetBrouterDocsPage` - the documentation site's pages: the same topics written as
+              narrative documentation, with the live routes that demonstrate them.
+            - `GetBrouterApiList` / `GetBrouterApiDetails` - the exact public API: every component parameter with its
+              type and default value, every service member, option and enum, straight out of the shipped assembly.
+              Call this before writing code against a member you are not sure about.
+            - `GetBrouterRouteConstraints` - every constraint usable in a route template, with a passing and a failing
+              example for each.
+            - `InspectBrouterRouteTemplate` - parse a route template with Brouter's own parser before you ship it: it
+              reports the parameters, the constraints, the specificity, and the exact error for an invalid template.
+            - `GetBrouterSourceFiles` / `GetBrouterSourceFile` - real, working source: the whole route table of this
+              site (`Demo/Client/AppRouter.razor`), every demo page behind it, and the minimal hosting samples for
+              each Blazor render mode (`Sample/Wasm/...`, `Sample/Server/...`, `Sample/Auto/...`).
+
+            ## Rules of thumb when writing Brouter code
+
+            - Register the services once per Blazor DI container with `AddBitBrouterServices` - in a Blazor Web App
+              that means both the server and the client project - and add `@using Bit.Brouter` to `_Imports.razor`.
+            - Route templates use the built-in Blazor router's grammar, so `@page` templates port over verbatim.
+            - Declared routes (`<Broute Path="...">`) and discovered `@page` components can be mixed: set
+              `AppAssembly`/`AdditionalAssemblies` on `<Brouter>` to enable discovery.
+            - A route renders either a `Component` or a `<Content>` fragment, never both.
+            - Nested routes need a `<BrouterOutlet />` in the parent's content, otherwise children have nowhere to go.
+            """);
+
+        return builder.ToString();
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterDocsList))]
+    [Description("Lists the pages of the Bit.Brouter documentation site with their descriptions and search keywords. Use it to pick the slug to pass to GetBrouterDocsPage.")]
+    public BrouterDocsPageDto[] GetBrouterDocsList()
+    {
+        return [.. DocsCatalog.Sections.SelectMany(section => section.Pages.Select(page => new BrouterDocsPageDto
+        {
+            Section = section.Title,
+            Slug = page.Slug,
+            Url = page.Url,
+            Title = page.Title,
+            Description = page.Description,
+            Keywords = page.Keywords
+        }))];
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterDocsPage))]
+    [Description("Gets one page of the Bit.Brouter documentation site as Markdown, including its code samples. Pass a slug from GetBrouterDocsList, e.g. 'guards', 'data-loading' or 'route-templates'. Omit it for the documentation overview.")]
+    public async Task<string> GetBrouterDocsPage(string? slug = null)
+    {
+        // The overview's own slug is the empty string; agents reach for a word instead.
+        if (slug is "overview" or "index" or "docs") slug = string.Empty;
+
+        var page = DocsCatalog.FindBySlug(slug);
+
+        if (page is null)
+        {
+            var slugs = string.Join(", ", DocsCatalog.AllPages.Select(p => p.Slug.Length == 0 ? "(empty)" : p.Slug));
+
+            return $"No documentation page has the slug '{slug}'. Available slugs: {slugs}.";
+        }
+
+        // The page is rendered by the same component the site serves, so the documentation an agent
+        // reads is the documentation a human reads - there is no second copy that could go stale.
+        var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var component = await htmlRenderer.RenderComponentAsync(page.PageType);
+
+            return component.ToHtmlString();
+        });
+
+        // The page renders its own <h1>, so only its source is prepended here.
+        return Truncate($"Bit.Brouter documentation page: {page.Url}\n\n{html.ToMarkdown()}");
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterGuideSections))]
+    [Description("Lists every section of the Bit.Brouter reference guide (the library's README), with its heading and size. Use it to pick the heading to pass to GetBrouterGuideSection.")]
+    public BrouterGuideSectionDto[] GetBrouterGuideSections()
+    {
+        return BrouterSourceCatalog.GuideSections;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterGuideSection))]
+    [Description("Gets one section of the Bit.Brouter reference guide as Markdown, with its code samples - e.g. 'Async guards', 'Data loader', 'Keep-alive routes', 'Typed routes (source generator)'. Sub-sections are included. Heading matching ignores case and punctuation.")]
+    public string GetBrouterGuideSection(string heading)
+    {
+        var section = BrouterSourceCatalog.GetGuideSection(heading);
+
+        if (section is null)
+        {
+            var headings = string.Join(", ", BrouterSourceCatalog.GuideSections.Select(s => $"'{s.Heading}'"));
+
+            return $"The guide has no section called '{heading}'. Available sections: {headings}.";
+        }
+
+        return Truncate(section);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterApiList))]
+    [Description("Lists every public type of the Bit.Brouter library - components, services, options, enums and value types - with its kind and summary. Use it to pick the type to pass to GetBrouterApiDetails.")]
+    public BrouterApiTypeDto[] GetBrouterApiList()
+    {
+        return BrouterApiCatalog.Types;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterApiDetails))]
+    [Description("Gets the full reference of one Bit.Brouter type: its Blazor parameters with types and default values, its properties, methods, events or enum values, each with its documentation. Call it before using a member you are unsure about, e.g. 'Broute', 'Brouter', 'BrouterLink', 'IBrouter', 'BrouterOptions', 'BrouterNavigationContext'.")]
+    public object GetBrouterApiDetails(string typeName)
+    {
+        var details = BrouterApiCatalog.GetTypeDetails(typeName);
+
+        if (details is not null) return details;
+
+        var candidates = BrouterApiCatalog.Types
+            .Where(t => t.Name.Contains(typeName ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+            .Select(t => t.Name)
+            .ToArray();
+
+        return candidates.Length > 0
+            ? $"Bit.Brouter has no public type called '{typeName}'. Did you mean: {string.Join(", ", candidates)}?"
+            : $"Bit.Brouter has no public type called '{typeName}'. Call GetBrouterApiList for the full list.";
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterRouteConstraints))]
+    [Description("Lists every route constraint usable inside a Bit.Brouter route template - the built-in type and validation constraints, a custom one, and constraint chaining - each with the rule it enforces plus a passing and a failing example.")]
+    public BrouterConstraintDto[] GetBrouterRouteConstraints()
+    {
+        return [.. ConstraintCatalog.All.Select(constraint => new BrouterConstraintDto
+        {
+            Token = constraint.Token,
+            Category = constraint.Category,
+            Rule = constraint.Rule,
+            PassExample = constraint.PassExample,
+            FailExample = constraint.FailExample,
+            TryUrl = $"/c/{constraint.Kind}/{constraint.PassExample}"
+        })];
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(InspectBrouterRouteTemplate))]
+    [Description("Parses a route template with Bit.Brouter's own parser and reports what it means: its segments, parameter names, constraints, default values, specificity, and notes about behavior that is easy to get wrong. An invalid template comes back with the exact error the router would throw. Example inputs: '/users/{id:int}', '/files/{name}.{ext?}', '/assets/{*path:nonfile}'.")]
+    public BrouterTemplateInspectionDto InspectBrouterRouteTemplate(string template)
+    {
+        // The app's own constraint registry, so custom constraints registered in
+        // AddBitBrouterServices (this demo registers "slug") resolve exactly as they do at runtime.
+        return BrouterTemplateInspector.Inspect(template, brouterOptions.Value.Constraints);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterSourceFiles))]
+    [Description("Lists the working Bit.Brouter source files this server can hand out: the whole route table of the documentation site, every page it routes to, and the minimal hosting samples for each Blazor render mode. Use it to pick the path to pass to GetBrouterSourceFile.")]
+    public BrouterSourceFileDto[] GetBrouterSourceFiles()
+    {
+        return BrouterSourceCatalog.SourceFiles;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBrouterSourceFile))]
+    [Description("Gets one source file listed by GetBrouterSourceFiles, verbatim - e.g. 'Demo/Client/AppRouter.razor' for a complete, working route table that exercises nearly every Bit.Brouter feature.")]
+    public string GetBrouterSourceFile(string path)
+    {
+        var content = BrouterSourceCatalog.GetSourceFile(path);
+
+        if (content is null)
+        {
+            var candidates = BrouterSourceCatalog.SourceFiles
+                .Where(f => f.Path.Contains(path ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+                .Select(f => f.Path)
+                .Take(10)
+                .ToArray();
+
+            return candidates.Length > 0
+                ? $"No source file at '{path}'. Did you mean: {string.Join(", ", candidates)}?"
+                : $"No source file at '{path}'. Call GetBrouterSourceFiles for the full list.";
+        }
+
+        return Truncate(content);
+    }
+
+    private static string Truncate(string text)
+    {
+        return text.Length <= MaxDocumentLength
+            ? text
+            : $"{text[..MaxDocumentLength]}\n\n[truncated - the full text is longer than {MaxDocumentLength} characters]";
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpPrompts.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpPrompts.cs
@@ -1,0 +1,127 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace Bit.Brouter.Demo.Server.Controllers;
+
+/// <summary>
+/// Ready-made workflows for the four things people actually ask a router for: add it to an app,
+/// build a feature with it, move off the built-in Router, and work out why a URL is not matching.
+/// <para>
+/// Each prompt spends its words on the order to call the tools in and on the mistakes that are
+/// expensive to make - the ones that produce a blank page rather than a compiler error - because
+/// the failure mode of an agent with a dozen tools is not ignorance, it is calling them in a
+/// sequence that skips the check which would have caught the bug.
+/// </para>
+/// </summary>
+[McpServerPromptType]
+public static class McpPrompts
+{
+    [McpServerPrompt(Name = "add-brouter-to-app")]
+    [Description("Walks through adding Bit.Brouter to an existing Blazor app, in the right order for its render mode.")]
+    public static string AddBrouterToApp(
+        [Description("The app's Blazor render mode: server, wasm, auto or standalone-wasm. Pass 'unknown' to have it determined from the project first.")] string renderMode = "unknown")
+    {
+        return $"""
+            Add Bit.Brouter to this Blazor app. Its render mode is: {renderMode}.
+
+            Work in this order:
+
+            1. If the render mode is 'unknown', determine it from the project first: look for
+               AddInteractiveServerComponents / AddInteractiveWebAssemblyComponents in Program.cs and for a separate
+               .Client project, then continue with what you find.
+            2. Call `GetBrouterSetupGuide` with that render mode and follow it. Registering the services in only one
+               of a Blazor Web App's two DI containers is the single most common setup bug - it fails during
+               prerendering, not at compile time.
+            3. Replace Blazor's built-in `<Router>`: add the catch-all host page and render `<Brouter>` from it. Do
+               not leave both routers in the tree.
+            4. Keep the app's existing `@page` components working by pointing `AppAssembly` (and
+               `AdditionalAssemblies` for any razor class libraries) at their assemblies - templates are
+               superset-compatible, so nothing about them has to change.
+            5. Before finishing, call `AnalyzeBrouterRouteTable` with every route template the app now declares, and
+               resolve anything it reports as ambiguous or invalid.
+            6. Build the app and fix what the compiler says.
+
+            Show me the diff for each file you change, and say explicitly which DI containers you registered the
+            services in.
+            """;
+    }
+
+    [McpServerPrompt(Name = "implement-brouter-feature")]
+    [Description("Implements a routing feature with Bit.Brouter - guards, loaders, nested layouts, keep-alive, transitions - using its real API rather than a guessed one.")]
+    public static string ImplementBrouterFeature(
+        [Description("What the routing should do, in your own words - e.g. 'warn before leaving a half-filled form' or 'load the order before the page renders and cache it for 30 seconds'.")] string feature)
+    {
+        return $"""
+            Implement this with Bit.Brouter: {feature}
+
+            Work in this order:
+
+            1. Call `SearchBrouter` with the request above. It searches the guide, the docs pages, every public
+               member and the demo's sources at once, and every hit tells you the exact follow-up call to make.
+            2. Read the best hit in full with the call it hands you, before writing any code.
+            3. Call `GetBrouterApiDetails` for every Brouter type you are about to use, and match the parameter
+               names, types and defaults exactly - do not infer a parameter from another router library.
+            4. If the work touches route templates, check them with `InspectBrouterRouteTemplate` (or
+               `AnalyzeBrouterRouteTable` for several) before you ship them.
+            5. Prefer the framework's own mechanism over hand-rolling one: a route `Guard` / `LeaveGuard` over manual
+               checks in OnInitialized, a route `Loader` over fetching in the component, `KeepAlive` over caching
+               state yourself, `<BrouterOutlet />` over conditional rendering.
+            6. Write the code, then say which tool call each non-obvious choice came from.
+
+            If the demo already contains a working example of this, fetch it with `GetBrouterSourceFile` and follow
+            its shape rather than inventing a new one.
+            """;
+    }
+
+    [McpServerPrompt(Name = "migrate-to-brouter")]
+    [Description("Migrates an app from Blazor's built-in Router to Bit.Brouter, keeping its existing @page components and authorization.")]
+    public static string MigrateToBrouter()
+    {
+        return """
+            Migrate this app from Blazor's built-in `<Router>` to Bit.Brouter.
+
+            Work in this order:
+
+            1. Call `GetBrouterGuideSection` with heading "Migrating from the built-in Router" and read it in full,
+               then `GetBrouterDocsPage` with slug "migration" for the parameter-by-parameter mapping table.
+            2. Call `GetBrouterSetupGuide` for this app's render mode and reconcile it with what the app already has.
+            3. Keep every existing `@page` component where it is: enable discovery with `AppAssembly` /
+               `AdditionalAssemblies` instead of rewriting templates. Route templates are superset-compatible.
+            4. Map the built-in Router's pieces rather than dropping them - `Found`/`RouteView`, `NotFound`,
+               `Navigating`, `AuthorizeRouteView` and layouts all have documented equivalents; the guide's migration
+               section states each one.
+            5. Call `AnalyzeBrouterRouteTable` with the full set of templates once discovery is on, since a
+               hand-declared route and a discovered `@page` can now collide.
+            6. Build, then walk the app's routes - including deep links and the 404 path - and report what changed.
+
+            Do not change route templates or component code beyond what the migration requires.
+            """;
+    }
+
+    [McpServerPrompt(Name = "debug-brouter-routing")]
+    [Description("Diagnoses a Bit.Brouter routing problem - a URL that does not match, a parameter that arrives null, a guard that does not fire, stale loader data.")]
+    public static string DebugBrouterRouting(
+        [Description("What goes wrong, with the URL and the route template involved if you know them.")] string symptom)
+    {
+        return $"""
+            Diagnose this Bit.Brouter problem: {symptom}
+
+            Work in this order:
+
+            1. Call `GetBrouterDocsPage` with slug "faq" - it lists the common symptoms with the reason behind each,
+               and the cause is often there verbatim.
+            2. If a route template is involved, call `InspectBrouterRouteTemplate` on it. It parses with Brouter's
+               own parser and reports the parameters, constraints and specificity - and the exact error if the
+               template is invalid. For a URL that picks the wrong route, call `AnalyzeBrouterRouteTable` with every
+               competing template: it ranks them the way the router does.
+            3. Call `SearchBrouter` with the symptom for anything the FAQ did not cover.
+            4. Confirm the API you are relying on with `GetBrouterApiDetails` before concluding it is a bug - check
+               the actual default value of the parameter involved.
+            5. Check the setup itself against `GetBrouterSetupGuide` for this render mode: services registered in
+               every DI container, the catch-all host page present, the built-in `<Router>` gone, `AppAssembly` set
+               if the route is a discovered `@page`.
+
+            Tell me the cause and the fix, and cite the tool call that established it.
+            """;
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpResources.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpResources.cs
@@ -1,0 +1,92 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using Bit.Brouter.Demo.Client;
+using Bit.Brouter.Demo.Server.Services;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Bit.Brouter.Demo.Server.Controllers;
+
+/// <summary>
+/// The same body of knowledge the tools serve, exposed as MCP resources.
+/// <para>
+/// Tools are for an agent that has decided what it needs; resources are for a client that wants to
+/// attach documentation to a conversation up front, or let a person browse and pin it. Both read
+/// the same catalogs, so neither can go stale relative to the other.
+/// </para>
+/// </summary>
+[McpServerResourceType]
+public class McpResources(HtmlRenderer htmlRenderer)
+{
+    [McpServerResource(UriTemplate = "brouter://guide", Name = "Bit.Brouter reference guide", MimeType = "text/markdown")]
+    [Description("The complete Bit.Brouter reference guide (the library's README), every section in one document.")]
+    public static string Guide() => BrouterSourceCatalog.Readme;
+
+    [McpServerResource(UriTemplate = "brouter://guide/{heading}", Name = "Guide section", MimeType = "text/markdown")]
+    [Description("One section of the Bit.Brouter reference guide by heading, e.g. brouter://guide/Async%20guards.")]
+    public static string GuideSection(string heading)
+        => BrouterSourceCatalog.GetGuideSection(heading) ?? $"The guide has no section called '{heading}'.";
+
+    [McpServerResource(UriTemplate = "brouter://api", Name = "Bit.Brouter public API", MimeType = "text/markdown")]
+    [Description("Every public Bit.Brouter type with its kind and summary.")]
+    public static string ApiList()
+    {
+        var lines = BrouterApiCatalog.Types.Select(type => $"- **{type.Name}** ({type.Kind}) - {type.Summary}");
+
+        return $"# Bit.Brouter public API\n\n{string.Join('\n', lines)}";
+    }
+
+    [McpServerResource(UriTemplate = "brouter://api/{typeName}", Name = "Type reference", MimeType = "text/markdown")]
+    [Description("The full reference of one Bit.Brouter type, e.g. brouter://api/BrouterOptions.")]
+    public static string ApiType(string typeName)
+    {
+        var details = BrouterApiCatalog.GetTypeDetails(typeName);
+        if (details is null) return $"Bit.Brouter has no public type called '{typeName}'.";
+
+        var builder = new System.Text.StringBuilder();
+
+        builder.AppendLine($"# {details.Name} ({details.Kind})").AppendLine();
+        if (details.Summary is not null) builder.AppendLine(details.Summary).AppendLine();
+        if (details.Remarks is not null) builder.AppendLine(details.Remarks).AppendLine();
+
+        foreach (var group in details.Members.GroupBy(m => m.Kind))
+        {
+            builder.AppendLine($"## {group.Key}").AppendLine();
+
+            foreach (var member in group)
+            {
+                builder.Append($"- **{member.Name}**{member.Signature}");
+                if (member.Type is not null) builder.Append($" : `{member.Type}`");
+                if (member.Default is not null) builder.Append($" = `{member.Default}`");
+                if (member.Required) builder.Append(" **(required)**");
+                if (member.Summary is not null) builder.Append($" - {member.Summary}");
+                builder.AppendLine();
+            }
+
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    [McpServerResource(UriTemplate = "brouter://source/{path}", Name = "Demo source file", MimeType = "text/plain")]
+    [Description("One source file of the demo or of the hosting samples, e.g. brouter://source/Demo%2FClient%2FAppRouter.razor.")]
+    public static string Source(string path)
+        => BrouterSourceCatalog.GetSourceFile(path) ?? $"No source file at '{path}'.";
+
+    [McpServerResource(UriTemplate = "brouter://docs/{slug}", Name = "Documentation page", MimeType = "text/markdown")]
+    [Description("One page of the Bit.Brouter documentation site, rendered as Markdown, e.g. brouter://docs/guards.")]
+    public async Task<string> DocsPage(string slug)
+    {
+        var page = DocsCatalog.FindBySlug(slug is "overview" or "index" ? string.Empty : slug);
+        if (page is null) return $"No documentation page has the slug '{slug}'.";
+
+        var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var component = await htmlRenderer.RenderComponentAsync(page.PageType);
+
+            return component.ToHtmlString();
+        });
+
+        return html.ToMarkdown();
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpResources.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Controllers/McpResources.cs
@@ -80,13 +80,8 @@ public class McpResources(HtmlRenderer htmlRenderer)
         var page = DocsCatalog.FindBySlug(slug is "overview" or "index" ? string.Empty : slug);
         if (page is null) return $"No documentation page has the slug '{slug}'.";
 
-        var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
-        {
-            var component = await htmlRenderer.RenderComponentAsync(page.PageType);
+        var (markdown, error) = await DocsPageRenderer.TryRenderMarkdownAsync(htmlRenderer, page);
 
-            return component.ToHtmlString();
-        });
-
-        return html.ToMarkdown();
+        return markdown ?? DocsPageRenderer.Unavailable(page, error);
     }
 }

--- a/src/Brouter/Bit.Brouter.Demo/Server/Dtos/BrouterMcpDtos.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Dtos/BrouterMcpDtos.cs
@@ -1,0 +1,176 @@
+namespace Bit.Brouter.Demo.Server.Dtos;
+
+/// <summary>One page of the documentation site (mirrors an entry of the client's DocsCatalog).</summary>
+public record BrouterDocsPageDto
+{
+    /// <summary>The sidebar section the page belongs to, e.g. "Routing".</summary>
+    public required string Section { get; init; }
+
+    /// <summary>The value to pass to GetBrouterDocsPage. Empty string for the docs overview.</summary>
+    public required string Slug { get; init; }
+
+    /// <summary>The page's URL on the live documentation site.</summary>
+    public required string Url { get; init; }
+
+    public required string Title { get; init; }
+
+    public required string Description { get; init; }
+
+    /// <summary>Space-separated search terms that the page covers - useful for picking the right slug.</summary>
+    public required string Keywords { get; init; }
+}
+
+/// <summary>One heading of the library's README, which doubles as its reference guide.</summary>
+public record BrouterGuideSectionDto
+{
+    /// <summary>The heading text, e.g. "Loader caching (stale-while-revalidate)". Pass it to GetBrouterGuideSection.</summary>
+    public required string Heading { get; init; }
+
+    /// <summary>Markdown heading level: 2 for a top-level section, 3 for a sub-section.</summary>
+    public required int Level { get; init; }
+
+    /// <summary>The owning level-2 section, or null when this entry is itself level 2.</summary>
+    public string? Parent { get; init; }
+
+    /// <summary>Number of markdown lines in the section (including its sub-sections).</summary>
+    public required int Lines { get; init; }
+}
+
+/// <summary>A public type of the Bit.Brouter assembly.</summary>
+public record BrouterApiTypeDto
+{
+    public required string Name { get; init; }
+
+    /// <summary>Component, Interface, Enum, Attribute, Delegate, Static class, Class, Struct or Record.</summary>
+    public required string Kind { get; init; }
+
+    public string? Summary { get; init; }
+}
+
+/// <summary>A member (parameter, property, method or enum value) of a public Bit.Brouter type.</summary>
+public record BrouterApiMemberDto
+{
+    public required string Name { get; init; }
+
+    /// <summary>Parameter, Property, Method, Event or EnumValue. "Parameter" means a Blazor [Parameter].</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The C# type of the member, or the signature's return type for a method.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>The method's parameter list, e.g. "(string url, bool replace = false)".</summary>
+    public string? Signature { get; init; }
+
+    /// <summary>The value the member has on a freshly created instance, when it could be determined.</summary>
+    public string? Default { get; init; }
+
+    /// <summary>True for [EditorRequired] Blazor parameters.</summary>
+    public bool Required { get; init; }
+
+    public string? Summary { get; init; }
+
+    /// <summary>The XML remarks, when the member has any - they carry the caveats.</summary>
+    public string? Remarks { get; init; }
+}
+
+/// <summary>The full reference of one public Bit.Brouter type.</summary>
+public record BrouterApiTypeDetailsDto
+{
+    public required string Name { get; init; }
+
+    public required string FullName { get; init; }
+
+    public required string Kind { get; init; }
+
+    public string? BaseType { get; init; }
+
+    public string[]? Implements { get; init; }
+
+    public string? Summary { get; init; }
+
+    public string? Remarks { get; init; }
+
+    public required BrouterApiMemberDto[] Members { get; init; }
+}
+
+/// <summary>A route constraint usable inside a route template, e.g. <c>{id:int}</c>.</summary>
+public record BrouterConstraintDto
+{
+    /// <summary>The constraint text as written in a template, e.g. "int" or "range(1,10)".</summary>
+    public required string Token { get; init; }
+
+    /// <summary>type (validates AND converts the bound value), validation (accepts/rejects, value stays a string), custom or chain.</summary>
+    public required string Category { get; init; }
+
+    public required string Rule { get; init; }
+
+    public required string PassExample { get; init; }
+
+    public required string FailExample { get; init; }
+
+    /// <summary>A live URL of the documentation site that exercises the constraint with the passing example.</summary>
+    public required string TryUrl { get; init; }
+}
+
+/// <summary>A source file of the demo/samples, retrievable through GetBrouterSourceFile.</summary>
+public record BrouterSourceFileDto
+{
+    /// <summary>The path to pass to GetBrouterSourceFile, e.g. "Demo/Pages/DataPage.razor".</summary>
+    public required string Path { get; init; }
+
+    /// <summary>Demo (this documentation site) or Sample (the minimal hosting-model samples).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The file's own header comment or page title, when it has one.</summary>
+    public string? Description { get; init; }
+
+    public required int Lines { get; init; }
+}
+
+/// <summary>One '/'-separated segment of a parsed route template.</summary>
+public record BrouterTemplateSegmentDto
+{
+    /// <summary>The segment text as written in the template.</summary>
+    public required string Value { get; init; }
+
+    /// <summary>Literal, Parameter, CatchAll, Wildcard or Complex.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Names of the parameters the segment binds (more than one for a complex segment).</summary>
+    public string[]? ParameterNames { get; init; }
+
+    /// <summary>Constraint tokens applied to the segment, in the order they are evaluated.</summary>
+    public string[]? Constraints { get; init; }
+
+    public bool IsOptional { get; init; }
+
+    /// <summary>The declared default value, e.g. "Index" for <c>{action=Index}</c>.</summary>
+    public string? DefaultValue { get; init; }
+
+    /// <summary>How specific the segment is - the router prefers the highest total when several routes match.</summary>
+    public int Specificity { get; init; }
+}
+
+/// <summary>The result of parsing a route template with Brouter's own parser.</summary>
+public record BrouterTemplateInspectionDto
+{
+    public required string Template { get; init; }
+
+    /// <summary>False when the template does not parse - Error then holds the reason the router would throw.</summary>
+    public required bool IsValid { get; init; }
+
+    public string? Error { get; init; }
+
+    /// <summary>The template as the router stores it (leading/trailing slashes and "~/" removed).</summary>
+    public string? NormalizedTemplate { get; init; }
+
+    /// <summary>Sum of the segment specificities - the tie-breaker between two routes that both match.</summary>
+    public int Specificity { get; init; }
+
+    public string[]? ParameterNames { get; init; }
+
+    public BrouterTemplateSegmentDto[]? Segments { get; init; }
+
+    /// <summary>Notes about the template's behavior that are easy to get wrong (middle optionals, catch-alls, ...).</summary>
+    public string[]? Notes { get; init; }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Dtos/BrouterMcpDtos.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Dtos/BrouterMcpDtos.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Bit.Brouter.Demo.Server.Dtos;
 
 /// <summary>One page of the documentation site (mirrors an entry of the client's DocsCatalog).</summary>
@@ -197,7 +199,10 @@ public record BrouterRouteTableEntryDto
     /// <summary>1 = the route the router prefers when several of them match the same URL.</summary>
     public int MatchOrder { get; init; }
 
-    /// <summary>The template with parameter names dropped - two routes sharing a shape match exactly the same URLs.</summary>
+    /// <summary>
+    /// The template reduced to what the router actually tells apart - parameter names dropped, but
+    /// constraints and declared defaults kept. Two routes sharing a shape are indistinguishable.
+    /// </summary>
     public string? Shape { get; init; }
 }
 
@@ -256,6 +261,14 @@ public record BrouterTemplateInspectionDto
     public string[]? ParameterNames { get; init; }
 
     public BrouterTemplateSegmentDto[]? Segments { get; init; }
+
+    /// <summary>
+    /// The canonical identity of what the template matches, mirroring the key the router itself uses
+    /// to reject ambiguous registrations. Serialized only as part of a route-table analysis, where
+    /// comparing one template against another is the point.
+    /// </summary>
+    [JsonIgnore]
+    public string? Shape { get; init; }
 
     /// <summary>Notes about the template's behavior that are easy to get wrong (middle optionals, catch-alls, ...).</summary>
     public string[]? Notes { get; init; }

--- a/src/Brouter/Bit.Brouter.Demo/Server/Dtos/BrouterMcpDtos.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Dtos/BrouterMcpDtos.cs
@@ -93,6 +93,16 @@ public record BrouterApiTypeDetailsDto
     public required BrouterApiMemberDto[] Members { get; init; }
 }
 
+/// <summary>What GetBrouterApiDetails answers: the type's reference, or why there is none.</summary>
+public record BrouterApiDetailsResultDto
+{
+    /// <summary>The full reference of the type, when a public type goes by the requested name.</summary>
+    public BrouterApiTypeDetailsDto? Details { get; init; }
+
+    /// <summary>Set instead of Details when nothing matched - it names the closest candidates.</summary>
+    public string? Message { get; init; }
+}
+
 /// <summary>A route constraint usable inside a route template, e.g. <c>{id:int}</c>.</summary>
 public record BrouterConstraintDto
 {
@@ -125,6 +135,82 @@ public record BrouterSourceFileDto
     public string? Description { get; init; }
 
     public required int Lines { get; init; }
+}
+
+/// <summary>One result of a search across everything this MCP server knows about Bit.Brouter.</summary>
+public record BrouterSearchHitDto
+{
+    /// <summary>What was found: "Guide section", "Docs page", "API component", "API parameter", "Route constraint", "Source file", ...</summary>
+    public required string Kind { get; init; }
+
+    public required string Title { get; init; }
+
+    /// <summary>Where the hit sits: the owning section, type or category.</summary>
+    public string? Context { get; init; }
+
+    /// <summary>The tool call that returns the full text of this hit - call it verbatim.</summary>
+    public required string Tool { get; init; }
+
+    /// <summary>The matching text, with a little of what surrounds it.</summary>
+    public required string Snippet { get; init; }
+}
+
+/// <summary>One URL builder emitted by the Bit.Brouter.Generators source generator.</summary>
+public record BrouterTypedRouteDto
+{
+    /// <summary>The generated method, e.g. "Counter".</summary>
+    public required string Method { get; init; }
+
+    /// <summary>Its parameter list, e.g. "(int init)".</summary>
+    public required string Signature { get; init; }
+
+    /// <summary>The URL it builds for a sample argument set - what the method is for, shown rather than described.</summary>
+    public string? ExampleUrl { get; init; }
+}
+
+/// <summary>The typed routes a project gets from the Bit.Brouter.Generators package.</summary>
+public record BrouterTypedRoutesDto
+{
+    /// <summary>The assembly whose route declarations produced these builders.</summary>
+    public required string GeneratedFor { get; init; }
+
+    /// <summary>How the generator produces this class, and how to enable it.</summary>
+    public required string HowItWorks { get; init; }
+
+    public required BrouterTypedRouteDto[] Builders { get; init; }
+
+    /// <summary>The constants under BrouterRoutes.Names - one per named route, for IBrouter.NavigateToName.</summary>
+    public required Dictionary<string, string> Names { get; init; }
+}
+
+/// <summary>One route of an analyzed route table.</summary>
+public record BrouterRouteTableEntryDto
+{
+    public required string Template { get; init; }
+
+    public required bool IsValid { get; init; }
+
+    public string? Error { get; init; }
+
+    public int Specificity { get; init; }
+
+    /// <summary>1 = the route the router prefers when several of them match the same URL.</summary>
+    public int MatchOrder { get; init; }
+
+    /// <summary>The template with parameter names dropped - two routes sharing a shape match exactly the same URLs.</summary>
+    public string? Shape { get; init; }
+}
+
+/// <summary>The result of analyzing a set of route templates together.</summary>
+public record BrouterRouteTableAnalysisDto
+{
+    /// <summary>The routes, most specific first - the order in which the router prefers them.</summary>
+    public required BrouterRouteTableEntryDto[] Routes { get; init; }
+
+    /// <summary>Groups of templates that match exactly the same URLs. Brouter throws at registration for these.</summary>
+    public required string[][] Ambiguous { get; init; }
+
+    public required string[] Notes { get; init; }
 }
 
 /// <summary>One '/'-separated segment of a parsed route template.</summary>

--- a/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
@@ -14,7 +14,9 @@ builder.Services.AddDemoServices();
 builder.Services.AddControllers();
 builder.Services.AddMcpServer()
     .WithHttpTransport()
-    .WithToolsFromAssembly();
+    .WithToolsFromAssembly()
+    .WithResourcesFromAssembly()
+    .WithPromptsFromAssembly();
 
 // Renders a docs page outside of a request's component hierarchy, so its content can be handed to
 // an MCP client as text. Scoped: a renderer belongs to the request that asked for the page.

--- a/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Brouter.Demo.Server.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +9,16 @@ builder.Services.AddRazorComponents()
 // The prerender pass instantiates the client's components in this container, so it has to
 // register the very same services the WebAssembly container does.
 builder.Services.AddDemoServices();
+
+// The MCP server (Controllers/McpController.cs) and the plain HTTP endpoints that mirror it.
+builder.Services.AddControllers();
+builder.Services.AddMcpServer()
+    .WithHttpTransport()
+    .WithToolsFromAssembly();
+
+// Renders a docs page outside of a request's component hierarchy, so its content can be handed to
+// an MCP client as text. Scoped: a renderer belongs to the request that asked for the page.
+builder.Services.AddScoped<HtmlRenderer>();
 
 var app = builder.Build();
 
@@ -25,6 +36,11 @@ app.UseHttpsRedirection();
 app.UseAntiforgery();
 
 app.MapStaticAssets();
+
+// Both are declared before the catch-all host page below: /api/... and /mcp are literal routes, so
+// they win over "/{*path}" regardless of order, but keeping them first says so out loud.
+app.MapControllers();
+app.MapMcp("/mcp");
 
 // Components/Pages/Host.razor is a catch-all page, so every deep link matches an endpoint and
 // gets the prerendered app back - Brouter then resolves the real route (including its own 404).

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterApiCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterApiCatalog.cs
@@ -1,0 +1,387 @@
+using System.Text;
+using System.Reflection;
+using Bit.Brouter.Demo.Server.Dtos;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Builds the API reference the MCP tools serve, by reflecting over the public surface of the
+/// Bit.Brouter assembly and pairing every type and member with its XML documentation.
+/// <para>
+/// Reflection rather than a hand-maintained table: the reference then cannot drift from the
+/// shipped library - a new parameter shows up the moment it is written, with the default value it
+/// actually has (read off a freshly constructed instance) instead of one someone remembered to
+/// copy into a document.
+/// </para>
+/// </summary>
+public static class BrouterApiCatalog
+{
+    private const BindingFlags Declared = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+    private static readonly Assembly _assembly = typeof(BrouterLink).Assembly;
+
+    private static readonly Lazy<Type[]> _publicTypes = new(() =>
+        [.. _assembly.GetExportedTypes()
+            .Where(t => t.IsNested is false && t.Name.Contains('<', StringComparison.Ordinal) is false)
+            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)]);
+
+    private static readonly Lazy<BrouterApiTypeDto[]> _types = new(() =>
+        [.. _publicTypes.Value.Select(t => new BrouterApiTypeDto
+        {
+            Name = FriendlyName(t),
+            Kind = KindOf(t),
+            Summary = BrouterXmlDocs.GetSummary(DocumentationId(t))
+        })]);
+
+    /// <summary>Every public type of Bit.Brouter, with its summary.</summary>
+    public static BrouterApiTypeDto[] Types => _types.Value;
+
+    /// <summary>
+    /// The full reference of one type - its Blazor parameters, properties, methods, events or enum
+    /// values - or null when no public type goes by that name.
+    /// </summary>
+    public static BrouterApiTypeDetailsDto? GetTypeDetails(string typeName)
+    {
+        var type = Find(typeName);
+        if (type is null) return null;
+
+        var instance = TryCreateInstance(type);
+
+        var members = new List<BrouterApiMemberDto>();
+
+        if (type.IsEnum)
+        {
+            members.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                                 .Select(field => new BrouterApiMemberDto
+                                 {
+                                     Name = field.Name,
+                                     Kind = "EnumValue",
+                                     Type = FriendlyName(type.GetEnumUnderlyingType()),
+                                     Default = Convert.ToInt64(field.GetRawConstantValue(), System.Globalization.CultureInfo.InvariantCulture)
+                                                      .ToString(System.Globalization.CultureInfo.InvariantCulture),
+                                     Summary = BrouterXmlDocs.GetSummary(DocumentationId(field)),
+                                     Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(field))
+                                 }));
+        }
+        else
+        {
+            members.AddRange(Properties(type, instance));
+            members.AddRange(Fields(type));
+            members.AddRange(Methods(type));
+            members.AddRange(Events(type));
+        }
+
+        return new BrouterApiTypeDetailsDto
+        {
+            Name = FriendlyName(type),
+            FullName = type.FullName ?? type.Name,
+            Kind = KindOf(type),
+            BaseType = type.BaseType is null || type.BaseType == typeof(object) || type.BaseType == typeof(ValueType)
+                ? null
+                : FriendlyName(type.BaseType),
+            Implements = [.. type.GetInterfaces()
+                .Where(i => i.IsPublic && i.DeclaringType is null)
+                .Select(FriendlyName)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)],
+            Summary = BrouterXmlDocs.GetSummary(DocumentationId(type)),
+            Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(type)),
+            Members = [.. members.OrderBy(m => KindOrder(m.Kind)).ThenBy(m => m.Name, StringComparer.OrdinalIgnoreCase)]
+        };
+    }
+
+    /// <summary>Resolves a type by its simple name, with or without a generic arity or argument list.</summary>
+    private static Type? Find(string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName)) return null;
+
+        var name = typeName.Trim();
+
+        var generic = name.IndexOf('<', StringComparison.Ordinal);
+        if (generic > 0) name = name[..generic];
+
+        return _publicTypes.Value.FirstOrDefault(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase))
+            ?? _publicTypes.Value.FirstOrDefault(t => string.Equals(StripArity(t.Name), name, StringComparison.OrdinalIgnoreCase))
+            ?? _publicTypes.Value.FirstOrDefault(t => string.Equals(t.FullName, name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The type and every base of it that Bit.Brouter itself declares. A component's inherited
+    /// parameters belong in its reference; the members it gets from ComponentBase do not.
+    /// </summary>
+    private static IEnumerable<Type> Hierarchy(Type type)
+    {
+        for (var current = type; current is not null && current.Assembly == _assembly; current = current.BaseType)
+        {
+            yield return current;
+        }
+    }
+
+    private static IEnumerable<BrouterApiMemberDto> Properties(Type type, object? instance)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var property in Hierarchy(type).SelectMany(t => t.GetProperties(Declared)))
+        {
+            if (property.GetIndexParameters().Length > 0) continue;
+            if (seen.Add(property.Name) is false) continue;
+
+            var isParameter = property.IsDefined(typeof(ParameterAttribute), inherit: true);
+
+            yield return new BrouterApiMemberDto
+            {
+                Name = property.Name,
+                Kind = isParameter ? "Parameter" : "Property",
+                Type = FriendlyName(property.PropertyType),
+                Default = DefaultValueOf(property, instance),
+                Required = property.IsDefined(typeof(EditorRequiredAttribute), inherit: true),
+                Summary = BrouterXmlDocs.GetSummary(DocumentationId(property)),
+                Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(property))
+            };
+        }
+    }
+
+    private static IEnumerable<BrouterApiMemberDto> Fields(Type type)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var field in Hierarchy(type).SelectMany(t => t.GetFields(Declared)))
+        {
+            if (field.Name.Contains('<', StringComparison.Ordinal)) continue;
+            if (seen.Add(field.Name) is false) continue;
+
+            yield return new BrouterApiMemberDto
+            {
+                Name = field.Name,
+                Kind = "Field",
+                Type = FriendlyName(field.FieldType),
+                Default = field.IsLiteral ? Format(field.GetRawConstantValue()) : null,
+                Summary = BrouterXmlDocs.GetSummary(DocumentationId(field)),
+                Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(field))
+            };
+        }
+    }
+
+    private static IEnumerable<BrouterApiMemberDto> Methods(Type type)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in Hierarchy(type).SelectMany(t => t.GetMethods(Declared)))
+        {
+            if (method.IsSpecialName) continue;                                     // property/event accessors and operators
+            if (method.Name.Contains('<', StringComparison.Ordinal)) continue;
+            if (method.DeclaringType == typeof(object)) continue;
+
+            var signature = Signature(method);
+            if (seen.Add($"{method.Name}{signature}") is false) continue;
+
+            yield return new BrouterApiMemberDto
+            {
+                Name = method.Name,
+                Kind = "Method",
+                Type = FriendlyName(method.ReturnType),
+                Signature = signature,
+                Summary = BrouterXmlDocs.GetSummary(DocumentationId(method)),
+                Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(method))
+            };
+        }
+    }
+
+    private static IEnumerable<BrouterApiMemberDto> Events(Type type)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var member in Hierarchy(type).SelectMany(t => t.GetEvents(Declared)))
+        {
+            if (seen.Add(member.Name) is false) continue;
+
+            yield return new BrouterApiMemberDto
+            {
+                Name = member.Name,
+                Kind = "Event",
+                Type = FriendlyName(member.EventHandlerType ?? typeof(void)),
+                Summary = BrouterXmlDocs.GetSummary(DocumentationId(member)),
+                Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(member))
+            };
+        }
+    }
+
+    /// <summary>
+    /// The value a property holds on a newly constructed instance - the default a caller gets when
+    /// the parameter is left unset.
+    /// </summary>
+    private static string? DefaultValueOf(PropertyInfo property, object? instance)
+    {
+        if (property.GetMethod is null || property.GetMethod.IsPublic is false) return null;
+        if (property.GetMethod.IsStatic is false && instance is null) return null;
+
+        try
+        {
+            return Format(property.GetValue(property.GetMethod.IsStatic ? null : instance));
+        }
+        catch (Exception)
+        {
+            // Members that only make sense on a mounted component (or throw by design) simply have
+            // no observable default; that is not a reason to fail the whole type's reference.
+            return null;
+        }
+    }
+
+    private static object? TryCreateInstance(Type type)
+    {
+        if (type.IsAbstract || type.IsInterface || type.IsEnum) return null;
+        if (type.IsValueType is false && type.GetConstructor(Type.EmptyTypes) is null) return null;
+
+        try
+        {
+            return Activator.CreateInstance(type);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static string? Format(object? value) => value switch
+    {
+        null => null,
+        string text => $"\"{text}\"",
+        bool flag => flag ? "true" : "false",
+        Enum enumValue => $"{enumValue.GetType().Name}.{enumValue}",
+        IFormattable formattable => formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
+        _ => Describe(value)
+    };
+
+    /// <summary>
+    /// A reference-typed default is worth reporting: a property that starts out holding an object
+    /// (BrouterOptions.Constraints does) is not the same thing as one that starts out null.
+    /// </summary>
+    private static string Describe(object value)
+    {
+        var type = value.GetType();
+        var text = value.ToString();
+
+        return string.IsNullOrEmpty(text) || text == type.FullName || text == type.Name
+            ? $"new {FriendlyName(type)}()"
+            : text;
+    }
+
+    private static string Signature(MethodInfo method)
+    {
+        var builder = new StringBuilder("(");
+
+        var parameters = method.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+
+            if (i > 0) builder.Append(", ");
+            if (i == 0 && method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false)) builder.Append("this ");
+            if (parameter.IsOut) builder.Append("out ");
+            else if (parameter.ParameterType.IsByRef) builder.Append("ref ");
+
+            builder.Append(FriendlyName(parameter.ParameterType)).Append(' ').Append(parameter.Name);
+
+            if (parameter.HasDefaultValue) builder.Append(" = ").Append(Format(parameter.DefaultValue) ?? "null");
+        }
+
+        return builder.Append(')').ToString();
+    }
+
+    private static string KindOf(Type type)
+    {
+        if (type.IsEnum) return "Enum";
+        if (typeof(IComponent).IsAssignableFrom(type)) return "Component";
+        if (type.IsInterface) return "Interface";
+        if (typeof(Attribute).IsAssignableFrom(type)) return "Attribute";
+        if (typeof(MulticastDelegate).IsAssignableFrom(type)) return "Delegate";
+        if (type.IsAbstract && type.IsSealed) return "Static class";
+        if (type.IsValueType) return "Struct";
+        if (type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance) is not null) return "Record";
+
+        return "Class";
+    }
+
+    private static int KindOrder(string kind) => kind switch
+    {
+        "Parameter" => 0,
+        "Property" => 1,
+        "Field" => 2,
+        "EnumValue" => 3,
+        "Method" => 4,
+        "Event" => 5,
+        _ => 6
+    };
+
+    /// <summary>The C# spelling of a type: "int?", "string[]", "Func&lt;BrouterNavigationContext, ValueTask&gt;".</summary>
+    private static string FriendlyName(Type type)
+    {
+        if (type.IsByRef) return FriendlyName(type.GetElementType()!);
+        if (type.IsArray) return $"{FriendlyName(type.GetElementType()!)}[]";
+
+        var nullable = Nullable.GetUnderlyingType(type);
+        if (nullable is not null) return $"{FriendlyName(nullable)}?";
+
+        if (type == typeof(void)) return "void";
+        if (type == typeof(object)) return "object";
+        if (type == typeof(string)) return "string";
+        if (type == typeof(bool)) return "bool";
+        if (type == typeof(int)) return "int";
+        if (type == typeof(long)) return "long";
+        if (type == typeof(double)) return "double";
+        if (type == typeof(float)) return "float";
+        if (type == typeof(decimal)) return "decimal";
+
+        if (type.IsGenericType is false) return type.Name;
+
+        var arguments = string.Join(", ", type.GetGenericArguments().Select(FriendlyName));
+
+        return $"{StripArity(type.Name)}<{arguments}>";
+    }
+
+    private static string StripArity(string name)
+    {
+        var arity = name.IndexOf('`', StringComparison.Ordinal);
+
+        return arity < 0 ? name : name[..arity];
+    }
+
+    private static string DocumentationId(Type type) => $"T:{type.FullName}";
+
+    private static string DocumentationId(PropertyInfo property) => $"P:{property.DeclaringType!.FullName}.{property.Name}";
+
+    private static string DocumentationId(FieldInfo field) => $"F:{field.DeclaringType!.FullName}.{field.Name}";
+
+    private static string DocumentationId(EventInfo member) => $"E:{member.DeclaringType!.FullName}.{member.Name}";
+
+    private static string DocumentationId(MethodInfo method)
+    {
+        var id = new StringBuilder("M:").Append(method.DeclaringType!.FullName).Append('.').Append(method.Name);
+
+        if (method.IsGenericMethodDefinition) id.Append("``").Append(method.GetGenericArguments().Length);
+
+        var parameters = method.GetParameters();
+        if (parameters.Length == 0) return id.ToString();
+
+        id.Append('(')
+          .Append(string.Join(',', parameters.Select(p => DocumentationTypeName(p.ParameterType))))
+          .Append(')');
+
+        return id.ToString();
+    }
+
+    /// <summary>Spells a type the way the C# compiler spells it inside a documentation id.</summary>
+    private static string DocumentationTypeName(Type type)
+    {
+        if (type.IsByRef) return $"{DocumentationTypeName(type.GetElementType()!)}@";
+        if (type.IsArray) return $"{DocumentationTypeName(type.GetElementType()!)}[]";
+        if (type.IsGenericParameter) return type.DeclaringMethod is null ? $"`{type.GenericParameterPosition}" : $"``{type.GenericParameterPosition}";
+
+        if (type.IsGenericType is false) return type.FullName ?? type.Name;
+
+        var definition = type.GetGenericTypeDefinition().FullName ?? type.Name;
+        var arguments = string.Join(',', type.GetGenericArguments().Select(DocumentationTypeName));
+
+        return $"{StripArity(definition)}{{{arguments}}}";
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterApiCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterApiCatalog.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Reflection;
+using System.Collections.Concurrent;
 using Bit.Brouter.Demo.Server.Dtos;
 using Microsoft.AspNetCore.Components;
 
@@ -26,6 +27,8 @@ public static class BrouterApiCatalog
             .Where(t => t.IsNested is false && t.Name.Contains('<', StringComparison.Ordinal) is false)
             .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)]);
 
+    private static readonly ConcurrentDictionary<string, BrouterApiTypeDetailsDto> _typeDetails = new(StringComparer.Ordinal);
+
     private static readonly Lazy<BrouterApiTypeDto[]> _types = new(() =>
         [.. _publicTypes.Value.Select(t => new BrouterApiTypeDto
         {
@@ -46,6 +49,13 @@ public static class BrouterApiCatalog
         var type = Find(typeName);
         if (type is null) return null;
 
+        // Every hit costs a full reflection walk plus an XML lookup per member, and the search index
+        // asks for all of them at once; the answer only changes when the assembly does.
+        return _typeDetails.GetOrAdd(type.FullName ?? type.Name, _ => BuildTypeDetails(type));
+    }
+
+    private static BrouterApiTypeDetailsDto BuildTypeDetails(Type type)
+    {
         var instance = TryCreateInstance(type);
 
         var members = new List<BrouterApiMemberDto>();
@@ -58,8 +68,9 @@ public static class BrouterApiCatalog
                                      Name = field.Name,
                                      Kind = "EnumValue",
                                      Type = FriendlyName(type.GetEnumUnderlyingType()),
-                                     Default = Convert.ToInt64(field.GetRawConstantValue(), System.Globalization.CultureInfo.InvariantCulture)
-                                                      .ToString(System.Globalization.CultureInfo.InvariantCulture),
+                                     // Formatted straight off the raw constant: a [Flags] enum backed by
+                                     // ulong has members that do not fit in an Int64.
+                                     Default = Format(field.GetRawConstantValue()),
                                      Summary = BrouterXmlDocs.GetSummary(DocumentationId(field)),
                                      Remarks = BrouterXmlDocs.GetRemarks(DocumentationId(field))
                                  }));
@@ -291,8 +302,9 @@ public static class BrouterApiCatalog
     private static string KindOf(Type type)
     {
         if (type.IsEnum) return "Enum";
-        if (typeof(IComponent).IsAssignableFrom(type)) return "Component";
+        // Before the IComponent test: an interface that extends IComponent is still an interface.
         if (type.IsInterface) return "Interface";
+        if (typeof(IComponent).IsAssignableFrom(type)) return "Component";
         if (typeof(Attribute).IsAssignableFrom(type)) return "Attribute";
         if (typeof(MulticastDelegate).IsAssignableFrom(type)) return "Delegate";
         if (type.IsAbstract && type.IsSealed) return "Static class";
@@ -314,7 +326,7 @@ public static class BrouterApiCatalog
     };
 
     /// <summary>The C# spelling of a type: "int?", "string[]", "Func&lt;BrouterNavigationContext, ValueTask&gt;".</summary>
-    private static string FriendlyName(Type type)
+    public static string FriendlyName(Type type)
     {
         if (type.IsByRef) return FriendlyName(type.GetElementType()!);
         if (type.IsArray) return $"{FriendlyName(type.GetElementType()!)}[]";

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSearchIndex.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSearchIndex.cs
@@ -1,0 +1,223 @@
+using Bit.Brouter.Demo.Client;
+using Bit.Brouter.Demo.Server.Dtos;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// One searchable index over everything this MCP server knows: the reference guide, the docs
+/// pages, every public type and member, the route constraints and the demo's source files.
+/// <para>
+/// Without it an agent has to guess which corpus holds the answer and what it is called there -
+/// "how do I stop a navigation from the page itself?" is a guide section, a docs page, a component
+/// base class and a demo page all at once. Each hit therefore carries the exact follow-up tool call
+/// that returns the full text, so one search is enough to know what to ask for next.
+/// </para>
+/// </summary>
+public static class BrouterSearchIndex
+{
+    private sealed record Entry(string Kind, string Title, string? Context, string Tool, string Body, string Boosted)
+    {
+        /// <summary>
+        /// The title split into words, camel-case humps included, so "KeepAliveMax" is found by
+        /// "keep alive" - and so a query word only counts as a title hit when it IS one of those
+        /// words, rather than merely appearing inside one ("data" inside "BrouterRouteData").
+        /// </summary>
+        public string[] TitleWords { get; } = SplitWords(Title);
+    }
+
+    private static readonly Lazy<Entry[]> _entries = new(Build);
+
+    private static readonly HashSet<string> _stopWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "how", "the", "and", "for", "with", "from", "that", "this", "what", "when", "where", "which",
+        "does", "did", "are", "was", "you", "your", "than", "then", "its", "but", "any", "some",
+        "please", "help", "about", "into", "way", "make", "want", "need", "would", "should", "could",
+        "there", "here", "have", "has", "get", "got", "let", "one", "two", "per", "via", "onto"
+    };
+
+    public static BrouterSearchHitDto[] Search(string query, int limit)
+    {
+        var terms = Tokenize(query);
+        if (terms.Length == 0) return [];
+
+        return [.. _entries.Value
+            .Select(entry => (Entry: entry, Score: Score(entry, terms)))
+            .Where(hit => hit.Score > 0)
+            .OrderByDescending(hit => hit.Score)
+            .ThenBy(hit => hit.Entry.Title, StringComparer.OrdinalIgnoreCase)
+            .Take(Math.Clamp(limit, 1, 50))
+            .Select(hit => new BrouterSearchHitDto
+            {
+                Kind = hit.Entry.Kind,
+                Title = hit.Entry.Title,
+                Context = hit.Entry.Context,
+                Tool = hit.Entry.Tool,
+                Snippet = Snippet(hit.Entry.Body, terms)
+            })];
+    }
+
+    private static int Score(Entry entry, string[] terms)
+    {
+        var score = 0;
+        var matched = 0;
+
+        foreach (var term in terms)
+        {
+            var isTitleWord = entry.TitleWords.Any(word => Equivalent(word, term));
+            var inTitle = isTitleWord ? 0 : Count(entry.Title, term);
+            var inBoosted = Count(entry.Boosted, term);
+            var inBody = Count(entry.Body, term);
+
+            if (isTitleWord is false && inTitle + inBoosted + inBody == 0) continue;
+
+            matched++;
+
+            // A term in a name is worth far more than the same term buried in prose: someone asking
+            // for "KeepAliveMax" wants the parameter, not the paragraphs that happen to mention it.
+            score += (isTitleWord ? 12 : 0) + inTitle * 3 + inBoosted * 5 + Math.Min(inBody, 6);
+        }
+
+        // Every term matching is the strongest signal a hit is the right one.
+        return matched == 0 ? 0 : score * matched;
+    }
+
+    /// <summary>
+    /// Same word, plural aside - "guard" has to find the section called "Async guards", and nobody
+    /// phrases a question in the number the heading happens to use.
+    /// </summary>
+    private static bool Equivalent(string word, string term)
+    {
+        return string.Equals(word, term, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(word, $"{term}s", StringComparison.OrdinalIgnoreCase)
+            || string.Equals($"{word}s", term, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int Count(string text, string term)
+    {
+        if (text.Length == 0) return 0;
+
+        var count = 0;
+        var index = text.IndexOf(term, StringComparison.OrdinalIgnoreCase);
+
+        while (index >= 0)
+        {
+            count++;
+            index = text.IndexOf(term, index + term.Length, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return count;
+    }
+
+    private static string Snippet(string body, string[] terms)
+    {
+        if (body.Length == 0) return string.Empty;
+
+        var index = -1;
+        foreach (var term in terms)
+        {
+            index = body.IndexOf(term, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0) break;
+        }
+
+        if (index < 0) index = 0;
+
+        var start = Math.Max(0, index - 80);
+        var length = Math.Min(240, body.Length - start);
+        var snippet = body.Substring(start, length).Replace('\n', ' ').Replace('\r', ' ').Trim();
+
+        return $"{(start > 0 ? "..." : null)}{snippet}{(start + length < body.Length ? "..." : null)}";
+    }
+
+    /// <summary>Splits a name or heading into words, breaking camel-case humps as well as punctuation.</summary>
+    private static string[] SplitWords(string text)
+    {
+        var words = new List<string>();
+        var current = new System.Text.StringBuilder();
+
+        foreach (var c in text)
+        {
+            if (char.IsLetterOrDigit(c) is false)
+            {
+                if (current.Length > 0) { words.Add(current.ToString()); current.Clear(); }
+                continue;
+            }
+
+            // A capital after a lowercase letter starts a new word ("KeepAliveMax" -> keep alive max),
+            // while a run of capitals stays together ("URL", "SSR").
+            if (char.IsUpper(c) && current.Length > 0 && char.IsLower(current[^1]))
+            {
+                words.Add(current.ToString());
+                current.Clear();
+            }
+
+            current.Append(c);
+        }
+
+        if (current.Length > 0) words.Add(current.ToString());
+
+        return [.. words];
+    }
+
+    private static string[] Tokenize(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return [];
+
+        return [.. query.Split(['.', ',', ';', ':', '?', '!', '"', '\'', '(', ')', '[', ']', '{', '}', '/', '\\', '<', '>', '-', '_', ' ', '\t', '\n', '\r'],
+                              StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            // One- and two-letter words ("a", "in", "do") match everything and rank nothing - and
+            // the words a question is phrased with do worse than nothing: "how do I redirect FROM a
+            // guard" would otherwise score a section whose heading merely contains "from".
+            .Where(term => term.Length > 2 && _stopWords.Contains(term) is false)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static Entry[] Build()
+    {
+        var entries = new List<Entry>(512);
+
+        foreach (var section in BrouterSourceCatalog.GuideSections)
+        {
+            var body = BrouterSourceCatalog.GetGuideSection(section.Heading) ?? string.Empty;
+
+            entries.Add(new Entry("Guide section", section.Heading, section.Parent,
+                $"GetBrouterGuideSection(heading: \"{section.Heading}\")", body, string.Empty));
+        }
+
+        foreach (var page in DocsCatalog.Sections.SelectMany(s => s.Pages.Select(p => (Section: s.Title, Page: p))))
+        {
+            entries.Add(new Entry("Docs page", page.Page.Title, page.Section,
+                $"GetBrouterDocsPage(slug: \"{page.Page.Slug}\")", page.Page.Description, page.Page.Keywords));
+        }
+
+        foreach (var type in BrouterApiCatalog.Types)
+        {
+            entries.Add(new Entry($"API {type.Kind.ToLowerInvariant()}", type.Name, null,
+                $"GetBrouterApiDetails(typeName: \"{type.Name}\")", type.Summary ?? string.Empty, string.Empty));
+
+            var details = BrouterApiCatalog.GetTypeDetails(type.Name);
+            if (details is null) continue;
+
+            foreach (var member in details.Members)
+            {
+                entries.Add(new Entry($"API {member.Kind.ToLowerInvariant()}", $"{type.Name}.{member.Name}", type.Name,
+                    $"GetBrouterApiDetails(typeName: \"{type.Name}\")",
+                    $"{member.Summary} {member.Remarks}".Trim(),
+                    $"{member.Type} {member.Signature}".Trim()));
+            }
+        }
+
+        foreach (var constraint in ConstraintCatalog.All)
+        {
+            entries.Add(new Entry("Route constraint", $"{{value:{constraint.Token}}}", constraint.Category,
+                "GetBrouterRouteConstraints()", constraint.Rule, constraint.Kind));
+        }
+
+        foreach (var file in BrouterSourceCatalog.SourceFiles)
+        {
+            entries.Add(new Entry("Source file", file.Path, file.Kind,
+                $"GetBrouterSourceFile(path: \"{file.Path}\")", file.Description ?? string.Empty, string.Empty));
+        }
+
+        return [.. entries];
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSearchIndex.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSearchIndex.cs
@@ -25,6 +25,8 @@ public static class BrouterSearchIndex
         public string[] TitleWords { get; } = SplitWords(Title);
     }
 
+    private const int MaxTerms = 16;
+
     private static readonly Lazy<Entry[]> _entries = new(Build);
 
     private static readonly HashSet<string> _stopWords = new(StringComparer.OrdinalIgnoreCase)
@@ -168,7 +170,10 @@ public static class BrouterSearchIndex
             // the words a question is phrased with do worse than nothing: "how do I redirect FROM a
             // guard" would otherwise score a section whose heading merely contains "from".
             .Where(term => term.Length > 2 && _stopWords.Contains(term) is false)
-            .Distinct(StringComparer.OrdinalIgnoreCase)];
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            // Every term is counted in every entry's body, so the work is terms x corpus. No question
+            // is phrased in more words than this, while a pasted file as a query would scan for hours.
+            .Take(MaxTerms)];
     }
 
     private static Entry[] Build()

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSetupGuide.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSetupGuide.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Bit.Brouter.Demo.Server.Services;
 
@@ -12,7 +13,7 @@ namespace Bit.Brouter.Demo.Server.Services;
 /// error. Handing over a known-good, compiling project instead of prose removes the guesswork.
 /// </para>
 /// </summary>
-public static class BrouterSetupGuide
+public static partial class BrouterSetupGuide
 {
     public static readonly string[] RenderModes = ["server", "wasm", "auto", "standalone-wasm"];
 
@@ -88,10 +89,13 @@ public static class BrouterSetupGuide
             var content = BrouterSourceCatalog.GetSourceFile(file.Path);
             if (content is null) continue;
 
+            content = content.TrimEnd();
+            var fence = Fence(content);
+
             builder.AppendLine($"### `{file.Path}`").AppendLine()
-                   .AppendLine($"```{Language(file.Path)}")
-                   .AppendLine(content.TrimEnd())
-                   .AppendLine("```")
+                   .AppendLine($"{fence}{Language(file.Path)}")
+                   .AppendLine(content)
+                   .AppendLine(fence)
                    .AppendLine();
         }
 
@@ -184,6 +188,18 @@ public static class BrouterSetupGuide
         6. Do not also render Blazor's built-in `<Router>`; Brouter replaces it.
         """;
 
+    /// <summary>
+    /// The fence for a file's code block. It has to outrun the longest run of backticks in the file
+    /// itself - a page that shows Markdown would otherwise end the block in the middle of its own
+    /// content, and the rest of the file would render as prose.
+    /// </summary>
+    private static string Fence(string content)
+    {
+        var longest = BacktickRunRegex().Matches(content).Select(match => match.Length).DefaultIfEmpty(0).Max();
+
+        return new string('`', Math.Max(3, longest + 1));
+    }
+
     private static string Language(string path) => Path.GetExtension(path).ToLowerInvariant() switch
     {
         ".razor" => "razor",
@@ -193,4 +209,7 @@ public static class BrouterSetupGuide
         ".js" => "javascript",
         _ => string.Empty
     };
+
+    [GeneratedRegex("`+")]
+    private static partial Regex BacktickRunRegex();
 }

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSetupGuide.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSetupGuide.cs
@@ -1,0 +1,196 @@
+using System.Text;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Assembles the wiring for one Blazor render mode: the checklist, plus the real files of the
+/// matching project under Samples/.
+/// <para>
+/// Setting a router up is where a render mode's differences actually bite - which DI container has
+/// to register the services, which assembly holds the catch-all host page, which assemblies the
+/// host has to be told about - and getting one of them wrong produces a blank page rather than an
+/// error. Handing over a known-good, compiling project instead of prose removes the guesswork.
+/// </para>
+/// </summary>
+public static class BrouterSetupGuide
+{
+    public static readonly string[] RenderModes = ["server", "wasm", "auto", "standalone-wasm"];
+
+    public static string? Get(string? renderMode)
+    {
+        var mode = (renderMode ?? string.Empty).Trim().ToLowerInvariant().Replace(" ", "-", StringComparison.Ordinal);
+
+        mode = mode switch
+        {
+            "interactiveserver" or "blazor-server" => "server",
+            "webassembly" or "interactivewebassembly" or "blazor-wasm" => "wasm",
+            "interactiveauto" => "auto",
+            "standalone" or "standalone-webassembly" or "standalone-wasm-app" => "standalone-wasm",
+            _ => mode
+        };
+
+        return mode switch
+        {
+            "server" => Compose(
+                "Blazor Web App - InteractiveServer",
+                """
+                One project. The host registers the router services once, and a catch-all host page hands every
+                URL to Brouter. `AddBitBrouterServices` goes in the single (server) container.
+                """,
+                "Sample/Server/"),
+
+            "wasm" => Compose(
+                "Blazor Web App - InteractiveWebAssembly",
+                """
+                Two projects, two DI containers: the server prerenders the very same components the browser then
+                hydrates, so `AddBitBrouterServices` must be called in BOTH `Program.cs` files - typically through
+                one shared extension method the two projects call (see `AddCoreServices` below). The catch-all host
+                page lives in the client project, so the host has to be told about that assembly with
+                `AddAdditionalAssemblies`.
+                """,
+                "Sample/Wasm/"),
+
+            "auto" => Compose(
+                "Blazor Web App - InteractiveAuto",
+                """
+                Same as InteractiveWebAssembly, plus the server-interactive path: the first visit runs on the server
+                while the WebAssembly runtime downloads, so both render modes are registered and both containers
+                register the router services.
+                """,
+                "Sample/Auto/"),
+
+            "standalone-wasm" => StandaloneWasm(),
+
+            _ => null
+        };
+    }
+
+    private static string Compose(string title, string summary, string samplePrefix)
+    {
+        var builder = new StringBuilder();
+
+        builder.AppendLine($"# Setting Brouter up - {title}").AppendLine();
+        builder.AppendLine(summary).AppendLine();
+        builder.AppendLine(Checklist).AppendLine();
+        builder.AppendLine("## The files, from a working sample").AppendLine();
+        builder.AppendLine("Everything below compiles as-is; rename the projects and namespaces to your own.").AppendLine();
+
+        // The shared registration method lives in the project all the sample hosts reference, so it
+        // sits outside the per-render-mode folder while being the piece most easily got wrong.
+        var files = BrouterSourceCatalog.SourceFiles
+            .Where(f => f.Path.StartsWith(samplePrefix, StringComparison.OrdinalIgnoreCase) ||
+                        f.Path.StartsWith("Sample/Core/Extensions/", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(f => f.Path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .ThenBy(f => f.Path, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in files)
+        {
+            var content = BrouterSourceCatalog.GetSourceFile(file.Path);
+            if (content is null) continue;
+
+            builder.AppendLine($"### `{file.Path}`").AppendLine()
+                   .AppendLine($"```{Language(file.Path)}")
+                   .AppendLine(content.TrimEnd())
+                   .AppendLine("```")
+                   .AppendLine();
+        }
+
+        builder.AppendLine("""
+            The routes themselves (`AppRouter.razor` and the pages it renders) live in a shared project both of the
+            above reference - call `GetBrouterSourceFile(path: "Demo/Client/AppRouter.razor")` for a route table that
+            exercises nearly every feature, or `GetBrouterGuideSection(heading: "Quick start")` for the smallest one.
+            """);
+
+        return builder.ToString();
+    }
+
+    private static string StandaloneWasm()
+    {
+        var builder = new StringBuilder();
+
+        builder.AppendLine("# Setting Brouter up - standalone Blazor WebAssembly").AppendLine();
+        builder.AppendLine("""
+            A standalone WebAssembly app has no server-rendered host page, so there is no catch-all `@page` to
+            declare: `<Brouter>` is rendered straight from the root component and owns the URL space from the start.
+            One project, one DI container.
+            """).AppendLine();
+        builder.AppendLine(Checklist).AppendLine();
+        builder.AppendLine("""
+            ## The files
+
+            ### `Program.cs`
+
+            ```csharp
+            using Microsoft.AspNetCore.Components.Web;
+            using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+            var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+            builder.RootComponents.Add<App>("#app");
+            builder.RootComponents.Add<HeadOutlet>("head::after");
+
+            builder.Services.AddBitBrouterServices(o =>
+            {
+                o.ScrollBehavior = BrouterScrollMode.ToTop;
+                o.FocusOnNavigateSelector = "h1";
+            });
+
+            await builder.Build().RunAsync();
+            ```
+
+            ### `App.razor`
+
+            ```razor
+            @* No host page and no built-in Router: Brouter is the root of the URL space. *@
+            <Brouter NotFoundUrl="404" AppAssembly="@GetType().Assembly">
+                <Routes>
+                    <Broute Path="/" Component="@typeof(HomePage)" />
+                    <Broute Path="/users/{id:int}" Component="@typeof(UserPage)" />
+
+                    <Broute Path="404">
+                        <Content><h1>404</h1><p>Nothing here.</p></Content>
+                    </Broute>
+                </Routes>
+            </Brouter>
+            ```
+
+            ### `_Imports.razor`
+
+            ```razor
+            @using Bit.Brouter
+            ```
+
+            `wwwroot/index.html` needs nothing beyond the usual `<div id="app">` and `blazor.webassembly.js`:
+            Brouter ships its JavaScript as a static web asset, so there is no script tag to add.
+            """);
+
+        return builder.ToString();
+    }
+
+    private const string Checklist = """
+        ## Checklist
+
+        1. `dotnet add package Bit.Brouter` (optionally `Bit.Brouter.Generators` with `PrivateAssets="all"` for the
+           typed `BrouterRoutes` URL builders).
+        2. Call `AddBitBrouterServices(...)` in EVERY DI container that renders your components - a Blazor Web App
+           with an interactive client has two of them, and a missing registration surfaces as a failure to resolve
+           `IBrouter` during prerendering.
+        3. Add `@using Bit.Brouter` to `_Imports.razor` of every project that declares routes.
+        4. Give Brouter the whole URL space: one catch-all host page (`@page "/"` + `@page "/{*path}"`) that renders
+           your `<Brouter>` component - it is what makes deep links work, because every URL then matches a Razor
+           component endpoint and Brouter resolves the real route (including its own 404) from there.
+        5. Declare the routes, and/or point `AppAssembly`/`AdditionalAssemblies` at the assemblies whose `@page`
+           components should be discovered.
+        6. Do not also render Blazor's built-in `<Router>`; Brouter replaces it.
+        """;
+
+    private static string Language(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    {
+        ".razor" => "razor",
+        ".cs" => "csharp",
+        ".csproj" => "xml",
+        ".css" => "css",
+        ".js" => "javascript",
+        _ => string.Empty
+    };
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSourceCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSourceCatalog.cs
@@ -24,6 +24,7 @@ public static partial class BrouterSourceCatalog
     private static readonly Assembly _assembly = typeof(BrouterSourceCatalog).Assembly;
 
     private static readonly Lazy<string> _readme = new(() => ReadResource(ReadmeResource) ?? string.Empty);
+    private static readonly Lazy<string[]> _readmeLines = new(() => Readme.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'));
     private static readonly Lazy<BrouterGuideSectionDto[]> _guideSections = new(BuildGuideSections);
     private static readonly Lazy<FrozenDictionary<string, string>> _sourceFiles = new(BuildSourceFiles);
     private static readonly Lazy<BrouterSourceFileDto[]> _sourceFileList = new(BuildSourceFileList);
@@ -46,12 +47,21 @@ public static partial class BrouterSourceCatalog
     {
         if (string.IsNullOrWhiteSpace(heading)) return null;
 
-        var lines = Readme.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var lines = _readmeLines.Value;
         var normalized = NormalizeHeading(heading);
 
         int start = -1, level = 0;
+        var fenced = false;
         for (int i = 0; i < lines.Length; i++)
         {
+            if (IsCodeFence(lines[i]))
+            {
+                fenced = fenced is false;
+                continue;
+            }
+
+            if (fenced) continue;
+
             if (TryReadHeading(lines[i], out var lineLevel, out var text) is false) continue;
 
             if (start < 0)
@@ -92,11 +102,20 @@ public static partial class BrouterSourceCatalog
 
     private static BrouterGuideSectionDto[] BuildGuideSections()
     {
-        var lines = Readme.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var lines = _readmeLines.Value;
         var headings = new List<(int Index, int Level, string Text)>();
 
+        var fenced = false;
         for (int i = 0; i < lines.Length; i++)
         {
+            if (IsCodeFence(lines[i]))
+            {
+                fenced = fenced is false;
+                continue;
+            }
+
+            if (fenced) continue;
+
             if (TryReadHeading(lines[i], out var level, out var text) && level is 2 or 3)
             {
                 headings.Add((i, level, text));
@@ -208,6 +227,17 @@ public static partial class BrouterSourceCatalog
         if (stop > 0) text = text[..(stop + 1)];
 
         return text.Length <= 220 ? text : $"{text[..217]}...";
+    }
+
+    /// <summary>
+    /// A Markdown code fence. A '#' line inside one is a shell comment or a C# preprocessor
+    /// directive, not a heading, and must not start or end a guide section.
+    /// </summary>
+    private static bool IsCodeFence(string line)
+    {
+        var text = line.TrimStart();
+
+        return text.StartsWith("```", StringComparison.Ordinal) || text.StartsWith("~~~", StringComparison.Ordinal);
     }
 
     private static bool TryReadHeading(string line, out int level, out string text)

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSourceCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSourceCatalog.cs
@@ -1,0 +1,262 @@
+using System.Text;
+using System.Reflection;
+using System.Collections.Frozen;
+using Bit.Brouter.Demo.Server.Dtos;
+using System.Text.RegularExpressions;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Serves the two bodies of hand-written source the MCP tools hand out: the library's README
+/// (its reference guide) and every source file of this demo plus the hosting samples.
+/// <para>
+/// All of them are embedded into this assembly by the .csproj rather than read from disk, so the
+/// MCP server keeps working from a published, single-folder deployment where the repository is
+/// nowhere to be found.
+/// </para>
+/// </summary>
+public static partial class BrouterSourceCatalog
+{
+    private const string ReadmeResource = "BrouterDocs/README.md";
+    private const string DemoPrefix = "BrouterSource/Demo/";
+    private const string SamplePrefix = "BrouterSource/Sample/";
+
+    private static readonly Assembly _assembly = typeof(BrouterSourceCatalog).Assembly;
+
+    private static readonly Lazy<string> _readme = new(() => ReadResource(ReadmeResource) ?? string.Empty);
+    private static readonly Lazy<BrouterGuideSectionDto[]> _guideSections = new(BuildGuideSections);
+    private static readonly Lazy<FrozenDictionary<string, string>> _sourceFiles = new(BuildSourceFiles);
+    private static readonly Lazy<BrouterSourceFileDto[]> _sourceFileList = new(BuildSourceFileList);
+
+    /// <summary>The library's README, in full.</summary>
+    public static string Readme => _readme.Value;
+
+    /// <summary>Every heading of the README, in reading order.</summary>
+    public static BrouterGuideSectionDto[] GuideSections => _guideSections.Value;
+
+    /// <summary>Every embedded source file, keyed by the path the tools expose.</summary>
+    public static BrouterSourceFileDto[] SourceFiles => _sourceFileList.Value;
+
+    /// <summary>
+    /// The README text under <paramref name="heading"/>, including its sub-sections. Matching is
+    /// case- and punctuation-insensitive so "loader caching" finds
+    /// "Loader caching (stale-while-revalidate)".
+    /// </summary>
+    public static string? GetGuideSection(string heading)
+    {
+        if (string.IsNullOrWhiteSpace(heading)) return null;
+
+        var lines = Readme.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var normalized = NormalizeHeading(heading);
+
+        int start = -1, level = 0;
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (TryReadHeading(lines[i], out var lineLevel, out var text) is false) continue;
+
+            if (start < 0)
+            {
+                if (NormalizeHeading(text) != normalized) continue;
+
+                start = i;
+                level = lineLevel;
+                continue;
+            }
+
+            // The section ends at the next heading of the same or a higher rank.
+            if (lineLevel > level) continue;
+
+            return string.Join('\n', lines[start..i]).TrimEnd();
+        }
+
+        return start < 0 ? null : string.Join('\n', lines[start..]).TrimEnd();
+    }
+
+    /// <summary>The content of an embedded source file, or null when the path is unknown.</summary>
+    public static string? GetSourceFile(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        return _sourceFiles.Value.GetValueOrDefault(Normalize(path));
+    }
+
+    private static string? ReadResource(string name)
+    {
+        using var stream = _assembly.GetManifestResourceStream(name);
+        if (stream is null) return null;
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+
+        return reader.ReadToEnd();
+    }
+
+    private static BrouterGuideSectionDto[] BuildGuideSections()
+    {
+        var lines = Readme.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var headings = new List<(int Index, int Level, string Text)>();
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (TryReadHeading(lines[i], out var level, out var text) && level is 2 or 3)
+            {
+                headings.Add((i, level, text));
+            }
+        }
+
+        var sections = new List<BrouterGuideSectionDto>(headings.Count);
+        string? parent = null;
+
+        for (int i = 0; i < headings.Count; i++)
+        {
+            var (index, level, text) = headings[i];
+
+            if (level == 2) parent = text;
+
+            // The section runs until the next heading of the same or a higher rank.
+            var end = lines.Length;
+            for (int j = i + 1; j < headings.Count; j++)
+            {
+                if (headings[j].Level > level) continue;
+                end = headings[j].Index;
+                break;
+            }
+
+            sections.Add(new BrouterGuideSectionDto
+            {
+                Heading = text,
+                Level = level,
+                Parent = level == 2 ? null : parent,
+                Lines = end - index
+            });
+        }
+
+        return [.. sections];
+    }
+
+    private static FrozenDictionary<string, string> BuildSourceFiles()
+    {
+        var files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var resource in _assembly.GetManifestResourceNames())
+        {
+            var normalized = Normalize(resource);
+
+            if (normalized.StartsWith(DemoPrefix, StringComparison.OrdinalIgnoreCase) is false &&
+                normalized.StartsWith(SamplePrefix, StringComparison.OrdinalIgnoreCase) is false) continue;
+
+            var content = ReadResource(resource);
+            if (content is null) continue;
+
+            files[normalized["BrouterSource/".Length..]] = content;
+        }
+
+        return files.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static BrouterSourceFileDto[] BuildSourceFileList()
+    {
+        return [.. _sourceFiles.Value
+            .Select(file => new BrouterSourceFileDto
+            {
+                Path = file.Key,
+                Kind = file.Key.StartsWith("Demo/", StringComparison.OrdinalIgnoreCase) ? "Demo" : "Sample",
+                Description = DescribeSource(file.Value),
+                Lines = file.Value.Count(c => c == '\n') + 1
+            })
+            .OrderBy(file => file.Kind, StringComparer.Ordinal)
+            .ThenBy(file => file.Path, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>
+    /// A one-line description of a source file, taken from whatever the file itself already says:
+    /// its leading razor/C# comment, or - for a docs page - its &lt;PageTitle&gt;.
+    /// </summary>
+    private static string? DescribeSource(string content)
+    {
+        var leadingComment = LeadingRazorCommentRegex().Match(content);
+        if (leadingComment.Success) return Summarize(leadingComment.Groups["text"].Value);
+
+        var summary = XmlSummaryRegex().Match(content);
+        if (summary.Success)
+        {
+            // An XML summary is markup: <paramref name="Slug"/> and friends are noise in a listing.
+            var text = summary.Groups["text"].Value.Replace("///", " ", StringComparison.Ordinal);
+
+            return Summarize(XmlTagRegex().Replace(text, string.Empty));
+        }
+
+        var title = PageTitleRegex().Match(content);
+        if (title.Success) return Summarize(title.Groups["text"].Value);
+
+        var lineComment = LeadingLineCommentRegex().Match(content);
+        if (lineComment.Success) return Summarize(lineComment.Value.Replace("//", " ", StringComparison.Ordinal));
+
+        // Nothing at the top of the file said what it is - the first commentary in it will do
+        // (AppRouter.razor, for one, explains itself right above its route table).
+        var comment = RazorCommentRegex().Match(content);
+
+        return comment.Success ? Summarize(comment.Groups["text"].Value) : null;
+    }
+
+    private static string? Summarize(string text)
+    {
+        text = WhitespaceRegex().Replace(text, " ").Trim();
+        if (text.Length == 0) return null;
+
+        // The first sentence is the description; the rest is the file's own commentary.
+        var stop = text.IndexOf(". ", StringComparison.Ordinal);
+        if (stop > 0) text = text[..(stop + 1)];
+
+        return text.Length <= 220 ? text : $"{text[..217]}...";
+    }
+
+    private static bool TryReadHeading(string line, out int level, out string text)
+    {
+        level = 0;
+        text = string.Empty;
+
+        while (level < line.Length && line[level] == '#') level++;
+
+        if (level is 0 or > 6 || level >= line.Length || line[level] != ' ') return false;
+
+        text = line[(level + 1)..].Trim();
+
+        return text.Length > 0;
+    }
+
+    /// <summary>Reduces a heading to its comparable core, so "Async guards" finds "## Async guards".</summary>
+    private static string NormalizeHeading(string heading)
+    {
+        var builder = new StringBuilder(heading.Length);
+
+        foreach (var c in heading)
+        {
+            if (char.IsLetterOrDigit(c)) builder.Append(char.ToLowerInvariant(c));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Normalize(string path) => path.Replace('\\', '/').Trim('/');
+
+    [GeneratedRegex(@"^\s*@\*(?<text>.*?)\*@", RegexOptions.Singleline)]
+    private static partial Regex LeadingRazorCommentRegex();
+
+    [GeneratedRegex(@"@\*(?<text>.*?)\*@", RegexOptions.Singleline)]
+    private static partial Regex RazorCommentRegex();
+
+    [GeneratedRegex(@"<[^>]+>")]
+    private static partial Regex XmlTagRegex();
+
+    [GeneratedRegex(@"///\s*<summary>(?<text>.*?)</summary>", RegexOptions.Singleline)]
+    private static partial Regex XmlSummaryRegex();
+
+    [GeneratedRegex(@"<PageTitle>(?<text>.*?)</PageTitle>", RegexOptions.Singleline | RegexOptions.IgnoreCase)]
+    private static partial Regex PageTitleRegex();
+
+    [GeneratedRegex(@"^\s*(//[^\n]*\n)+")]
+    private static partial Regex LeadingLineCommentRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSourceCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterSourceCatalog.cs
@@ -180,10 +180,23 @@ public static partial class BrouterSourceCatalog
                 Path = file.Key,
                 Kind = file.Key.StartsWith("Demo/", StringComparison.OrdinalIgnoreCase) ? "Demo" : "Sample",
                 Description = DescribeSource(file.Value),
-                Lines = file.Value.Count(c => c == '\n') + 1
+                Lines = CountLines(file.Value)
             })
             .OrderBy(file => file.Kind, StringComparer.Ordinal)
             .ThenBy(file => file.Path, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>
+    /// The number of lines in a file. A trailing newline ends the last line rather than starting
+    /// another one, so a file that has one is not reported a line longer than it is.
+    /// </summary>
+    private static int CountLines(string content)
+    {
+        if (content.Length == 0) return 0;
+
+        var newlines = content.Count(c => c == '\n');
+
+        return content[^1] == '\n' ? newlines : newlines + 1;
     }
 
     /// <summary>

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTemplateInspector.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTemplateInspector.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Collections;
 using System.Reflection;
 using Bit.Brouter.Demo.Server.Dtos;
@@ -81,6 +82,7 @@ public static class BrouterTemplateInspector
                 Specificity = dtos.Sum(s => s.Specificity),
                 ParameterNames = [.. dtos.SelectMany(s => s.ParameterNames ?? [])],
                 Segments = dtos,
+                Shape = string.Join('/', segments.Select(segment => SegmentShape(parser, segment))),
                 Notes = [.. Notes(dtos)]
             };
         }
@@ -115,7 +117,7 @@ public static class BrouterTemplateInspector
             IsValid = inspection.IsValid,
             Error = inspection.Error,
             Specificity = inspection.Specificity,
-            Shape = inspection.IsValid ? Shape(inspection) : null
+            Shape = inspection.Shape
         }).ToArray();
 
         // Specificity is the router's tie-break between routes that all match a URL.
@@ -151,43 +153,93 @@ public static class BrouterTemplateInspector
     }
 
     /// <summary>
-    /// The template stripped of everything matching ignores - parameter names above all, since
+    /// One segment stripped of everything matching ignores - parameter names above all, since
     /// "/users/{id}" and "/users/{userId}" accept exactly the same URLs.
+    /// <para>
+    /// This mirrors the router's own BuildTemplateCollisionKey segment for segment, because that is
+    /// the function deciding which registrations it refuses as ambiguous. What it keeps is kept here
+    /// too: a declared default (so "{page}" and "{page=1}" stay distinct - they bind different
+    /// values for the same URL), the constraints of a catch-all, and the literal text between the
+    /// parameters of a complex segment.
+    /// </para>
     /// </summary>
-    private static string Shape(BrouterTemplateInspectionDto inspection)
+    private static string SegmentShape(Reflected parser, object segment)
     {
-        return string.Join('/', (inspection.Segments ?? []).Select(segment => segment.Kind switch
-        {
-            "Literal" => segment.Value.ToLowerInvariant(),
-            "Wildcard" => "*",
-            "CatchAll" => $"{{**{string.Concat((segment.Constraints ?? []).Select(c => $":{c.ToLowerInvariant()}"))}}}",
-            "Complex" => ComplexShape(segment),
-            _ => $"{{{string.Concat((segment.Constraints ?? []).Select(c => $":{c.ToLowerInvariant()}"))}{(segment.IsOptional ? "?" : null)}}}"
-        }));
-    }
+        var builder = new StringBuilder();
 
-    private static string ComplexShape(BrouterTemplateSegmentDto segment)
-    {
-        // The literal text between the parameters is what distinguishes two complex segments, and it
-        // survives in the segment's own text once the parameter names are blanked out.
-        var shape = segment.Value;
-
-        foreach (var name in segment.ParameterNames ?? [])
+        if ((bool)parser.IsCatchAll.GetValue(segment)!)
         {
-            shape = shape.Replace($"{{{name}", "{", StringComparison.OrdinalIgnoreCase);
+            // The literal "**" and a "{**rest}" parameter unify: a catch-all's name and optional
+            // flag change nothing, it already matches zero or more segments. Constraints do not.
+            builder.Append("**");
+
+            foreach (var constraint in ConstraintNames(parser, parser.Constraints.GetValue(segment)))
+            {
+                builder.Append(':').Append(constraint.ToLowerInvariant());
+            }
+        }
+        else if (parser.Parts.GetValue(segment) is IEnumerable parts)
+        {
+            foreach (var part in parts.Cast<object>())
+            {
+                if ((bool)parser.PartIsParameter.GetValue(part)! is false)
+                {
+                    AppendShapeLiteral(builder, (string)parser.PartValue.GetValue(part)!);
+                    continue;
+                }
+
+                builder.Append('{')
+                       .Append(string.Join(':', ConstraintNames(parser, parser.PartConstraints.GetValue(part)).Select(c => c.ToLowerInvariant())));
+                if ((bool)parser.PartIsOptional.GetValue(part)!) builder.Append('?');
+                builder.Append('}');
+            }
+        }
+        else if ((bool)parser.IsParameter.GetValue(segment)!)
+        {
+            builder.Append('{')
+                   .Append(string.Join(':', ConstraintNames(parser, parser.Constraints.GetValue(segment)).Select(c => c.ToLowerInvariant())));
+            if ((bool)parser.IsOptional.GetValue(segment)!) builder.Append('?');
+
+            // A default changes the value bound when the URL omits the segment, so "{page?}" and
+            // "{page=1}" match the same URLs without being interchangeable.
+            if (parser.DefaultValue.GetValue(segment) is string defaultValue) builder.Append('=').Append(defaultValue);
+
+            builder.Append('}');
+        }
+        else
+        {
+            // Plain literals, and the single-segment wildcard "*" - the parser never produces a
+            // literal "*", so it cannot collide with one.
+            AppendShapeLiteral(builder, (string)parser.Value.GetValue(segment)!);
         }
 
-        return shape.ToLowerInvariant();
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Literal text goes into the shape with its braces doubled, exactly as the router does, so a
+    /// literal written with escaped braces ("{{x}}" -> "{x}") can never read as a parameter.
+    /// </summary>
+    private static void AppendShapeLiteral(StringBuilder builder, string literal)
+    {
+        // Case folds because the router matches literals case-insensitively unless BrouterOptions
+        // .CaseSensitive is turned on, which this demo - like the default - leaves off.
+        var text = literal.ToLowerInvariant();
+
+        builder.Append(text.Contains('{') || text.Contains('}')
+            ? text.Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal)
+            : text);
     }
 
     private static BrouterTemplateSegmentDto Describe(Reflected parser, object segment)
     {
         var parts = parser.Parts.GetValue(segment);
+        var isParameter = (bool)parser.IsParameter.GetValue(segment)!;
 
         var kind = (bool)parser.IsCatchAll.GetValue(segment)! ? "CatchAll"
                  : (bool)parser.IsSingleWildcard.GetValue(segment)! ? "Wildcard"
                  : parts is not null ? "Complex"
-                 : (bool)parser.IsParameter.GetValue(segment)! ? "Parameter"
+                 : isParameter ? "Parameter"
                  : "Literal";
 
         var names = ((IEnumerable)parser.ParameterNames.GetValue(segment)!).Cast<string>().ToArray();
@@ -207,8 +259,9 @@ public static class BrouterTemplateInspector
         return new BrouterTemplateSegmentDto
         {
             // A parameter segment stores the bare parameter name; spelled back out the way it was
-            // written, it stays recognizable in the notes below.
-            Value = kind is "Parameter" or "CatchAll"
+            // written, it stays recognizable in the notes below. A literal segment - including the
+            // nameless catch-all "**" and the wildcard "*" - already IS its own text.
+            Value = isParameter
                 ? $"{{{(kind == "CatchAll" ? "*" : null)}{value}{string.Concat(constraints.Select(c => $":{c}"))}{(isOptional ? "?" : null)}{(defaultValue is null ? null : $"={defaultValue}")}}}"
                 : value,
             Kind = kind,
@@ -242,8 +295,8 @@ public static class BrouterTemplateInspector
 
             if (segment.Kind == "CatchAll")
             {
-                yield return $"'{segment.Value}' is a catch-all: it binds the whole remainder of the URL (slashes included) and must be the last segment. " +
-                             "{*name} and {**name} match identically.";
+                yield return $"'{segment.Value}' is a catch-all: it matches the whole remainder of the URL (slashes included) and must be the last segment. " +
+                             "'{*name}', '{**name}' and the nameless '**' all match the same URLs; only the named forms bind the remainder to a parameter.";
             }
 
             if (segment.Kind == "Complex")
@@ -281,7 +334,12 @@ public static class BrouterTemplateInspector
 
             const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
-            var parse = parserType.GetMethod("ParseTemplate", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            // The signature is checked, not just the name: Inspect invokes this with exactly
+            // (template, constraints), so a method that grew a parameter - or an overload set this
+            // no longer picks the right member out of - has to read as unavailable here rather than
+            // throw on every single call.
+            var parse = parserType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                                  .FirstOrDefault(method => method.Name == "ParseTemplate" && Accepts(method));
             if (parse is null) return null;
 
             // Every property is read unconditionally later on, so a single one that moved has to fail
@@ -298,12 +356,16 @@ public static class BrouterTemplateInspector
             var parts = segmentType.GetProperty("Parts", flags);
             var parameterNames = segmentType.GetProperty("ParameterNames", flags);
             var specificity = segmentType.GetProperty("Specificity", flags);
+            var partValue = partType.GetProperty("Value", flags);
+            var partIsParameter = partType.GetProperty("IsParameter", flags);
+            var partIsOptional = partType.GetProperty("IsOptional", flags);
             var partConstraints = partType.GetProperty("Constraints", flags);
             var constraintName = bindingType.GetProperty("Name", flags);
 
             if (template is null || segments is null || value is null || isParameter is null || isCatchAll is null ||
                 isSingleWildcard is null || isOptional is null || defaultValue is null || constraints is null ||
-                parts is null || parameterNames is null || specificity is null || partConstraints is null ||
+                parts is null || parameterNames is null || specificity is null || partValue is null ||
+                partIsParameter is null || partIsOptional is null || partConstraints is null ||
                 constraintName is null) return null;
 
             return new Reflected
@@ -321,6 +383,9 @@ public static class BrouterTemplateInspector
                 Parts = parts,
                 ParameterNames = parameterNames,
                 Specificity = specificity,
+                PartValue = partValue,
+                PartIsParameter = partIsParameter,
+                PartIsOptional = partIsOptional,
                 PartConstraints = partConstraints,
                 ConstraintName = constraintName
             };
@@ -329,6 +394,16 @@ public static class BrouterTemplateInspector
         {
             return null;
         }
+    }
+
+    /// <summary>Whether a method takes the two arguments <see cref="Inspect"/> passes it.</summary>
+    private static bool Accepts(MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+
+        return parameters.Length == 2 &&
+               parameters[0].ParameterType == typeof(string) &&
+               parameters[1].ParameterType.IsAssignableFrom(typeof(BrouterConstraintRegistry));
     }
 
     private sealed record Reflected
@@ -346,6 +421,9 @@ public static class BrouterTemplateInspector
         public required PropertyInfo Parts { get; init; }
         public required PropertyInfo ParameterNames { get; init; }
         public required PropertyInfo Specificity { get; init; }
+        public required PropertyInfo PartValue { get; init; }
+        public required PropertyInfo PartIsParameter { get; init; }
+        public required PropertyInfo PartIsOptional { get; init; }
         public required PropertyInfo PartConstraints { get; init; }
         public required PropertyInfo ConstraintName { get; init; }
     }

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTemplateInspector.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTemplateInspector.cs
@@ -60,27 +60,124 @@ public static class BrouterTemplateInspector
 
         if (parsed is null)
         {
-            return new BrouterTemplateInspectionDto { Template = template, IsValid = false, Error = "The template could not be parsed." };
+            return Unavailable(template);
         }
 
-        var segments = ((IEnumerable)parser.Segments.GetValue(parsed)!).Cast<object>().ToArray();
-        var dtos = new BrouterTemplateSegmentDto[segments.Length];
-
-        for (int i = 0; i < segments.Length; i++)
+        try
         {
-            dtos[i] = Describe(parser, segments[i]);
+            var segments = (parser.Segments.GetValue(parsed) as IEnumerable)?.Cast<object>().ToArray() ?? [];
+            var dtos = new BrouterTemplateSegmentDto[segments.Length];
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                dtos[i] = Describe(parser, segments[i]);
+            }
+
+            return new BrouterTemplateInspectionDto
+            {
+                Template = template,
+                IsValid = true,
+                NormalizedTemplate = parser.Template.GetValue(parsed) as string,
+                Specificity = dtos.Sum(s => s.Specificity),
+                ParameterNames = [.. dtos.SelectMany(s => s.ParameterNames ?? [])],
+                Segments = dtos,
+                Notes = [.. Notes(dtos)]
+            };
+        }
+        catch (Exception)
+        {
+            // The template parsed; only reading the result back failed - a property that moved or
+            // changed shape. Same answer as an unreachable parser: unavailable, never a wrong report.
+            return Unavailable(template);
+        }
+    }
+
+    private static BrouterTemplateInspectionDto Unavailable(string template) => new()
+    {
+        Template = template,
+        IsValid = false,
+        Error = "The template could not be parsed."
+    };
+
+    /// <summary>
+    /// Parses a whole set of templates and reports how they relate: which one the router prefers
+    /// when more than one matches, and which of them are indistinguishable.
+    /// </summary>
+    public static BrouterRouteTableAnalysisDto Analyze(IEnumerable<string> templates, BrouterConstraintRegistry? constraints)
+    {
+        var inspections = templates.Where(t => string.IsNullOrWhiteSpace(t) is false)
+                                   .Select(t => Inspect(t.Trim(), constraints))
+                                   .ToArray();
+
+        var entries = inspections.Select(inspection => new BrouterRouteTableEntryDto
+        {
+            Template = inspection.Template,
+            IsValid = inspection.IsValid,
+            Error = inspection.Error,
+            Specificity = inspection.Specificity,
+            Shape = inspection.IsValid ? Shape(inspection) : null
+        }).ToArray();
+
+        // Specificity is the router's tie-break between routes that all match a URL.
+        var ordered = entries.OrderByDescending(e => e.IsValid)
+                             .ThenByDescending(e => e.Specificity)
+                             .Select((entry, index) => entry with { MatchOrder = index + 1 })
+                             .ToArray();
+
+        var ambiguous = ordered.Where(e => e.Shape is not null)
+                               .GroupBy(e => e.Shape!, StringComparer.Ordinal)
+                               .Where(group => group.Count() > 1)
+                               .Select(group => group.Select(e => e.Template).ToArray())
+                               .ToArray();
+
+        var notes = new List<string>();
+
+        if (ambiguous.Length > 0)
+        {
+            notes.Add("Templates sharing a shape match exactly the same URLs, so the winner would come down to " +
+                      "registration order alone - Brouter refuses to register them and throws. Change or remove one of each group.");
         }
 
-        return new BrouterTemplateInspectionDto
+        if (ordered.Any(e => e.IsValid is false))
         {
-            Template = template,
-            IsValid = true,
-            NormalizedTemplate = (string?)parser.Template.GetValue(parsed),
-            Specificity = dtos.Sum(s => s.Specificity),
-            ParameterNames = [.. dtos.SelectMany(s => s.ParameterNames ?? [])],
-            Segments = dtos,
-            Notes = [.. Notes(dtos)]
-        };
+            notes.Add("An invalid template throws while its <Broute> initializes, so the route never registers.");
+        }
+
+        notes.Add("Specificity ranks routes that ALL match the same URL; it does not decide whether a route matches at all. " +
+                  "This analysis treats the templates as a flat set - nesting depth and index routes ('' under a parent) add " +
+                  "further tie-breaks that only exist once the routes sit in a tree.");
+
+        return new BrouterRouteTableAnalysisDto { Routes = ordered, Ambiguous = ambiguous, Notes = [.. notes] };
+    }
+
+    /// <summary>
+    /// The template stripped of everything matching ignores - parameter names above all, since
+    /// "/users/{id}" and "/users/{userId}" accept exactly the same URLs.
+    /// </summary>
+    private static string Shape(BrouterTemplateInspectionDto inspection)
+    {
+        return string.Join('/', (inspection.Segments ?? []).Select(segment => segment.Kind switch
+        {
+            "Literal" => segment.Value.ToLowerInvariant(),
+            "Wildcard" => "*",
+            "CatchAll" => $"{{**{string.Concat((segment.Constraints ?? []).Select(c => $":{c.ToLowerInvariant()}"))}}}",
+            "Complex" => ComplexShape(segment),
+            _ => $"{{{string.Concat((segment.Constraints ?? []).Select(c => $":{c.ToLowerInvariant()}"))}{(segment.IsOptional ? "?" : null)}}}"
+        }));
+    }
+
+    private static string ComplexShape(BrouterTemplateSegmentDto segment)
+    {
+        // The literal text between the parameters is what distinguishes two complex segments, and it
+        // survives in the segment's own text once the parameter names are blanked out.
+        var shape = segment.Value;
+
+        foreach (var name in segment.ParameterNames ?? [])
+        {
+            shape = shape.Replace($"{{{name}", "{", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return shape.ToLowerInvariant();
     }
 
     private static BrouterTemplateSegmentDto Describe(Reflected parser, object segment)
@@ -187,23 +284,45 @@ public static class BrouterTemplateInspector
             var parse = parserType.GetMethod("ParseTemplate", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (parse is null) return null;
 
+            // Every property is read unconditionally later on, so a single one that moved has to fail
+            // the whole reflection - the tool then says "unavailable" instead of throwing per call.
+            var template = templateType.GetProperty("Template", flags);
+            var segments = templateType.GetProperty("TemplateSegments", flags);
+            var value = segmentType.GetProperty("Value", flags);
+            var isParameter = segmentType.GetProperty("IsParameter", flags);
+            var isCatchAll = segmentType.GetProperty("IsCatchAll", flags);
+            var isSingleWildcard = segmentType.GetProperty("IsSingleWildcard", flags);
+            var isOptional = segmentType.GetProperty("IsOptional", flags);
+            var defaultValue = segmentType.GetProperty("DefaultValue", flags);
+            var constraints = segmentType.GetProperty("Constraints", flags);
+            var parts = segmentType.GetProperty("Parts", flags);
+            var parameterNames = segmentType.GetProperty("ParameterNames", flags);
+            var specificity = segmentType.GetProperty("Specificity", flags);
+            var partConstraints = partType.GetProperty("Constraints", flags);
+            var constraintName = bindingType.GetProperty("Name", flags);
+
+            if (template is null || segments is null || value is null || isParameter is null || isCatchAll is null ||
+                isSingleWildcard is null || isOptional is null || defaultValue is null || constraints is null ||
+                parts is null || parameterNames is null || specificity is null || partConstraints is null ||
+                constraintName is null) return null;
+
             return new Reflected
             {
                 ParseTemplate = parse,
-                Template = templateType.GetProperty("Template", flags)!,
-                Segments = templateType.GetProperty("TemplateSegments", flags)!,
-                Value = segmentType.GetProperty("Value", flags)!,
-                IsParameter = segmentType.GetProperty("IsParameter", flags)!,
-                IsCatchAll = segmentType.GetProperty("IsCatchAll", flags)!,
-                IsSingleWildcard = segmentType.GetProperty("IsSingleWildcard", flags)!,
-                IsOptional = segmentType.GetProperty("IsOptional", flags)!,
-                DefaultValue = segmentType.GetProperty("DefaultValue", flags)!,
-                Constraints = segmentType.GetProperty("Constraints", flags)!,
-                Parts = segmentType.GetProperty("Parts", flags)!,
-                ParameterNames = segmentType.GetProperty("ParameterNames", flags)!,
-                Specificity = segmentType.GetProperty("Specificity", flags)!,
-                PartConstraints = partType.GetProperty("Constraints", flags)!,
-                ConstraintName = bindingType.GetProperty("Name", flags)!
+                Template = template,
+                Segments = segments,
+                Value = value,
+                IsParameter = isParameter,
+                IsCatchAll = isCatchAll,
+                IsSingleWildcard = isSingleWildcard,
+                IsOptional = isOptional,
+                DefaultValue = defaultValue,
+                Constraints = constraints,
+                Parts = parts,
+                ParameterNames = parameterNames,
+                Specificity = specificity,
+                PartConstraints = partConstraints,
+                ConstraintName = constraintName
             };
         }
         catch (Exception)

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTemplateInspector.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTemplateInspector.cs
@@ -1,0 +1,233 @@
+using System.Collections;
+using System.Reflection;
+using Bit.Brouter.Demo.Server.Dtos;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Parses a route template with Brouter's own parser and reports what it made of it.
+/// <para>
+/// The point is that the answer is authoritative: rather than re-implementing the template grammar
+/// here - where it would quietly drift from the router and start telling MCP clients things that
+/// are not true - the real parser is invoked and its result is read back. It is internal to the
+/// library (nothing outside the router has a reason to parse a template), so this reaches it
+/// through reflection, and degrades to a plain "unavailable" answer if that surface ever moves.
+/// </para>
+/// </summary>
+public static class BrouterTemplateInspector
+{
+    private static readonly Lazy<Reflected?> _parser = new(Reflect);
+
+    public static BrouterTemplateInspectionDto Inspect(string template, BrouterConstraintRegistry? constraints)
+    {
+        template ??= string.Empty;
+
+        var parser = _parser.Value;
+        if (parser is null)
+        {
+            return new BrouterTemplateInspectionDto
+            {
+                Template = template,
+                IsValid = false,
+                Error = "The route template parser could not be reached in this build, so the template was not checked."
+            };
+        }
+
+        object? parsed;
+        try
+        {
+            parsed = parser.ParseTemplate.Invoke(null, [template, constraints]);
+        }
+        catch (TargetInvocationException exception)
+        {
+            // Exactly the exception the router throws while rendering an invalid <Broute Path="...">.
+            return new BrouterTemplateInspectionDto
+            {
+                Template = template,
+                IsValid = false,
+                Error = exception.InnerException?.Message ?? exception.Message
+            };
+        }
+        catch (Exception exception)
+        {
+            return new BrouterTemplateInspectionDto
+            {
+                Template = template,
+                IsValid = false,
+                Error = exception.Message
+            };
+        }
+
+        if (parsed is null)
+        {
+            return new BrouterTemplateInspectionDto { Template = template, IsValid = false, Error = "The template could not be parsed." };
+        }
+
+        var segments = ((IEnumerable)parser.Segments.GetValue(parsed)!).Cast<object>().ToArray();
+        var dtos = new BrouterTemplateSegmentDto[segments.Length];
+
+        for (int i = 0; i < segments.Length; i++)
+        {
+            dtos[i] = Describe(parser, segments[i]);
+        }
+
+        return new BrouterTemplateInspectionDto
+        {
+            Template = template,
+            IsValid = true,
+            NormalizedTemplate = (string?)parser.Template.GetValue(parsed),
+            Specificity = dtos.Sum(s => s.Specificity),
+            ParameterNames = [.. dtos.SelectMany(s => s.ParameterNames ?? [])],
+            Segments = dtos,
+            Notes = [.. Notes(dtos)]
+        };
+    }
+
+    private static BrouterTemplateSegmentDto Describe(Reflected parser, object segment)
+    {
+        var parts = parser.Parts.GetValue(segment);
+
+        var kind = (bool)parser.IsCatchAll.GetValue(segment)! ? "CatchAll"
+                 : (bool)parser.IsSingleWildcard.GetValue(segment)! ? "Wildcard"
+                 : parts is not null ? "Complex"
+                 : (bool)parser.IsParameter.GetValue(segment)! ? "Parameter"
+                 : "Literal";
+
+        var names = ((IEnumerable)parser.ParameterNames.GetValue(segment)!).Cast<string>().ToArray();
+
+        var constraints = ConstraintNames(parser, parser.Constraints.GetValue(segment));
+        if (parts is not null)
+        {
+            // A complex segment carries its constraints on the individual parts.
+            constraints = [.. ((IEnumerable)parts).Cast<object>()
+                .SelectMany(part => ConstraintNames(parser, parser.PartConstraints.GetValue(part)))];
+        }
+
+        var value = (string)parser.Value.GetValue(segment)!;
+        var isOptional = (bool)parser.IsOptional.GetValue(segment)!;
+        var defaultValue = (string?)parser.DefaultValue.GetValue(segment);
+
+        return new BrouterTemplateSegmentDto
+        {
+            // A parameter segment stores the bare parameter name; spelled back out the way it was
+            // written, it stays recognizable in the notes below.
+            Value = kind is "Parameter" or "CatchAll"
+                ? $"{{{(kind == "CatchAll" ? "*" : null)}{value}{string.Concat(constraints.Select(c => $":{c}"))}{(isOptional ? "?" : null)}{(defaultValue is null ? null : $"={defaultValue}")}}}"
+                : value,
+            Kind = kind,
+            ParameterNames = names.Length == 0 ? null : names,
+            Constraints = constraints.Length == 0 ? null : constraints,
+            IsOptional = isOptional,
+            DefaultValue = defaultValue,
+            Specificity = (int)parser.Specificity.GetValue(segment)!
+        };
+    }
+
+    private static string[] ConstraintNames(Reflected parser, object? bindings)
+    {
+        if (bindings is not IEnumerable enumerable) return [];
+
+        return [.. enumerable.Cast<object>().Select(b => (string)parser.ConstraintName.GetValue(b)!)];
+    }
+
+    /// <summary>The behaviors of a parsed template that are easy to get wrong.</summary>
+    private static IEnumerable<string> Notes(BrouterTemplateSegmentDto[] segments)
+    {
+        for (int i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+
+            if (segment.IsOptional && i < segments.Length - 1)
+            {
+                yield return $"'{segment.Value}' is an optional parameter that is not last. Like the built-in Blazor router, " +
+                             "it parses but matches as required - only the trailing run of optional/default-valued segments can be omitted by a shorter URL.";
+            }
+
+            if (segment.Kind == "CatchAll")
+            {
+                yield return $"'{segment.Value}' is a catch-all: it binds the whole remainder of the URL (slashes included) and must be the last segment. " +
+                             "{*name} and {**name} match identically.";
+            }
+
+            if (segment.Kind == "Complex")
+            {
+                yield return $"'{segment.Value}' is a complex segment - several parameters inside one URL segment. It is matched right-to-left, " +
+                             "and each of its parameters needs at least one character (a declared default is used for URL generation only).";
+            }
+
+            if (segment.DefaultValue is not null)
+            {
+                yield return $"'{segment.Value}' binds \"{segment.DefaultValue}\" when the URL omits the segment.";
+            }
+
+            if (segment.Constraints is { Length: > 1 })
+            {
+                yield return $"'{segment.Value}' chains constraints: every one of them has to accept the value, and the last TYPE constraint " +
+                             "decides the type the parameter binds as.";
+            }
+        }
+    }
+
+    private static Reflected? Reflect()
+    {
+        try
+        {
+            var assembly = typeof(BrouterLink).Assembly;
+
+            var parserType = assembly.GetType("Bit.Brouter.BrouterTemplateParser", throwOnError: false);
+            var templateType = assembly.GetType("Bit.Brouter.BrouterRouteTemplate", throwOnError: false);
+            var segmentType = assembly.GetType("Bit.Brouter.BrouterTemplateSegment", throwOnError: false);
+            var partType = assembly.GetType("Bit.Brouter.BrouterTemplatePart", throwOnError: false);
+            var bindingType = assembly.GetType("Bit.Brouter.BrouterRouteConstraintBinding", throwOnError: false);
+
+            if (parserType is null || templateType is null || segmentType is null || partType is null || bindingType is null) return null;
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+            var parse = parserType.GetMethod("ParseTemplate", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            if (parse is null) return null;
+
+            return new Reflected
+            {
+                ParseTemplate = parse,
+                Template = templateType.GetProperty("Template", flags)!,
+                Segments = templateType.GetProperty("TemplateSegments", flags)!,
+                Value = segmentType.GetProperty("Value", flags)!,
+                IsParameter = segmentType.GetProperty("IsParameter", flags)!,
+                IsCatchAll = segmentType.GetProperty("IsCatchAll", flags)!,
+                IsSingleWildcard = segmentType.GetProperty("IsSingleWildcard", flags)!,
+                IsOptional = segmentType.GetProperty("IsOptional", flags)!,
+                DefaultValue = segmentType.GetProperty("DefaultValue", flags)!,
+                Constraints = segmentType.GetProperty("Constraints", flags)!,
+                Parts = segmentType.GetProperty("Parts", flags)!,
+                ParameterNames = segmentType.GetProperty("ParameterNames", flags)!,
+                Specificity = segmentType.GetProperty("Specificity", flags)!,
+                PartConstraints = partType.GetProperty("Constraints", flags)!,
+                ConstraintName = bindingType.GetProperty("Name", flags)!
+            };
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private sealed record Reflected
+    {
+        public required MethodInfo ParseTemplate { get; init; }
+        public required PropertyInfo Template { get; init; }
+        public required PropertyInfo Segments { get; init; }
+        public required PropertyInfo Value { get; init; }
+        public required PropertyInfo IsParameter { get; init; }
+        public required PropertyInfo IsCatchAll { get; init; }
+        public required PropertyInfo IsSingleWildcard { get; init; }
+        public required PropertyInfo IsOptional { get; init; }
+        public required PropertyInfo DefaultValue { get; init; }
+        public required PropertyInfo Constraints { get; init; }
+        public required PropertyInfo Parts { get; init; }
+        public required PropertyInfo ParameterNames { get; init; }
+        public required PropertyInfo Specificity { get; init; }
+        public required PropertyInfo PartConstraints { get; init; }
+        public required PropertyInfo ConstraintName { get; init; }
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTypedRoutesCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTypedRoutesCatalog.cs
@@ -44,7 +44,18 @@ public static class BrouterTypedRoutesCatalog
     {
         var assembly = typeof(DocsCatalog).Assembly;
 
-        var type = assembly.GetTypes().FirstOrDefault(t => t.Name == "BrouterRoutes" && t.IsAbstract && t.IsSealed);
+        Type? type;
+        try
+        {
+            type = assembly.GetTypes().FirstOrDefault(t => t.Name == "BrouterRoutes" && t.IsAbstract && t.IsSealed);
+        }
+        catch (ReflectionTypeLoadException)
+        {
+            // A type that fails to load says nothing about the generator's output, and a Lazy caches
+            // whatever it is given - an exception here would fail every later call, not just this one.
+            return null;
+        }
+
         if (type is null) return null;
 
         var builders = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTypedRoutesCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterTypedRoutesCatalog.cs
@@ -1,0 +1,113 @@
+using System.Reflection;
+using Bit.Brouter.Demo.Client;
+using Bit.Brouter.Demo.Server.Dtos;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Reads back the <c>BrouterRoutes</c> class that the Bit.Brouter.Generators source generator
+/// produced for this demo.
+/// <para>
+/// The generator's output cannot be listed from the library - it is emitted into each consuming
+/// project from that project's own route declarations - so the only honest way to show an agent
+/// what it gets is to show a real one. This demo compiled against the generator, so its builders
+/// are right here in the referenced assembly, sample URLs and all.
+/// </para>
+/// </summary>
+public static class BrouterTypedRoutesCatalog
+{
+    private const string HowItWorks = """
+        Reference the analyzer-only package and the very next build emits a `static partial class BrouterRoutes`
+        into your project's root namespace, with one URL builder per route template found in your `.razor` files -
+        both `@page` directives and `<Broute Path="...">` declarations:
+
+            <PackageReference Include="Bit.Brouter.Generators" Version="10.6.0-pre-02" PrivateAssets="all" />
+
+        Route parameters become method parameters typed by their constraint (`{id:int}` -> `int id`), optional and
+        default-valued parameters become optional arguments, and a catch-all takes the remainder. Named routes
+        (`<Broute Name="counter" ...>`) additionally get a constant under `BrouterRoutes.Names`, which is what
+        `IBrouter.NavigateToName` / `ResolveUrl` take. Renaming or removing a route then breaks the call site at
+        compile time instead of producing a 404 at run time:
+
+            <BrouterLink Href="@BrouterRoutes.Counter(1234)">Counter</BrouterLink>
+            brouter.NavigateToName(BrouterRoutes.Names.Counter, new Dictionary<string, object> { ["init"] = 1234 });
+
+        The builders below are the real output for this documentation site, generated from the route table in
+        Demo/Client/AppRouter.razor.
+        """;
+
+    private static readonly Lazy<BrouterTypedRoutesDto?> _typedRoutes = new(Build);
+
+    public static BrouterTypedRoutesDto? TypedRoutes => _typedRoutes.Value;
+
+    private static BrouterTypedRoutesDto? Build()
+    {
+        var assembly = typeof(DocsCatalog).Assembly;
+
+        var type = assembly.GetTypes().FirstOrDefault(t => t.Name == "BrouterRoutes" && t.IsAbstract && t.IsSealed);
+        if (type is null) return null;
+
+        var builders = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(method => method.IsSpecialName is false && method.ReturnType == typeof(string))
+            .OrderBy(method => method.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(method => new BrouterTypedRouteDto
+            {
+                Method = method.Name,
+                Signature = $"({string.Join(", ", method.GetParameters().Select(Describe))})",
+                ExampleUrl = TryInvoke(method)
+            })
+            .ToArray();
+
+        var names = type.GetNestedType("Names", BindingFlags.Public)
+                       ?.GetFields(BindingFlags.Public | BindingFlags.Static)
+                        .Where(field => field.IsLiteral && field.FieldType == typeof(string))
+                        .ToDictionary(field => field.Name, field => (string)field.GetRawConstantValue()!)
+                    ?? [];
+
+        return new BrouterTypedRoutesDto
+        {
+            GeneratedFor = assembly.GetName().Name ?? "Bit.Brouter.Demo.Client",
+            HowItWorks = HowItWorks,
+            Builders = builders,
+            Names = names
+        };
+    }
+
+    private static string Describe(ParameterInfo parameter)
+    {
+        var name = BrouterApiCatalog.FriendlyName(parameter.ParameterType);
+
+        return parameter.HasDefaultValue ? $"{name} {parameter.Name} = {parameter.DefaultValue ?? "null"}" : $"{name} {parameter.Name}";
+    }
+
+    /// <summary>Calls a builder with placeholder arguments, so the listing shows the URL it produces.</summary>
+    private static string? TryInvoke(MethodInfo method)
+    {
+        try
+        {
+            var arguments = method.GetParameters().Select(Sample).ToArray();
+
+            return method.Invoke(null, arguments) as string;
+        }
+        catch (Exception)
+        {
+            // A builder that needs something this code cannot guess simply shows no example.
+            return null;
+        }
+    }
+
+    private static object? Sample(ParameterInfo parameter)
+    {
+        if (parameter.HasDefaultValue) return parameter.DefaultValue;
+
+        var type = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
+
+        if (type == typeof(string)) return parameter.Name;
+        if (type == typeof(Guid)) return Guid.Empty;
+        if (type == typeof(DateTime)) return new DateTime(2026, 1, 1);
+        if (type == typeof(bool)) return true;
+        if (type.IsValueType) return Convert.ChangeType(1, type, System.Globalization.CultureInfo.InvariantCulture);
+
+        return null;
+    }
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
@@ -18,6 +18,7 @@ public static partial class BrouterXmlDocs
     private const char CodeMarker = (char)1;
 
     private static readonly Lazy<FrozenDictionary<string, XElement>> _members = new(Load);
+    private static readonly Lazy<FrozenDictionary<string, XElement>> _overloads = new(BuildOverloads);
 
     /// <summary>The flattened &lt;summary&gt; of a documented member, or null.</summary>
     public static string? GetSummary(string documentationId) => GetSection(documentationId, "summary");
@@ -27,24 +28,28 @@ public static partial class BrouterXmlDocs
 
     private static string? GetSection(string documentationId, string section)
     {
-        if (_members.Value.TryGetValue(documentationId, out var member) is false)
-        {
-            // Overloads are told apart by their parameter list; when building it did not produce an
-            // exact hit (generics, modifiers), one overload's documentation still beats none. Which
-            // one is decided by ordering the candidates - a FrozenDictionary enumerates in whatever
-            // order it hashed into, so picking off it directly would answer differently per build.
-            var prefix = $"{documentationId}(";
-            member = _members.Value.Where(m => m.Key.StartsWith(prefix, StringComparison.Ordinal))
-                                   .OrderBy(m => m.Key, StringComparer.Ordinal)
-                                   .Select(m => m.Value)
-                                   .FirstOrDefault();
-
-            if (member is null) return null;
-        }
+        // Overloads are told apart by their parameter list; when building it did not produce an exact
+        // hit (generics, modifiers), one overload's documentation still beats none.
+        if (_members.Value.TryGetValue(documentationId, out var member) is false &&
+            _overloads.Value.TryGetValue(documentationId, out member) is false) return null;
 
         var element = member.Element(section);
 
         return element is null ? null : Flatten(element);
+    }
+
+    /// <summary>
+    /// Every documented method by its id without the parameter list, so an inexact id still finds an
+    /// overload without walking the whole table. Which overload is decided by ordering the candidates
+    /// - a FrozenDictionary enumerates in whatever order it hashed into, so taking one off it
+    /// directly would answer differently per build.
+    /// </summary>
+    private static FrozenDictionary<string, XElement> BuildOverloads()
+    {
+        return _members.Value.Where(m => m.Key.Contains('(', StringComparison.Ordinal))
+                             .OrderBy(m => m.Key, StringComparer.Ordinal)
+                             .GroupBy(m => m.Key[..m.Key.IndexOf('(', StringComparison.Ordinal)], StringComparer.Ordinal)
+                             .ToFrozenDictionary(g => g.Key, g => g.First().Value, StringComparer.Ordinal);
     }
 
     private static FrozenDictionary<string, XElement> Load()

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
@@ -15,6 +15,8 @@ namespace Bit.Brouter.Demo.Server.Services;
 /// </summary>
 public static partial class BrouterXmlDocs
 {
+    private const char CodeMarker = (char)1;
+
     private static readonly Lazy<FrozenDictionary<string, XElement>> _members = new(Load);
 
     /// <summary>The flattened &lt;summary&gt; of a documented member, or null.</summary>
@@ -65,8 +67,9 @@ public static partial class BrouterXmlDocs
     private static string Flatten(XElement element)
     {
         var builder = new StringBuilder();
+        var codeSamples = new List<string>();
 
-        Write(element, builder);
+        Write(element, builder, codeSamples);
 
         var text = builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
 
@@ -76,10 +79,23 @@ public static partial class BrouterXmlDocs
         text = ParagraphBreakRegex().Replace(text, "\n\n");
         text = RepeatedSpaceRegex().Replace(text, " ");
 
+        // A code sample only stood in as a placeholder while the prose was unwrapped: its own line
+        // breaks and indentation are the sample, not source wrapping, and go back in verbatim.
+        for (int i = 0; i < codeSamples.Count; i++)
+        {
+            text = text.Replace(CodePlaceholder(i), codeSamples[i], StringComparison.Ordinal);
+        }
+
         return text.Trim();
     }
 
-    private static void Write(XNode node, StringBuilder builder)
+    /// <summary>
+    /// Stands in for a code sample while the prose is unwrapped. U+0001 never occurs in
+    /// documentation text, and none of the whitespace passes above can touch it.
+    /// </summary>
+    private static string CodePlaceholder(int index) => $"{CodeMarker}{index}{CodeMarker}";
+
+    private static void Write(XNode node, StringBuilder builder, List<string> codeSamples)
     {
         switch (node)
         {
@@ -100,21 +116,24 @@ public static partial class BrouterXmlDocs
 
                     case "para":
                         builder.Append('\n');
-                        foreach (var child in element.Nodes()) Write(child, builder);
+                        foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
                         builder.Append('\n');
                         return;
 
                     case "code":
-                        builder.Append('\n').Append(element.Value.Trim()).Append('\n');
+                        // Blank lines on both sides, so the sample is a block of its own rather than
+                        // a sentence that happens to continue in code.
+                        builder.Append("\n\n").Append(CodePlaceholder(codeSamples.Count)).Append("\n\n");
+                        codeSamples.Add(element.Value.Trim());
                         return;
 
                     case "param" or "typeparam":
                         builder.Append('\n').Append(element.Attribute("name")?.Value).Append(": ");
-                        foreach (var child in element.Nodes()) Write(child, builder);
+                        foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
                         return;
 
                     default:
-                        foreach (var child in element.Nodes()) Write(child, builder);
+                        foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
                         return;
                 }
         }

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
@@ -1,0 +1,153 @@
+using System.Text;
+using System.Xml.Linq;
+using System.Reflection;
+using System.Collections.Frozen;
+using System.Text.RegularExpressions;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Reads the XML documentation the Bit.Brouter build emits next to its assembly and flattens each
+/// entry into plain text: <c>&lt;see cref="T:Bit.Brouter.IBrouter"/&gt;</c> becomes
+/// <c>IBrouter</c>, <c>&lt;c&gt;</c> spans become their content, and paragraphs become blank
+/// lines. That text is the same prose a developer reads in IntelliSense, which makes it the most
+/// accurate answer an MCP client can get about a member - no second copy to keep in sync.
+/// </summary>
+public static partial class BrouterXmlDocs
+{
+    private static readonly Lazy<FrozenDictionary<string, XElement>> _members = new(Load);
+
+    /// <summary>The flattened &lt;summary&gt; of a documented member, or null.</summary>
+    public static string? GetSummary(string documentationId) => GetSection(documentationId, "summary");
+
+    /// <summary>The flattened &lt;remarks&gt; of a documented member, or null.</summary>
+    public static string? GetRemarks(string documentationId) => GetSection(documentationId, "remarks");
+
+    private static string? GetSection(string documentationId, string section)
+    {
+        if (_members.Value.TryGetValue(documentationId, out var member) is false)
+        {
+            // Overloads are told apart by their parameter list; when building it did not produce an
+            // exact hit (generics, modifiers), the first overload's documentation still beats none.
+            var prefix = $"{documentationId}(";
+            member = _members.Value.FirstOrDefault(m => m.Key.StartsWith(prefix, StringComparison.Ordinal)).Value;
+
+            if (member is null) return null;
+        }
+
+        var element = member.Element(section);
+
+        return element is null ? null : Flatten(element);
+    }
+
+    private static FrozenDictionary<string, XElement> Load()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, $"{typeof(BrouterLink).Assembly.GetName().Name}.xml");
+
+        if (File.Exists(path) is false) return FrozenDictionary<string, XElement>.Empty;
+
+        try
+        {
+            var document = XDocument.Load(path);
+
+            return document.Descendants("member")
+                           .Where(m => m.Attribute("name") is not null)
+                           .GroupBy(m => m.Attribute("name")!.Value, StringComparer.Ordinal)
+                           .ToFrozenDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+        }
+        catch (Exception)
+        {
+            // Documentation is a nicety: a malformed or half-written file must not take the tools down.
+            return FrozenDictionary<string, XElement>.Empty;
+        }
+    }
+
+    private static string Flatten(XElement element)
+    {
+        var builder = new StringBuilder();
+
+        Write(element, builder);
+
+        var text = builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        // The source wraps its prose across lines, so a single newline is just a space - while the
+        // blank line a <para> emits is a real paragraph break and has to survive.
+        text = WrappedLineRegex().Replace(text, " ");
+        text = ParagraphBreakRegex().Replace(text, "\n\n");
+        text = RepeatedSpaceRegex().Replace(text, " ");
+
+        return text.Trim();
+    }
+
+    private static void Write(XNode node, StringBuilder builder)
+    {
+        switch (node)
+        {
+            case XText text:
+                builder.Append(text.Value);
+                return;
+
+            case XElement element:
+                switch (element.Name.LocalName)
+                {
+                    case "see" or "seealso":
+                        builder.Append(Reference(element));
+                        return;
+
+                    case "paramref" or "typeparamref":
+                        builder.Append(element.Attribute("name")?.Value);
+                        return;
+
+                    case "para":
+                        builder.Append('\n');
+                        foreach (var child in element.Nodes()) Write(child, builder);
+                        builder.Append('\n');
+                        return;
+
+                    case "code":
+                        builder.Append('\n').Append(element.Value.Trim()).Append('\n');
+                        return;
+
+                    case "param" or "typeparam":
+                        builder.Append('\n').Append(element.Attribute("name")?.Value).Append(": ");
+                        foreach (var child in element.Nodes()) Write(child, builder);
+                        return;
+
+                    default:
+                        foreach (var child in element.Nodes()) Write(child, builder);
+                        return;
+                }
+        }
+    }
+
+    /// <summary>Turns a cref such as "T:Bit.Brouter.BrouterOptions.ScrollBehavior" into "BrouterOptions.ScrollBehavior".</summary>
+    private static string Reference(XElement element)
+    {
+        var target = element.Attribute("cref")?.Value ?? element.Attribute("langword")?.Value ?? element.Value;
+
+        if (string.IsNullOrEmpty(target)) return string.Empty;
+
+        var kind = target.Length > 2 && target[1] == ':' ? target[0] : '\0';
+        if (kind != '\0') target = target[2..];
+
+        // Drop the arity marker of a generic type ("BrouterTypeRouteConstraint`1").
+        var arity = target.IndexOf('`', StringComparison.Ordinal);
+        if (arity > 0) target = target[..arity];
+
+        var parts = target.Split('.');
+
+        // A type reads best on its own; a member keeps the type it belongs to.
+        var keep = kind is 'T' or 'N' ? 1 : 2;
+
+        return parts.Length <= keep ? target : string.Join('.', parts[^keep..]);
+    }
+
+    [GeneratedRegex(@"(?<!\n)[ \t]*\n[ \t]*(?!\n)")]
+    private static partial Regex WrappedLineRegex();
+
+    [GeneratedRegex(@"[ \t]*\n[ \t\n]*")]
+    private static partial Regex ParagraphBreakRegex();
+
+    [GeneratedRegex(@"[ \t]{2,}")]
+    private static partial Regex RepeatedSpaceRegex();
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/BrouterXmlDocs.cs
@@ -30,9 +30,14 @@ public static partial class BrouterXmlDocs
         if (_members.Value.TryGetValue(documentationId, out var member) is false)
         {
             // Overloads are told apart by their parameter list; when building it did not produce an
-            // exact hit (generics, modifiers), the first overload's documentation still beats none.
+            // exact hit (generics, modifiers), one overload's documentation still beats none. Which
+            // one is decided by ordering the candidates - a FrozenDictionary enumerates in whatever
+            // order it hashed into, so picking off it directly would answer differently per build.
             var prefix = $"{documentationId}(";
-            member = _members.Value.FirstOrDefault(m => m.Key.StartsWith(prefix, StringComparison.Ordinal)).Value;
+            member = _members.Value.Where(m => m.Key.StartsWith(prefix, StringComparison.Ordinal))
+                                   .OrderBy(m => m.Key, StringComparer.Ordinal)
+                                   .Select(m => m.Value)
+                                   .FirstOrDefault();
 
             if (member is null) return null;
         }
@@ -148,6 +153,12 @@ public static partial class BrouterXmlDocs
 
         var kind = target.Length > 2 && target[1] == ':' ? target[0] : '\0';
         if (kind != '\0') target = target[2..];
+
+        // A method cref carries its parameter list ("M:Bit.Brouter.IBrouter.BackAsync(System.Int32)").
+        // Fully qualified argument types read as noise in prose, and the '.'s inside them would
+        // otherwise be split on below - which would keep the arguments and drop the owning type.
+        var arguments = target.IndexOf('(', StringComparison.Ordinal);
+        if (arguments > 0) target = target[..arguments];
 
         // Drop the arity marker of a generic type ("BrouterTypeRouteConstraint`1").
         var arity = target.IndexOf('`', StringComparison.Ordinal);

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/DocsPageRenderer.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/DocsPageRenderer.cs
@@ -1,0 +1,44 @@
+using Bit.Brouter.Demo.Client;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Renders a documentation page component and flattens it to Markdown, for the tool and the
+/// resource that both hand out the docs.
+/// <para>
+/// The component is the very one the site serves, so what an MCP client reads is what a human
+/// reads. It renders on its own, though - outside the app's &lt;Brouter&gt; and its layout - so a
+/// page that reaches for the router or for JS interop while initializing throws instead of
+/// producing HTML. That has to come back as a page-shaped answer explaining itself, never as a
+/// failed tool call that tells the agent nothing.
+/// </para>
+/// </summary>
+public static class DocsPageRenderer
+{
+    /// <summary>The page as Markdown, or a null <c>Markdown</c> and the reason it could not be rendered.</summary>
+    public static async Task<(string? Markdown, string? Error)> TryRenderMarkdownAsync(HtmlRenderer htmlRenderer, DocsPageInfo page)
+    {
+        try
+        {
+            var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+            {
+                var component = await htmlRenderer.RenderComponentAsync(page.PageType);
+
+                return component.ToHtmlString();
+            });
+
+            return (html.ToMarkdown(), null);
+        }
+        catch (Exception exception)
+        {
+            return (null, exception.Message);
+        }
+    }
+
+    /// <summary>What to answer with when the page did not render - and where its content is anyway.</summary>
+    public static string Unavailable(DocsPageInfo page, string? error) =>
+        $"The '{page.Title}' documentation page could not be rendered on the server{(error is null ? null : $": {error}")}. " +
+        $"It is readable at {page.Url} on the live documentation site. For the same material as text, " +
+        $"call SearchBrouter(query: \"{page.Keywords.Split(' ').FirstOrDefault()}\") or GetBrouterGuideSections.";
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/HtmlToMarkdownService.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/HtmlToMarkdownService.cs
@@ -169,8 +169,13 @@ public static partial class HtmlToMarkdownService
         var code = WebUtility.HtmlDecode(node.InnerText).Trim('\n', '\r');
         if (code.Trim().Length == 0) return;
 
+        // The fence has to outrun the longest run of backticks in the sample itself - the docs do
+        // show Markdown - or the block would end in the middle of its own content.
+        var longest = BacktickRunRegex().Matches(code).Select(match => match.Length).DefaultIfEmpty(0).Max();
+        var fence = new string('`', Math.Max(3, longest + 1));
+
         AppendBlockBreak(builder);
-        builder.Append("```\n").Append(code).Append("\n```");
+        builder.Append(fence).Append('\n').Append(code).Append('\n').Append(fence);
         AppendBlockBreak(builder);
     }
 
@@ -318,7 +323,9 @@ public static partial class HtmlToMarkdownService
     private static string Normalize(string markdown)
     {
         markdown = markdown.Replace("\r\n", "\n", StringComparison.Ordinal);
-        markdown = TrailingSpacesRegex().Replace(markdown, string.Empty);
+        // Only the spaces go - the newline that ended the line has to stay, or every table row
+        // (each of which ends in the "| " a cell separator leaves behind) folds into its neighbour.
+        markdown = TrailingSpacesRegex().Replace(markdown, "\n");
         markdown = BlankLinesRegex().Replace(markdown, "\n\n");
 
         return markdown.Trim();
@@ -332,4 +339,7 @@ public static partial class HtmlToMarkdownService
 
     [GeneratedRegex(@"\n{3,}")]
     private static partial Regex BlankLinesRegex();
+
+    [GeneratedRegex("`+")]
+    private static partial Regex BacktickRunRegex();
 }

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/HtmlToMarkdownService.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/HtmlToMarkdownService.cs
@@ -1,0 +1,322 @@
+using System.Net;
+using System.Text;
+using HtmlAgilityPack;
+using System.Text.RegularExpressions;
+
+namespace Bit.Brouter.Demo.Server.Services;
+
+/// <summary>
+/// Converts the rendered HTML of a documentation page into Markdown.
+/// <para>
+/// The docs pages are written for humans: syntax highlighting wraps every keyword in a
+/// &lt;span&gt;, cards and grids add layers of &lt;div&gt;s, and the whole thing carries CSS
+/// classes an MCP client has no use for. Handing that HTML to a model burns most of its budget on
+/// markup, so pages are flattened here into the Markdown an LLM reads natively - headings,
+/// paragraphs, lists, tables and fenced code blocks - which is typically a fifth of the size.
+/// </para>
+/// </summary>
+public static partial class HtmlToMarkdownService
+{
+    // Elements whose content is presentation-only or already unusable as text.
+    private static readonly HashSet<string> _skippedElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "script", "style", "svg", "path", "template", "noscript", "head"
+    };
+
+    // Elements that start on their own line and are followed by a blank one.
+    private static readonly HashSet<string> _blockElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "address", "article", "aside", "blockquote", "div", "dl", "fieldset", "figure", "footer",
+        "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "main", "nav", "ol", "p",
+        "pre", "section", "table", "ul"
+    };
+
+    public static string ToMarkdown(this string html)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return string.Empty;
+
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        var builder = new StringBuilder(html.Length / 2);
+        WriteChildren(document.DocumentNode, builder, listDepth: 0);
+
+        return Normalize(builder.ToString());
+    }
+
+    private static void WriteChildren(HtmlNode node, StringBuilder builder, int listDepth)
+    {
+        foreach (var child in node.ChildNodes)
+        {
+            WriteNode(child, builder, listDepth);
+        }
+    }
+
+    private static void WriteNode(HtmlNode node, StringBuilder builder, int listDepth)
+    {
+        if (node.NodeType == HtmlNodeType.Comment) return;
+
+        if (node.NodeType == HtmlNodeType.Text)
+        {
+            AppendText(builder, WebUtility.HtmlDecode(node.InnerText));
+            return;
+        }
+
+        if (node.NodeType != HtmlNodeType.Element) return;
+
+        var name = node.Name.ToLowerInvariant();
+
+        if (_skippedElements.Contains(name)) return;
+
+        switch (name)
+        {
+            case "br":
+                builder.Append('\n');
+                return;
+
+            case "hr":
+                AppendBlockBreak(builder);
+                builder.Append("---");
+                AppendBlockBreak(builder);
+                return;
+
+            case "h1" or "h2" or "h3" or "h4" or "h5" or "h6":
+                AppendBlockBreak(builder);
+                builder.Append('#', name[1] - '0').Append(' ').Append(Inline(node));
+                AppendBlockBreak(builder);
+                return;
+
+            case "pre":
+                AppendCodeBlock(node, builder);
+                return;
+
+            case "code" when node.ParentNode?.Name.Equals("pre", StringComparison.OrdinalIgnoreCase) is false:
+                AppendText(builder, $"`{Inline(node)}`", collapse: false);
+                return;
+
+            case "strong" or "b":
+                AppendWrapped(node, builder, "**");
+                return;
+
+            case "em" or "i":
+                AppendWrapped(node, builder, "_");
+                return;
+
+            case "a":
+                AppendLink(node, builder);
+                return;
+
+            case "img":
+                var alt = node.GetAttributeValue("alt", string.Empty);
+                if (string.IsNullOrWhiteSpace(alt) is false) AppendText(builder, $"[image: {alt}]");
+                return;
+
+            case "ul" or "ol":
+                AppendList(node, builder, listDepth);
+                return;
+
+            case "table":
+                AppendTable(node, builder);
+                return;
+
+            case "dl":
+                AppendDefinitionList(node, builder, listDepth);
+                return;
+
+            case "button":
+                // Interactive affordances ("Copy", "Show menu") are noise in a document.
+                return;
+        }
+
+        var isBlock = _blockElements.Contains(name);
+
+        if (isBlock) AppendBlockBreak(builder);
+
+        WriteChildren(node, builder, listDepth);
+
+        if (isBlock) AppendBlockBreak(builder);
+    }
+
+    private static void AppendWrapped(HtmlNode node, StringBuilder builder, string marker)
+    {
+        var content = Inline(node);
+        if (content.Length == 0) return;
+
+        AppendText(builder, $"{marker}{content}{marker}", collapse: false);
+    }
+
+    private static void AppendLink(HtmlNode node, StringBuilder builder)
+    {
+        var text = Inline(node);
+        if (text.Length == 0) return;
+
+        var href = node.GetAttributeValue("href", string.Empty);
+
+        // A link whose text already is its target (the docs link to their own routes that way)
+        // reads better as plain text than as a Markdown link that repeats itself.
+        if (string.IsNullOrWhiteSpace(href) || href.StartsWith('#') || string.Equals(href, text, StringComparison.OrdinalIgnoreCase))
+        {
+            AppendText(builder, text, collapse: false);
+            return;
+        }
+
+        AppendText(builder, $"[{text}]({WebUtility.HtmlDecode(href)})", collapse: false);
+    }
+
+    private static void AppendCodeBlock(HtmlNode node, StringBuilder builder)
+    {
+        // The highlighting spans carry no information: their text content already is the code.
+        var code = WebUtility.HtmlDecode(node.InnerText).Trim('\n', '\r');
+        if (code.Trim().Length == 0) return;
+
+        AppendBlockBreak(builder);
+        builder.Append("```\n").Append(code).Append("\n```");
+        AppendBlockBreak(builder);
+    }
+
+    private static void AppendList(HtmlNode node, StringBuilder builder, int listDepth)
+    {
+        var ordered = node.Name.Equals("ol", StringComparison.OrdinalIgnoreCase);
+        var index = 1;
+
+        AppendBlockBreak(builder);
+
+        foreach (var item in node.ChildNodes.Where(n => n.Name.Equals("li", StringComparison.OrdinalIgnoreCase)))
+        {
+            TrimTrailingWhitespace(builder);
+            if (builder.Length > 0) builder.Append('\n');
+
+            builder.Append(new string(' ', listDepth * 2))
+                   .Append(ordered ? $"{index++}. " : "- ");
+
+            var content = new StringBuilder();
+            WriteChildren(item, content, listDepth + 1);
+
+            // Keep a nested list attached to its parent item, but never leave a blank line inside one.
+            builder.Append(Normalize(content.ToString()).Replace("\n\n", "\n", StringComparison.Ordinal));
+        }
+
+        AppendBlockBreak(builder);
+    }
+
+    private static void AppendDefinitionList(HtmlNode node, StringBuilder builder, int listDepth)
+    {
+        AppendBlockBreak(builder);
+
+        foreach (var child in node.ChildNodes)
+        {
+            if (child.Name.Equals("dt", StringComparison.OrdinalIgnoreCase))
+            {
+                TrimTrailingWhitespace(builder);
+                if (builder.Length > 0) builder.Append('\n');
+                builder.Append("- **").Append(Inline(child)).Append("**");
+            }
+            else if (child.Name.Equals("dd", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = Inline(child);
+                if (value.Length > 0) builder.Append(": ").Append(value);
+            }
+        }
+
+        AppendBlockBreak(builder);
+    }
+
+    private static void AppendTable(HtmlNode node, StringBuilder builder)
+    {
+        var rows = node.Descendants()
+                       .Where(n => n.Name.Equals("tr", StringComparison.OrdinalIgnoreCase))
+                       .Select(tr => tr.ChildNodes
+                                       .Where(c => c.Name.Equals("th", StringComparison.OrdinalIgnoreCase) ||
+                                                   c.Name.Equals("td", StringComparison.OrdinalIgnoreCase))
+                                       .Select(c => Inline(c).Replace("|", "\\|", StringComparison.Ordinal))
+                                       .ToArray())
+                       .Where(cells => cells.Length > 0)
+                       .ToArray();
+
+        if (rows.Length == 0) return;
+
+        var columns = rows.Max(r => r.Length);
+
+        AppendBlockBreak(builder);
+
+        for (int i = 0; i < rows.Length; i++)
+        {
+            var cells = rows[i];
+            builder.Append("| ");
+            for (int c = 0; c < columns; c++)
+            {
+                builder.Append(c < cells.Length ? cells[c] : string.Empty).Append(" | ");
+            }
+            builder.Append('\n');
+
+            // Markdown needs the delimiter row right after the first one, header or not.
+            if (i == 0)
+            {
+                builder.Append("| ");
+                for (int c = 0; c < columns; c++) builder.Append("--- | ");
+                builder.Append('\n');
+            }
+        }
+
+        AppendBlockBreak(builder);
+    }
+
+    /// <summary>Renders a node's content as a single line, for headings and table/list cells.</summary>
+    private static string Inline(HtmlNode node)
+    {
+        var builder = new StringBuilder();
+        WriteChildren(node, builder, listDepth: 0);
+
+        return WhitespaceRegex().Replace(builder.ToString(), " ").Trim();
+    }
+
+    private static void AppendText(StringBuilder builder, string text, bool collapse = true)
+    {
+        if (collapse)
+        {
+            text = WhitespaceRegex().Replace(text, " ");
+            if (text.Trim().Length == 0)
+            {
+                // A single separating space still matters between two inline elements.
+                if (text.Length > 0 && builder.Length > 0 && char.IsWhiteSpace(builder[^1]) is false) builder.Append(' ');
+                return;
+            }
+        }
+
+        // Never start a line with the whitespace that only existed to indent the HTML source.
+        if (builder.Length == 0 || builder[^1] == '\n') text = text.TrimStart();
+
+        builder.Append(text);
+    }
+
+    private static void AppendBlockBreak(StringBuilder builder)
+    {
+        if (builder.Length == 0) return;
+
+        TrimTrailingWhitespace(builder);
+        builder.Append("\n\n");
+    }
+
+    private static void TrimTrailingWhitespace(StringBuilder builder)
+    {
+        while (builder.Length > 0 && char.IsWhiteSpace(builder[^1])) builder.Length--;
+    }
+
+    private static string Normalize(string markdown)
+    {
+        markdown = markdown.Replace("\r\n", "\n", StringComparison.Ordinal);
+        markdown = TrailingSpacesRegex().Replace(markdown, string.Empty);
+        markdown = BlankLinesRegex().Replace(markdown, "\n\n");
+
+        return markdown.Trim();
+    }
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex(@"[ \t]+\n")]
+    private static partial Regex TrailingSpacesRegex();
+
+    [GeneratedRegex(@"\n{3,}")]
+    private static partial Regex BlankLinesRegex();
+}

--- a/src/Brouter/Bit.Brouter.Demo/Server/Services/HtmlToMarkdownService.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Services/HtmlToMarkdownService.cs
@@ -90,7 +90,7 @@ public static partial class HtmlToMarkdownService
                 AppendCodeBlock(node, builder);
                 return;
 
-            case "code" when node.ParentNode?.Name.Equals("pre", StringComparison.OrdinalIgnoreCase) is false:
+            case "code" when node.ParentNode is null || node.ParentNode.Name.Equals("pre", StringComparison.OrdinalIgnoreCase) is false:
                 AppendText(builder, $"`{Inline(node)}`", collapse: false);
                 return;
 
@@ -223,8 +223,10 @@ public static partial class HtmlToMarkdownService
 
     private static void AppendTable(HtmlNode node, StringBuilder builder)
     {
+        // Descendants() reaches into a nested table too, and its rows belong to that table - which
+        // renders itself when the cell holding it is written out.
         var rows = node.Descendants()
-                       .Where(n => n.Name.Equals("tr", StringComparison.OrdinalIgnoreCase))
+                       .Where(n => n.Name.Equals("tr", StringComparison.OrdinalIgnoreCase) && OwningTable(n) == node)
                        .Select(tr => tr.ChildNodes
                                        .Where(c => c.Name.Equals("th", StringComparison.OrdinalIgnoreCase) ||
                                                    c.Name.Equals("td", StringComparison.OrdinalIgnoreCase))
@@ -259,6 +261,17 @@ public static partial class HtmlToMarkdownService
         }
 
         AppendBlockBreak(builder);
+    }
+
+    /// <summary>The innermost table a row sits in.</summary>
+    private static HtmlNode? OwningTable(HtmlNode row)
+    {
+        for (var parent = row.ParentNode; parent is not null; parent = parent.ParentNode)
+        {
+            if (parent.Name.Equals("table", StringComparison.OrdinalIgnoreCase)) return parent;
+        }
+
+        return null;
     }
 
     /// <summary>Renders a node's content as a single line, for headings and table/list cells.</summary>

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -33,6 +33,14 @@ troubleshooting guide), and a `/playground` index of live, clickable demo routes
 self-contained Blazor WebAssembly app with prerendering - and it is routed by Brouter itself, so
 every page you read is also a working proof of the feature it documents.
 
+That same server hosts an **MCP server** at `/mcp`, so an AI agent can work against Brouter's real
+API instead of guessing at it: the tools serve the reference guide below, the docs pages, the exact
+public API (every parameter with its type and default, read out of the shipped assembly), every
+route constraint, the demo's own source files, and a route-template checker that parses a template
+with Brouter's own parser. Point an MCP client at `http://localhost:5185/mcp` and start with the
+`GetBrouterOverview` tool; each tool is also a plain HTTP GET under `/api/mcp/...` if you just want
+to look. See [McpController](Bit.Brouter.Demo/Server/Controllers/McpController.cs).
+
 [`Samples`](Samples/) is the render-mode harness rather than the docs: one shared
 [Core](Samples/Core/) project of demo routes, hosted unchanged under
 [Server](Samples/Server/), [WASM](Samples/Wasm/) and [Auto](Samples/Auto/) so the same routing

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -34,12 +34,24 @@ self-contained Blazor WebAssembly app with prerendering - and it is routed by Br
 every page you read is also a working proof of the feature it documents.
 
 That same server hosts an **MCP server** at `/mcp`, so an AI agent can work against Brouter's real
-API instead of guessing at it: the tools serve the reference guide below, the docs pages, the exact
-public API (every parameter with its type and default, read out of the shipped assembly), every
-route constraint, the demo's own source files, and a route-template checker that parses a template
-with Brouter's own parser. Point an MCP client at `http://localhost:5185/mcp` and start with the
-`GetBrouterOverview` tool; each tool is also a plain HTTP GET under `/api/mcp/...` if you just want
-to look. See [McpController](Bit.Brouter.Demo/Server/Controllers/McpController.cs).
+API instead of guessing at it. Point an MCP client at `http://localhost:5185/mcp`; every tool is
+also a plain HTTP GET under `/api/mcp/...` if you just want to look. It offers:
+
+- **Search** across everything at once (`SearchBrouter`) - the guide below, the docs pages, every
+  public member, the constraints and the demo's sources - with the exact follow-up call on each hit.
+- **Setup** per Blazor render mode (`GetBrouterSetupGuide`), as the real files of a working project.
+- **The exact API** (`GetBrouterApiList` / `GetBrouterApiDetails`), reflected out of the shipped
+  assembly with every parameter's type, default value and XML documentation.
+- **Route-template checking** (`InspectBrouterRouteTemplate`, `AnalyzeBrouterRouteTable`) using
+  Brouter's own parser: parameters, constraints, specificity ranking, ambiguous pairs, real errors.
+- **The docs and the guide** as text, the constraint catalog, the demo's source files, and the typed
+  routes the source generator emitted for this very site.
+- **Resources** (`brouter://guide/...`, `brouter://api/...`, `brouter://docs/...`) and **prompts**
+  for the four common jobs: adding Brouter to an app, implementing a routing feature, migrating off
+  the built-in Router, and debugging a route that will not match.
+
+Start with the `GetBrouterOverview` tool. See
+[McpController](Bit.Brouter.Demo/Server/Controllers/McpController.cs).
 
 [`Samples`](Samples/) is the render-mode harness rather than the docs: one shared
 [Core](Samples/Core/) project of demo routes, hosted unchanged under


### PR DESCRIPTION
closes #12937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tools and HTTP endpoints for Brouter documentation, setup guidance, API metadata, typed routes, route constraints, route analysis, and source files.
  * Added searchable documentation covering guides, APIs, constraints, pages, and source code.
  * Added route-template inspection with parameter, constraint, validity, matching, and ambiguity details.
  * Added guided workflows for setup, feature implementation, migration, and routing diagnostics.
  * Added Markdown rendering and helpful suggestions for unavailable or incorrect pages.
* **Bug Fixes**
  * Improved route URL generation when no router is mounted.
* **Documentation**
  * Updated the README with MCP capabilities and HTTP endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->