### PR TITLE
Add MCP server to Bmotion demo website (#12950)

### DIFF
--- a/.github/workflows/bit.ci.Bmotion.yml
+++ b/.github/workflows/bit.ci.Bmotion.yml
@@ -57,7 +57,10 @@ jobs:
     - name: dotnet test (C# engine + component tests)
       # Run from inside src so src/global.json's "test" runner setting applies
       # (from the repo root the SDK falls back to the unsupported VSTest path).
-      run: cd src/Bmotion && dotnet test Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj -f net10.0
+      run: cd src/Bmotion && dotnet test Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj -f net10.0 --no-build
+
+    - name: dotnet test (MCP server)
+      run: cd src/Bmotion && dotnet test Tests/Bit.Bmotion.Tests.Mcp/Bit.Bmotion.Tests.Mcp.csproj -f net10.0 --no-build
 
     - name: JS tests (bit-bmotion.js drag/scroll math)
       run: |

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Extensions/IServiceCollectionExtensions.cs
@@ -10,9 +10,19 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class IServiceCollectionExtensions
 {
-    public static IServiceCollection AddDemoServices(this IServiceCollection services)
+    /// <param name="baseAddress">
+    /// The app's own origin, for the <see cref="HttpClient"/> the MCP page calls the demo's
+    /// /api/mcp endpoints with. The prerendering host passes nothing: it registers the client so
+    /// the page's injection resolves, but the page only ever issues a request from a button, which
+    /// cannot happen during prerendering.
+    /// </param>
+    public static IServiceCollection AddDemoServices(this IServiceCollection services, string? baseAddress = null)
     {
         services.AddBitBmotionServices();
+
+        services.AddScoped(_ => baseAddress is null
+            ? new HttpClient()
+            : new HttpClient { BaseAddress = new Uri(baseAddress) });
 
         return services;
     }

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Pages/McpServerPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Pages/McpServerPage.razor
@@ -1,0 +1,966 @@
+@page "/mcp"
+@using System.Net.Http.Json
+@inject HttpClient Http
+
+@* The MCP server's own documentation page. Everything interactive on it calls the demo's real
+   /api/mcp endpoints - the same methods the MCP server exposes as tools - so what a reader tries
+   here is exactly what an agent gets, and the page cannot document a tool that does not work.
+
+   The tool, prompt and resource tables are fetched rather than written out, for the same reason:
+   they come from GetMcpCatalog, which reflects over the attributes that declare them. *@
+
+<PageTitle>MCP server - Bit.Bmotion</PageTitle>
+
+<h1>MCP server</h1>
+
+<p class="page-intro">
+    This demo ships a <strong>Model Context Protocol</strong> server, so an AI agent can write
+    Bmotion code from what the library <em>actually</em> is rather than from what it remembers.
+    Half of its tools answer from this build's own text - the guide, the XML documentation compiled
+    into the assembly, the source of every page you have been reading. The other half answer by
+    <strong>running the real animation engine off-screen</strong> and reporting what it did. That
+    second half is the reason it exists: no amount of documentation can tell you that
+    <code>Bm.Spring(stiffness: 400, damping: 2)</code> wobbles for five seconds, or that animating
+    <code>height</code> stops moving the moment your app is served over Blazor Server.
+</p>
+
+<div class="demo-section">
+    <h2>Why an animation library needs one</h2>
+    <p>
+        Almost every way of getting an animation wrong is silent. There is no compiler error, no
+        exception, and nothing in the browser console - the page simply does not move, or moves
+        differently in production than it did on your machine. Three examples this server answers
+        directly:
+    </p>
+
+    <div class="mcp-why">
+        @foreach (var (index, problem) in _problems.Index())
+        {
+            <Bmotion Initial="Bm.To(opacity: 0, y: 18)"
+                     WhileInView="Bm.To(opacity: 1, y: 0)"
+                     Once="true"
+                     Transition="@Bm.Spring(bounce: 0.2, duration: 0.5).WithDelay(index * 0.08)">
+                <div class="mcp-why-card">
+                    <span class="mcp-why-symptom">@problem.Symptom</span>
+                    <p>@problem.Cause</p>
+                    <code>@problem.Tool</code>
+                </div>
+            </Bmotion>
+        }
+    </div>
+</div>
+
+<div class="demo-section">
+    <h2>Connect your agent</h2>
+    <p>
+        The server speaks MCP over HTTP at <code>/mcp</code>. Run this demo, then point any MCP
+        client at it. The same methods are also plain <code>GET</code> endpoints under
+        <code>/api/mcp/...</code>, so you can open any of them in a browser tab - which is exactly
+        what the panels further down this page do.
+    </p>
+
+    <div class="mcp-tabs" role="tablist">
+        @foreach (var client in _clients)
+        {
+            <button type="button" role="tab" class="mcp-tab @(_client == client.Name ? "active" : null)"
+                    aria-selected="@(_client == client.Name)"
+                    @onclick="@(() => _client = client.Name)">
+                @client.Name
+            </button>
+        }
+    </div>
+
+    @{
+        var selected = _clients.First(c => c.Name == _client);
+    }
+
+    <p class="mcp-tab-note">@selected.Note</p>
+    <CodeSnippet Code="@selected.Config" />
+</div>
+
+<div class="demo-section">
+    <h2>The transition lab</h2>
+    <p>
+        <code>SimulateBmotionTransition</code> plays a transition on the real engine with no browser
+        involved, and reports what the motion does. A spring has no duration argument - how long it
+        takes and how far it overshoots fall out of the physics - so this is the only way to know
+        what one feels like before shipping it.
+    </p>
+    <p>
+        The box below is not an approximation: it replays the exact per-frame values the server
+        measured, handed back as keyframes.
+    </p>
+
+    <div class="mcp-lab">
+        <div class="mcp-lab-controls">
+            <label for="mcp-spec">Transition</label>
+            <input id="mcp-spec" type="text" value="@_spec" @onchange="OnSpecChanged" disabled="@_busy" />
+
+            <div class="mcp-presets">
+                @foreach (var preset in _presets)
+                {
+                    <button type="button" class="mcp-chip" disabled="@_busy"
+                            @onclick="@(() => RunSimulationAsync(preset))">
+                        @preset
+                    </button>
+                }
+            </div>
+
+            <button class="btn-bm" @onclick="@(() => RunSimulationAsync(_spec))" disabled="@_busy">
+                @(_busy ? "Measuring..." : "Measure it")
+            </button>
+        </div>
+
+        <div class="mcp-lab-stage">
+            @if (_simulation is { Samples.Length: > 1 })
+            {
+                @* @key on the replay counter: changing it re-mounts the element, which is what makes
+                   the keyframe animation play again rather than sit at its resting value. *@
+                <Bmotion Animate="Bm.To(x: _replayFrames)"
+                         Transition="Bm.Tween(_simulation.SettleSeconds, BmEase.Linear)"
+                         @key="_replay">
+                    <div class="box box-sm" />
+                </Bmotion>
+            }
+            else
+            {
+                <div class="box box-sm mcp-box-idle" />
+            }
+        </div>
+    </div>
+
+    @if (_error is not null)
+    {
+        <p class="mcp-error">@_error</p>
+    }
+    else if (_simulation is not null)
+    {
+        <div class="mcp-metrics">
+            <div><span>Settles in</span><strong>@_simulation.SettleSeconds.ToString("0.00")s</strong></div>
+            <div><span>Overshoot</span><strong>@_simulation.OvershootPercent.ToString("0.#")%</strong></div>
+            <div><span>Crossings</span><strong>@_simulation.TargetCrossings</strong></div>
+            <div><span>90% at</span><strong>@_simulation.TimeTo90Percent.ToString("0.00")s</strong></div>
+        </div>
+
+        <pre class="mcp-sparkline">@_simulation.Sparkline</pre>
+        <p class="mcp-reading">@_simulation.Reading</p>
+
+        @foreach (var warning in _simulation.Warnings)
+        {
+            <p class="mcp-warning">@warning</p>
+        }
+    }
+</div>
+
+<div class="demo-section">
+    <h2>Will it work on Blazor Server?</h2>
+    <p>
+        Only animations the browser compositor can own play on Blazor Server; everything else needs
+        the C# per-frame loop, which does not exist there, and becomes an instant jump.
+        <code>AnalyzeBmotionAnimation</code> does not consult a table - it starts the animation on
+        the real engine and watches which path the engine takes.
+    </p>
+
+    <div class="mcp-check">
+        <div class="mcp-check-row">
+            <label for="mcp-props">Properties</label>
+            <input id="mcp-props" type="text" value="@_properties" @onchange="OnPropertiesChanged" disabled="@_checking" />
+        </div>
+        <div class="mcp-check-row">
+            <label for="mcp-trans">Transition</label>
+            <input id="mcp-trans" type="text" value="@_checkSpec" @onchange="OnCheckSpecChanged" disabled="@_checking" />
+        </div>
+
+        <div class="mcp-presets">
+            @foreach (var example in _checkExamples)
+            {
+                <button type="button" class="mcp-chip" disabled="@_checking"
+                        @onclick="@(() => RunCheckAsync(example.Properties, example.Transition))">
+                    @example.Properties
+                </button>
+            }
+        </div>
+
+        <button class="btn-bm" @onclick="@(() => RunCheckAsync(_properties, _checkSpec))" disabled="@_checking">
+            @(_checking ? "Asking the engine..." : "Ask the engine")
+        </button>
+    </div>
+
+    @* An unreadable transition comes back as data rather than as a failed call, so the verdict is
+       only shown when there is one - a "Snaps on Blazor Server" banner for an animation that was
+       never analysed would be a claim about the animation, and a wrong one. *@
+    @if (_playback?.Error is not null)
+    {
+        <p class="mcp-error">@_playback.Error</p>
+    }
+    else if (_playback is not null)
+    {
+        <div class="mcp-verdict @(_playback.WorksOnBlazorServer ? "ok" : "warn")">
+            <strong>@(_playback.WorksOnBlazorServer ? "Plays on Blazor Server" : "Snaps on Blazor Server")</strong>
+            <span>@_playback.Path</span>
+        </div>
+
+        <p class="mcp-reading">@_playback.Reason</p>
+
+        @if (_playback.HowToOffload is { Length: > 0 })
+        {
+            <ul class="mcp-fixes">
+                @foreach (var fix in _playback.HowToOffload)
+                {
+                    <li>@fix</li>
+                }
+            </ul>
+        }
+    }
+</div>
+
+<div class="demo-section">
+    <h2>Review your markup</h2>
+    <p>
+        <code>ReviewBmotionCode</code> is the pass that closes the loop after an agent writes code.
+        It looks for the mistakes that compile cleanly and then do nothing - an <code>Exit</code>
+        with no presence component around it, a <code>@@foreach</code> with no <code>@@key</code>, a
+        spring whose duration the engine ignores. The sample below contains several on purpose.
+    </p>
+
+    <textarea class="mcp-code" rows="9" spellcheck="false"
+              value="@_review" @onchange="OnReviewChanged" disabled="@_reviewing"></textarea>
+
+    <div class="demo-actions">
+        <button class="btn-bm" @onclick="RunReviewAsync" disabled="@_reviewing">
+            @(_reviewing ? "Reviewing..." : "Review it")
+        </button>
+    </div>
+
+    @if (_findings is not null)
+    {
+        @if (_findings.Findings.Length == 0)
+        {
+            <p class="mcp-reading">Nothing to report - all @_findings.RulesApplied.Length rules passed.</p>
+        }
+        else
+        {
+            <ul class="mcp-findings">
+                @foreach (var finding in _findings.Findings)
+                {
+                    <Bmotion Initial="Bm.To(opacity: 0, x: -12)"
+                             Animate="Bm.To(opacity: 1, x: 0)"
+                             Transition="Bm.Tween(0.25)">
+                        <li class="mcp-finding @finding.Severity.ToLowerInvariant()">
+                            <span class="mcp-severity">@finding.Severity</span>
+                            <span class="mcp-rule">@finding.Rule</span>
+                            <span class="mcp-line">line @finding.Line</span>
+                            <p>@finding.Message</p>
+                            <p class="mcp-fix">@finding.Fix</p>
+                        </li>
+                    </Bmotion>
+                }
+            </ul>
+        }
+    }
+</div>
+
+<div class="demo-section">
+    <h2>One search across everything</h2>
+    <p>
+        An agent rarely knows which corpus holds the answer. <code>SearchBmotion</code> covers the
+        guide, every public member, the animatable properties, the easing presets, the recipes, the
+        setup guides and the demo's sources at once - and every hit carries the exact follow-up call
+        that returns it in full.
+    </p>
+
+    <div class="mcp-search">
+        <input type="search" value="@_query" @onchange="OnQueryChanged" disabled="@_searching"
+               placeholder="make a list appear one item at a time" aria-label="Search Bmotion" />
+        <button class="btn-bm" @onclick="RunSearchAsync" disabled="@_searching">
+            @(_searching ? "Searching..." : "Search")
+        </button>
+    </div>
+
+    @if (_hits is { Length: > 0 })
+    {
+        <ul class="mcp-hits">
+            @foreach (var hit in _hits)
+            {
+                <li>
+                    <span class="mcp-hit-kind">@hit.Kind</span>
+                    <span class="mcp-hit-title">@hit.Title</span>
+                    <code>@hit.Tool</code>
+                </li>
+            }
+        </ul>
+    }
+    else if (_hits is not null)
+    {
+        <p class="mcp-reading">Nothing matched that.</p>
+    }
+</div>
+
+<div class="demo-section">
+    <h2>Tools</h2>
+    <p>
+        Eighteen of them, listed here straight from the attributes that declare them - so this table
+        cannot fall out of step with the server.
+    </p>
+
+    @if (_catalog is null)
+    {
+        <p class="mcp-reading">Loading the catalog...</p>
+    }
+    else
+    {
+        <div class="mcp-table-wrap">
+            <table class="mcp-table">
+                <thead>
+                    <tr><th>Tool</th><th>Parameters</th><th>What it answers</th></tr>
+                </thead>
+                <tbody>
+                    @foreach (var tool in _catalog.Tools)
+                    {
+                        <tr>
+                            <td><code>@tool.Name</code></td>
+                            <td class="mcp-params">
+                                @if (tool.Parameters.Length == 0)
+                                {
+                                    <span class="mcp-none">none</span>
+                                }
+                                else
+                                {
+                                    @foreach (var parameter in tool.Parameters)
+                                    {
+                                        <code>@parameter</code>
+                                    }
+                                }
+                            </td>
+                            <td>@Shorten(tool.Description)</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>
+
+<div class="demo-section">
+    <h2>Prompts</h2>
+    <p>
+        Prompts are the workflows: the order to call the tools in for a whole task. They exist
+        because the failure mode of an agent holding eighteen tools is not ignorance - it is calling
+        them in a sequence that skips the check which would have caught the bug.
+    </p>
+
+    @if (_catalog is not null)
+    {
+        <div class="mcp-cards">
+            @foreach (var prompt in _catalog.Prompts)
+            {
+                <Bmotion WhileHover="Bm.To(y: -3, scale: 1.01)" Transition="Bm.Spring(stiffness: 400, damping: 28)">
+                    <div class="mcp-card">
+                        <code>@prompt.Name</code>
+                        <p>@prompt.Description</p>
+                        @if (prompt.Parameters.Length > 0)
+                        {
+                            <span class="mcp-card-params">@string.Join(" · ", prompt.Parameters)</span>
+                        }
+                    </div>
+                </Bmotion>
+            }
+        </div>
+    }
+</div>
+
+<div class="demo-section">
+    <h2>Resources</h2>
+    <p>
+        The same knowledge as URIs, for clients that attach documentation to a conversation up front
+        or let a person browse and pin it. They read the same catalogs the tools do, so neither can
+        go stale relative to the other.
+    </p>
+
+    @if (_catalog is not null)
+    {
+        <ul class="mcp-resources">
+            @foreach (var resource in _catalog.Resources)
+            {
+                <li><code>@resource.Name</code><span>@resource.Description</span></li>
+            }
+        </ul>
+    }
+</div>
+
+<div class="demo-section">
+    <h2>How it stays true</h2>
+    <p>
+        Documentation that is written down separately drifts, and an agent cannot tell a stale answer
+        from a fresh one. So nothing here is written down twice:
+    </p>
+
+    <ul class="mcp-principles">
+        <li>
+            <strong>The API reference is reflected</strong> out of the shipped assembly and paired
+            with the XML documentation compiled into it. A new component parameter appears the moment
+            it is written, with the default value it actually has - read off a freshly constructed
+            instance. In an animation library the defaults <em>are</em> the behaviour.
+        </li>
+        <li>
+            <strong>The guide, the demo pages and their sources are embedded</strong> into the server
+            assembly, so the tools keep working from a published deployment and always hand out the
+            same text this site renders.
+        </li>
+        <li>
+            <strong>The motion is measured, not described.</strong> A headless
+            <code>IBmotionInterop</code> lets the server construct a real
+            <code>BmotionAnimationEngine</code> with no DOM anywhere and advance its frame clock
+            itself. A three-second spring is simulated in microseconds.
+        </li>
+        <li>
+            <strong>The compositor verdict is observed.</strong> The engine decides whether an
+            animation can go to the browser through a long rule set; restating that rule set here
+            would mean maintaining a second copy of it and being wrong in exactly the cases that
+            matter. Instead the server starts the animation and records whether the engine reached
+            for the Web Animations API - including for every animatable property, once, to build the
+            table behind <code>GetBmotionAnimatableProperties</code>.
+        </li>
+    </ul>
+
+    <CodeSnippet Code="@_architectureCode" />
+</div>
+
+@code {
+    private sealed record Problem(string Symptom, string Cause, string Tool);
+
+    private sealed record McpClient(string Name, string Note, string Config);
+
+    private sealed record CheckExample(string Properties, string Transition);
+
+    // The response shapes of the endpoints this page calls. They mirror the server's DTOs rather
+    // than sharing them: the client project does not reference the host, and these are the four
+    // fields the page renders out of each - not the whole contract.
+    private sealed record Simulation(double SettleSeconds, double OvershootPercent, int TargetCrossings,
+        double TimeTo90Percent, Sample[] Samples, string Sparkline, string Reading, string[] Warnings, string? Error);
+
+    private sealed record Sample(double Seconds, double Value);
+
+    private sealed record Playback(string Path, bool WorksOnBlazorServer, string Reason, string[]? HowToOffload, string? Error);
+
+    private sealed record Review(bool Passed, Finding[] Findings, string[] RulesApplied);
+
+    private sealed record Finding(string Severity, string Rule, int? Line, string Message, string Fix);
+
+    private sealed record Hit(string Kind, string Title, string? Context, string Tool, string Snippet);
+
+    private sealed record Catalog(CatalogMember[] Tools, CatalogMember[] Prompts, CatalogMember[] Resources);
+
+    private sealed record CatalogMember(string Name, string Description, string[] Parameters);
+
+    private static readonly Problem[] _problems =
+    [
+        new("It works locally, not in production",
+            "The animation touches a property the browser compositor cannot own, so it needs the C# frame loop - which does not exist on Blazor Server.",
+            "AnalyzeBmotionAnimation"),
+        new("The exit animation never plays",
+            "Blazor removed the element the moment the condition flipped. Exit needs a presence component to hold it in the DOM.",
+            "ReviewBmotionCode"),
+        new("The spring feels wrong and the numbers do not help",
+            "Stiffness and damping do not describe motion out loud. How long it takes and how far it overshoots are consequences, not settings.",
+            "SimulateBmotionTransition"),
+    ];
+
+    private static readonly McpClient[] _clients =
+    [
+        new("Claude Code",
+            "One command, from anywhere in your project.",
+            """
+            claude mcp add --transport http bmotion https://localhost:5001/mcp
+            """),
+        new("Claude Desktop",
+            "Add it to claude_desktop_config.json, then restart the app.",
+            """
+            {
+              "mcpServers": {
+                "bmotion": {
+                  "type": "http",
+                  "url": "https://localhost:5001/mcp"
+                }
+              }
+            }
+            """),
+        new("VS Code",
+            "Add it to .vscode/mcp.json in the workspace, and it is offered to Copilot in agent mode.",
+            """
+            {
+              "servers": {
+                "bmotion": {
+                  "type": "http",
+                  "url": "https://localhost:5001/mcp"
+                }
+              }
+            }
+            """),
+        new("Cursor",
+            "Add it to .cursor/mcp.json for this project, or to ~/.cursor/mcp.json for all of them.",
+            """
+            {
+              "mcpServers": {
+                "bmotion": {
+                  "url": "https://localhost:5001/mcp"
+                }
+              }
+            }
+            """),
+    ];
+
+    private static readonly string[] _presets =
+    [
+        "spring(stiffness: 260, damping: 12)",
+        "spring(bounce: 0.2, duration: 0.4)",
+        "spring(stiffness: 400, damping: 2)",
+        "tween(0.4, InOut)",
+        "tween(0.6, BackOut)",
+        "inertia(velocity: 500)",
+    ];
+
+    private static readonly CheckExample[] _checkExamples =
+    [
+        new("x, opacity", "spring(stiffness: 200, damping: 20)"),
+        new("width, height", "tween(0.4)"),
+        new("backgroundColor", "tween(0.4)"),
+        new("x", "inertia(velocity: 500)"),
+    ];
+
+    private const string _architectureCode = """
+        // Server/Services/BmotionMotionLab.cs - the whole trick, in five lines.
+        //
+        // HeadlessBmotionInterop is an IBmotionInterop that reports IsInProcess = true and forwards
+        // nothing to a browser, so the engine behaves exactly as it does on WebAssembly while the
+        // simulation owns the clock. Frames are advanced by calling ComputeFrame directly.
+
+        var interop = new HeadlessBmotionInterop();
+        await using var engine = new BmotionAnimationEngine(interop);
+        var service = new BmotionAnimateService(engine, interop);
+
+        var frames = new List<(double Seconds, double Value)>();
+        var clockMs = 0.0;
+
+        var animation = service.AnimateAsync(from, to, value => frames.Add((clockMs / 1000, value)), transition);
+
+        while (animation.IsCompleted is false && clockMs < MaxMs)
+        {
+            engine.ComputeFrame(clockMs);
+            clockMs += 1000.0 / 60;
+        }
+
+        // For the render-mode question the interop is the instrument rather than the stage: if the
+        // engine called PlayWaapiAnimationAsync, the browser owns the animation - and it plays on
+        // Blazor Server. If it never did, the animation needs the frame loop, and it does not.
+        """;
+
+    private string _spec = "spring(stiffness: 260, damping: 12)";
+    private string _client = "Claude Code";
+    private bool _busy;
+    private int _replay;
+    private string? _error;
+    private Simulation? _simulation;
+    private double[] _replayFrames = [];
+
+    private string _properties = "x, opacity";
+    private string _checkSpec = "spring(stiffness: 200, damping: 20)";
+    private bool _checking;
+    private Playback? _playback;
+
+    private string _review = """
+        @if (_show)
+        {
+            <Bmotion Animate="Bm.To(opacity: 1)"
+                     Exit="Bm.To(opacity: 0)"
+                     Transition="Bm.Spring(duration: 0.5)">
+                <div class="toast">Saved</div>
+            </Bmotion>
+        }
+        """;
+
+    private bool _reviewing;
+    private Review? _findings;
+
+    private string _query = "make a list appear one item at a time";
+    private bool _searching;
+    private Hit[]? _hits;
+
+    private Catalog? _catalog;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Every call on this page goes to the app's own API, which prerendering has no way to reach
+        // and no reason to: the catalog is chrome, not content.
+        if (firstRender is false || RendererInfo.IsInteractive is false) return;
+
+        _catalog = await GetAsync<Catalog>("api/mcp/GetMcpCatalog");
+
+        StateHasChanged();
+    }
+
+    private void OnSpecChanged(ChangeEventArgs e) => _spec = e.Value?.ToString() ?? "";
+
+    private void OnPropertiesChanged(ChangeEventArgs e) => _properties = e.Value?.ToString() ?? "";
+
+    private void OnCheckSpecChanged(ChangeEventArgs e) => _checkSpec = e.Value?.ToString() ?? "";
+
+    private void OnReviewChanged(ChangeEventArgs e) => _review = e.Value?.ToString() ?? "";
+
+    private void OnQueryChanged(ChangeEventArgs e) => _query = e.Value?.ToString() ?? "";
+
+    private async Task RunSimulationAsync(string spec)
+    {
+        _spec = spec;
+        _busy = true;
+        _error = null;
+
+        var result = await GetAsync<Simulation>($"api/mcp/SimulateBmotionTransition?transition={Uri.EscapeDataString(spec)}");
+
+        if (result is null)
+        {
+            _error = "The demo's own API did not answer. Is the server still running?";
+            _simulation = null;
+        }
+        else if (result.Error is not null)
+        {
+            // The server read the spec and could not make sense of it, and said why - which is a
+            // better message than anything this page could compose about it.
+            _error = result.Error;
+            _simulation = null;
+        }
+        else
+        {
+            _simulation = result;
+
+            // The samples are evenly spaced in time, so they are keyframes as they stand: replaying
+            // them with a linear tween of the measured settle time reproduces the motion the server
+            // measured, rather than a second animation that merely resembles it.
+            _replayFrames = [.. result.Samples.Select(sample => sample.Value / 100 * 220)];
+            _replay++;
+        }
+
+        _busy = false;
+    }
+
+    private async Task RunCheckAsync(string properties, string transition)
+    {
+        _properties = properties;
+        _checkSpec = transition;
+        _checking = true;
+
+        _playback = await GetAsync<Playback>(
+            $"api/mcp/AnalyzeBmotionAnimation?properties={Uri.EscapeDataString(properties)}" +
+            $"&transition={Uri.EscapeDataString(transition)}");
+
+        _checking = false;
+    }
+
+    private async Task RunReviewAsync()
+    {
+        _reviewing = true;
+
+        _findings = await GetAsync<Review>($"api/mcp/ReviewBmotionCode?code={Uri.EscapeDataString(_review)}");
+
+        _reviewing = false;
+    }
+
+    private async Task RunSearchAsync()
+    {
+        _searching = true;
+
+        _hits = await GetAsync<Hit[]>($"api/mcp/SearchBmotion?query={Uri.EscapeDataString(_query)}&limit=8") ?? [];
+
+        _searching = false;
+    }
+
+    /// <summary>
+    /// Calls one of the demo's own MCP endpoints. A failure leaves the panel showing what it showed
+    /// before rather than taking the page down - these are demonstrations, and the page around them
+    /// is documentation that still reads perfectly well without a live answer.
+    /// </summary>
+    private async Task<T?> GetAsync<T>(string url)
+    {
+        try
+        {
+            return await Http.GetFromJsonAsync<T>(url);
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    private static string Shorten(string description)
+    {
+        // The tool descriptions are written for an agent deciding whether to call the tool, so they
+        // are long by design. The table wants the first sentence.
+        var stop = description.IndexOf(". ", StringComparison.Ordinal);
+
+        return stop > 0 ? description[..(stop + 1)] : description;
+    }
+}
+
+<style>
+    .mcp-why {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+        margin-block: 1.25rem;
+    }
+
+    .mcp-why-card {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: .5rem;
+        padding: 1rem;
+        border: 1px solid var(--bit-clr-brd-sec);
+        border-radius: .5rem;
+        background-color: var(--bit-clr-bg-sec);
+    }
+
+    .mcp-why-symptom { font-weight: 700; color: var(--bit-clr-fg-pri); }
+
+    .mcp-why-card p { margin: 0; font-size: .875rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-why-card code { align-self: flex-start; margin-top: auto; }
+
+    .mcp-tabs { display: flex; flex-wrap: wrap; gap: .5rem; margin-block: 1rem .75rem; }
+
+    .mcp-tab {
+        padding: .4rem .85rem;
+        border: 1px solid var(--bit-clr-brd-sec);
+        border-radius: 2rem;
+        background: none;
+        color: var(--bit-clr-fg-sec);
+        font: inherit;
+        font-size: .875rem;
+        cursor: pointer;
+    }
+
+    .mcp-tab:hover { border-color: var(--bit-clr-pri); color: var(--bit-clr-fg-pri); }
+
+    .mcp-tab.active {
+        border-color: var(--bit-clr-pri);
+        background-color: var(--bit-clr-pri);
+        color: var(--bit-clr-pri-text, #fff);
+    }
+
+    .mcp-tab-note { font-size: .875rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-lab {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: center;
+        padding: 1.25rem;
+        border: 1px solid var(--bit-clr-brd-sec);
+        border-radius: .5rem;
+        background-color: var(--bit-clr-bg-sec);
+    }
+
+    .mcp-lab-controls { flex: 1 1 20rem; display: flex; flex-direction: column; gap: .6rem; }
+
+    .mcp-lab-controls label { font-size: .8125rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-lab-controls input,
+    .mcp-check input,
+    .mcp-search input,
+    .mcp-code {
+        width: 100%;
+        padding: .5rem .65rem;
+        border: 1px solid var(--bit-clr-brd-sec);
+        border-radius: .375rem;
+        background-color: var(--bit-clr-bg-pri);
+        color: var(--bit-clr-fg-pri);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: .8125rem;
+    }
+
+    .mcp-lab-controls .btn-bm { align-self: flex-start; }
+
+    .mcp-presets { display: flex; flex-wrap: wrap; gap: .4rem; }
+
+    .mcp-chip {
+        padding: .25rem .6rem;
+        border: 1px solid var(--bit-clr-brd-sec);
+        border-radius: 2rem;
+        background: none;
+        color: var(--bit-clr-fg-sec);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: .75rem;
+        cursor: pointer;
+    }
+
+    .mcp-chip:hover { border-color: var(--bit-clr-pri); color: var(--bit-clr-fg-pri); }
+
+    .mcp-lab-stage {
+        flex: 1 1 16rem;
+        min-height: 5rem;
+        display: flex;
+        align-items: center;
+    }
+
+    .mcp-box-idle { opacity: .35; }
+
+    .mcp-metrics {
+        display: grid;
+        gap: .75rem;
+        grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+        margin-block: 1rem .75rem;
+    }
+
+    .mcp-metrics div { display: flex; flex-direction: column; gap: .15rem; }
+
+    .mcp-metrics span { font-size: .75rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-metrics strong { font-size: 1.25rem; color: var(--bit-clr-fg-pri); }
+
+    .mcp-sparkline {
+        overflow-x: auto;
+        margin: 0 0 .75rem;
+        padding: .6rem .75rem;
+        border-radius: .375rem;
+        background-color: var(--bit-clr-bg-sec);
+        color: var(--bit-clr-pri);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: .8125rem;
+        white-space: pre;
+    }
+
+    .mcp-reading, .mcp-warning, .mcp-error { font-size: .875rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-warning, .mcp-error { color: #d2691e; }
+
+    .mcp-check { display: flex; flex-direction: column; gap: .6rem; margin-block: 1rem; }
+
+    .mcp-check-row { display: flex; flex-direction: column; gap: .25rem; }
+
+    .mcp-check-row label { font-size: .8125rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-check .btn-bm { align-self: flex-start; }
+
+    .mcp-verdict {
+        display: flex;
+        flex-wrap: wrap;
+        gap: .5rem 1rem;
+        align-items: baseline;
+        padding: .75rem 1rem;
+        border-left: 3px solid;
+        border-radius: .375rem;
+        background-color: var(--bit-clr-bg-sec);
+    }
+
+    .mcp-verdict.ok { border-color: #2fa35e; }
+
+    .mcp-verdict.warn { border-color: #d2691e; }
+
+    .mcp-verdict span { font-size: .8125rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-fixes { margin: .5rem 0 0; padding-left: 1.25rem; font-size: .875rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-code { min-height: 9rem; resize: vertical; line-height: 1.5; }
+
+    .mcp-findings { list-style: none; margin: 1rem 0 0; padding: 0; display: grid; gap: .6rem; }
+
+    .mcp-finding {
+        padding: .75rem 1rem;
+        border-left: 3px solid var(--bit-clr-brd-sec);
+        border-radius: .375rem;
+        background-color: var(--bit-clr-bg-sec);
+    }
+
+    .mcp-finding.error { border-color: #d9534f; }
+
+    .mcp-finding.warning { border-color: #d2691e; }
+
+    .mcp-finding.suggestion { border-color: var(--bit-clr-pri); }
+
+    .mcp-severity, .mcp-rule, .mcp-line { font-size: .75rem; margin-right: .5rem; }
+
+    .mcp-severity { font-weight: 700; color: var(--bit-clr-fg-pri); }
+
+    .mcp-rule { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--bit-clr-pri); }
+
+    .mcp-line { color: var(--bit-clr-fg-sec); }
+
+    .mcp-finding p { margin: .4rem 0 0; font-size: .875rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-fix { color: var(--bit-clr-fg-pri) !important; }
+
+    .mcp-search { display: flex; flex-wrap: wrap; gap: .6rem; margin-block: 1rem; }
+
+    .mcp-search input { flex: 1 1 18rem; }
+
+    .mcp-hits { list-style: none; margin: 0; padding: 0; display: grid; gap: .5rem; }
+
+    .mcp-hits li {
+        display: flex;
+        flex-wrap: wrap;
+        gap: .35rem .75rem;
+        align-items: baseline;
+        padding: .5rem .75rem;
+        border-radius: .375rem;
+        background-color: var(--bit-clr-bg-sec);
+    }
+
+    .mcp-hit-kind { font-size: .6875rem; text-transform: uppercase; letter-spacing: .04em; color: var(--bit-clr-fg-sec); }
+
+    .mcp-hit-title { font-weight: 600; color: var(--bit-clr-fg-pri); }
+
+    .mcp-table-wrap { overflow-x: auto; }
+
+    .mcp-table { width: 100%; border-collapse: collapse; font-size: .8125rem; }
+
+    .mcp-table th, .mcp-table td {
+        padding: .5rem .6rem;
+        border-bottom: 1px solid var(--bit-clr-brd-sec);
+        text-align: left;
+        vertical-align: top;
+    }
+
+    .mcp-table th { font-weight: 700; color: var(--bit-clr-fg-pri); }
+
+    .mcp-table td { color: var(--bit-clr-fg-sec); }
+
+    .mcp-params { display: flex; flex-direction: column; gap: .2rem; }
+
+    .mcp-none { opacity: .6; }
+
+    .mcp-cards {
+        display: grid;
+        gap: .75rem;
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+    }
+
+    .mcp-card {
+        height: 100%;
+        padding: .9rem 1rem;
+        border: 1px solid var(--bit-clr-brd-sec);
+        border-radius: .5rem;
+        background-color: var(--bit-clr-bg-sec);
+    }
+
+    .mcp-card p { margin: .45rem 0 0; font-size: .8125rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-card-params {
+        display: block;
+        margin-top: .5rem;
+        font-size: .75rem;
+        color: var(--bit-clr-fg-sec);
+        opacity: .8;
+    }
+
+    .mcp-resources { list-style: none; margin: 0; padding: 0; display: grid; gap: .5rem; }
+
+    .mcp-resources li { display: flex; flex-wrap: wrap; gap: .35rem .75rem; align-items: baseline; }
+
+    .mcp-resources span { font-size: .8125rem; color: var(--bit-clr-fg-sec); }
+
+    .mcp-principles { margin: 1rem 0 1.25rem; padding-left: 1.25rem; display: grid; gap: .6rem; }
+
+    .mcp-principles li { color: var(--bit-clr-fg-sec); }
+
+    .mcp-principles strong { color: var(--bit-clr-fg-pri); }
+</style>

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Pages/McpServerPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Pages/McpServerPage.razor
@@ -59,23 +59,41 @@
         what the panels further down this page do.
     </p>
 
-    <div class="mcp-tabs" role="tablist">
+    @* A tablist is one stop in the tab order: tab moves past the whole group, and the arrow keys
+       move between the tabs inside it. Announced as tabs but navigated as four separate buttons,
+       these would be worse than plain buttons - so the roles come with the behaviour they promise:
+       every tab names the panel it controls, and only the selected one is tabbable.
+
+       aria-selected is written out as a word rather than bound to the bool: a false bool renders
+       as no attribute at all, and an unselected tab has to say so. *@
+    <div class="mcp-tabs" role="tablist" aria-label="MCP client">
         @foreach (var client in _clients)
         {
-            <button type="button" role="tab" class="mcp-tab @(_client == client.Name ? "active" : null)"
-                    aria-selected="@(_client == client.Name)"
-                    @onclick="@(() => _client = client.Name)">
+            var isSelected = _client == client.Name;
+
+            <button type="button" role="tab" class="mcp-tab @(isSelected ? "active" : null)"
+                    id="@TabId(client.Name)"
+                    aria-selected="@(isSelected ? "true" : "false")"
+                    aria-controls="@PanelId(client.Name)"
+                    tabindex="@(isSelected ? 0 : -1)"
+                    @ref="_tabs[client.Name]"
+                    @onclick="@(() => _client = client.Name)"
+                    @onkeydown="OnTabKeyDown">
                 @client.Name
             </button>
         }
     </div>
 
-    @{
-        var selected = _clients.First(c => c.Name == _client);
+    @* Every panel is rendered, and the ones that are not selected are hidden: aria-controls has to
+       point at an element that exists, on the tabs that are not the current one too. *@
+    @foreach (var client in _clients)
+    {
+        <div role="tabpanel" id="@PanelId(client.Name)" aria-labelledby="@TabId(client.Name)"
+             hidden="@(_client != client.Name)">
+            <p class="mcp-tab-note">@client.Note</p>
+            <CodeSnippet Code="@client.Config" />
+        </div>
     }
-
-    <p class="mcp-tab-note">@selected.Note</p>
-    <CodeSnippet Code="@selected.Config" />
 </div>
 
 <div class="demo-section">
@@ -145,7 +163,7 @@
         <pre class="mcp-sparkline">@_simulation.Sparkline</pre>
         <p class="mcp-reading">@_simulation.Reading</p>
 
-        @foreach (var warning in _simulation.Warnings)
+        @foreach (var warning in _simulation.Warnings ?? [])
         {
             <p class="mcp-warning">@warning</p>
         }
@@ -234,9 +252,9 @@
 
     @if (_findings is not null)
     {
-        @if (_findings.Findings.Length == 0)
+        @if (_findings.Findings is null or { Length: 0 })
         {
-            <p class="mcp-reading">Nothing to report - all @_findings.RulesApplied.Length rules passed.</p>
+            <p class="mcp-reading">Nothing to report - all @(_findings.RulesApplied?.Length ?? 0) rules passed.</p>
         }
         else
         {
@@ -246,7 +264,7 @@
                     <Bmotion Initial="Bm.To(opacity: 0, x: -12)"
                              Animate="Bm.To(opacity: 1, x: 0)"
                              Transition="Bm.Tween(0.25)">
-                        <li class="mcp-finding @finding.Severity.ToLowerInvariant()">
+                        <li class="mcp-finding @finding.Severity?.ToLowerInvariant()">
                             <span class="mcp-severity">@finding.Severity</span>
                             <span class="mcp-rule">@finding.Rule</span>
                             <span class="mcp-line">line @finding.Line</span>
@@ -298,10 +316,6 @@
 
 <div class="demo-section">
     <h2>Tools</h2>
-    <p>
-        Eighteen of them, listed here straight from the attributes that declare them - so this table
-        cannot fall out of step with the server.
-    </p>
 
     @if (_catalog is null)
     {
@@ -309,6 +323,11 @@
     }
     else
     {
+        <p>
+            @_catalog.Tools.Length of them, listed here straight from the attributes that declare
+            them - so this table cannot fall out of step with the server, and neither can this count.
+        </p>
+
         <div class="mcp-table-wrap">
             <table class="mcp-table">
                 <thead>
@@ -437,15 +456,18 @@
     // than sharing them: the client project does not reference the host, and these are the four
     // fields the page renders out of each - not the whole contract.
     private sealed record Simulation(double SettleSeconds, double OvershootPercent, int TargetCrossings,
-        double TimeTo90Percent, Sample[] Samples, string Sparkline, string Reading, string[] Warnings, string? Error);
+        double TimeTo90Percent, Sample[]? Samples, string Sparkline, string Reading, string[]? Warnings, string? Error);
 
     private sealed record Sample(double Seconds, double Value);
 
     private sealed record Playback(string Path, bool WorksOnBlazorServer, string Reason, string[]? HowToOffload, string? Error);
 
-    private sealed record Review(bool Passed, Finding[] Findings, string[] RulesApplied);
+    // Nullable arrays throughout: what comes back is JSON, and a body that is missing a field - or a
+    // panel pointed at a server that answers with something else entirely - deserialises to null
+    // rather than to an empty array.
+    private sealed record Review(bool Passed, Finding[]? Findings, string[]? RulesApplied);
 
-    private sealed record Finding(string Severity, string Rule, int? Line, string Message, string Fix);
+    private sealed record Finding(string? Severity, string Rule, int? Line, string Message, string Fix);
 
     private sealed record Hit(string Kind, string Title, string? Context, string Tool, string Snippet);
 
@@ -557,6 +579,10 @@
 
     private string _spec = "spring(stiffness: 260, damping: 12)";
     private string _client = "Claude Code";
+
+    /// <summary>The tab buttons by client name, so arrow-key navigation can move focus with the selection.</summary>
+    private readonly Dictionary<string, ElementReference> _tabs = [];
+
     private bool _busy;
     private int _replay;
     private string? _error;
@@ -599,6 +625,36 @@
         StateHasChanged();
     }
 
+    private static string TabId(string client) => $"mcp-tab-{Slug(client)}";
+
+    private static string PanelId(string client) => $"mcp-panel-{Slug(client)}";
+
+    private static string Slug(string client) => client.ToLowerInvariant().Replace(' ', '-');
+
+    /// <summary>
+    /// Arrow keys move between the tabs, wrapping at both ends - the tablist pattern. The focus moves
+    /// with the selection: leaving it on the tab that was pressed would put the focus ring on a tab
+    /// that is no longer the current one.
+    /// </summary>
+    private async Task OnTabKeyDown(KeyboardEventArgs e)
+    {
+        var step = e.Key switch
+        {
+            "ArrowRight" or "ArrowDown" => 1,
+            "ArrowLeft" or "ArrowUp" => -1,
+            _ => 0
+        };
+
+        if (step == 0) return;
+
+        var index = Array.FindIndex(_clients, client => client.Name == _client);
+        var next = _clients[((index + step) % _clients.Length + _clients.Length) % _clients.Length];
+
+        _client = next.Name;
+
+        if (_tabs.TryGetValue(next.Name, out var tab)) await tab.FocusAsync();
+    }
+
     private void OnSpecChanged(ChangeEventArgs e) => _spec = e.Value?.ToString() ?? "";
 
     private void OnPropertiesChanged(ChangeEventArgs e) => _properties = e.Value?.ToString() ?? "";
@@ -609,38 +665,47 @@
 
     private void OnQueryChanged(ChangeEventArgs e) => _query = e.Value?.ToString() ?? "";
 
+    // The four handlers below each reset their own flag in a finally: the flag disables the panel's
+    // controls while a call is out, so losing it - to a body that did not deserialise into the shape
+    // these records describe, say - would leave the panel disabled with no way back but a reload.
+
     private async Task RunSimulationAsync(string spec)
     {
         _spec = spec;
         _busy = true;
         _error = null;
 
-        var result = await GetAsync<Simulation>($"api/mcp/SimulateBmotionTransition?transition={Uri.EscapeDataString(spec)}");
-
-        if (result is null)
+        try
         {
-            _error = "The demo's own API did not answer. Is the server still running?";
-            _simulation = null;
-        }
-        else if (result.Error is not null)
-        {
-            // The server read the spec and could not make sense of it, and said why - which is a
-            // better message than anything this page could compose about it.
-            _error = result.Error;
-            _simulation = null;
-        }
-        else
-        {
-            _simulation = result;
+            var result = await GetAsync<Simulation>($"api/mcp/SimulateBmotionTransition?transition={Uri.EscapeDataString(spec)}");
 
-            // The samples are evenly spaced in time, so they are keyframes as they stand: replaying
-            // them with a linear tween of the measured settle time reproduces the motion the server
-            // measured, rather than a second animation that merely resembles it.
-            _replayFrames = [.. result.Samples.Select(sample => sample.Value / 100 * 220)];
-            _replay++;
-        }
+            if (result is null)
+            {
+                _error = "The demo's own API did not answer. Is the server still running?";
+                _simulation = null;
+            }
+            else if (result.Error is not null)
+            {
+                // The server read the spec and could not make sense of it, and said why - which is a
+                // better message than anything this page could compose about it.
+                _error = result.Error;
+                _simulation = null;
+            }
+            else
+            {
+                _simulation = result;
 
-        _busy = false;
+                // The samples are evenly spaced in time, so they are keyframes as they stand: replaying
+                // them with a linear tween of the measured settle time reproduces the motion the server
+                // measured, rather than a second animation that merely resembles it.
+                _replayFrames = [.. (result.Samples ?? []).Select(sample => sample.Value / 100 * 220)];
+                _replay++;
+            }
+        }
+        finally
+        {
+            _busy = false;
+        }
     }
 
     private async Task RunCheckAsync(string properties, string transition)
@@ -649,29 +714,44 @@
         _checkSpec = transition;
         _checking = true;
 
-        _playback = await GetAsync<Playback>(
-            $"api/mcp/AnalyzeBmotionAnimation?properties={Uri.EscapeDataString(properties)}" +
-            $"&transition={Uri.EscapeDataString(transition)}");
-
-        _checking = false;
+        try
+        {
+            _playback = await GetAsync<Playback>(
+                $"api/mcp/AnalyzeBmotionAnimation?properties={Uri.EscapeDataString(properties)}" +
+                $"&transition={Uri.EscapeDataString(transition)}");
+        }
+        finally
+        {
+            _checking = false;
+        }
     }
 
     private async Task RunReviewAsync()
     {
         _reviewing = true;
 
-        _findings = await GetAsync<Review>($"api/mcp/ReviewBmotionCode?code={Uri.EscapeDataString(_review)}");
-
-        _reviewing = false;
+        try
+        {
+            _findings = await GetAsync<Review>($"api/mcp/ReviewBmotionCode?code={Uri.EscapeDataString(_review)}");
+        }
+        finally
+        {
+            _reviewing = false;
+        }
     }
 
     private async Task RunSearchAsync()
     {
         _searching = true;
 
-        _hits = await GetAsync<Hit[]>($"api/mcp/SearchBmotion?query={Uri.EscapeDataString(_query)}&limit=8") ?? [];
-
-        _searching = false;
+        try
+        {
+            _hits = await GetAsync<Hit[]>($"api/mcp/SearchBmotion?query={Uri.EscapeDataString(_query)}&limit=8") ?? [];
+        }
+        finally
+        {
+            _searching = false;
+        }
     }
 
     /// <summary>

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Pages/McpServerPage.razor
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Pages/McpServerPage.razor
@@ -1,4 +1,4 @@
-@page "/mcp"
+@page "/mcp-server"
 @using System.Net.Http.Json
 @inject HttpClient Http
 
@@ -207,7 +207,11 @@
     @* An unreadable transition comes back as data rather than as a failed call, so the verdict is
        only shown when there is one - a "Snaps on Blazor Server" banner for an animation that was
        never analysed would be a claim about the animation, and a wrong one. *@
-    @if (_playback?.Error is not null)
+    @if (_checkError is not null)
+    {
+        <p class="mcp-error">@_checkError</p>
+    }
+    else if (_playback?.Error is not null)
     {
         <p class="mcp-error">@_playback.Error</p>
     }
@@ -250,7 +254,11 @@
         </button>
     </div>
 
-    @if (_findings is not null)
+    @if (_reviewError is not null)
+    {
+        <p class="mcp-error">@_reviewError</p>
+    }
+    else if (_findings is not null)
     {
         @if (_findings.Findings is null or { Length: 0 })
         {
@@ -295,7 +303,11 @@
         </button>
     </div>
 
-    @if (_hits is { Length: > 0 })
+    @if (_searchError is not null)
+    {
+        <p class="mcp-error">@_searchError</p>
+    }
+    else if (_hits is { Length: > 0 })
     {
         <ul class="mcp-hits">
             @foreach (var hit in _hits)
@@ -493,7 +505,7 @@
         new("Claude Code",
             "One command, from anywhere in your project.",
             """
-            claude mcp add --transport http bmotion https://localhost:5001/mcp
+            claude mcp add --transport http bmotion https://localhost:5071/mcp
             """),
         new("Claude Desktop",
             "Add it to claude_desktop_config.json, then restart the app.",
@@ -502,7 +514,7 @@
               "mcpServers": {
                 "bmotion": {
                   "type": "http",
-                  "url": "https://localhost:5001/mcp"
+                  "url": "https://localhost:5071/mcp"
                 }
               }
             }
@@ -514,7 +526,7 @@
               "servers": {
                 "bmotion": {
                   "type": "http",
-                  "url": "https://localhost:5001/mcp"
+                  "url": "https://localhost:5071/mcp"
                 }
               }
             }
@@ -525,7 +537,7 @@
             {
               "mcpServers": {
                 "bmotion": {
-                  "url": "https://localhost:5001/mcp"
+                  "url": "https://localhost:5071/mcp"
                 }
               }
             }
@@ -583,6 +595,12 @@
     /// <summary>The tab buttons by client name, so arrow-key navigation can move focus with the selection.</summary>
     private readonly Dictionary<string, ElementReference> _tabs = [];
 
+    /// <summary>What every panel says when a call to the demo's own API comes back with nothing.</summary>
+    private const string Unreachable = "The demo's own API did not answer. Is the server still running?";
+
+    /// <summary>The longest request line the review panel will build; Kestrel refuses 8,192 bytes.</summary>
+    private const int MaxReviewUrlLength = 6_000;
+
     private bool _busy;
     private int _replay;
     private string? _error;
@@ -592,6 +610,7 @@
     private string _properties = "x, opacity";
     private string _checkSpec = "spring(stiffness: 200, damping: 20)";
     private bool _checking;
+    private string? _checkError;
     private Playback? _playback;
 
     private string _review = """
@@ -606,10 +625,12 @@
         """;
 
     private bool _reviewing;
+    private string? _reviewError;
     private Review? _findings;
 
     private string _query = "make a list appear one item at a time";
     private bool _searching;
+    private string? _searchError;
     private Hit[]? _hits;
 
     private Catalog? _catalog;
@@ -668,6 +689,8 @@
     // The four handlers below each reset their own flag in a finally: the flag disables the panel's
     // controls while a call is out, so losing it - to a body that did not deserialise into the shape
     // these records describe, say - would leave the panel disabled with no way back but a reload.
+    // Each also clears its own error first and sets it on a null answer, so a panel never shows a
+    // stale result under a fresh question.
 
     private async Task RunSimulationAsync(string spec)
     {
@@ -681,7 +704,7 @@
 
             if (result is null)
             {
-                _error = "The demo's own API did not answer. Is the server still running?";
+                _error = Unreachable;
                 _simulation = null;
             }
             else if (result.Error is not null)
@@ -713,12 +736,16 @@
         _properties = properties;
         _checkSpec = transition;
         _checking = true;
+        _checkError = null;
 
         try
         {
-            _playback = await GetAsync<Playback>(
+            var result = await GetAsync<Playback>(
                 $"api/mcp/AnalyzeBmotionAnimation?properties={Uri.EscapeDataString(properties)}" +
                 $"&transition={Uri.EscapeDataString(transition)}");
+
+            _checkError = result is null ? Unreachable : null;
+            _playback = result;
         }
         finally
         {
@@ -728,11 +755,31 @@
 
     private async Task RunReviewAsync()
     {
+        _reviewError = null;
+
+        var url = $"api/mcp/ReviewBmotionCode?code={Uri.EscapeDataString(_review)}";
+
+        // The tool itself reviews up to 40,000 characters, but this page hands the code over in the
+        // query string, and a request line that long is refused by the server before the tool sees
+        // it. Saying which is happening beats a 414 the panel cannot explain.
+        if (url.Length > MaxReviewUrlLength)
+        {
+            _reviewError = $"That is {_review.Length} characters, which is more than this page can put " +
+                           "in a URL. Paste the component - or just the <Bmotion> element in question - " +
+                           "rather than a whole file. The MCP tool itself takes far more.";
+            _findings = null;
+
+            return;
+        }
+
         _reviewing = true;
 
         try
         {
-            _findings = await GetAsync<Review>($"api/mcp/ReviewBmotionCode?code={Uri.EscapeDataString(_review)}");
+            var result = await GetAsync<Review>(url);
+
+            _reviewError = result is null ? Unreachable : null;
+            _findings = result;
         }
         finally
         {
@@ -743,10 +790,14 @@
     private async Task RunSearchAsync()
     {
         _searching = true;
+        _searchError = null;
 
         try
         {
-            _hits = await GetAsync<Hit[]>($"api/mcp/SearchBmotion?query={Uri.EscapeDataString(_query)}&limit=8") ?? [];
+            var result = await GetAsync<Hit[]>($"api/mcp/SearchBmotion?query={Uri.EscapeDataString(_query)}&limit=8");
+
+            _searchError = result is null ? Unreachable : null;
+            _hits = result;
         }
         finally
         {
@@ -755,9 +806,9 @@
     }
 
     /// <summary>
-    /// Calls one of the demo's own MCP endpoints. A failure leaves the panel showing what it showed
-    /// before rather than taking the page down - these are demonstrations, and the page around them
-    /// is documentation that still reads perfectly well without a live answer.
+    /// Calls one of the demo's own MCP endpoints, answering null when it cannot be reached or did
+    /// not come back in the expected shape. Every caller turns that into its own panel saying so:
+    /// leaving the last answer on screen would read as the answer to the question just asked.
     /// </summary>
     private async Task<T?> GetAsync<T>(string url)
     {

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Program.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Program.cs
@@ -2,8 +2,7 @@
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-builder.Services.AddDemoServices();
+builder.Services.AddDemoServices(builder.HostEnvironment.BaseAddress);
 
 // No RootComponents are registered on purpose: the host page drives the app through
 // blazor.web.js render-mode markers (<Routes @rendermode="InteractiveWebAssembly" />),

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Shared/AppNavPanel.razor
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Shared/AppNavPanel.razor
@@ -42,8 +42,12 @@
     {
         _filter = e.Value?.ToString() ?? "";
 
+        // Keywords are matched as well as titles: a reader searching for "hover" or "stagger" is
+        // naming the feature, not the page it happens to live on, and every page carries the terms
+        // it covers (see NavItem).
         _visibleItems = _filter.Trim() is { Length: > 0 } term
-            ? NavItem.All.Where(i => i.Title.Contains(term, StringComparison.OrdinalIgnoreCase)).ToArray()
+            ? NavItem.All.Where(i => i.Title.Contains(term, StringComparison.OrdinalIgnoreCase)
+                                  || i.Keywords.Contains(term, StringComparison.OrdinalIgnoreCase)).ToArray()
             : NavItem.All;
     }
 }

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Shared/NavItem.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Shared/NavItem.cs
@@ -4,32 +4,105 @@
 /// One entry of the docs navigation. The list itself is <see cref="All"/>: the nav panel renders
 /// it and the search box filters it, so both the drawer and the sticky rail always show the same
 /// set of pages in the same order.
+/// <para>
+/// It is also what the demo's MCP server answers <c>GetBmotionDemoPages</c> with, which is why
+/// each entry carries a description, search keywords and the file it is implemented in. A page
+/// therefore describes itself once, and the site's search box, the nav panel and an AI agent
+/// looking for a worked example all read the same words.
+/// </para>
 /// </summary>
 /// <param name="Title">The label shown in the nav panel.</param>
 /// <param name="Href">The route, relative to the app base.</param>
-public sealed record NavItem(string Title, string Href)
+/// <param name="Description">What the page demonstrates, in one sentence.</param>
+/// <param name="Keywords">Space-separated terms the page covers, for the search box and the MCP index.</param>
+/// <param name="Source">The page's file name under Client/Pages, for GetBmotionSourceFile.</param>
+public sealed record NavItem(string Title, string Href, string Description, string Keywords, string Source)
 {
+    /// <summary>The path the MCP server hands this page's source out under.</summary>
+    public string SourcePath => $"Demo/Client/Pages/{Source}";
+
     /// <summary>Every demo page, in the order they are meant to be read.</summary>
     public static readonly NavItem[] All =
     [
-        new("Home", ""),
-        new("Basics", "basic"),
-        new("Springs", "springs"),
-        new("Easing", "easing"),
-        new("Gestures", "gestures"),
-        new("Variants", "variants"),
-        new("Keyframes", "keyframes"),
-        new("Split Text", "split-text"),
-        new("AnimatePresence", "presence"),
-        new("Drag", "drag"),
-        new("Reorder", "reorder"),
-        new("Scroll", "scroll"),
-        new("Layout", "layout"),
-        new("Programmatic", "programmatic"),
-        new("Color", "color"),
-        new("Motion Path", "motion-path"),
-        new("View Transitions", "view-transitions"),
-        new("CSS Props", "css-props"),
-        new("Accessibility", "accessibility"),
+        new("Home", "",
+            "The landing page: what Bmotion is, and the feature tiles that link into the rest of the demos.",
+            "home landing overview introduction start",
+            "Home.razor"),
+        new("Basics", "basic",
+            "Initial and Animate on a single element, the shape of every Bmotion animation, and what runs on mount.",
+            "initial animate mount enter first render bmotion component transition basics hello world",
+            "BasicAnimations.razor"),
+        new("Springs", "springs",
+            "Physics springs: stiffness and damping, the intuitive bounce and duration form, overshoot on mount, and repeating springs.",
+            "spring stiffness damping mass bounce duration overshoot physics velocity repeat mirror",
+            "Springs.razor"),
+        new("Easing", "easing",
+            "Every BmEase preset side by side, custom cubic beziers, stepped easing, and per-segment easing across keyframes.",
+            "ease easing bezier cubic steps linear in out inout back elastic bounce circ expo quad quart quint sine",
+            "Easing.razor"),
+        new("Gestures", "gestures",
+            "WhileHover, WhileTap, WhileFocus and WhileInView - animation states the element enters while something is true.",
+            "hover tap press focus inview viewport gesture whilehover whiletap whilefocus whileinview intersection",
+            "Gestures.razor"),
+        new("Variants", "variants",
+            "Named animation states shared down a subtree, with orchestration: staggered children, before/after children, and propagation.",
+            "variants named states orchestration stagger staggerchildren delaychildren when beforechildren afterchildren propagate parent child",
+            "Variants.razor"),
+        new("Keyframes", "keyframes",
+            "Multi-step animations from arrays of values, with Times for uneven spacing and Bm.Current as the wildcard first frame.",
+            "keyframes array multi step times wildcard current sequence repeat mirror loop",
+            "Keyframes.razor"),
+        new("Split Text", "split-text",
+            "BmotionSplitText breaking a headline into characters, words or lines so each piece can animate on its own stagger.",
+            "split text characters words lines stagger headline typography reveal per letter",
+            "SplitText.razor"),
+        new("AnimatePresence", "presence",
+            "Exit animations: how an element animates out before Blazor removes it, plus presence modes and switching between views.",
+            "exit animate presence unmount remove leave mode wait popLayout sync switch group conditional rendering",
+            "AnimatePresencePage.razor"),
+        new("Drag", "drag",
+            "Pointer dragging with axis locks, constraints, elastic edges, momentum on release and drag-driven values.",
+            "drag pointer pan constraints elastic momentum inertia snap axis lock draggable",
+            "DragPage.razor"),
+        new("Reorder", "reorder",
+            "BmotionReorderGroup: a drag-to-reorder list where the other items animate out of the way as one is moved.",
+            "reorder sortable list drag drop rearrange items order group",
+            "ReorderPage.razor"),
+        new("Scroll", "scroll",
+            "Scroll-driven animation: progress-linked timelines that the browser scrubs, and enter-on-scroll reveals.",
+            "scroll parallax progress timeline scrolltimeline viewtimeline reveal sticky offset viewport",
+            "ScrollAnimations.razor"),
+        new("Layout", "layout",
+            "FLIP layout animations: an element animating between two positions or sizes it was merely re-rendered into, and shared-element transitions.",
+            "layout flip shared element magic move layoutid position size reposition transition morph",
+            "LayoutPage.razor"),
+        new("Programmatic", "programmatic",
+            "The imperative API: animating by selector or ElementReference, motion values, sequences and playback controls.",
+            "programmatic imperative animate service selector elementreference motion value bmvalue sequence timeline controls pause play stop speed",
+            "Programmatic.razor"),
+        new("Color", "color",
+            "Colour interpolation and why the space matters: sRGB against Oklab, LCH and HSL on the same crossfade.",
+            "color colour interpolation srgb oklab lch hsl space mixing gradient crossfade",
+            "ColorSpaces.razor"),
+        new("Motion Path", "motion-path",
+            "Moving an element along an SVG path with offsetPath and offsetDistance, and bending a straight move into an arc.",
+            "motion path offsetpath offsetdistance svg curve arc trajectory follow",
+            "MotionPath.razor"),
+        new("View Transitions", "view-transitions",
+            "The browser View Transitions API driven from C#: cross-fading a whole DOM update rather than one element.",
+            "view transition startviewtransition cross fade page navigation document update",
+            "ViewTransitions.razor"),
+        new("CSS Props", "css-props",
+            "Animating properties with no dedicated argument: arbitrary CSS through Css, and CSS custom properties through CssVars.",
+            "css custom properties variables cssvars arbitrary property backdrop filter escape hatch",
+            "CssProps.razor"),
+        new("Accessibility", "accessibility",
+            "prefers-reduced-motion policies, what reduced motion keeps animating, global speed control, and the live engine inspector.",
+            "accessibility a11y reduced motion prefers-reduced-motion diagnostics inspector speed reducemotion policy",
+            "Accessibility.razor"),
+        new("MCP Server", "mcp",
+            "The demo's Model Context Protocol server: the tools, prompts and resources that let an AI agent write correct Bmotion code.",
+            "mcp model context protocol ai agent llm tools prompts resources claude cursor copilot server integration",
+            "McpServerPage.razor"),
     ];
 }

--- a/src/Bmotion/Bit.Bmotion.Demo/Client/Shared/NavItem.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Client/Shared/NavItem.cs
@@ -100,7 +100,7 @@ public sealed record NavItem(string Title, string Href, string Description, stri
             "prefers-reduced-motion policies, what reduced motion keeps animating, global speed control, and the live engine inspector.",
             "accessibility a11y reduced motion prefers-reduced-motion diagnostics inspector speed reducemotion policy",
             "Accessibility.razor"),
-        new("MCP Server", "mcp",
+        new("MCP Server", "mcp-server",
             "The demo's Model Context Protocol server: the tools, prompts and resources that let an AI agent write correct Bmotion code.",
             "mcp model context protocol ai agent llm tools prompts resources claude cursor copilot server integration",
             "McpServerPage.razor"),

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Bit.Bmotion.Demo.Server.csproj
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Bit.Bmotion.Demo.Server.csproj
@@ -10,11 +10,41 @@
   <ItemGroup>
     <!-- Serves the client's _framework payload and enables WebAssembly debugging from this host. -->
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+    <!-- The MCP server (see Controllers/McpController.cs), mapped at /mcp. -->
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Bit.Bmotion\Bit.Bmotion.csproj" />
     <ProjectReference Include="..\Client\Bit.Bmotion.Demo.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Bit.Bmotion" />
+    <Using Include="Microsoft.AspNetCore.Mvc" />
+  </ItemGroup>
+
+  <!-- Text the MCP server hands out. It is embedded rather than read from disk so the tools keep
+       working from a published deployment, where none of these files exist next to the app.
+       LogicalName is set explicitly because the resource name IS the path an MCP client asks for. -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\README.md" LogicalName="BmotionDocs/README.md" />
+
+    <!-- Every demo page, which is also every worked example the tools can point an agent at. -->
+    <EmbeddedResource Include="..\Client\**\*.razor;..\Client\**\*.cs;..\Client\**\*.css"
+                      Exclude="..\Client\bin\**;..\Client\obj\**">
+      <LogicalName>BmotionSource/Demo/Client/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+
+    <!-- The host: how a Blazor Web App is wired up around Bmotion, which is what the setup guide
+         has to be able to show as a real file rather than as a paraphrase. -->
+    <EmbeddedResource Include="Program.cs" LogicalName="BmotionSource/Demo/Server/Program.cs" />
+
+    <!-- The Components\ prefix is written out: %(RecursiveDir) only captures what the '**' matched,
+         so it would start at the folder below and drop the one the components live in. -->
+    <EmbeddedResource Include="Components\**\*.razor">
+      <LogicalName>BmotionSource/Demo/Server/Components/%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpController.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpController.cs
@@ -1,0 +1,426 @@
+using System.Text;
+using System.Reflection;
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using Bit.Bmotion.Demo.Server.Dtos;
+using Bit.Bmotion.Demo.Server.Services;
+using Bit.Bmotion.Demo.Client.Shared;
+
+namespace Bit.Bmotion.Demo.Server.Controllers;
+
+/// <summary>
+/// The Bmotion MCP server: the tools an AI agent calls to build animations with Bit.Bmotion
+/// without guessing at its API - or at what the motion will look like.
+/// <para>
+/// Documentation tools alone are not enough for an animation library. An agent can read every
+/// parameter of <c>Bm.Spring</c> and still not know that
+/// <c>Bm.Spring(stiffness: 400, damping: 2)</c> wobbles for five seconds, or that animating
+/// <c>height</c> stops working the moment the app is served over Blazor Server. Both facts live in
+/// the engine, not in prose. So the tools here fall into two halves: the ones that answer from
+/// this build's own text - the guide, the XML documentation compiled into the assembly, the demo's
+/// sources - and the ones that answer by <b>running the real engine off-screen</b> and reporting
+/// what it did.
+/// </para>
+/// <para>
+/// Every method is also a plain HTTP GET endpoint under <c>/api/mcp/...</c>, which makes each of
+/// them inspectable from a browser - and is what the demo's own MCP page calls to show the tools
+/// working live.
+/// </para>
+/// </summary>
+[ApiController]
+[McpServerToolType]
+[Route("api/[controller]/[action]")]
+public class McpController : ControllerBase
+{
+    // Long enough for the largest guide section, short enough that a couple of tool calls cannot
+    // crowd out a client's context window.
+    private const int MaxDocumentLength = 40_000;
+
+    private static readonly string BmotionVersion =
+        typeof(Bm).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(Bm).Assembly.GetName().Version?.ToString()
+        ?? "unknown";
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionOverview))]
+    [Description("Start here. Explains what Bit.Bmotion is, how to install and register it, the one thing that decides whether an animation works on Blazor Server, and which of the other Bmotion tools to call for what.")]
+    public string GetBmotionOverview()
+    {
+        var builder = new StringBuilder();
+
+        var readme = BmotionSourceCatalog.Readme;
+        var firstSection = readme.IndexOf("\n## ", StringComparison.Ordinal);
+
+        builder.AppendLine(firstSection > 0 ? readme[..firstSection].Trim() : readme).AppendLine();
+
+        // Which build the answers come from: every tool below reflects THIS assembly, not a
+        // remembered version.
+        builder.AppendLine($"_These tools answer from Bit.Bmotion {BmotionVersion}, loaded in this server._").AppendLine();
+
+        AppendGuideSection(builder, "Installation");
+        AppendGuideSection(builder, "Quick Start");
+
+        builder.AppendLine("""
+            ---
+
+            ## Which tool to call
+
+            - `SearchBmotion` - **the default entry point.** One query across the guide, every public type and
+              member, the animatable properties, the easing presets, the recipes and the demo's sources; each hit
+              carries the exact follow-up call. Reach for it whenever you do not already know the name of what you
+              want.
+            - `GetBmotionRecipes` / `GetBmotionRecipe` - complete, copy-pasteable patterns for the things people
+              actually ask for: a staggered list, a modal, an exit animation, a scroll reveal, a shared-element
+              transition. **Start here when writing an animation** - each recipe carries the caveat that is not
+              visible in the code.
+            - `SimulateBmotionTransition` - runs a transition on the real engine and reports how long it takes to
+              settle, how far it overshoots and what the curve looks like. A spring has no duration argument, so
+              this is the only way to know what one does before shipping it. `CompareBmotionTransitions` does
+              several at once, which is how to choose between them.
+            - `AnalyzeBmotionAnimation` - **call this before finishing any animation for an app that is not
+              WebAssembly-only.** It starts the animation on the real engine and reports which playback path the
+              engine chose, which is exactly what decides whether the animation plays or silently snaps on Blazor
+              Server.
+            - `ReviewBmotionCode` - checks written markup for the Bmotion mistakes that compile cleanly and then do
+              nothing: an `Exit` with no presence component, a `@foreach` with no `@key`, a spring whose duration
+              is ignored. Run it on what you wrote before you call the work done.
+            - `GetBmotionSetupGuide` - the complete wiring for one Blazor render mode ('wasm', 'server', 'auto',
+              'standalone-wasm'), as the real files of a working project.
+            - `GetBmotionApiList` / `GetBmotionApiDetails` - the exact public API: every component parameter with
+              its type and default value, straight out of the shipped assembly. Call this before using a member you
+              are not sure about - in an animation library the defaults *are* the behaviour.
+            - `GetBmotionAnimatableProperties` - every property that can be animated, and for each one whether the
+              browser compositor can own it.
+            - `GetBmotionEasings` - every `BmEase` preset with its curve sampled from the library, so a name like
+              "BackOut" becomes numbers instead of a guess.
+            - `GetBmotionGuideSections` / `GetBmotionGuideSection` - the library's own reference guide, one topic
+              at a time, with copy-pasteable code.
+            - `GetBmotionDemoPages` / `GetBmotionSourceFiles` / `GetBmotionSourceFile` - the demo site's pages as
+              real, working source. Every feature has one.
+
+            ## Rules of thumb when writing Bmotion code
+
+            - **Only transform components (`x`, `y`, `z`, `scale`, `rotate`, `skew`, `perspective`) and `opacity`
+              can be handed to the browser compositor.** Those animations play everywhere, including Blazor Server.
+              Everything else - colour, `width`/`height`, keyframe arrays, drag, motion values - needs the C# frame
+              loop, which exists only on WebAssembly. On Server it becomes an instant jump, with no error anywhere.
+            - Prefer `x`/`y` over `top`/`left`, and `scale` over `width`/`height`. Same visual result, no layout
+              cost, and it stays on the compositor.
+            - `Initial` runs on mount only. To replay an entrance, change the element's `@key`.
+            - `Exit` needs a presence component (`BmotionAnimatePresence`, `BmotionPresenceGroup`,
+              `BmotionPresenceSwitch`) around it. Wrapping the content in `@if` instead is the single most common
+              Bmotion bug: Blazor removes the element before the animation can start.
+            - Gesture overlays (`WhileHover`, `WhileTap`, ...) revert on their own. Do not also write the resting
+              state into them.
+            - Orchestration - `staggerChildren`, `delayChildren`, `when`, `childStagger` - belongs on the
+              **container's** transition, not on the children.
+            - `Bm.Spring(duration: ...)` does nothing on its own. Duration only shapes the spring when `bounce` is
+              given too.
+            - Register the services in every DI container the components run in - in a Blazor Web App that means
+              both the server and the client project - and add `@using Bit.Bmotion` to `_Imports.razor`.
+            """);
+
+        return builder.ToString();
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(SearchBmotion))]
+    [Description("Searches everything known about Bit.Bmotion at once - the guide, every public type and member, the animatable properties, the easing presets, the ready-made recipes and the demo's source files - and returns the best matches, each with the exact follow-up tool call that returns its full text. Use this first whenever you do not already know which section, type or recipe holds the answer. Example queries: 'make a list appear one item at a time', 'animate something out before it is removed', 'drag within bounds', 'why does my animation not run on the server'.")]
+    public Task<BmotionSearchHitDto[]> SearchBmotion(string query, int limit = 12)
+    {
+        return BmotionSearchIndex.SearchAsync(query, limit);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionSetupGuide))]
+    [Description("Gets the complete wiring needed to add Bit.Bmotion to a Blazor app in one render mode, as the real files of a working project: 'wasm' (Blazor Web App, InteractiveWebAssembly), 'server' (InteractiveServer), 'auto' (InteractiveAuto) or 'standalone-wasm'. Call this before writing any setup code - which DI containers register the services, and which library features work at all, both differ per render mode.")]
+    public string GetBmotionSetupGuide(string renderMode)
+    {
+        return BmotionSetupGuide.Get(renderMode)
+            ?? $"'{renderMode}' is not a known render mode. Use one of: {string.Join(", ", BmotionSetupGuide.RenderModes)}.";
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionRecipes))]
+    [Description("Lists the ready-made Bit.Bmotion patterns this server can hand out complete - a staggered list, an exit animation, a modal, hover feedback, a scroll reveal, a layout animation, a shared-element transition, drag, a spinner, split text, programmatic animation, reduced motion. Use it to pick the id to pass to GetBmotionRecipe. This is usually the fastest route from a request to correct code.")]
+    public BmotionRecipeDto[] GetBmotionRecipes()
+    {
+        return BmotionRecipeCatalog.Summaries;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionRecipe))]
+    [Description("Gets one Bit.Bmotion recipe in full: the Razor markup, and the caveat that is not visible in the code - the missing @key, the presence component it needs, the render mode it will not survive. Pass an id from GetBmotionRecipes, e.g. 'staggered-list', 'exit-animation', 'modal-dialog', 'reveal-on-scroll', 'shared-element'.")]
+    public object GetBmotionRecipe(string id)
+    {
+        var recipe = BmotionRecipeCatalog.Find(id);
+
+        if (recipe is not null) return recipe;
+
+        var ids = string.Join(", ", BmotionRecipeCatalog.All.Select(entry => entry.Id));
+
+        return $"There is no recipe called '{id}'. Available recipes: {ids}. " +
+               "Call SearchBmotion with what you are trying to build if none of them fit.";
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(SimulateBmotionTransition))]
+    [Description("Runs a transition on the real Bit.Bmotion engine, off-screen, and reports what the motion actually does: how long it takes to come to rest, how far it overshoots its target, how many times it wobbles, and the shape of the curve. Springs have no duration argument - their length falls out of the physics - so this is the only way to know what one feels like without opening a browser. Accepts 'spring(stiffness: 260, damping: 12)', 'spring(bounce: 0.4, duration: 0.6)', 'tween(0.4, InOut)' or 'inertia(velocity: 500)'.")]
+    public Task<BmotionSimulationDto> SimulateBmotionTransition(
+        [Description("The transition, e.g. 'spring(stiffness: 260, damping: 12)'. A Bm.Spring(...) call copied out of Razor works verbatim.")] string transition,
+        [Description("The value the animation starts at. The default of 0 to 100 reads as a percentage of the distance travelled.")] double from = 0,
+        [Description("The value the animation targets.")] double to = 100)
+    {
+        return BmotionMotionLab.SimulateAsync(transition, from, to);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(CompareBmotionTransitions))]
+    [Description("Runs several transitions through the real engine and returns their measurements side by side, so the one that matches the intended feel can be chosen on evidence rather than on the names of the arguments. Pass the transitions separated by semicolons or newlines, e.g. 'spring(stiffness: 260, damping: 12); spring(bounce: 0.2, duration: 0.4); tween(0.3, BackOut)'.")]
+    public async Task<BmotionSimulationDto[]> CompareBmotionTransitions(
+        [Description("The transitions to compare, separated by semicolons or newlines.")] string transitions,
+        double from = 0,
+        double to = 100)
+    {
+        var specs = (transitions ?? string.Empty)
+            .Split([';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            // Simulating dozens at once would spend more of the client's context than any comparison
+            // is read with; the interesting comparisons are between two and four candidates.
+            .Take(8)
+            .ToArray();
+
+        var results = new List<BmotionSimulationDto>(specs.Length);
+
+        foreach (var spec in specs)
+        {
+            results.Add(await BmotionMotionLab.SimulateAsync(spec, from, to));
+        }
+
+        return [.. results];
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(AnalyzeBmotionAnimation))]
+    [Description("Starts an animation on the real Bit.Bmotion engine and reports which playback path the engine chose for it: the browser compositor (Web Animations API), or the C# per-frame loop. That choice is what decides whether the animation plays on Blazor Server or silently collapses into an instant state change there - nothing in the build output or the browser console says which. Call it before finishing any animation for an app that is not WebAssembly-only. When the answer is the frame loop, it also says why, and what to change.")]
+    public Task<BmotionPlaybackDto> AnalyzeBmotionAnimation(
+        [Description("The animated properties by their Bm.To(...) argument names, separated by commas, e.g. 'x, opacity' or 'width, backgroundColor'.")] string properties,
+        [Description("The transition, e.g. 'spring(stiffness: 200, damping: 20)' or 'tween(0.4, InOut)'. Defaults to a plain tween.")] string? transition = null)
+    {
+        var names = (properties ?? string.Empty)
+            .Split([',', ';', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToArray();
+
+        return BmotionMotionLab.AnalyzePlaybackAsync(names, transition);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(ReviewBmotionCode))]
+    [Description("Reviews Razor or C# that uses Bit.Bmotion and reports the mistakes that compile cleanly and then do nothing: an Exit with no presence component around it, an animated element in a loop with no @key, a spring whose duration the engine ignores, a nested-quote attribute that does not parse as intended, properties that will snap rather than animate on Blazor Server. Every finding names the line and the correction. Run this on animation code before calling it done - none of these produce a compiler warning, an exception or a console message.")]
+    public BmotionReviewDto ReviewBmotionCode(
+        [Description("The Razor markup or C# to review. A component, a fragment, or just the <Bmotion> element in question.")] string code)
+    {
+        return BmotionCodeReview.Review(code);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionAnimatableProperties))]
+    [Description("Lists every property Bit.Bmotion can animate, with the CSS it writes, an example value, and - measured by running each one through the real engine - whether the browser compositor can own it and therefore whether it animates or jumps on Blazor Server. Use it when choosing what to animate, or to find the compositor-friendly equivalent of a property that is not.")]
+    public Task<BmotionPropertyDto[]> GetBmotionAnimatableProperties()
+    {
+        return BmotionPropertyCatalog.GetAsync();
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionEasings))]
+    [Description("Lists every BmEase preset with its curve sampled from the library's own easing implementation - eleven points, a text sparkline, and whether the curve leaves the 0-1 range and so makes the element overshoot. Call it when choosing an easing: the names alone do not say how BackOut differs from ExpoOut, or which presets are unusable on an element with a hard edge.")]
+    public Task<BmotionEasingDto[]> GetBmotionEasings()
+    {
+        return BmotionEasingCatalog.GetAsync();
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionGuideSections))]
+    [Description("Lists every section of the Bit.Bmotion guide (the library README), with its heading and size. Use it to pick the heading to pass to GetBmotionGuideSection.")]
+    public BmotionGuideSectionDto[] GetBmotionGuideSections()
+    {
+        return BmotionSourceCatalog.GuideSections;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionGuideSection))]
+    [Description("Gets one section of the Bit.Bmotion guide as Markdown, with its code samples - e.g. 'Variants', 'Drag', 'Layout & shared elements', 'Scroll timelines', 'Motion values', 'Accessibility'. Sub-sections are included. Heading matching ignores case and punctuation.")]
+    public string GetBmotionGuideSection(string heading)
+    {
+        var section = BmotionSourceCatalog.GetGuideSection(heading);
+
+        if (section is null)
+        {
+            var headings = string.Join(", ", BmotionSourceCatalog.GuideSections.Select(entry => $"'{entry.Heading}'"));
+
+            return $"The guide has no section called '{heading}'. Available sections: {headings}.";
+        }
+
+        return Truncate(section);
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionApiList))]
+    [Description("Lists every public type of the Bit.Bmotion library - components, services, transitions, targets, options and enums - with its kind and summary. Use it to pick the type to pass to GetBmotionApiDetails.")]
+    public BmotionApiTypeDto[] GetBmotionApiList()
+    {
+        return BmotionApiCatalog.Types;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionApiDetails))]
+    [Description("Gets the full reference of one Bit.Bmotion type: its Blazor parameters with types and default values, its properties, methods, events or enum values, each with its documentation - read straight out of the shipped assembly. Call it before using a member you are unsure about, e.g. 'Bmotion', 'Bm', 'BmSpring', 'BmTween', 'BmotionAnimatePresence', 'BmVariants', 'BmDrag', 'BmScrollTimeline', 'BmotionAnimateService'. In an animation library the default values are the behaviour, so guessing at them produces motion that is subtly wrong rather than code that fails.")]
+    public BmotionApiDetailsResultDto GetBmotionApiDetails(string typeName)
+    {
+        var details = BmotionApiCatalog.GetTypeDetails(typeName);
+
+        if (details is not null) return new BmotionApiDetailsResultDto { Details = details };
+
+        var candidates = BmotionApiCatalog.Types
+            .Where(type => type.Name.Contains(typeName ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+            .Select(type => type.Name)
+            .ToArray();
+
+        return new BmotionApiDetailsResultDto
+        {
+            Message = candidates.Length > 0
+                ? $"Bit.Bmotion has no public type called '{typeName}'. Did you mean: {string.Join(", ", candidates)}?"
+                : $"Bit.Bmotion has no public type called '{typeName}'. Call GetBmotionApiList for the full list."
+        };
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionDemoPages))]
+    [Description("Lists the pages of the Bit.Bmotion demo site - one per feature area - with what each demonstrates and the source file behind it. Every page is a working example of the feature it covers, so this is the way to find real code for a feature rather than a fragment.")]
+    public BmotionDemoPageDto[] GetBmotionDemoPages()
+    {
+        return [.. NavItem.All.Select(page => new BmotionDemoPageDto
+        {
+            Slug = page.Href,
+            Title = page.Title,
+            Description = page.Description,
+            Keywords = page.Keywords,
+            SourcePath = page.SourcePath
+        })];
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionSourceFiles))]
+    [Description("Lists the working Bit.Bmotion source files this server can hand out: every page of the demo site, its layout and shared components, and the host wiring. Use it to pick the path to pass to GetBmotionSourceFile.")]
+    public BmotionSourceFileDto[] GetBmotionSourceFiles()
+    {
+        return BmotionSourceCatalog.SourceFiles;
+    }
+
+    [HttpGet]
+    [McpServerTool(Name = nameof(GetBmotionSourceFile))]
+    [Description("Gets one source file listed by GetBmotionSourceFiles or GetBmotionDemoPages, verbatim - e.g. 'Demo/Client/Pages/Springs.razor' for a complete, working page that exercises every form of spring.")]
+    public string GetBmotionSourceFile(string path)
+    {
+        var content = BmotionSourceCatalog.GetSourceFile(path);
+
+        if (content is null)
+        {
+            var candidates = BmotionSourceCatalog.SourceFiles
+                .Where(file => file.Path.Contains(path ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+                .Select(file => file.Path)
+                .Take(10)
+                .ToArray();
+
+            return candidates.Length > 0
+                ? $"No source file at '{path}'. Did you mean: {string.Join(", ", candidates)}?"
+                : $"No source file at '{path}'. Call GetBmotionSourceFiles for the full list.";
+        }
+
+        return Truncate(content);
+    }
+
+    /// <summary>
+    /// Everything this server exposes over MCP - its tools, prompts and resources - read off the
+    /// attributes that declare them.
+    /// <para>
+    /// Deliberately not an MCP tool: an agent already gets this from the protocol's own
+    /// <c>tools/list</c>. It exists for the /mcp demo page, which documents the server to a human
+    /// reader. Reflecting over the registrations rather than restating them means the page cannot
+    /// end up describing a tool that no longer exists, or missing one that was just added.
+    /// </para>
+    /// </summary>
+    [HttpGet]
+    public BmotionMcpCatalogDto GetMcpCatalog()
+    {
+        return new BmotionMcpCatalogDto
+        {
+            Tools = [.. typeof(McpController)
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Select(method => (Method: method,
+                                   Tool: method.GetCustomAttribute<McpServerToolAttribute>(),
+                                   Description: method.GetCustomAttribute<DescriptionAttribute>()))
+                .Where(entry => entry.Tool is not null)
+                .Select(entry => new BmotionMcpMemberDto
+                {
+                    Name = entry.Tool!.Name ?? entry.Method.Name,
+                    Description = entry.Description?.Description ?? string.Empty,
+                    Parameters = [.. entry.Method.GetParameters().Select(FormatParameter)]
+                })
+                .OrderBy(tool => tool.Name, StringComparer.Ordinal)],
+
+            Prompts = [.. typeof(McpPrompts)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Select(method => (Method: method,
+                                   Prompt: method.GetCustomAttribute<McpServerPromptAttribute>(),
+                                   Description: method.GetCustomAttribute<DescriptionAttribute>()))
+                .Where(entry => entry.Prompt is not null)
+                .Select(entry => new BmotionMcpMemberDto
+                {
+                    Name = entry.Prompt!.Name ?? entry.Method.Name,
+                    Description = entry.Description?.Description ?? string.Empty,
+                    Parameters = [.. entry.Method.GetParameters().Select(FormatParameter)]
+                })
+                .OrderBy(prompt => prompt.Name, StringComparer.Ordinal)],
+
+            Resources = [.. typeof(McpResources)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Select(method => (Resource: method.GetCustomAttribute<McpServerResourceAttribute>(),
+                                   Description: method.GetCustomAttribute<DescriptionAttribute>()))
+                .Where(entry => entry.Resource is not null)
+                .Select(entry => new BmotionMcpMemberDto
+                {
+                    Name = entry.Resource!.UriTemplate ?? entry.Resource.Name ?? string.Empty,
+                    Description = entry.Description?.Description ?? string.Empty,
+                    Parameters = []
+                })
+                .OrderBy(resource => resource.Name, StringComparer.Ordinal)]
+        };
+    }
+
+    /// <summary>A tool or prompt parameter, as "name: type" with "?" for the optional ones.</summary>
+    private static string FormatParameter(ParameterInfo parameter)
+    {
+        var type = BmotionApiCatalog.FriendlyName(parameter.ParameterType);
+
+        return parameter.HasDefaultValue ? $"{parameter.Name}?: {type}" : $"{parameter.Name}: {type}";
+    }
+
+    /// <summary>
+    /// A renamed guide heading must not silently leave a blank gap in the overview - the agent is
+    /// told where the text went instead.
+    /// </summary>
+    private static void AppendGuideSection(StringBuilder builder, string heading)
+    {
+        builder.AppendLine(BmotionSourceCatalog.GetGuideSection(heading)
+                           ?? $"_The guide's \"{heading}\" section was not found in this build. " +
+                              $"Call GetBmotionGuideSections for the sections it does have._")
+               .AppendLine();
+    }
+
+    private static string Truncate(string text)
+    {
+        return text.Length <= MaxDocumentLength
+            ? text
+            : $"{text[..MaxDocumentLength]}\n\n[truncated - the full text is longer than {MaxDocumentLength} characters]";
+    }
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpController.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpController.cs
@@ -151,16 +151,19 @@ public class McpController : ControllerBase
     [HttpGet]
     [McpServerTool(Name = nameof(GetBmotionRecipe))]
     [Description("Gets one Bit.Bmotion recipe in full: the Razor markup, and the caveat that is not visible in the code - the missing @key, the presence component it needs, the render mode it will not survive. Pass an id from GetBmotionRecipes, e.g. 'staggered-list', 'exit-animation', 'modal-dialog', 'reveal-on-scroll', 'shared-element'.")]
-    public object GetBmotionRecipe(string id)
+    public BmotionRecipeResultDto GetBmotionRecipe(string id)
     {
         var recipe = BmotionRecipeCatalog.Find(id);
 
-        if (recipe is not null) return recipe;
+        if (recipe is not null) return new BmotionRecipeResultDto { Recipe = recipe };
 
         var ids = string.Join(", ", BmotionRecipeCatalog.All.Select(entry => entry.Id));
 
-        return $"There is no recipe called '{id}'. Available recipes: {ids}. " +
-               "Call SearchBmotion with what you are trying to build if none of them fit.";
+        return new BmotionRecipeResultDto
+        {
+            Message = $"There is no recipe called '{id}'. Available recipes: {ids}. " +
+                      "Call SearchBmotion with what you are trying to build if none of them fit."
+        };
     }
 
     [HttpGet]
@@ -189,14 +192,9 @@ public class McpController : ControllerBase
             .Take(8)
             .ToArray();
 
-        var results = new List<BmotionSimulationDto>(specs.Length);
-
-        foreach (var spec in specs)
-        {
-            results.Add(await BmotionMotionLab.SimulateAsync(spec, from, to));
-        }
-
-        return [.. results];
+        // Every run owns its engine and its frame clock (see BmotionMotionLab), so the comparison
+        // costs one simulation rather than the sum of them. Task.WhenAll keeps the order asked for.
+        return await Task.WhenAll(specs.Select(spec => BmotionMotionLab.SimulateAsync(spec, from, to)));
     }
 
     [HttpGet]
@@ -219,7 +217,32 @@ public class McpController : ControllerBase
     public BmotionReviewDto ReviewBmotionCode(
         [Description("The Razor markup or C# to review. A component, a fragment, or just the <Bmotion> element in question.")] string code)
     {
-        return BmotionCodeReview.Review(code);
+        var text = code ?? string.Empty;
+
+        // Every rule below is a pass over every line, so the reviewed body is bounded by the same
+        // limit as the documents this server hands out. What was cut is reported rather than dropped:
+        // a review that silently covered the first half of a file would read as a clean bill of health.
+        if (text.Length <= MaxDocumentLength) return BmotionCodeReview.Review(text);
+
+        var review = BmotionCodeReview.Review(text[..MaxDocumentLength]);
+
+        return review with
+        {
+            Passed = false,
+            Findings =
+            [
+                new BmotionReviewFindingDto
+                {
+                    Severity = "Warning",
+                    Rule = "code-too-long",
+                    Message = $"Only the first {MaxDocumentLength} characters were reviewed; the code passed in is " +
+                              $"{text.Length} characters long, so anything after that was not checked.",
+                    Fix = "Review the component or the fragment in question rather than a whole file, and call this " +
+                          "tool once per piece."
+                },
+                .. review.Findings
+            ]
+        };
     }
 
     [HttpGet]

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpController.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpController.cs
@@ -33,8 +33,10 @@ namespace Bit.Bmotion.Demo.Server.Controllers;
 public class McpController : ControllerBase
 {
     // Long enough for the largest guide section, short enough that a couple of tool calls cannot
-    // crowd out a client's context window.
-    private const int MaxDocumentLength = 40_000;
+    // crowd out a client's context window. McpResources reads the same bound: the resources hand
+    // out the same documents, so a client that pins one instead of calling the tool gets the same
+    // text rather than an unbounded one.
+    internal const int MaxDocumentLength = 40_000;
 
     private static readonly string BmotionVersion =
         typeof(Bm).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
@@ -440,7 +442,7 @@ public class McpController : ControllerBase
                .AppendLine();
     }
 
-    private static string Truncate(string text)
+    internal static string Truncate(string text)
     {
         return text.Length <= MaxDocumentLength
             ? text

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpPrompts.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpPrompts.cs
@@ -1,0 +1,154 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace Bit.Bmotion.Demo.Server.Controllers;
+
+/// <summary>
+/// Ready-made workflows for the four things people actually ask an animation library for: build an
+/// animation, add the library to an app, tune how something feels, and work out why nothing moves.
+/// <para>
+/// Each prompt spends its words on the order to call the tools in, because the failure mode of an
+/// agent holding eighteen tools is not ignorance - it is calling them in a sequence that skips the
+/// check which would have caught the bug. For Bmotion that check is nearly always the same one:
+/// nothing here fails loudly. An animation that will not play on Blazor Server compiles, deploys
+/// and renders; it just does not move. So every workflow below ends by running the code back
+/// through the engine rather than by declaring victory when it builds.
+/// </para>
+/// </summary>
+[McpServerPromptType]
+public static class McpPrompts
+{
+    [McpServerPrompt(Name = "animate-with-bmotion")]
+    [Description("Builds an animation with Bit.Bmotion - an entrance, an exit, a gesture, a list, a scroll reveal - using its real API, and verifies the motion before finishing.")]
+    public static string AnimateWithBmotion(
+        [Description("What should move, and how it should feel, in your own words - e.g. 'the cards should appear one after another as I scroll to them' or 'the dialog should pop in and fade out quickly'.")] string request,
+        [Description("The app's Blazor render mode: wasm, server, auto or standalone-wasm. Pass 'unknown' to have it determined from the project first.")] string renderMode = "unknown")
+    {
+        return $"""
+            Build this with Bit.Bmotion: {request}
+
+            The app's render mode is: {renderMode}.
+
+            Work in this order:
+
+            1. If the render mode is 'unknown', determine it from the project before writing anything: look for
+               AddInteractiveServerComponents / AddInteractiveWebAssemblyComponents in Program.cs and for a separate
+               .Client project. It decides which features are available at all, not just how fast they are.
+            2. Call `GetBmotionRecipes` and look for a pattern that already covers the request. If one does, fetch
+               it with `GetBmotionRecipe` and follow its shape - including its Notes, which carry the caveat the
+               code cannot show. If none fits, call `SearchBmotion` with the request as written.
+            3. Call `GetBmotionApiDetails` for every Bmotion type you are about to use and match the parameter
+               names, types and defaults exactly. Do not carry over parameter names from Framer Motion or from
+               another animation library - several are close enough to look right and behave differently.
+            4. Choose the transition with evidence, not adjectives: call `SimulateBmotionTransition` on the one you
+               intend to use, or `CompareBmotionTransitions` on two or three candidates, and pick by settle time and
+               overshoot. A spring has no duration argument, so this is the only way to know how long it takes.
+            5. Write the code.
+            6. Call `AnalyzeBmotionAnimation` with the properties and transition you settled on. If it reports the
+               C# frame loop and this app is not WebAssembly-only, either switch to the compositor-friendly
+               equivalent it suggests, or tell me explicitly that this animation will snap rather than play on
+               Server and let me decide.
+            7. Call `ReviewBmotionCode` on what you wrote and fix every Error and Warning it reports.
+            8. Build the app and fix what the compiler says.
+
+            Show me the final markup, say which transition you chose and what its measured settle time and overshoot
+            were, and state plainly whether the animation works in every render mode this app uses.
+            """;
+    }
+
+    [McpServerPrompt(Name = "add-bmotion-to-app")]
+    [Description("Walks through adding Bit.Bmotion to an existing Blazor app, in the right order for its render mode.")]
+    public static string AddBmotionToApp(
+        [Description("The app's Blazor render mode: wasm, server, auto or standalone-wasm. Pass 'unknown' to have it determined from the project first.")] string renderMode = "unknown")
+    {
+        return $"""
+            Add Bit.Bmotion to this Blazor app. Its render mode is: {renderMode}.
+
+            Work in this order:
+
+            1. If the render mode is 'unknown', determine it from the project first: look for
+               AddInteractiveServerComponents / AddInteractiveWebAssemblyComponents in Program.cs and for a separate
+               .Client project, then continue with what you find.
+            2. Call `GetBmotionSetupGuide` with that render mode and follow it. Registering the services in only one
+               of a Blazor Web App's two DI containers is the most common setup bug - it fails during prerendering,
+               not at compile time.
+            3. Add `@using Bit.Bmotion` to `_Imports.razor` in every project that renders animations.
+            4. Set the reduced-motion policy while you are in Program.cs:
+               `AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMode.User)`. The default is
+               back-compatible rather than correct, and this is the one moment when adding it costs nothing.
+            5. Add one small animation from `GetBmotionRecipe(id: "fade-in-on-mount")` to prove the wiring works
+               end to end, and build.
+
+            Show me the diff for each file you change, and say explicitly which DI containers you registered the
+            services in. If the render mode is 'server' or 'auto', also summarise for me which parts of the library
+            will not be available.
+            """;
+    }
+
+    [McpServerPrompt(Name = "tune-bmotion-motion")]
+    [Description("Tunes how an existing Bit.Bmotion animation feels - too slow, too bouncy, too abrupt - by measuring the alternatives instead of guessing at numbers.")]
+    public static string TuneBmotionMotion(
+        [Description("The transition as it is written today, e.g. 'Bm.Spring(stiffness: 100, damping: 10)'.")] string current,
+        [Description("What is wrong with how it feels - e.g. 'too slow to settle', 'too bouncy', 'feels lifeless', 'the tail drags'.")] string complaint)
+    {
+        return $"""
+            Tune this Bit.Bmotion transition: {current}
+
+            What is wrong with it: {complaint}
+
+            Work in this order:
+
+            1. Call `SimulateBmotionTransition` on the current transition. Read the settle time, the overshoot, the
+               number of target crossings and the time to 90% of the distance. State which of those numbers
+               corresponds to the complaint - "too slow" is usually a long tail after a fast start, which is the gap
+               between TimeTo90Percent and SettleSeconds, not the duration anyone configured.
+            2. Propose three candidates that move that specific number in the right direction, and call
+               `CompareBmotionTransitions` on all three at once.
+            3. Recommend one, citing its measurements against the current transition's.
+            4. If the complaint is about feel rather than timing, consider the form as well as the numbers:
+               `Bm.Spring(bounce:, duration:)` expresses intent directly and cannot be configured into a spring that
+               never settles, while stiffness and damping can. Say so if switching form is the better fix.
+            5. Call `AnalyzeBmotionAnimation` with the animated properties and the new transition, to confirm the
+               change did not cost the animation its compositor path - a spring with an initial velocity, for one,
+               drops off it silently.
+
+            Give me the replacement line, the before-and-after numbers, and one sentence on what the reader will
+            actually notice.
+            """;
+    }
+
+    [McpServerPrompt(Name = "debug-bmotion-animation")]
+    [Description("Diagnoses a Bit.Bmotion animation that does not work - nothing moves, the exit never plays, it works locally but not in production, the wrong item animates.")]
+    public static string DebugBmotionAnimation(
+        [Description("What goes wrong, with the markup involved if you have it.")] string symptom)
+    {
+        return $"""
+            Diagnose this Bit.Bmotion problem: {symptom}
+
+            Bmotion fails silently almost everywhere, so work through the silent causes in order of how often they
+            are the answer:
+
+            1. Call `ReviewBmotionCode` on the markup involved. It checks the mistakes that compile cleanly and then
+               do nothing - an `Exit` with no presence component, a `@foreach` with no `@key`, a spring whose
+               duration is ignored, a nested-quote attribute that does not parse as intended. The cause is often
+               there verbatim.
+            2. If nothing animates at all, establish the render mode, then call `AnalyzeBmotionAnimation` with the
+               properties and transition. An animation the engine keeps on the C# frame loop becomes an instant
+               state change on Blazor Server - which is exactly the "works on my machine, not in production" shape,
+               and the "works on the second visit but not the first" shape under InteractiveAuto.
+            3. If the element does not move on mount, check whether `Initial` is set. `Animate` alone leaves the
+               element already at its target with nothing to travel from.
+            4. If the motion happens but looks wrong, call `SimulateBmotionTransition` on the transition. A spring
+               that appears not to stop, or one that arrives instantly and then drifts, is visible in the numbers.
+            5. Confirm the API you are relying on with `GetBmotionApiDetails` before concluding it is a bug -
+               check the actual default value of the parameter involved.
+            6. Check the setup itself against `GetBmotionSetupGuide` for this render mode: services registered in
+               every DI container the components run in, and `@using Bit.Bmotion` present.
+            7. Rule out reduced motion. If the operating system asks for reduced motion and the app sets
+               `BmReducedMotionMode.User` or `Always`, transforms and layout changes snap by design while opacity
+               and colour keep animating. That is correct behaviour, and it looks exactly like a bug.
+
+            Tell me the cause and the fix, and cite the tool call that established it.
+            """;
+    }
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpResources.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpResources.cs
@@ -1,0 +1,143 @@
+using System.Text;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using Bit.Bmotion.Demo.Server.Services;
+
+namespace Bit.Bmotion.Demo.Server.Controllers;
+
+/// <summary>
+/// The same body of knowledge the tools serve, exposed as MCP resources.
+/// <para>
+/// Tools are for an agent that has decided what it needs; resources are for a client that wants to
+/// attach documentation to a conversation up front, or let a person browse and pin it. Both read
+/// the same catalogs, so neither can go stale relative to the other.
+/// </para>
+/// </summary>
+[McpServerResourceType]
+public static class McpResources
+{
+    [McpServerResource(UriTemplate = "bmotion://guide", Name = "Bit.Bmotion guide", MimeType = "text/markdown")]
+    [Description("The complete Bit.Bmotion guide (the library README), every section in one document.")]
+    public static string Guide() => BmotionSourceCatalog.Readme;
+
+    [McpServerResource(UriTemplate = "bmotion://guide/{heading}", Name = "Guide section", MimeType = "text/markdown")]
+    [Description("One section of the Bit.Bmotion guide by heading, e.g. bmotion://guide/Variants.")]
+    public static string GuideSection(string heading)
+        => BmotionSourceCatalog.GetGuideSection(heading) ?? $"The guide has no section called '{heading}'.";
+
+    [McpServerResource(UriTemplate = "bmotion://api", Name = "Bit.Bmotion public API", MimeType = "text/markdown")]
+    [Description("Every public Bit.Bmotion type with its kind and summary.")]
+    public static string ApiList()
+    {
+        var lines = BmotionApiCatalog.Types.Select(type => $"- **{type.Name}** ({type.Kind}) - {type.Summary}");
+
+        return $"# Bit.Bmotion public API\n\n{string.Join('\n', lines)}";
+    }
+
+    [McpServerResource(UriTemplate = "bmotion://api/{typeName}", Name = "Type reference", MimeType = "text/markdown")]
+    [Description("The full reference of one Bit.Bmotion type, e.g. bmotion://api/BmSpring.")]
+    public static string ApiType(string typeName)
+    {
+        var details = BmotionApiCatalog.GetTypeDetails(typeName);
+
+        if (details is null) return $"Bit.Bmotion has no public type called '{typeName}'.";
+
+        var builder = new StringBuilder();
+
+        builder.AppendLine($"# {details.Name} ({details.Kind})").AppendLine();
+        if (details.Summary is not null) builder.AppendLine(details.Summary).AppendLine();
+        if (details.Remarks is not null) builder.AppendLine(details.Remarks).AppendLine();
+
+        foreach (var group in details.Members.GroupBy(member => member.Kind))
+        {
+            builder.AppendLine($"## {group.Key}").AppendLine();
+
+            foreach (var member in group)
+            {
+                builder.Append($"- **{member.Name}**{member.Signature}");
+                if (member.Type is not null) builder.Append($" : `{member.Type}`");
+                if (member.Default is not null) builder.Append($" = `{member.Default}`");
+                if (member.Required) builder.Append(" **(required)**");
+                if (member.Summary is not null) builder.Append($" - {member.Summary}");
+                builder.AppendLine();
+            }
+
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    [McpServerResource(UriTemplate = "bmotion://properties", Name = "Animatable properties", MimeType = "text/markdown")]
+    [Description("Every property Bit.Bmotion can animate, and whether it survives on Blazor Server.")]
+    public static async Task<string> Properties()
+    {
+        var properties = await BmotionPropertyCatalog.GetAsync();
+
+        var builder = new StringBuilder();
+
+        builder.AppendLine("# Animatable properties").AppendLine();
+        builder.AppendLine("| Property | Category | CSS | Compositor | On Blazor Server |");
+        builder.AppendLine("|---|---|---|---|---|");
+
+        foreach (var property in properties)
+        {
+            builder.AppendLine($"| `{property.Name}` | {property.Category} | `{property.Css}` | " +
+                               $"{(property.CompositorEligible ? "yes" : "no")} | {property.OnBlazorServer} |");
+        }
+
+        return builder.ToString();
+    }
+
+    [McpServerResource(UriTemplate = "bmotion://easings", Name = "Easing presets", MimeType = "text/markdown")]
+    [Description("Every BmEase preset with its curve sampled from the library's own easing implementation.")]
+    public static async Task<string> Easings()
+    {
+        var easings = await BmotionEasingCatalog.GetAsync();
+
+        var builder = new StringBuilder();
+
+        builder.AppendLine("# BmEase presets").AppendLine();
+        builder.AppendLine("| Preset | Family | Curve | Overshoots |");
+        builder.AppendLine("|---|---|---|---|");
+
+        foreach (var easing in easings)
+        {
+            builder.AppendLine($"| `BmEase.{easing.Name}` | {easing.Family} | `{easing.Sparkline}` | " +
+                               $"{(easing.Overshoots ? "yes" : "no")} |");
+        }
+
+        return builder.ToString();
+    }
+
+    [McpServerResource(UriTemplate = "bmotion://recipes", Name = "Bmotion recipes", MimeType = "text/markdown")]
+    [Description("Every ready-made Bit.Bmotion pattern, with its markup and its caveats.")]
+    public static string Recipes()
+    {
+        var builder = new StringBuilder();
+
+        builder.AppendLine("# Bit.Bmotion recipes").AppendLine();
+
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            builder.AppendLine($"## {recipe.Title}").AppendLine();
+            builder.AppendLine(recipe.Intent).AppendLine();
+            builder.AppendLine("```razor").AppendLine(recipe.Code).AppendLine("```").AppendLine();
+
+            if (recipe.Notes is not null) builder.AppendLine($"> {recipe.Notes}").AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    [McpServerResource(UriTemplate = "bmotion://source/{path}", Name = "Demo source file", MimeType = "text/plain")]
+    [Description("One source file of the demo site, e.g. bmotion://source/Demo%2FClient%2FPages%2FSprings.razor.")]
+    public static string Source(string path)
+        => BmotionSourceCatalog.GetSourceFile(path) ?? $"No source file at '{path}'.";
+
+    [McpServerResource(UriTemplate = "bmotion://setup/{renderMode}", Name = "Setup guide", MimeType = "text/markdown")]
+    [Description("The complete wiring for one Blazor render mode, e.g. bmotion://setup/wasm or bmotion://setup/server.")]
+    public static string Setup(string renderMode)
+        => BmotionSetupGuide.Get(renderMode)
+           ?? $"'{renderMode}' is not a known render mode. Use one of: {string.Join(", ", BmotionSetupGuide.RenderModes)}.";
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpResources.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpResources.cs
@@ -18,7 +18,16 @@ public static class McpResources
 {
     [McpServerResource(UriTemplate = "bmotion://guide", Name = "Bit.Bmotion guide", MimeType = "text/markdown")]
     [Description("The complete Bit.Bmotion guide (the library README), every section in one document.")]
-    public static string Guide() => BmotionSourceCatalog.Readme;
+    public static string Guide()
+    {
+        var readme = BmotionSourceCatalog.Readme;
+
+        // The guide is an embedded resource, so an empty one means it was not embedded in this build.
+        // Saying so is an answer; an empty document reads as a library with nothing written about it.
+        return readme.Length > 0
+            ? readme
+            : "The Bit.Bmotion guide is not available in this build: the README was not embedded in the assembly.";
+    }
 
     [McpServerResource(UriTemplate = "bmotion://guide/{heading}", Name = "Guide section", MimeType = "text/markdown")]
     [Description("One section of the Bit.Bmotion guide by heading, e.g. bmotion://guide/Variants.")]

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpResources.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Controllers/McpResources.cs
@@ -32,7 +32,13 @@ public static class McpResources
     [McpServerResource(UriTemplate = "bmotion://guide/{heading}", Name = "Guide section", MimeType = "text/markdown")]
     [Description("One section of the Bit.Bmotion guide by heading, e.g. bmotion://guide/Variants.")]
     public static string GuideSection(string heading)
-        => BmotionSourceCatalog.GetGuideSection(heading) ?? $"The guide has no section called '{heading}'.";
+    {
+        var section = BmotionSourceCatalog.GetGuideSection(heading);
+
+        return section is null
+            ? $"The guide has no section called '{heading}'."
+            : McpController.Truncate(section);
+    }
 
     [McpServerResource(UriTemplate = "bmotion://api", Name = "Bit.Bmotion public API", MimeType = "text/markdown")]
     [Description("Every public Bit.Bmotion type with its kind and summary.")]
@@ -142,7 +148,13 @@ public static class McpResources
     [McpServerResource(UriTemplate = "bmotion://source/{path}", Name = "Demo source file", MimeType = "text/plain")]
     [Description("One source file of the demo site, e.g. bmotion://source/Demo%2FClient%2FPages%2FSprings.razor.")]
     public static string Source(string path)
-        => BmotionSourceCatalog.GetSourceFile(path) ?? $"No source file at '{path}'.";
+    {
+        var content = BmotionSourceCatalog.GetSourceFile(path);
+
+        return content is null
+            ? $"No source file at '{path}'."
+            : McpController.Truncate(content);
+    }
 
     [McpServerResource(UriTemplate = "bmotion://setup/{renderMode}", Name = "Setup guide", MimeType = "text/markdown")]
     [Description("The complete wiring for one Blazor render mode, e.g. bmotion://setup/wasm or bmotion://setup/server.")]

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Dtos/BmotionMcpDtos.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Dtos/BmotionMcpDtos.cs
@@ -26,7 +26,7 @@ public record BmotionApiTypeDto
 {
     public required string Name { get; init; }
 
-    /// <summary>Component, Interface, Enum, Delegate, Static class, Class, Struct or Record.</summary>
+    /// <summary>Component, Interface, Enum, Attribute, Delegate, Static class, Class, Struct or Record.</summary>
     public required string Kind { get; init; }
 
     public string? Summary { get; init; }
@@ -293,7 +293,10 @@ public record BmotionRecipeDto
     /// <summary>The Razor markup. Present on GetBmotionRecipe, omitted from the listing.</summary>
     public string? Code { get; init; }
 
-    /// <summary>What to know before using it - the caveat that is not visible in the code.</summary>
+    /// <summary>
+    /// What to know before using it - the caveat that is not visible in the code. Present on
+    /// GetBmotionRecipe, omitted from the listing.
+    /// </summary>
     public string? Notes { get; init; }
 
     /// <summary>The demo page that shows it running, e.g. "/scroll".</summary>

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Dtos/BmotionMcpDtos.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Dtos/BmotionMcpDtos.cs
@@ -1,0 +1,373 @@
+namespace Bit.Bmotion.Demo.Server.Dtos;
+
+// The shapes every Bmotion MCP tool answers with. They are records with documented members rather
+// than loose dictionaries because the MCP client turns them into the tool's output schema: an agent
+// that can see "SettleSeconds" and "OvershootPercent" as named, described fields does not have to
+// infer what a number means, and cannot mistake one for another.
+
+/// <summary>One section of the Bit.Bmotion guide (the library README).</summary>
+public record BmotionGuideSectionDto
+{
+    /// <summary>The heading text, e.g. "Drag". Pass it to GetBmotionGuideSection.</summary>
+    public required string Heading { get; init; }
+
+    /// <summary>Markdown heading level: 2 for a top-level section, 3 for a sub-section.</summary>
+    public required int Level { get; init; }
+
+    /// <summary>The owning level-2 section, or null when this entry is itself level 2.</summary>
+    public string? Parent { get; init; }
+
+    /// <summary>Number of markdown lines in the section, including its sub-sections.</summary>
+    public required int Lines { get; init; }
+}
+
+/// <summary>A public type of the Bit.Bmotion assembly.</summary>
+public record BmotionApiTypeDto
+{
+    public required string Name { get; init; }
+
+    /// <summary>Component, Interface, Enum, Delegate, Static class, Class, Struct or Record.</summary>
+    public required string Kind { get; init; }
+
+    public string? Summary { get; init; }
+}
+
+/// <summary>A member (parameter, property, method, event or enum value) of a public Bit.Bmotion type.</summary>
+public record BmotionApiMemberDto
+{
+    public required string Name { get; init; }
+
+    /// <summary>Parameter, Property, Field, EnumValue, Method or Event. "Parameter" means a Blazor [Parameter].</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The C# type of the member, or a method's return type.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>A method's parameter list, e.g. "(double delay)".</summary>
+    public string? Signature { get; init; }
+
+    /// <summary>The value the member holds on a freshly created instance, when it could be determined.</summary>
+    public string? Default { get; init; }
+
+    /// <summary>True for [EditorRequired] Blazor parameters.</summary>
+    public bool Required { get; init; }
+
+    public string? Summary { get; init; }
+
+    /// <summary>The XML remarks, when the member has any - they carry the caveats.</summary>
+    public string? Remarks { get; init; }
+}
+
+/// <summary>The full reference of one public Bit.Bmotion type.</summary>
+public record BmotionApiTypeDetailsDto
+{
+    public required string Name { get; init; }
+
+    public required string FullName { get; init; }
+
+    public required string Kind { get; init; }
+
+    public string? BaseType { get; init; }
+
+    public required string[] Implements { get; init; }
+
+    public string? Summary { get; init; }
+
+    public string? Remarks { get; init; }
+
+    public required BmotionApiMemberDto[] Members { get; init; }
+}
+
+/// <summary>The answer of GetBmotionApiDetails: the type, or a message naming the near misses.</summary>
+public record BmotionApiDetailsResultDto
+{
+    public BmotionApiTypeDetailsDto? Details { get; init; }
+
+    /// <summary>Set instead of Details when no public type goes by the requested name.</summary>
+    public string? Message { get; init; }
+}
+
+/// <summary>One property that Bit.Bmotion can animate, and what animating it costs.</summary>
+public record BmotionPropertyDto
+{
+    /// <summary>The <c>Bm.To(...)</c> argument name, e.g. "backgroundColor".</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Transform, Visual, Layout, Typography, SVG, Motion path or Custom.</summary>
+    public required string Category { get; init; }
+
+    /// <summary>The CSS property (or transform component) the engine writes.</summary>
+    public required string Css { get; init; }
+
+    /// <summary>The C# type of the argument: BmKeyframes (numeric) or BmStringKeyframes (CSS value).</summary>
+    public required string ValueType { get; init; }
+
+    /// <summary>
+    /// True when the browser compositor can own this property, so the animation plays through the
+    /// Web Animations API with no per-frame interop - and therefore plays on Blazor Server too.
+    /// </summary>
+    public required bool CompositorEligible { get; init; }
+
+    /// <summary>
+    /// What happens on Blazor Server: "Animates" for a compositor-eligible property, or
+    /// "Jumps to the target" for one that needs the per-frame loop.
+    /// </summary>
+    public required string OnBlazorServer { get; init; }
+
+    /// <summary>How to write a value for it, e.g. "x: 100", "backgroundColor: \"#FD7F36\"".</summary>
+    public required string Example { get; init; }
+
+    public string? Notes { get; init; }
+}
+
+/// <summary>One <see cref="BmEase"/> preset, sampled from the library's own easing function.</summary>
+public record BmotionEasingDto
+{
+    /// <summary>The enum member name, e.g. "InOut". Write it as <c>BmEase.InOut</c>.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>In, Out, InOut or Linear - which end of the motion the easing slows.</summary>
+    public required string Direction { get; init; }
+
+    /// <summary>The family: Cubic bezier, Circ, Back, Sine, Quad, Quart, Quint, Expo, Elastic, Bounce.</summary>
+    public required string Family { get; init; }
+
+    /// <summary>What it feels like, and when to reach for it.</summary>
+    public required string Feel { get; init; }
+
+    /// <summary>Eleven samples of the curve at t = 0, 0.1 ... 1, straight from BmEaseFunctions.</summary>
+    public required double[] Curve { get; init; }
+
+    /// <summary>The same curve drawn as text, so it can be read in a terminal.</summary>
+    public required string Sparkline { get; init; }
+
+    /// <summary>True when the curve leaves the 0-1 range, which makes the element overshoot.</summary>
+    public required bool Overshoots { get; init; }
+}
+
+/// <summary>The result of running a transition through the real engine, off-screen.</summary>
+public record BmotionSimulationDto
+{
+    /// <summary>The transition as it was understood, written as the C# call that produces it.</summary>
+    public required string Transition { get; init; }
+
+    /// <summary>Spring, Tween or Inertia.</summary>
+    public required string Kind { get; init; }
+
+    public required double From { get; init; }
+
+    public required double To { get; init; }
+
+    /// <summary>
+    /// How long the motion actually takes, measured rather than configured: for a spring this is
+    /// where the physics comes to rest, which no duration argument states.
+    /// </summary>
+    public required double SettleSeconds { get; init; }
+
+    /// <summary>
+    /// How far past the target the value travels, as a percentage of the distance covered. 0 for a
+    /// motion that never crosses its target; around 20 for a lively spring.
+    /// </summary>
+    public required double OvershootPercent { get; init; }
+
+    /// <summary>How many times the value crosses the target before resting - the wobble count.</summary>
+    public required int TargetCrossings { get; init; }
+
+    /// <summary>The greatest speed reached, in units per second.</summary>
+    public required double PeakVelocity { get; init; }
+
+    /// <summary>Seconds from the start to the moment 90% of the distance is covered.</summary>
+    public required double TimeTo90Percent { get; init; }
+
+    /// <summary>Evenly spaced samples of the motion: (seconds, value) pairs.</summary>
+    public required BmotionSampleDto[] Samples { get; init; }
+
+    /// <summary>The motion drawn as text, so the shape can be read without plotting it.</summary>
+    public required string Sparkline { get; init; }
+
+    /// <summary>What the numbers mean, in a sentence - including whether the feel matches the intent.</summary>
+    public required string Reading { get; init; }
+
+    /// <summary>Anything the spec said that was not applied, and assumptions that were made.</summary>
+    public required string[] Warnings { get; init; }
+
+    /// <summary>
+    /// Set instead of a measurement when the transition could not be read, and says how to write it.
+    /// An unreadable spec is a correctable mistake, so it comes back as data the caller can act on
+    /// rather than as a failed call whose reason the protocol reduces to "an error occurred".
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>One sampled instant of a simulated motion.</summary>
+public record BmotionSampleDto
+{
+    public required double Seconds { get; init; }
+
+    public required double Value { get; init; }
+}
+
+/// <summary>How an animation will actually be played, as decided by the engine itself.</summary>
+public record BmotionPlaybackDto
+{
+    /// <summary>The properties that were analysed.</summary>
+    public required string[] Properties { get; init; }
+
+    /// <summary>The transition, written as the C# call that produces it.</summary>
+    public required string Transition { get; init; }
+
+    /// <summary>"Compositor (Web Animations API)" or "C# frame loop (requestAnimationFrame)".</summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// True when the animation plays on Blazor Server as it does on WebAssembly. False means it
+    /// collapses to an instant state change there, because it needs the per-frame loop.
+    /// </summary>
+    public required bool WorksOnBlazorServer { get; init; }
+
+    /// <summary>Why the engine chose that path, in the engine's own terms.</summary>
+    public required string Reason { get; init; }
+
+    /// <summary>The duration the compositor was given, in milliseconds, when the animation was offloaded.</summary>
+    public double? CompositorDurationMs { get; init; }
+
+    /// <summary>The CSS easing handed to the browser, when the animation was offloaded.</summary>
+    public string? CompositorEasing { get; init; }
+
+    /// <summary>What to change to make it play on Blazor Server, when it does not.</summary>
+    public string[]? HowToOffload { get; init; }
+
+    /// <summary>
+    /// Set instead of a verdict when the transition could not be read, and says how to write it.
+    /// When this is present the rest of the fields state nothing: in particular WorksOnBlazorServer
+    /// is false because nothing was analysed, not because the animation would fail there.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>One finding from reviewing Bmotion markup.</summary>
+public record BmotionReviewFindingDto
+{
+    /// <summary>Error, Warning or Suggestion. An Error is markup the library will not honour.</summary>
+    public required string Severity { get; init; }
+
+    /// <summary>The rule that fired, e.g. "animate-without-initial".</summary>
+    public required string Rule { get; init; }
+
+    /// <summary>The 1-based line of the reviewed code the finding sits on, when it maps to one.</summary>
+    public int? Line { get; init; }
+
+    /// <summary>What is wrong.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>What to do about it.</summary>
+    public required string Fix { get; init; }
+}
+
+/// <summary>The result of reviewing a piece of Bmotion markup.</summary>
+public record BmotionReviewDto
+{
+    /// <summary>True when nothing above a suggestion was found.</summary>
+    public required bool Passed { get; init; }
+
+    public required BmotionReviewFindingDto[] Findings { get; init; }
+
+    /// <summary>What was checked, so an empty result is not mistaken for an unchecked one.</summary>
+    public required string[] RulesApplied { get; init; }
+}
+
+/// <summary>A ready-made, copy-pasteable Bmotion pattern.</summary>
+public record BmotionRecipeDto
+{
+    /// <summary>The id to pass to GetBmotionRecipe, e.g. "fade-in-on-scroll".</summary>
+    public required string Id { get; init; }
+
+    public required string Title { get; init; }
+
+    /// <summary>What it is for, phrased the way the request usually arrives.</summary>
+    public required string Intent { get; init; }
+
+    /// <summary>Search terms the recipe covers.</summary>
+    public required string Keywords { get; init; }
+
+    /// <summary>The Razor markup. Present on GetBmotionRecipe, omitted from the listing.</summary>
+    public string? Code { get; init; }
+
+    /// <summary>What to know before using it - the caveat that is not visible in the code.</summary>
+    public string? Notes { get; init; }
+
+    /// <summary>The demo page that shows it running, e.g. "/scroll".</summary>
+    public string? SeeAlso { get; init; }
+}
+
+/// <summary>One page of the Bit.Bmotion demo site.</summary>
+public record BmotionDemoPageDto
+{
+    /// <summary>The route, e.g. "springs". Empty for the landing page.</summary>
+    public required string Slug { get; init; }
+
+    public required string Title { get; init; }
+
+    /// <summary>What the page demonstrates.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Space-separated search terms the page covers.</summary>
+    public required string Keywords { get; init; }
+
+    /// <summary>The source file to pass to GetBmotionSourceFile for the page behind this demo.</summary>
+    public required string SourcePath { get; init; }
+}
+
+/// <summary>One source file the MCP server can hand out verbatim.</summary>
+public record BmotionSourceFileDto
+{
+    /// <summary>The path to pass to GetBmotionSourceFile.</summary>
+    public required string Path { get; init; }
+
+    /// <summary>Demo, Library or Host.</summary>
+    public required string Kind { get; init; }
+
+    public string? Description { get; init; }
+
+    public required int Lines { get; init; }
+}
+
+/// <summary>Everything this server exposes over MCP, for the demo page that documents it.</summary>
+public record BmotionMcpCatalogDto
+{
+    public required BmotionMcpMemberDto[] Tools { get; init; }
+
+    public required BmotionMcpMemberDto[] Prompts { get; init; }
+
+    public required BmotionMcpMemberDto[] Resources { get; init; }
+}
+
+/// <summary>One tool, prompt or resource, read off the attribute that declares it.</summary>
+public record BmotionMcpMemberDto
+{
+    /// <summary>The tool or prompt name, or the resource's URI template.</summary>
+    public required string Name { get; init; }
+
+    public required string Description { get; init; }
+
+    /// <summary>The parameters, as "name: type" with a "?" on the optional ones.</summary>
+    public required string[] Parameters { get; init; }
+}
+
+/// <summary>One hit from the unified search, carrying the call that returns its full text.</summary>
+public record BmotionSearchHitDto
+{
+    /// <summary>What kind of thing was found: "Guide section", "API component", "Recipe", ...</summary>
+    public required string Kind { get; init; }
+
+    public required string Title { get; init; }
+
+    /// <summary>Where it sits - the parent section, the owning type, the category.</summary>
+    public string? Context { get; init; }
+
+    /// <summary>The exact tool call that returns this hit in full.</summary>
+    public required string Tool { get; init; }
+
+    /// <summary>The matching text, with a little of what surrounds it.</summary>
+    public required string Snippet { get; init; }
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Dtos/BmotionMcpDtos.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Dtos/BmotionMcpDtos.cs
@@ -300,6 +300,15 @@ public record BmotionRecipeDto
     public string? SeeAlso { get; init; }
 }
 
+/// <summary>The answer of GetBmotionRecipe: the recipe, or a message naming the ones that exist.</summary>
+public record BmotionRecipeResultDto
+{
+    public BmotionRecipeDto? Recipe { get; init; }
+
+    /// <summary>Set instead of Recipe when no recipe goes by the requested id.</summary>
+    public string? Message { get; init; }
+}
+
 /// <summary>One page of the Bit.Bmotion demo site.</summary>
 public record BmotionDemoPageDto
 {

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
@@ -10,7 +10,9 @@ builder.Services.AddRazorComponents()
 builder.Services.AddDemoServices();
 
 // The MCP server (Controllers/McpController.cs) and the plain HTTP endpoints that mirror it - the
-// same methods, reachable from a browser, which is what the /mcp demo page calls to show them live.
+// same methods, reachable from a browser, which is what the /mcp-server demo page calls to show them
+// live. That page's route has to differ from MapMcp's below: two literal endpoints on /mcp would
+// make a GET of it ambiguous.
 builder.Services.AddControllers();
 builder.Services.AddMcpServer()
     .WithHttpTransport()

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
@@ -51,3 +51,10 @@ app.MapRazorComponents<App>()
     .AddAdditionalAssemblies(typeof(Bit.Bmotion.Demo.Client._Imports).Assembly);
 
 app.Run();
+
+/// <summary>
+/// Named so the tests can host this exact file in-memory. Top-level statements compile to an
+/// internal Program, which WebApplicationFactory cannot reach - and testing a second, hand-written
+/// registration of the MCP server instead would leave the wiring above the only part nothing checks.
+/// </summary>
+public partial class Program;

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
@@ -9,6 +9,15 @@ builder.Services.AddRazorComponents()
 // register the very same services the WebAssembly container does.
 builder.Services.AddDemoServices();
 
+// The MCP server (Controllers/McpController.cs) and the plain HTTP endpoints that mirror it - the
+// same methods, reachable from a browser, which is what the /mcp demo page calls to show them live.
+builder.Services.AddControllers();
+builder.Services.AddMcpServer()
+    .WithHttpTransport()
+    .WithToolsFromAssembly()
+    .WithResourcesFromAssembly()
+    .WithPromptsFromAssembly();
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -31,6 +40,11 @@ app.UseHttpsRedirection();
 app.UseAntiforgery();
 
 app.MapStaticAssets();
+
+// Both are literal routes, so they are matched before any component route regardless of order;
+// declaring them first says so out loud.
+app.MapControllers();
+app.MapMcp("/mcp");
 
 app.MapRazorComponents<App>()
     .AddInteractiveWebAssemblyRenderMode()

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionApiCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionApiCatalog.cs
@@ -1,0 +1,403 @@
+using System.Text;
+using System.Reflection;
+using System.Globalization;
+using System.Collections.Concurrent;
+using Bit.Bmotion.Demo.Server.Dtos;
+using Microsoft.AspNetCore.Components;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Builds the API reference the MCP tools serve, by reflecting over the public surface of the
+/// Bit.Bmotion assembly and pairing every type and member with its XML documentation.
+/// <para>
+/// Reflection rather than a hand-maintained table: the reference then cannot drift from the shipped
+/// library - a new component parameter shows up the moment it is written, with the default value it
+/// actually has (read off a freshly constructed instance) instead of one someone remembered to copy
+/// into a document. For an animation library that matters twice over, because the defaults
+/// <i>are</i> the behaviour: whether Damping is 10 or 20 is the difference between the motion an
+/// agent wrote and the motion it meant.
+/// </para>
+/// </summary>
+public static class BmotionApiCatalog
+{
+    private const BindingFlags Declared = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+    private static readonly Assembly _assembly = typeof(Bm).Assembly;
+
+    private static readonly Lazy<Type[]> _publicTypes = new(() =>
+        [.. _assembly.GetExportedTypes()
+            .Where(type => type.IsNested is false && type.Name.Contains('<', StringComparison.Ordinal) is false)
+            .OrderBy(type => type.Name, StringComparer.OrdinalIgnoreCase)]);
+
+    private static readonly ConcurrentDictionary<string, BmotionApiTypeDetailsDto> _typeDetails = new(StringComparer.Ordinal);
+
+    private static readonly Lazy<BmotionApiTypeDto[]> _types = new(() =>
+        [.. _publicTypes.Value.Select(type => new BmotionApiTypeDto
+        {
+            Name = FriendlyName(type),
+            Kind = KindOf(type),
+            Summary = BmotionXmlDocs.GetSummary(DocumentationId(type))
+        })]);
+
+    /// <summary>Every public type of Bit.Bmotion, with its summary.</summary>
+    public static BmotionApiTypeDto[] Types => _types.Value;
+
+    /// <summary>
+    /// The full reference of one type - its Blazor parameters, properties, methods, events or enum
+    /// values - or null when no public type goes by that name.
+    /// </summary>
+    public static BmotionApiTypeDetailsDto? GetTypeDetails(string typeName)
+    {
+        var type = Find(typeName);
+        if (type is null) return null;
+
+        // Every hit costs a full reflection walk plus an XML lookup per member, and the search index
+        // asks for all of them at once; the answer only changes when the assembly does.
+        return _typeDetails.GetOrAdd(type.FullName ?? type.Name, _ => BuildTypeDetails(type));
+    }
+
+    private static BmotionApiTypeDetailsDto BuildTypeDetails(Type type)
+    {
+        var instance = TryCreateInstance(type);
+
+        var members = new List<BmotionApiMemberDto>();
+
+        if (type.IsEnum)
+        {
+            members.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                                 .Select(field => new BmotionApiMemberDto
+                                 {
+                                     Name = field.Name,
+                                     Kind = "EnumValue",
+                                     Type = FriendlyName(type.GetEnumUnderlyingType()),
+                                     // Formatted straight off the raw constant: a [Flags] enum backed
+                                     // by ulong has members that do not fit in an Int64.
+                                     Default = Format(field.GetRawConstantValue()),
+                                     Summary = BmotionXmlDocs.GetSummary(DocumentationId(field)),
+                                     Remarks = BmotionXmlDocs.GetRemarks(DocumentationId(field))
+                                 }));
+        }
+        else
+        {
+            members.AddRange(Properties(type, instance));
+            members.AddRange(Fields(type));
+            members.AddRange(Methods(type));
+            members.AddRange(Events(type));
+        }
+
+        return new BmotionApiTypeDetailsDto
+        {
+            Name = FriendlyName(type),
+            FullName = type.FullName ?? type.Name,
+            Kind = KindOf(type),
+            BaseType = type.BaseType is null || type.BaseType == typeof(object) || type.BaseType == typeof(ValueType)
+                ? null
+                : FriendlyName(type.BaseType),
+            Implements = [.. type.GetInterfaces()
+                .Where(contract => contract.IsPublic && contract.DeclaringType is null)
+                .Select(FriendlyName)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)],
+            Summary = BmotionXmlDocs.GetSummary(DocumentationId(type)),
+            Remarks = BmotionXmlDocs.GetRemarks(DocumentationId(type)),
+            Members = [.. members.OrderBy(member => KindOrder(member.Kind)).ThenBy(member => member.Name, StringComparer.OrdinalIgnoreCase)]
+        };
+    }
+
+    /// <summary>Resolves a type by its simple name, with or without a generic arity or argument list.</summary>
+    private static Type? Find(string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName)) return null;
+
+        var name = typeName.Trim();
+
+        var generic = name.IndexOf('<', StringComparison.Ordinal);
+        if (generic > 0) name = name[..generic];
+
+        return _publicTypes.Value.FirstOrDefault(type => string.Equals(type.Name, name, StringComparison.OrdinalIgnoreCase))
+            ?? _publicTypes.Value.FirstOrDefault(type => string.Equals(StripArity(type.Name), name, StringComparison.OrdinalIgnoreCase))
+            ?? _publicTypes.Value.FirstOrDefault(type => string.Equals(type.FullName, name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The type and every base of it that Bit.Bmotion itself declares. A component's inherited
+    /// parameters belong in its reference; the members it gets from ComponentBase do not.
+    /// </summary>
+    private static IEnumerable<Type> Hierarchy(Type type)
+    {
+        for (var current = type; current is not null && current.Assembly == _assembly; current = current.BaseType)
+        {
+            yield return current;
+        }
+    }
+
+    private static IEnumerable<BmotionApiMemberDto> Properties(Type type, object? instance)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var property in Hierarchy(type).SelectMany(t => t.GetProperties(Declared)))
+        {
+            if (property.GetIndexParameters().Length > 0) continue;
+            if (seen.Add(property.Name) is false) continue;
+
+            var isParameter = property.IsDefined(typeof(ParameterAttribute), inherit: true);
+
+            yield return new BmotionApiMemberDto
+            {
+                Name = property.Name,
+                Kind = isParameter ? "Parameter" : "Property",
+                Type = FriendlyName(property.PropertyType),
+                Default = DefaultValueOf(property, instance),
+                Required = property.IsDefined(typeof(EditorRequiredAttribute), inherit: true),
+                Summary = BmotionXmlDocs.GetSummary(DocumentationId(property)),
+                Remarks = BmotionXmlDocs.GetRemarks(DocumentationId(property))
+            };
+        }
+    }
+
+    private static IEnumerable<BmotionApiMemberDto> Fields(Type type)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var field in Hierarchy(type).SelectMany(t => t.GetFields(Declared)))
+        {
+            if (field.Name.Contains('<', StringComparison.Ordinal)) continue;
+            if (seen.Add(field.Name) is false) continue;
+
+            yield return new BmotionApiMemberDto
+            {
+                Name = field.Name,
+                Kind = "Field",
+                Type = FriendlyName(field.FieldType),
+                Default = field.IsLiteral ? Format(field.GetRawConstantValue()) : null,
+                Summary = BmotionXmlDocs.GetSummary(DocumentationId(field)),
+                Remarks = BmotionXmlDocs.GetRemarks(DocumentationId(field))
+            };
+        }
+    }
+
+    private static IEnumerable<BmotionApiMemberDto> Methods(Type type)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in Hierarchy(type).SelectMany(t => t.GetMethods(Declared)))
+        {
+            if (method.IsSpecialName) continue;                                     // property/event accessors and operators
+            if (method.Name.Contains('<', StringComparison.Ordinal)) continue;
+            if (method.DeclaringType == typeof(object)) continue;
+
+            var signature = Signature(method);
+            if (seen.Add($"{method.Name}{signature}") is false) continue;
+
+            yield return new BmotionApiMemberDto
+            {
+                Name = method.Name,
+                Kind = "Method",
+                Type = FriendlyName(method.ReturnType),
+                Signature = signature,
+                Summary = BmotionXmlDocs.GetSummary(DocumentationId(method)),
+                Remarks = BmotionXmlDocs.GetRemarks(DocumentationId(method))
+            };
+        }
+    }
+
+    private static IEnumerable<BmotionApiMemberDto> Events(Type type)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var member in Hierarchy(type).SelectMany(t => t.GetEvents(Declared)))
+        {
+            if (seen.Add(member.Name) is false) continue;
+
+            yield return new BmotionApiMemberDto
+            {
+                Name = member.Name,
+                Kind = "Event",
+                Type = FriendlyName(member.EventHandlerType ?? typeof(void)),
+                Summary = BmotionXmlDocs.GetSummary(DocumentationId(member)),
+                Remarks = BmotionXmlDocs.GetRemarks(DocumentationId(member))
+            };
+        }
+    }
+
+    /// <summary>
+    /// The value a property holds on a newly constructed instance - the default a caller gets when
+    /// the parameter is left unset.
+    /// </summary>
+    private static string? DefaultValueOf(PropertyInfo property, object? instance)
+    {
+        if (property.GetMethod is null || property.GetMethod.IsPublic is false) return null;
+        if (property.GetMethod.IsStatic is false && instance is null) return null;
+
+        try
+        {
+            return Format(property.GetValue(property.GetMethod.IsStatic ? null : instance));
+        }
+        catch (Exception)
+        {
+            // Members that only make sense on a mounted component (or throw by design) simply have
+            // no observable default; that is not a reason to fail the whole type's reference.
+            return null;
+        }
+    }
+
+    private static object? TryCreateInstance(Type type)
+    {
+        if (type.IsAbstract || type.IsInterface || type.IsEnum) return null;
+        if (type.IsValueType is false && type.GetConstructor(Type.EmptyTypes) is null) return null;
+
+        try
+        {
+            return Activator.CreateInstance(type);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static string? Format(object? value) => value switch
+    {
+        null => null,
+        string text => $"\"{text}\"",
+        bool flag => flag ? "true" : "false",
+        Enum enumValue => $"{enumValue.GetType().Name}.{enumValue}",
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => Describe(value)
+    };
+
+    /// <summary>
+    /// A reference-typed default is worth reporting: a property that starts out holding an object is
+    /// not the same thing as one that starts out null.
+    /// </summary>
+    private static string Describe(object value)
+    {
+        var type = value.GetType();
+        var text = value.ToString();
+
+        return string.IsNullOrEmpty(text) || text == type.FullName || text == type.Name
+            ? $"new {FriendlyName(type)}()"
+            : text;
+    }
+
+    private static string Signature(MethodInfo method)
+    {
+        var builder = new StringBuilder("(");
+
+        var parameters = method.GetParameters();
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+
+            if (i > 0) builder.Append(", ");
+            if (i == 0 && method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false)) builder.Append("this ");
+            if (parameter.IsOut) builder.Append("out ");
+            else if (parameter.ParameterType.IsByRef) builder.Append("ref ");
+
+            builder.Append(FriendlyName(parameter.ParameterType)).Append(' ').Append(parameter.Name);
+
+            if (parameter.HasDefaultValue) builder.Append(" = ").Append(Format(parameter.DefaultValue) ?? "null");
+        }
+
+        return builder.Append(')').ToString();
+    }
+
+    private static string KindOf(Type type)
+    {
+        if (type.IsEnum) return "Enum";
+        // Before the IComponent test: an interface that extends IComponent is still an interface.
+        if (type.IsInterface) return "Interface";
+        if (typeof(IComponent).IsAssignableFrom(type)) return "Component";
+        if (typeof(Attribute).IsAssignableFrom(type)) return "Attribute";
+        if (typeof(MulticastDelegate).IsAssignableFrom(type)) return "Delegate";
+        if (type.IsAbstract && type.IsSealed) return "Static class";
+        if (type.IsValueType) return "Struct";
+        if (type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance) is not null) return "Record";
+
+        return "Class";
+    }
+
+    private static int KindOrder(string kind) => kind switch
+    {
+        "Parameter" => 0,
+        "Property" => 1,
+        "Field" => 2,
+        "EnumValue" => 3,
+        "Method" => 4,
+        "Event" => 5,
+        _ => 6
+    };
+
+    /// <summary>The C# spelling of a type: "double?", "string[]", "BmValue&lt;double&gt;".</summary>
+    public static string FriendlyName(Type type)
+    {
+        if (type.IsByRef) return FriendlyName(type.GetElementType()!);
+        if (type.IsArray) return $"{FriendlyName(type.GetElementType()!)}[]";
+
+        var nullable = Nullable.GetUnderlyingType(type);
+        if (nullable is not null) return $"{FriendlyName(nullable)}?";
+
+        if (type == typeof(void)) return "void";
+        if (type == typeof(object)) return "object";
+        if (type == typeof(string)) return "string";
+        if (type == typeof(bool)) return "bool";
+        if (type == typeof(int)) return "int";
+        if (type == typeof(long)) return "long";
+        if (type == typeof(double)) return "double";
+        if (type == typeof(float)) return "float";
+        if (type == typeof(decimal)) return "decimal";
+
+        if (type.IsGenericType is false) return type.Name;
+
+        var arguments = string.Join(", ", type.GetGenericArguments().Select(FriendlyName));
+
+        return $"{StripArity(type.Name)}<{arguments}>";
+    }
+
+    private static string StripArity(string name)
+    {
+        var arity = name.IndexOf('`', StringComparison.Ordinal);
+
+        return arity < 0 ? name : name[..arity];
+    }
+
+    private static string DocumentationId(Type type) => $"T:{type.FullName}";
+
+    private static string DocumentationId(PropertyInfo property) => $"P:{property.DeclaringType!.FullName}.{property.Name}";
+
+    private static string DocumentationId(FieldInfo field) => $"F:{field.DeclaringType!.FullName}.{field.Name}";
+
+    private static string DocumentationId(EventInfo member) => $"E:{member.DeclaringType!.FullName}.{member.Name}";
+
+    private static string DocumentationId(MethodInfo method)
+    {
+        var id = new StringBuilder("M:").Append(method.DeclaringType!.FullName).Append('.').Append(method.Name);
+
+        if (method.IsGenericMethodDefinition) id.Append("``").Append(method.GetGenericArguments().Length);
+
+        var parameters = method.GetParameters();
+        if (parameters.Length == 0) return id.ToString();
+
+        id.Append('(')
+          .Append(string.Join(',', parameters.Select(parameter => DocumentationTypeName(parameter.ParameterType))))
+          .Append(')');
+
+        return id.ToString();
+    }
+
+    /// <summary>Spells a type the way the C# compiler spells it inside a documentation id.</summary>
+    private static string DocumentationTypeName(Type type)
+    {
+        if (type.IsByRef) return $"{DocumentationTypeName(type.GetElementType()!)}@";
+        if (type.IsArray) return $"{DocumentationTypeName(type.GetElementType()!)}[]";
+        if (type.IsGenericParameter) return type.DeclaringMethod is null ? $"`{type.GenericParameterPosition}" : $"``{type.GenericParameterPosition}";
+
+        if (type.IsGenericType is false) return type.FullName ?? type.Name;
+
+        var definition = type.GetGenericTypeDefinition().FullName ?? type.Name;
+        var arguments = string.Join(',', type.GetGenericArguments().Select(DocumentationTypeName));
+
+        return $"{StripArity(definition)}{{{arguments}}}";
+    }
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
@@ -186,34 +186,57 @@ public static partial class BmotionCodeReview
     /// <summary>A &lt;Bmotion&gt; inside a loop with no @key: Blazor reuses elements across items.</summary>
     private static void CheckLoopKeys(string[] lines, List<BmotionReviewFindingDto> findings)
     {
-        var loopDepth = -1;
+        var loopStart = -1;
+        var braces = 0;
+        var bodyOpened = false;
 
         for (int i = 0; i < lines.Length; i++)
         {
-            if (LoopRegex().IsMatch(lines[i])) loopDepth = i;
-
-            // The loop body is assumed to be the dozen lines after the @foreach - enough for a
-            // realistic item template, short enough not to reach unrelated markup below it.
-            if (loopDepth < 0 || i - loopDepth > 12) continue;
-
-            if (lines[i].Contains("<Bmotion", StringComparison.Ordinal) is false) continue;
-
-            var window = string.Join('\n', lines[i..Math.Min(lines.Length, i + 4)]);
-
-            if (window.Contains("@key", StringComparison.Ordinal)) continue;
-
-            findings.Add(new BmotionReviewFindingDto
+            if (loopStart < 0)
             {
-                Severity = "Warning",
-                Rule = "missing-key-in-loop",
-                Line = i + 1,
-                Message = "An animated element inside a loop has no @key. Blazor reuses DOM elements between " +
-                          "renders, so when the collection changes an item's animation state carries over to " +
-                          "whatever item takes its place - entrances are skipped and exits play on the wrong row.",
-                Fix = "Add @key=\"item.Id\" (any stable identity) to the <Bmotion> element."
-            });
+                if (LoopRegex().IsMatch(lines[i]) is false) continue;
 
-            loopDepth = -1;
+                loopStart = i;
+                braces = 0;
+                bodyOpened = false;
+            }
+
+            if (lines[i].Contains("<Bmotion", StringComparison.Ordinal))
+            {
+                var window = string.Join('\n', lines[i..Math.Min(lines.Length, i + 4)]);
+
+                if (window.Contains("@key", StringComparison.Ordinal) is false)
+                {
+                    findings.Add(new BmotionReviewFindingDto
+                    {
+                        Severity = "Warning",
+                        Rule = "missing-key-in-loop",
+                        Line = i + 1,
+                        Message = "An animated element inside a loop has no @key. Blazor reuses DOM elements between " +
+                                  "renders, so when the collection changes an item's animation state carries over to " +
+                                  "whatever item takes its place - entrances are skipped and exits play on the wrong row.",
+                        Fix = "Add @key=\"item.Id\" (any stable identity) to the <Bmotion> element."
+                    });
+
+                    loopStart = -1;
+
+                    continue;
+                }
+            }
+
+            // Where the loop body ends. Tracking its braces rather than counting lines is what keeps
+            // the rule off the markup *after* a correctly keyed loop - the else branch of the @if
+            // around it is not a second iteration of anything, and reporting it there is the kind of
+            // false positive that teaches an agent to stop reading the review.
+            foreach (var c in lines[i])
+            {
+                if (c == '{') { braces++; bodyOpened = true; }
+                else if (c == '}') braces--;
+            }
+
+            // The line cap stays as the backstop for a body this cannot read - one whose braces sit
+            // inside a Razor expression, or a single-line body written without any.
+            if ((bodyOpened && braces <= 0) || i - loopStart > 12) loopStart = -1;
         }
     }
 

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
@@ -515,7 +515,11 @@ public static partial class BmotionCodeReview
     [GeneratedRegex(@"^\s*<(?<tag>[A-Za-z][\w.]*)")]
     private static partial Regex FirstChildTagRegex();
 
-    [GeneratedRegex(@"\bBm\.To\s*\((?<args>[^()]*(\([^()]*\))?[^()]*)\)")]
+    // The two runs of non-parenthesis text around the optional nested call are ambiguous, so a
+    // Bm.To( that is never closed - which is exactly what half-written code under review looks like -
+    // makes the backtracking engine walk the line quadratically. NonBacktracking matches the same
+    // strings in one pass.
+    [GeneratedRegex(@"\bBm\.To\s*\((?<args>[^()]*(\([^()]*\))?[^()]*)\)", RegexOptions.NonBacktracking)]
     private static partial Regex TargetCallRegex();
 
     [GeneratedRegex(@"(?<name>[a-zA-Z][a-zA-Z0-9]*)\s*:")]

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
@@ -166,8 +166,13 @@ public static partial class BmotionCodeReview
             if (tag.Contains("Animate=", StringComparison.Ordinal) is false) continue;
             if (tag.Contains("Initial=", StringComparison.Ordinal)) continue;
             // An element whose Animate is bound to state animates when that state changes, which is
-            // a different (and correct) pattern from an entrance.
-            if (tag.Contains("@(", StringComparison.Ordinal) || tag.Contains("_", StringComparison.Ordinal)) continue;
+            // a different (and correct) pattern from an entrance. Only the bound Animate value says
+            // so: an underscore in a CSS class or in an unrelated attribute is not state.
+            if (tag.Contains("@(", StringComparison.Ordinal)) continue;
+
+            var animate = AnimateValueRegex().Match(tag);
+
+            if (animate.Success && PrivateFieldRegex().IsMatch(animate.Groups["value"].Value)) continue;
 
             findings.Add(new BmotionReviewFindingDto
             {
@@ -514,6 +519,13 @@ public static partial class BmotionCodeReview
 
     [GeneratedRegex(@"^\s*<(?<tag>[A-Za-z][\w.]*)")]
     private static partial Regex FirstChildTagRegex();
+
+    [GeneratedRegex(@"\bAnimate\s*=\s*""(?<value>[^""]*)""")]
+    private static partial Regex AnimateValueRegex();
+
+    /// <summary>A reference to a private field - the convention Blazor component state is written in.</summary>
+    [GeneratedRegex(@"(?<!\w)_\w")]
+    private static partial Regex PrivateFieldRegex();
 
     // The two runs of non-parenthesis text around the optional nested call are ambiguous, so a
     // Bm.To( that is never closed - which is exactly what half-written code under review looks like -

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionCodeReview.cs
@@ -1,0 +1,506 @@
+using Bit.Bmotion.Demo.Server.Dtos;
+using System.Text.RegularExpressions;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Reviews a piece of Bmotion markup for the mistakes that compile cleanly and then do nothing.
+/// <para>
+/// Almost every way of getting Bmotion wrong is silent. An <c>Exit</c> without a presence component
+/// around it is valid Razor that never plays, because Blazor removed the element before the
+/// animation could start. <c>Bm.Spring(duration: 0.5)</c> is a valid call whose duration the engine
+/// ignores. A <c>&lt;Bmotion&gt;</c> in a <c>@foreach</c> without a <c>@key</c> animates the wrong
+/// rows when the list changes. None of these produce a warning from the compiler, a message in the
+/// console, or an exception - the page simply does not move, or moves wrongly, and the usual next
+/// step is to add more animation code on top of the part that was never running.
+/// </para>
+/// <para>
+/// This is the pass that closes the loop after an agent writes code: generate, review, fix. Each
+/// finding names the rule, the line, and the correction - so it can be acted on without another
+/// round of searching.
+/// </para>
+/// </summary>
+public static partial class BmotionCodeReview
+{
+    /// <summary>The rules this review applies, so an empty result is not mistaken for an unchecked one.</summary>
+    public static readonly string[] Rules =
+    [
+        "exit-without-presence",
+        "spring-duration-without-bounce",
+        "animate-without-initial",
+        "missing-key-in-loop",
+        "nested-quotes-in-attribute",
+        "component-as-animated-root",
+        "empty-bmotion",
+        "frame-loop-only-properties",
+        "drag-without-capability-guard",
+        "eased-infinite-rotation",
+        "resting-state-in-gesture",
+        "reduced-motion-not-configured",
+    ];
+
+    /// <summary>Reviews Razor or C# source and reports what will not work as written.</summary>
+    public static BmotionReviewDto Review(string? code)
+    {
+        var text = code ?? string.Empty;
+        var findings = new List<BmotionReviewFindingDto>();
+
+        if (text.Trim().Length == 0)
+        {
+            return new BmotionReviewDto
+            {
+                Passed = true,
+                Findings = [],
+                RulesApplied = Rules
+            };
+        }
+
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+
+        var hasPresence = text.Contains("BmotionAnimatePresence", StringComparison.Ordinal)
+                       || text.Contains("BmotionPresenceGroup", StringComparison.Ordinal)
+                       || text.Contains("BmotionPresenceSwitch", StringComparison.Ordinal);
+
+        CheckExit(lines, hasPresence, findings);
+        CheckSpringDuration(lines, findings);
+        CheckInitial(text, lines, findings);
+        CheckLoopKeys(lines, findings);
+        CheckNestedQuotes(lines, findings);
+        CheckAnimatedRoot(lines, findings);
+        CheckEmptyBmotion(lines, findings);
+        CheckFrameLoopProperties(lines, findings);
+        CheckDragGuard(text, lines, findings);
+        CheckEasedRotation(lines, findings);
+        CheckRestingStateInGesture(lines, findings);
+        CheckReducedMotion(text, lines, findings);
+
+        var ordered = findings
+            .OrderBy(finding => SeverityOrder(finding.Severity))
+            .ThenBy(finding => finding.Line ?? int.MaxValue)
+            .ToArray();
+
+        return new BmotionReviewDto
+        {
+            Passed = ordered.Any(finding => finding.Severity != "Suggestion") is false,
+            Findings = ordered,
+            RulesApplied = Rules
+        };
+    }
+
+    /// <summary>
+    /// An Exit target with nothing to hold the element in the DOM while it plays. This is the single
+    /// most common Bmotion bug, and it looks exactly like an animation that "does not work".
+    /// </summary>
+    private static void CheckExit(string[] lines, bool hasPresence, List<BmotionReviewFindingDto> findings)
+    {
+        if (hasPresence) return;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (ExitAttributeRegex().IsMatch(lines[i]) is false) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Error",
+                Rule = "exit-without-presence",
+                Line = i + 1,
+                Message = "Exit is set, but nothing in this markup keeps the element alive while the exit animation " +
+                          "plays. Blazor removes the element as soon as the condition changes, so Exit never runs.",
+                Fix = "Wrap the element in <BmotionAnimatePresence IsPresent=\"...\">, or use BmotionPresenceGroup " +
+                      "for a list and BmotionPresenceSwitch when one item replaces another."
+            });
+        }
+    }
+
+    /// <summary>
+    /// A spring given a duration but no bounce. The duration is only used to derive stiffness and
+    /// damping when bounce is present, so on its own it is silently ignored.
+    /// </summary>
+    private static void CheckSpringDuration(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            foreach (Match match in SpringCallRegex().Matches(lines[i]))
+            {
+                var arguments = match.Groups["args"].Value;
+
+                if (arguments.Contains("duration", StringComparison.OrdinalIgnoreCase) is false) continue;
+                if (arguments.Contains("bounce", StringComparison.OrdinalIgnoreCase)) continue;
+
+                findings.Add(new BmotionReviewFindingDto
+                {
+                    Severity = "Warning",
+                    Rule = "spring-duration-without-bounce",
+                    Line = i + 1,
+                    Message = "Bm.Spring(duration: ...) without a bounce does not set the spring's length. Duration " +
+                              "is only used to derive stiffness and damping when bounce is given as well; on its " +
+                              "own it is ignored, and the spring runs at its default stiffness of 100 and damping " +
+                              "of 10.",
+                    Fix = "Pass both - Bm.Spring(bounce: 0.2, duration: 0.5) - or configure the physics directly " +
+                          "with Bm.Spring(stiffness: ..., damping: ...). Use SimulateBmotionTransition to see how " +
+                          "long the result actually takes."
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// An Animate target with no Initial. The element is already at its resting state when it
+    /// mounts, so there is nothing to animate from and the entrance never happens.
+    /// </summary>
+    private static void CheckInitial(string text, string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        // Only for markup that is clearly an entrance: a variant-driven or state-driven element
+        // animates on change instead, and gesture overlays have their own resting state.
+        if (text.Contains("Variants", StringComparison.Ordinal)) return;
+        if (text.Contains("Timeline", StringComparison.Ordinal)) return;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var match = BmotionOpenTagRegex().Match(string.Join('\n', lines[i..Math.Min(lines.Length, i + 12)]));
+
+            if (match.Success is false || match.Index > lines[i].Length) continue;
+
+            var tag = match.Value;
+
+            if (tag.Contains("Animate=", StringComparison.Ordinal) is false) continue;
+            if (tag.Contains("Initial=", StringComparison.Ordinal)) continue;
+            // An element whose Animate is bound to state animates when that state changes, which is
+            // a different (and correct) pattern from an entrance.
+            if (tag.Contains("@(", StringComparison.Ordinal) || tag.Contains("_", StringComparison.Ordinal)) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Suggestion",
+                Rule = "animate-without-initial",
+                Line = i + 1,
+                Message = "Animate is set to a constant target with no Initial. The element mounts already at that " +
+                          "target, so nothing animates on the first render.",
+                Fix = "Add an Initial for the state to animate from, e.g. Initial=\"Bm.To(opacity: 0, y: 20)\". " +
+                      "If the animation is meant to run on a state change rather than on mount, bind Animate to " +
+                      "that state instead."
+            });
+        }
+    }
+
+    /// <summary>A &lt;Bmotion&gt; inside a loop with no @key: Blazor reuses elements across items.</summary>
+    private static void CheckLoopKeys(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        var loopDepth = -1;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (LoopRegex().IsMatch(lines[i])) loopDepth = i;
+
+            // The loop body is assumed to be the dozen lines after the @foreach - enough for a
+            // realistic item template, short enough not to reach unrelated markup below it.
+            if (loopDepth < 0 || i - loopDepth > 12) continue;
+
+            if (lines[i].Contains("<Bmotion", StringComparison.Ordinal) is false) continue;
+
+            var window = string.Join('\n', lines[i..Math.Min(lines.Length, i + 4)]);
+
+            if (window.Contains("@key", StringComparison.Ordinal)) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Warning",
+                Rule = "missing-key-in-loop",
+                Line = i + 1,
+                Message = "An animated element inside a loop has no @key. Blazor reuses DOM elements between " +
+                          "renders, so when the collection changes an item's animation state carries over to " +
+                          "whatever item takes its place - entrances are skipped and exits play on the wrong row.",
+                Fix = "Add @key=\"item.Id\" (any stable identity) to the <Bmotion> element."
+            });
+
+            loopDepth = -1;
+        }
+    }
+
+    /// <summary>
+    /// A Razor attribute delimited by double quotes whose value contains a string literal. The
+    /// attribute ends at the inner quote, so the markup means something other than it looks like.
+    /// </summary>
+    private static void CheckNestedQuotes(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            foreach (Match match in DoubleQuotedAttributeRegex().Matches(lines[i]))
+            {
+                var value = match.Groups["value"].Value;
+
+                if (value.Contains("Bm.", StringComparison.Ordinal) is false) continue;
+
+                // The value as Razor sees it ends at the next double quote. If the Bm call inside it
+                // still has an unclosed parenthesis at that point, the attribute was cut short by a
+                // quote that was meant to be part of the value - a colour, a CSS length, a path.
+                var depth = 0;
+
+                foreach (var c in value)
+                {
+                    if (c == '(') depth++;
+                    else if (c == ')') depth--;
+                }
+
+                if (depth <= 0) continue;
+
+                var name = match.Groups["name"].Value;
+
+                findings.Add(new BmotionReviewFindingDto
+                {
+                    Severity = "Error",
+                    Rule = "nested-quotes-in-attribute",
+                    Line = i + 1,
+                    Message = $"The {name} attribute is delimited by double quotes and its value contains a " +
+                              "double-quoted string. Razor ends the attribute at that inner quote, so the call is " +
+                              "left unclosed and the markup does not mean what it looks like.",
+                    Fix = $"Single-quote the attribute instead: {name}='Bm.To(...)', keeping the double-quoted " +
+                          "literal inside it."
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// A component as the first child of &lt;Bmotion&gt;. The engine injects its id and initial style
+    /// into the first root HTML element, and a component is not one.
+    /// </summary>
+    private static void CheckAnimatedRoot(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].TrimStart().StartsWith("<Bmotion", StringComparison.Ordinal) is false) continue;
+
+            // The child is the next non-blank line that opens a tag, once the opening tag has closed.
+            for (int j = i; j < Math.Min(lines.Length, i + 8); j++)
+            {
+                if (lines[j].Contains('>', StringComparison.Ordinal) is false) continue;
+
+                var child = FirstChildTagRegex().Match(string.Join('\n', lines[(j + 1)..Math.Min(lines.Length, j + 3)]));
+
+                if (child.Success is false) break;
+
+                var name = child.Groups["tag"].Value;
+
+                // A component is PascalCase; an HTML element is not. Bmotion's own components are
+                // excluded: nesting them is normal and they resolve to elements of their own.
+                if (char.IsUpper(name[0]) is false || name.StartsWith("Bmotion", StringComparison.Ordinal)) break;
+
+                findings.Add(new BmotionReviewFindingDto
+                {
+                    Severity = "Warning",
+                    Rule = "component-as-animated-root",
+                    Line = j + 2,
+                    Message = $"The first child of <Bmotion> is the component <{name}>, not an HTML element. " +
+                              "Bmotion injects the engine id and the initial inline style into the first root HTML " +
+                              "element of its content, so there is nothing here for it to animate.",
+                    Fix = $"Wrap it in a plain element - <div><{name} /></div> - or move the <Bmotion> inside " +
+                          $"{name} around the element that should actually move."
+                });
+
+                break;
+            }
+        }
+    }
+
+    /// <summary>A self-closed &lt;Bmotion /&gt;: it wraps the element it animates, so it needs one.</summary>
+    private static void CheckEmptyBmotion(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (SelfClosedBmotionRegex().IsMatch(lines[i]) is false) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Error",
+                Rule = "empty-bmotion",
+                Line = i + 1,
+                Message = "<Bmotion /> is self-closed, so it has no content. Bmotion animates the element written " +
+                          "inside it; with no child there is nothing on the page for it to touch.",
+                Fix = "Put the element inside it: <Bmotion ...><div class=\"box\" /></Bmotion>."
+            });
+        }
+    }
+
+    /// <summary>
+    /// Properties the browser compositor cannot own. They animate on WebAssembly and jump on Blazor
+    /// Server, which is a difference no build output will point out.
+    /// </summary>
+    private static void CheckFrameLoopProperties(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        var reported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            foreach (Match match in TargetCallRegex().Matches(lines[i]))
+            {
+                foreach (Match argument in ArgumentNameRegex().Matches(match.Groups["args"].Value))
+                {
+                    var name = argument.Groups["name"].Value;
+
+                    if (name is "transition") continue;
+                    if (BmotionPropertyCatalog.IsCompositorProperty(name)) continue;
+                    if (reported.Add(name) is false) continue;
+
+                    findings.Add(new BmotionReviewFindingDto
+                    {
+                        Severity = "Suggestion",
+                        Rule = "frame-loop-only-properties",
+                        Line = i + 1,
+                        Message = $"'{name}' cannot be handed to the browser compositor, so this animation runs on " +
+                                  "the C# per-frame loop. That is fine on Blazor WebAssembly, and on Blazor Server " +
+                                  "it becomes an instant jump to the target.",
+                        Fix = "Ignore this if the app is WebAssembly-only. Otherwise animate x, y, scale, rotate " +
+                              "and opacity instead, and confirm with AnalyzeBmotionAnimation."
+                    });
+                }
+            }
+        }
+    }
+
+    /// <summary>Drag on a page that may be served over Blazor Server, with nothing to say so.</summary>
+    private static void CheckDragGuard(string text, string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        if (text.Contains("SupportsFrameLoop", StringComparison.Ordinal)) return;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (DragAttributeRegex().IsMatch(lines[i]) is false) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Suggestion",
+                Rule = "drag-without-capability-guard",
+                Line = i + 1,
+                Message = "Drag needs the synchronous per-frame loop, so it only works on Blazor WebAssembly. On " +
+                          "Blazor Server the element simply does not move when the user tries to drag it, which " +
+                          "reads as a broken page rather than as an unavailable feature.",
+                Fix = "If this page can ever render on Server, gate it: inject BmotionCapabilities and check " +
+                      "Caps.SupportsFrameLoop, giving the Server path a non-dragging equivalent.",
+            });
+
+            break;
+        }
+    }
+
+    /// <summary>An endlessly repeating rotation with an easing - the stutter every spinner has.</summary>
+    private static void CheckEasedRotation(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains("rotate:", StringComparison.Ordinal) is false) continue;
+
+            var window = string.Join('\n', lines[i..Math.Min(lines.Length, i + 4)]);
+
+            if (window.Contains("BmRepeat.Forever", StringComparison.Ordinal) is false &&
+                window.Contains("BmRepeat.Loop()", StringComparison.Ordinal) is false) continue;
+
+            if (window.Contains("BmEase.Linear", StringComparison.Ordinal)) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Warning",
+                Rule = "eased-infinite-rotation",
+                Line = i + 1,
+                Message = "A continuously repeating rotation without BmEase.Linear speeds up and slows down once " +
+                          "per revolution, so the spinner visibly stutters at the seam. Bm.Tween defaults to " +
+                          "BmEase.Out, which is the wrong curve for looping motion.",
+                Fix = "Pass BmEase.Linear: Bm.Tween(1, BmEase.Linear, repeat: BmRepeat.Forever)."
+            });
+
+            break;
+        }
+    }
+
+    /// <summary>A gesture overlay that also writes the resting state, which the overlay restores anyway.</summary>
+    private static void CheckRestingStateInGesture(string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains("WhileHover", StringComparison.Ordinal) is false &&
+                lines[i].Contains("WhileTap", StringComparison.Ordinal) is false) continue;
+
+            if (RestingScaleRegex().IsMatch(lines[i]) is false) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Suggestion",
+                Rule = "resting-state-in-gesture",
+                Line = i + 1,
+                Message = "A gesture overlay is set to the element's resting value (scale: 1). Gesture overlays " +
+                          "revert on their own when the gesture ends, so this has no effect beyond what already " +
+                          "happens.",
+                Fix = "Give the gesture the state it should move TO, and let it revert by itself."
+            });
+        }
+    }
+
+    /// <summary>Registration that never states a reduced-motion policy.</summary>
+    private static void CheckReducedMotion(string text, string[] lines, List<BmotionReviewFindingDto> findings)
+    {
+        if (text.Contains("AddBitBmotionServices", StringComparison.Ordinal) is false) return;
+        if (text.Contains("ReducedMotion", StringComparison.Ordinal)) return;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains("AddBitBmotionServices", StringComparison.Ordinal) is false) continue;
+
+            findings.Add(new BmotionReviewFindingDto
+            {
+                Severity = "Suggestion",
+                Rule = "reduced-motion-not-configured",
+                Line = i + 1,
+                Message = "No reduced-motion policy is set, so the library keeps its back-compatible default " +
+                          "(IgnoreUnlessConfigured), which consults the operating system preference only inside a " +
+                          "<BmotionConfig>. Users who have asked their system for less motion will get the full " +
+                          "animations everywhere else.",
+                Fix = "AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMode.User) - the web-platform " +
+                      "default. Reduced motion still animates opacity and colour, so the interface stays legible."
+            });
+
+            break;
+        }
+    }
+
+    private static int SeverityOrder(string severity) => severity switch
+    {
+        "Error" => 0,
+        "Warning" => 1,
+        _ => 2
+    };
+
+    [GeneratedRegex(@"\bExit\s*=")]
+    private static partial Regex ExitAttributeRegex();
+
+    [GeneratedRegex(@"\bBm\.Spring\s*\((?<args>[^()]*)\)")]
+    private static partial Regex SpringCallRegex();
+
+    [GeneratedRegex(@"<Bmotion\b[^>]*>", RegexOptions.Singleline)]
+    private static partial Regex BmotionOpenTagRegex();
+
+    [GeneratedRegex(@"<Bmotion\b[^>]*/>", RegexOptions.Singleline)]
+    private static partial Regex SelfClosedBmotionRegex();
+
+    [GeneratedRegex(@"@(foreach|for)\s*\(")]
+    private static partial Regex LoopRegex();
+
+    // A double-quoted attribute and the value Razor would read out of it - everything up to the next
+    // double quote, which is exactly where a nested literal cuts the value short.
+    [GeneratedRegex(@"\b(?<name>Initial|Animate|Exit|While\w+|Transition|Variants|DragConstraints|Viewport)\s*=\s*""(?<value>[^""]*)""")]
+    private static partial Regex DoubleQuotedAttributeRegex();
+
+    [GeneratedRegex(@"^\s*<(?<tag>[A-Za-z][\w.]*)")]
+    private static partial Regex FirstChildTagRegex();
+
+    [GeneratedRegex(@"\bBm\.To\s*\((?<args>[^()]*(\([^()]*\))?[^()]*)\)")]
+    private static partial Regex TargetCallRegex();
+
+    [GeneratedRegex(@"(?<name>[a-zA-Z][a-zA-Z0-9]*)\s*:")]
+    private static partial Regex ArgumentNameRegex();
+
+    [GeneratedRegex(@"\bDrag\s*=\s*""(?!false)")]
+    private static partial Regex DragAttributeRegex();
+
+    [GeneratedRegex(@"While(Hover|Tap)\s*=\s*['""]Bm\.To\([^)]*\bscale:\s*1\s*[,)]")]
+    private static partial Regex RestingScaleRegex();
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionEasingCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionEasingCatalog.cs
@@ -45,7 +45,20 @@ public static class BmotionEasingCatalog
 
         foreach (var ease in Enum.GetValues<BmEase>())
         {
-            var curve = await BmotionMotionLab.SampleEaseAsync(ease);
+            double[] curve;
+
+            try
+            {
+                curve = await BmotionMotionLab.SampleEaseAsync(ease);
+            }
+            catch (Exception)
+            {
+                // Same reasoning as BmotionPropertyCatalog: this list is built once for the life of
+                // the process. A preset that would not sample is left out rather than described with
+                // a curve nobody measured, and every other preset still answers.
+                continue;
+            }
+
             var name = ease.ToString();
 
             easings.Add(new BmotionEasingDto

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionEasingCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionEasingCatalog.cs
@@ -1,0 +1,129 @@
+using System.Collections.Frozen;
+using Bit.Bmotion.Demo.Server.Dtos;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Every <see cref="BmEase"/> preset, with the shape of its curve measured rather than described.
+/// <para>
+/// "BackOut" and "Anticipate" mean nothing to a model that has never seen them plotted, and the
+/// difference between QuadOut and ExpoOut is the entire question when choosing one. So each preset
+/// here is run through the real easing implementation - a one-second tween from 0 to 1, sampled at
+/// eleven points - which turns the choice into numbers an agent can reason about, and reveals the
+/// property that actually decides whether a preset is usable in a given place: whether it leaves
+/// the 0-1 range, and therefore whether the element overshoots.
+/// </para>
+/// </summary>
+public static class BmotionEasingCatalog
+{
+    private static readonly Lazy<Task<BmotionEasingDto[]>> _easings = new(BuildAsync);
+
+    // What each family feels like. The numbers come from the library; these words are the part a
+    // measurement cannot supply - when to reach for it.
+    private static readonly FrozenDictionary<string, string> _feel = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["Linear"] = "No acceleration at all. Right for continuous motion - a spinner, a marquee, a progress bar - and wrong for anything that starts or stops, where it reads as mechanical.",
+        ["Sine"] = "The gentlest curve there is. Good for slow, ambient motion that should not draw attention.",
+        ["Quad"] = "A mild acceleration. The safe default when Out is not quite enough.",
+        ["Cubic"] = "The standard interface curve - what In, Out and InOut approximate.",
+        ["Quart"] = "A firm acceleration: slow to leave, quick to arrive.",
+        ["Quint"] = "Sharper still. The element barely moves, then rushes.",
+        ["Expo"] = "The most extreme non-overshooting curve. Dramatic entrances; too much for anything that repeats.",
+        ["Circ"] = "Flat then suddenly steep, like the edge of a circle. Mechanical and precise.",
+        ["Back"] = "Pulls back before going, or overshoots on arrival. The cheapest way to make an element feel physical without a spring.",
+        ["Elastic"] = "Oscillates around the target like a plucked string. Playful, and distracting on anything the user sees often.",
+        ["Bounce"] = "Lands, bounces, lands again. Reads as a falling object; almost never right for interface chrome.",
+        ["Anticipate"] = "A small wind-up before the move. Signals intent, which makes the motion feel deliberate.",
+    }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>Every easing preset, with its measured curve.</summary>
+    public static Task<BmotionEasingDto[]> GetAsync() => _easings.Value;
+
+    private static async Task<BmotionEasingDto[]> BuildAsync()
+    {
+        var easings = new List<BmotionEasingDto>();
+
+        foreach (var ease in Enum.GetValues<BmEase>())
+        {
+            var curve = await BmotionMotionLab.SampleEaseAsync(ease);
+            var name = ease.ToString();
+
+            easings.Add(new BmotionEasingDto
+            {
+                Name = name,
+                Direction = DirectionOf(name),
+                Family = FamilyOf(name),
+                Feel = _feel.GetValueOrDefault(FamilyOf(name), "A named easing curve.") + " " + DirectionNote(DirectionOf(name)),
+                Curve = [.. curve.Select(value => Math.Round(value, 4))],
+                Sparkline = Sparkline(curve),
+                // A curve that leaves 0-1 moves the element past its target and back. That is the
+                // single fact which decides whether a preset can be used on something that must not
+                // appear to move beyond its bounds - a drawer, a modal, anything with a hard edge.
+                Overshoots = curve.Any(value => value < -0.001 || value > 1.001)
+            });
+        }
+
+        return [.. easings];
+    }
+
+    /// <summary>
+    /// Draws the curve as text. Read left to right it is time; the height is progress toward the
+    /// target, with the top of the range being the furthest the curve travels - so an overshooting
+    /// preset visibly rises above where it settles.
+    /// </summary>
+    private static string Sparkline(double[] curve)
+    {
+        const string Blocks = "_.-=+*#%@";
+
+        if (curve.Length == 0) return string.Empty;
+
+        var min = Math.Min(0, curve.Min());
+        var max = Math.Max(1, curve.Max());
+        var range = max - min;
+
+        return string.Concat(curve.Select(value =>
+        {
+            var level = range > 0 ? (value - min) / range : 0;
+
+            return Blocks[Math.Clamp((int)Math.Round(level * (Blocks.Length - 1)), 0, Blocks.Length - 1)];
+        }));
+    }
+
+    private static string DirectionOf(string name)
+    {
+        if (name == "Linear") return "Linear";
+        if (name.EndsWith("InOut", StringComparison.Ordinal)) return "InOut";
+        if (name.EndsWith("Out", StringComparison.Ordinal)) return "Out";
+        if (name.EndsWith("In", StringComparison.Ordinal)) return "In";
+
+        return "Custom";
+    }
+
+    private static string FamilyOf(string name)
+    {
+        if (name == "Linear" || name == "Anticipate") return name;
+
+        var family = name;
+
+        foreach (var suffix in new[] { "InOut", "Out", "In" })
+        {
+            if (family.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                family = family[..^suffix.Length];
+                break;
+            }
+        }
+
+        // The bare In / Out / InOut members are the library's default cubic bezier curves.
+        return family.Length == 0 ? "Cubic" : family;
+    }
+
+    private static string DirectionNote(string direction) => direction switch
+    {
+        "In" => "Accelerating: slow to start, fastest at the end - use it for something leaving the screen.",
+        "Out" => "Decelerating: fastest at the start, easing into the target - the right default for something arriving.",
+        "InOut" => "Both ends eased - the right choice when the element starts and stops on screen.",
+        "Linear" => string.Empty,
+        _ => "A shaped curve rather than a plain direction."
+    };
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionMotionLab.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionMotionLab.cs
@@ -1,0 +1,505 @@
+using System.Globalization;
+using Bit.Bmotion.Demo.Server.Dtos;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Runs Bit.Bmotion off-screen, so the MCP tools can answer questions about motion with measurements.
+/// <para>
+/// Two questions about an animation cannot be answered by reading documentation, and an agent that
+/// guesses at either produces code that looks right and feels wrong:
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>What does this transition actually do?</b> A spring has no duration argument - how long it
+///     takes and how far it overshoots fall out of the physics. <see cref="SimulateAsync"/> plays
+///     the transition on the real driver and reports the settle time, the overshoot and the shape.
+///   </description></item>
+///   <item><description>
+///     <b>Will it play on Blazor Server?</b> Only animations the browser compositor can own do; the
+///     rest need the per-frame loop and collapse to an instant change. The rule set behind that
+///     decision is long and lives in the engine. <see cref="AnalyzePlaybackAsync"/> asks the engine
+///     instead of restating it: it starts the animation and watches which path the engine takes.
+///   </description></item>
+/// </list>
+/// <para>
+/// Every run gets its own engine and its own <see cref="HeadlessBmotionInterop"/>, so one
+/// simulation cannot see another's elements, and the frame clock starts at zero each time.
+/// </para>
+/// </summary>
+public static class BmotionMotionLab
+{
+    /// <summary>The frame interval the browser would tick at - 60 fps, the resolution of the answer.</summary>
+    private const double FrameMs = 1000.0 / 60;
+
+    /// <summary>
+    /// The longest motion that will be simulated. A badly conditioned spring (very low damping) can
+    /// ring for a long time; past this the answer is "it does not settle", which is the useful
+    /// finding, and there is no reason to spend the frames proving it further.
+    /// </summary>
+    private const double MaxSeconds = 20;
+
+    /// <summary>How many evenly spaced samples come back, regardless of how long the motion ran.</summary>
+    private const int SampleCount = 24;
+
+    /// <summary>
+    /// Plays <paramref name="transition"/> from <paramref name="from"/> to <paramref name="to"/> on
+    /// the library's own driver and measures the result.
+    /// </summary>
+    /// <param name="spec">The transition spec as written by the caller, e.g. "spring(stiffness: 260, damping: 12)".</param>
+    /// <param name="from">The starting value.</param>
+    /// <param name="to">The target value.</param>
+    public static async Task<BmotionSimulationDto> SimulateAsync(string? spec, double from = 0, double to = 100)
+    {
+        var parsed = BmotionTransitionSpec.Parse(spec);
+
+        // A spec that could not be read is a correctable mistake, not a failure: handing it back as
+        // data keeps the explanation intact. Thrown instead, MCP reduces it to "an error occurred
+        // invoking SimulateBmotionTransition", and the caller learns nothing about how to fix it.
+        if (parsed.Transition is null) return Unreadable(spec, parsed.Error, from, to);
+
+        var warnings = new List<string>(parsed.Warnings);
+        var transition = parsed.Transition;
+
+        // An endless animation has no settle time to measure, and pumping it would only stop at the
+        // frame cap. Measure one pass instead and say so - the shape is what the caller is after.
+        if (transition.Repeat is { IsForever: true })
+        {
+            transition.Repeat = null;
+            warnings.Add("The repeat was dropped for this simulation: an endless animation has no settle time. " +
+                         "The numbers below describe one pass of it.");
+        }
+
+        var (frames, settled) = await RecordAsync(transition, from, to);
+
+        // Inertia has no target: it decelerates from its velocity and rests wherever the physics
+        // puts it. Measuring it against the caller's "to" would report a meaningless overshoot, so
+        // the measurement is retargeted at where it actually stopped and the caller is told why.
+        if (transition is BmInertia && frames.Count > 0)
+        {
+            warnings.Add($"Inertia ignores the target: it decelerates from its velocity and comes to rest " +
+                         $"wherever that puts it - here at {frames[^1].Value:0.##}, not at {to:0.##}. The numbers " +
+                         "below measure the glide to that resting point.");
+
+            to = frames[^1].Value;
+        }
+
+        if (settled is false)
+        {
+            warnings.Add($"The motion had not come to rest after {MaxSeconds:0} seconds. That is almost always " +
+                         "too little damping for the stiffness - raise 'damping', or switch to bounce/duration, " +
+                         "which cannot be configured into a spring that never settles.");
+        }
+
+        return Measure(parsed.Canonical, KindOf(transition), from, to, frames, warnings);
+    }
+
+    /// <summary>
+    /// Samples one <see cref="BmEase"/> preset by running a one-second tween through it and reading
+    /// the value back at <paramref name="points"/> evenly spaced instants.
+    /// <para>
+    /// The curve therefore comes from the library's own easing implementation rather than from a
+    /// formula restated here - which matters most for exactly the presets nobody can picture:
+    /// whether BackOut overshoots by 5% or 15%, and where BounceOut lands between its steps.
+    /// </para>
+    /// </summary>
+    public static async Task<double[]> SampleEaseAsync(BmEase ease, int points = 11)
+    {
+        var (frames, _) = await RecordAsync(new BmTween { Duration = 1, Ease = ease }, 0, 1);
+
+        if (frames.Count == 0) return [];
+
+        var curve = new double[points];
+
+        for (int i = 0; i < points; i++)
+        {
+            var at = (double)i / (points - 1);
+
+            // The frames land on the 60 fps grid, not on the tenths being asked about, so the value
+            // between two of them is interpolated the way the browser would show it.
+            curve[i] = ValueAt(frames, at);
+        }
+
+        return curve;
+    }
+
+    /// <summary>
+    /// Starts a real animation on the engine and reports which playback path it took - which is what
+    /// decides whether it survives on Blazor Server.
+    /// </summary>
+    /// <param name="properties">The animated properties, by their <c>Bm.To(...)</c> names.</param>
+    /// <param name="spec">The transition spec, e.g. "tween(0.4, InOut)".</param>
+    public static async Task<BmotionPlaybackDto> AnalyzePlaybackAsync(IReadOnlyCollection<string> properties, string? spec)
+    {
+        var parsed = BmotionTransitionSpec.Parse(spec);
+
+        if (parsed.Transition is null)
+        {
+            return new BmotionPlaybackDto
+            {
+                Properties = [.. properties],
+                Transition = spec ?? string.Empty,
+                Path = "Not analysed",
+                WorksOnBlazorServer = false,
+                Reason = parsed.Error ?? "The transition could not be read.",
+                Error = parsed.Error
+            };
+        }
+
+        var props = BmotionPropertyCatalog.BuildTarget(properties, out var unknown);
+
+        var interop = new HeadlessBmotionInterop();
+        await using var engine = new BmotionAnimationEngine(interop);
+        var service = new BmotionAnimateService(engine, interop);
+
+        var controls = await service.AnimateAsync(".bmotion-target", props, parsed.Transition);
+
+        // The compositor decision is taken inside the animation's first few asynchronous steps, and
+        // the frame-loop path needs frames to finish at all. Pump a bounded number of both so the
+        // engine reaches its decision either way; the verdict is read from the interop afterwards.
+        var clockMs = 0.0;
+        var completion = controls.WhenCompleteAsync();
+
+        for (int frame = 0; frame < 240 && completion.IsCompleted is false; frame++)
+        {
+            engine.ComputeFrame(clockMs);
+            clockMs += FrameMs;
+
+            // Lets the engine's own awaits run: without this the compositor hand-off, which is
+            // asynchronous, could still be in flight when the verdict is read.
+            if (frame % 8 == 0) await Task.Yield();
+        }
+
+        controls.Stop();
+
+        var offloaded = interop.WaapiCalls.Count > 0;
+        var timing = offloaded ? AsDictionary(interop.WaapiCalls[0].Timing) : null;
+
+        var reasons = BmotionPropertyCatalog.ExplainPlayback(properties, parsed.Transition, offloaded);
+
+        return new BmotionPlaybackDto
+        {
+            Properties = [.. properties],
+            Transition = parsed.Canonical,
+            Path = offloaded ? "Compositor (Web Animations API)" : "C# frame loop (requestAnimationFrame)",
+            WorksOnBlazorServer = offloaded,
+            Reason = reasons.Reason + (unknown.Length > 0
+                ? $" Ignored, because Bm.To has no such argument: {string.Join(", ", unknown)}."
+                : string.Empty),
+            CompositorDurationMs = timing is not null && timing.TryGetValue("duration", out var duration)
+                ? Convert.ToDouble(duration, CultureInfo.InvariantCulture)
+                : null,
+            CompositorEasing = timing is not null && timing.TryGetValue("easing", out var easing)
+                ? easing?.ToString()
+                : null,
+            HowToOffload = offloaded ? null : reasons.Remedies
+        };
+    }
+
+    /// <summary>
+    /// Plays a transition on the engine and records every value it produced, against the frame clock
+    /// the simulation drives itself. A three-second animation is measured in microseconds of real
+    /// time, because nothing here waits for a real frame.
+    /// </summary>
+    /// <returns>The recorded frames, and whether the motion came to rest inside the frame cap.</returns>
+    private static async Task<(List<(double Seconds, double Value)> Frames, bool Settled)> RecordAsync(
+        BmTransition transition, double from, double to)
+    {
+        var frames = new List<(double Seconds, double Value)>(256);
+
+        var interop = new HeadlessBmotionInterop();
+        await using var engine = new BmotionAnimationEngine(interop);
+        var service = new BmotionAnimateService(engine, interop);
+
+        var clockMs = 0.0;
+        var animation = service.AnimateAsync(from, to, value => frames.Add((clockMs / 1000, value)), transition);
+
+        var maxFrames = (int)(MaxSeconds * 1000 / FrameMs);
+
+        for (int frame = 0; frame < maxFrames && animation.IsCompleted is false; frame++)
+        {
+            engine.ComputeFrame(clockMs);
+            clockMs += FrameMs;
+        }
+
+        // The driver resolves its completion on the thread pool, so the loop above can exit a frame
+        // or two before the task itself reports done. Nothing is left to tick either way.
+        return (frames, await WaitOrAbandonAsync(animation));
+    }
+
+    /// <summary>
+    /// The answer for a transition spec that could not be read: no measurement, and the explanation
+    /// of how to write it in both <c>Error</c> and <c>Reading</c>, so a caller that only renders the
+    /// human-facing field still sees it.
+    /// </summary>
+    private static BmotionSimulationDto Unreadable(string? spec, string? error, double from, double to)
+    {
+        var message = error ?? "The transition could not be read.";
+
+        return new BmotionSimulationDto
+        {
+            Transition = spec ?? string.Empty,
+            Kind = "Unknown",
+            From = from,
+            To = to,
+            SettleSeconds = 0,
+            OvershootPercent = 0,
+            TargetCrossings = 0,
+            PeakVelocity = 0,
+            TimeTo90Percent = 0,
+            Samples = [],
+            Sparkline = string.Empty,
+            Reading = message,
+            Warnings = [],
+            Error = message
+        };
+    }
+
+    /// <summary>The recorded value at a moment between two frames, linearly interpolated.</summary>
+    private static double ValueAt(List<(double Seconds, double Value)> frames, double seconds)
+    {
+        if (seconds <= frames[0].Seconds) return frames[0].Value;
+        if (seconds >= frames[^1].Seconds) return frames[^1].Value;
+
+        for (int i = 1; i < frames.Count; i++)
+        {
+            if (frames[i].Seconds < seconds) continue;
+
+            var (previousSeconds, previousValue) = frames[i - 1];
+            var (nextSeconds, nextValue) = frames[i];
+            var span = nextSeconds - previousSeconds;
+
+            return span <= 0
+                ? nextValue
+                : previousValue + (nextValue - previousValue) * ((seconds - previousSeconds) / span);
+        }
+
+        return frames[^1].Value;
+    }
+
+    /// <summary>
+    /// Waits briefly for the animation to acknowledge that it finished. A motion that never settles
+    /// is abandoned rather than awaited: its driver died with the engine at the end of the frame
+    /// loop above, so nothing is still running - only its completion will never be signalled.
+    /// </summary>
+    private static async Task<bool> WaitOrAbandonAsync(Task animation)
+    {
+        try
+        {
+            await animation.WaitAsync(TimeSpan.FromSeconds(2));
+
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static BmotionSimulationDto Measure(
+        string canonical, string kind, double from, double to,
+        List<(double Seconds, double Value)> frames, List<string> warnings)
+    {
+        // A transition with no frames at all animated nothing - a zero-length distance, or a driver
+        // that refused the values. Reporting zeroes would read as "instant", which is a different
+        // thing, so the reading says which it was.
+        if (frames.Count == 0)
+        {
+            return new BmotionSimulationDto
+            {
+                Transition = canonical,
+                Kind = kind,
+                From = from,
+                To = to,
+                SettleSeconds = 0,
+                OvershootPercent = 0,
+                TargetCrossings = 0,
+                PeakVelocity = 0,
+                TimeTo90Percent = 0,
+                Samples = [],
+                Sparkline = string.Empty,
+                Reading = "Nothing was animated: the engine produced no frames for this transition.",
+                Warnings = [.. warnings]
+            };
+        }
+
+        var distance = to - from;
+        var span = Math.Abs(distance);
+        var last = frames[^1];
+
+        var overshoot = 0.0;
+        var crossings = 0;
+        var peakVelocity = 0.0;
+        var timeTo90 = last.Seconds;
+        var reached90 = false;
+
+        for (int i = 0; i < frames.Count; i++)
+        {
+            var (seconds, value) = frames[i];
+
+            // How far past the target this frame went, in the direction of travel. A motion that
+            // undershoots contributes nothing.
+            var beyond = span == 0 ? 0 : (distance >= 0 ? value - to : to - value);
+            if (beyond > overshoot) overshoot = beyond;
+
+            if (reached90 is false && span > 0 && Math.Abs(value - from) >= span * 0.9)
+            {
+                timeTo90 = seconds;
+                reached90 = true;
+            }
+
+            if (i == 0) continue;
+
+            var (previousSeconds, previousValue) = frames[i - 1];
+            var dt = seconds - previousSeconds;
+
+            if (dt > 0) peakVelocity = Math.Max(peakVelocity, Math.Abs(value - previousValue) / dt);
+
+            // A sign change in "which side of the target are we on" is one crossing: the count is
+            // the number of wobbles a viewer sees.
+            var before = previousValue - to;
+            var after = value - to;
+
+            if (before != 0 && after != 0 && Math.Sign(before) != Math.Sign(after)) crossings++;
+        }
+
+        var overshootPercent = span > 0 ? overshoot / span * 100 : 0;
+
+        return new BmotionSimulationDto
+        {
+            Transition = canonical,
+            Kind = kind,
+            From = from,
+            To = to,
+            SettleSeconds = Round(last.Seconds),
+            OvershootPercent = Round(overshootPercent),
+            TargetCrossings = crossings,
+            PeakVelocity = Round(peakVelocity),
+            TimeTo90Percent = Round(timeTo90),
+            Samples = Resample(frames),
+            Sparkline = Sparkline([.. frames.Select(f => f.Value)], from, to),
+            Reading = Read(kind, last.Seconds, overshootPercent, crossings, timeTo90),
+            Warnings = [.. warnings]
+        };
+    }
+
+    /// <summary>
+    /// Thins the recorded frames down to a fixed number of evenly spaced samples. A 3-second spring
+    /// records ~180 frames, and handing all of them to a client spends its context on a resolution
+    /// nobody reads.
+    /// </summary>
+    private static BmotionSampleDto[] Resample(List<(double Seconds, double Value)> frames)
+    {
+        if (frames.Count <= SampleCount)
+        {
+            return [.. frames.Select(f => new BmotionSampleDto { Seconds = Round(f.Seconds), Value = Round(f.Value) })];
+        }
+
+        var samples = new BmotionSampleDto[SampleCount];
+
+        for (int i = 0; i < SampleCount; i++)
+        {
+            // The last sample is pinned to the final frame, so the value the motion rests at is
+            // always present rather than being rounded past.
+            var index = (int)Math.Round((double)i * (frames.Count - 1) / (SampleCount - 1));
+            var frame = frames[index];
+
+            samples[i] = new BmotionSampleDto { Seconds = Round(frame.Seconds), Value = Round(frame.Value) };
+        }
+
+        return samples;
+    }
+
+    /// <summary>
+    /// Draws the motion as a row of block characters, scaled so the target sits near the top and any
+    /// overshoot is visible above it. It is the fastest way for a reader - person or model - to tell
+    /// a critically damped spring from a bouncy one without reading two dozen numbers.
+    /// </summary>
+    private static string Sparkline(double[] values, double from, double to)
+    {
+        const string Blocks = " .:-=+*#%@";
+
+        if (values.Length == 0) return string.Empty;
+
+        var min = Math.Min(values.Min(), Math.Min(from, to));
+        var max = Math.Max(values.Max(), Math.Max(from, to));
+        var range = max - min;
+
+        var width = Math.Min(values.Length, 48);
+        var line = new char[width];
+
+        for (int i = 0; i < width; i++)
+        {
+            var value = values[(int)Math.Round((double)i * (values.Length - 1) / Math.Max(1, width - 1))];
+            var level = range > 0 ? (value - min) / range : 1;
+
+            line[i] = Blocks[Math.Clamp((int)Math.Round(level * (Blocks.Length - 1)), 0, Blocks.Length - 1)];
+        }
+
+        return new string(line);
+    }
+
+    /// <summary>
+    /// States what the measurements add up to. The numbers alone still leave the question an agent
+    /// is really asking - is this the feel I asked for? - so the reading names the character of the
+    /// motion and, when it is likely to be unwanted, what to change.
+    /// </summary>
+    private static string Read(string kind, double settle, double overshootPercent, int crossings, double timeTo90)
+    {
+        var pace = settle switch
+        {
+            < 0.2 => "very fast",
+            < 0.4 => "fast",
+            < 0.8 => "unhurried",
+            < 1.5 => "slow",
+            _ => "very slow"
+        };
+
+        var character = (kind, overshootPercent, crossings) switch
+        {
+            ("Spring", < 0.5, _) => "no overshoot at all - critically damped, so it eases in and stops dead",
+            ("Spring", < 5, _) => "a barely visible overshoot - crisp, and calm enough for interface chrome",
+            ("Spring", < 15, _) => "a light bounce - the usual choice for buttons, cards and entrances",
+            ("Spring", < 30, _) => "a pronounced bounce - playful, and distracting on anything that moves often",
+            ("Spring", _, _) => "a large overshoot - it reads as elastic, and is easy to overuse",
+            ("Inertia", _, _) => "a decelerating glide, as a flung element comes to rest",
+            (_, < 0.5, _) => "a straight run to the target with no overshoot",
+            _ => "an easing that carries the element past its target before settling"
+        };
+
+        var wobble = crossings > 2
+            ? $" It crosses the target {crossings} times before resting, which is visible as a wobble."
+            : string.Empty;
+
+        // The gap between "looks arrived" and "actually settled" is the number that surprises people
+        // about springs: the tail is real time during which the element is still moving.
+        var tail = settle - timeTo90 > 0.25
+            ? $" It covers 90% of the distance in {timeTo90:0.00}s but only comes to rest at {settle:0.00}s - " +
+              "the tail is the part that reads as sluggish."
+            : string.Empty;
+
+        return $"Settles in {settle:0.00}s ({pace}), with {character}.{wobble}{tail}";
+    }
+
+    private static string KindOf(BmTransition transition) => transition switch
+    {
+        BmSpring => "Spring",
+        BmInertia => "Inertia",
+        _ => "Tween"
+    };
+
+    /// <summary>Reads the engine's WAAPI timing bag, whatever concrete dictionary type it used.</summary>
+    private static Dictionary<string, object?>? AsDictionary(object value)
+    {
+        if (value is Dictionary<string, object?> typed) return typed;
+
+        if (value is IReadOnlyDictionary<string, object?> readOnly)
+        {
+            return readOnly.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
+        }
+
+        return null;
+    }
+
+    private static double Round(double value) => Math.Round(value, 4, MidpointRounding.AwayFromZero);
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionMotionLab.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionMotionLab.cs
@@ -109,6 +109,10 @@ public static class BmotionMotionLab
 
         if (frames.Count == 0) return [];
 
+        // Two is the fewest points a curve can be read from, and the fraction below divides by
+        // points - 1: asking for one or fewer would sample nothing, or divide by zero.
+        points = Math.Max(2, points);
+
         var curve = new double[points];
 
         for (int i = 0; i < points; i++)
@@ -186,8 +190,13 @@ public static class BmotionMotionLab
             Reason = reasons.Reason + (unknown.Length > 0
                 ? $" Ignored, because Bm.To has no such argument: {string.Join(", ", unknown)}."
                 : string.Empty),
-            CompositorDurationMs = timing is not null && timing.TryGetValue("duration", out var duration)
-                ? Convert.ToDouble(duration, CultureInfo.InvariantCulture)
+            // The timing is whatever the engine handed the interop layer, so the duration is read
+            // defensively: a value of an unexpected shape leaves it unreported rather than throwing
+            // out of a tool whose whole answer is the path, not the milliseconds.
+            CompositorDurationMs = timing is not null
+                                && timing.TryGetValue("duration", out var duration)
+                                && double.TryParse(duration?.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var durationMs)
+                ? durationMs
                 : null,
             CompositorEasing = timing is not null && timing.TryGetValue("easing", out var easing)
                 ? easing?.ToString()
@@ -290,8 +299,11 @@ public static class BmotionMotionLab
 
             return true;
         }
-        catch (TimeoutException)
+        catch
         {
+            // Timed out, or the animation faulted. Either is the same answer to the only question
+            // being asked - did it finish - and the caller reports the recording as unreadable
+            // rather than letting a headless run throw out of a tool call.
             return false;
         }
     }

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionPropertyCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionPropertyCatalog.cs
@@ -289,19 +289,30 @@ public static class BmotionPropertyCatalog
         // probed; it is a CSS write, which is never compositor-eligible.
         if (unknown.Length > 0) return false;
 
-        var interop = new HeadlessBmotionInterop();
-        await using var engine = new BmotionAnimationEngine(interop);
-        var service = new BmotionAnimateService(engine, interop);
+        try
+        {
+            var interop = new HeadlessBmotionInterop();
+            await using var engine = new BmotionAnimationEngine(interop);
+            var service = new BmotionAnimateService(engine, interop);
 
-        var controls = await service.AnimateAsync(".bmotion-probe", props, new BmTween { Duration = 0.3 });
+            var controls = await service.AnimateAsync(".bmotion-probe", props, new BmTween { Duration = 0.3 });
 
-        // The hand-off is asynchronous; give its continuations a turn before reading the verdict.
-        await Task.Yield();
-        await Task.Yield();
+            // The hand-off is asynchronous; give its continuations a turn before reading the verdict.
+            await Task.Yield();
+            await Task.Yield();
 
-        controls.Stop();
+            controls.Stop();
 
-        return interop.WaapiCalls.Count > 0;
+            return interop.WaapiCalls.Count > 0;
+        }
+        catch (Exception)
+        {
+            // The catalog is built once and cached for the life of the process, so a throw here would
+            // not cost one property its verdict - it would leave the whole tool answering with the
+            // same exception forever. A property that could not be probed is reported the way an
+            // unprobeable one already is: not offloaded.
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionPropertyCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionPropertyCatalog.cs
@@ -1,0 +1,370 @@
+using System.Reflection;
+using System.Collections.Frozen;
+using Bit.Bmotion.Demo.Server.Dtos;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Every property Bit.Bmotion can animate, and the one thing about each that an agent cannot read
+/// off the API: what animating it costs.
+/// <para>
+/// The list itself comes from reflecting over <see cref="BmProps"/>, so a property added to the
+/// library appears here without anyone remembering to add it. The expensive claim - whether the
+/// browser compositor can own the animation, and therefore whether it survives on Blazor Server -
+/// is <b>measured</b>: each property is animated once through the real engine at first use and the
+/// catalog records which playback path the engine chose. Writing that table by hand would mean
+/// maintaining a second copy of a rule set that lives in the engine, and being wrong about it in
+/// exactly the cases that matter.
+/// </para>
+/// </summary>
+public static class BmotionPropertyCatalog
+{
+    /// <summary>Descriptive metadata for a property: everything except the measured verdict.</summary>
+    private sealed record Facts(string Category, string Css, string Example, string? Notes = null);
+
+    private static readonly Lazy<Task<BmotionPropertyDto[]>> _properties = new(ProbeAsync);
+
+    private static readonly Lazy<FrozenDictionary<string, PropertyInfo>> _bmPropsByName = new(() =>
+        typeof(BmProps).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                       .Where(property => property.CanWrite && property.Name != nameof(BmProps.Transition))
+                       .ToFrozenDictionary(property => CamelCase(property.Name), StringComparer.OrdinalIgnoreCase));
+
+    // What each property is for, in the terms someone writing an animation thinks in. Only the
+    // prose is here; the names come from BmProps and the playback verdict from the engine.
+    private static readonly FrozenDictionary<string, Facts> _facts = new Dictionary<string, Facts>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["x"] = new("Transform", "transform: translateX()", "x: 100", "Pixels by default. The cheapest thing to animate, along with y and opacity."),
+        ["y"] = new("Transform", "transform: translateY()", "y: -20"),
+        ["z"] = new("Transform", "transform: translateZ()", "z: 50", "Needs a perspective on this element or an ancestor to be visible."),
+        ["scale"] = new("Transform", "transform: scale()", "scale: 1.2", "Scales text and borders with the element; animate width/height instead when that is unwanted."),
+        ["scaleX"] = new("Transform", "transform: scaleX()", "scaleX: 0"),
+        ["scaleY"] = new("Transform", "transform: scaleY()", "scaleY: 0"),
+        ["rotate"] = new("Transform", "transform: rotate()", "rotate: 180", "Degrees. Values beyond 360 keep turning rather than wrapping, so rotate: 720 is two full turns."),
+        ["rotateX"] = new("Transform", "transform: rotateX()", "rotateX: 45", "A 3D turn: pair it with perspective or it looks like a squash."),
+        ["rotateY"] = new("Transform", "transform: rotateY()", "rotateY: 180", "The card-flip axis."),
+        ["rotateZ"] = new("Transform", "transform: rotateZ()", "rotateZ: 90", "The same axis as rotate; use one or the other on an element."),
+        ["skewX"] = new("Transform", "transform: skewX()", "skewX: 12"),
+        ["skewY"] = new("Transform", "transform: skewY()", "skewY: 12"),
+        ["perspective"] = new("Transform", "transform: perspective()", "perspective: 800", "Set it on the element being turned, or as a CSS perspective on its parent."),
+        ["originX"] = new("Transform", "transform-origin", "originX: 0", "0-1 across the element. Not animated - it is set, and it changes what every transform pivots around."),
+        ["originY"] = new("Transform", "transform-origin", "originY: 1", "0-1 down the element. Set both to move the pivot, e.g. originY: 1 to grow upward."),
+
+        ["opacity"] = new("Visual", "opacity", "opacity: 0", "The other compositor-cheap property. Prefer it to visibility or display, which cannot be animated at all."),
+        ["backgroundColor"] = new("Visual", "background-color", "backgroundColor: \"#FD7F36\"", "Interpolated in C#; see BmColorSpace for Oklab/LCH mixing rather than sRGB."),
+        ["color"] = new("Visual", "color", "color: \"#1276C6\""),
+        ["borderColor"] = new("Visual", "border-color", "borderColor: \"tomato\""),
+        ["outlineColor"] = new("Visual", "outline-color", "outlineColor: \"#0B72E7\""),
+        ["fill"] = new("Visual", "fill", "fill: \"#FD7F36\"", "SVG only."),
+        ["stroke"] = new("Visual", "stroke", "stroke: \"#FD7F36\"", "SVG only."),
+        ["width"] = new("Visual", "width", "width: \"320px\"", "Triggers layout on every frame. A scaleX with a layout animation is usually cheaper and smoother."),
+        ["height"] = new("Visual", "height", "height: \"0px\"", "The usual accordion property. Layout-bound, so it cannot go to the compositor."),
+        ["borderRadius"] = new("Visual", "border-radius", "borderRadius: \"50%\"", "Percentages and pixels interpolate; mixing the two units in one animation does not."),
+        ["boxShadow"] = new("Visual", "box-shadow", "boxShadow: \"0 8px 30px rgba(0,0,0,.2)\"", "Interpolated piece by piece, so both ends need the same shadow count and shape."),
+        ["filter"] = new("Visual", "filter", "filter: \"blur(4px)\"", "Both ends need the same filter functions in the same order."),
+
+        ["top"] = new("Layout", "top", "top: \"0px\"", "Prefer y: it does the same thing without touching layout."),
+        ["left"] = new("Layout", "left", "left: \"0px\"", "Prefer x."),
+        ["right"] = new("Layout", "right", "right: \"0px\""),
+        ["bottom"] = new("Layout", "bottom", "bottom: \"0px\""),
+        ["margin"] = new("Layout", "margin", "margin: \"16px\""),
+        ["padding"] = new("Layout", "padding", "padding: \"24px\""),
+        ["gap"] = new("Layout", "gap", "gap: \"12px\""),
+
+        ["letterSpacing"] = new("Typography", "letter-spacing", "letterSpacing: \"0.2em\""),
+        ["lineHeight"] = new("Typography", "line-height", "lineHeight: \"1.8\""),
+        ["fontSize"] = new("Typography", "font-size", "fontSize: \"2rem\""),
+
+        ["clipPath"] = new("Visual", "clip-path", "clipPath: \"circle(70%)\"", "Both ends need the same shape function."),
+        ["backgroundPosition"] = new("Visual", "background-position", "backgroundPosition: \"100% 50%\""),
+        ["backgroundSize"] = new("Visual", "background-size", "backgroundSize: \"120%\""),
+
+        ["offsetPath"] = new("Motion path", "offset-path", "offsetPath: \"path('M 0 0 C 80 -60 160 60 240 0')\"", "Set the path once, then animate offsetDistance along it."),
+        ["offsetDistance"] = new("Motion path", "offset-distance", "offsetDistance: \"100%\"", "The value that actually moves the element along an offsetPath."),
+
+        ["d"] = new("SVG", "d", "d: \"M 0 0 L 100 0\"", "Shape morphing: both paths need the same command sequence."),
+        ["pathLength"] = new("SVG", "stroke-dasharray", "pathLength: 1", "0-1 of the stroke drawn. The line-drawing effect."),
+        ["pathOffset"] = new("SVG", "stroke-dashoffset", "pathOffset: 0.5"),
+        ["pathSpacing"] = new("SVG", "stroke-dasharray", "pathSpacing: 0.2"),
+
+        ["cssVars"] = new("Custom", "--custom-property", "cssVars: new() { [\"--glow\"] = \"18px\" }", "Written verbatim into inline style. See BmCssSafeMode before binding untrusted input."),
+        ["css"] = new("Custom", "any CSS property", "css: new() { [\"backdropFilter\"] = \"blur(8px)\" }", "The escape hatch for a property with no dedicated argument."),
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Every animatable property, with its measured playback verdict.</summary>
+    public static Task<BmotionPropertyDto[]> GetAsync() => _properties.Value;
+
+    /// <summary>
+    /// Builds a <see cref="BmProps"/> that animates exactly <paramref name="names"/>, using a
+    /// representative value for each. The values are placeholders - what the engine decides depends
+    /// on which properties are animated and their value shape, not on the numbers themselves.
+    /// </summary>
+    public static BmProps BuildTarget(IReadOnlyCollection<string> names, out string[] unknown)
+    {
+        var props = new BmProps();
+        var missing = new List<string>();
+
+        foreach (var name in names)
+        {
+            var key = name.Trim().Trim('"');
+
+            if (_bmPropsByName.Value.TryGetValue(key, out var property) is false)
+            {
+                missing.Add(key);
+                continue;
+            }
+
+            var value = SampleValueFor(property, key);
+
+            if (value is null) missing.Add(key);
+            else property.SetValue(props, value);
+        }
+
+        unknown = [.. missing];
+
+        return props;
+    }
+
+    /// <summary>
+    /// Explains the engine's playback decision in the engine's own terms, and - when the animation
+    /// stayed on the frame loop - what would have to change for the compositor to take it.
+    /// </summary>
+    public static (string Reason, string[] Remedies) ExplainPlayback(
+        IReadOnlyCollection<string> properties, BmTransition transition, bool offloaded)
+    {
+        if (offloaded)
+        {
+            return ("Every animated property is a transform component or opacity, and the transition has no " +
+                    "feature the Web Animations API cannot express. The engine pre-samples the curve in C# and " +
+                    "hands the whole animation to the browser, so it plays off the main thread with no per-frame " +
+                    "interop - which is also why it works on Blazor Server.", []);
+        }
+
+        // The engine has already given its verdict; these are the reasons it could have had, named
+        // so the caller learns which lever to pull rather than only that a lever exists.
+        var blockers = new List<string>();
+        var remedies = new List<string>();
+
+        var ineligible = properties
+            .Select(name => name.Trim().Trim('"'))
+            .Where(name => IsCompositorProperty(name) is false)
+            .ToArray();
+
+        if (ineligible.Length > 0)
+        {
+            blockers.Add($"{string.Join(", ", ineligible)} - only transform components (x, y, z, scale, scaleX, " +
+                         "scaleY, rotate, rotateX, rotateY, rotateZ, skewX, skewY, perspective) and opacity can be " +
+                         "handed to the browser");
+
+            foreach (var name in ineligible)
+            {
+                remedies.Add(name switch
+                {
+                    "width" or "height" => $"Replace {name} with a scale (plus Layout=\"BmLayout.Size\" when the content must not stretch).",
+                    "top" or "left" or "right" or "bottom" => $"Replace {name} with x/y, which move the element without touching layout.",
+                    "backgroundColor" or "color" or "borderColor" or "outlineColor" or "fill" or "stroke" =>
+                        $"Cross-fade {name} with two stacked elements animating opacity, or accept that it snaps on Blazor Server.",
+                    _ => $"There is no compositor equivalent for {name}; it needs the frame loop."
+                });
+            }
+        }
+
+        if (transition is BmInertia)
+        {
+            blockers.Add("the transition is inertia, whose target is not known until the motion decelerates");
+            remedies.Add("Use a spring or a tween when the animation has to play on Blazor Server.");
+        }
+
+        if (transition is BmSpring { Velocity: not 0 })
+        {
+            blockers.Add("the spring starts with an initial velocity, which produces a curve that depends on the " +
+                         "distance travelled and cannot be shipped as one shared easing");
+            remedies.Add("Drop the initial velocity (velocity: 0) to let the spring be pre-sampled.");
+        }
+
+        if (transition is BmTween { Duration: <= 0 })
+        {
+            blockers.Add("the tween has no duration");
+            remedies.Add("Give the tween a duration greater than zero.");
+        }
+
+        if (transition.Properties is { Count: > 0 })
+        {
+            blockers.Add("the transition carries per-property overrides, which the compositor cannot express as one timeline");
+            remedies.Add("Split the animation into one call per property group instead of using Transition.Properties.");
+        }
+
+        if (transition.Repeat is { Delay: > 0 })
+        {
+            blockers.Add("the repeat has a delay between iterations");
+            remedies.Add("Remove the repeat delay, or accept the frame loop.");
+        }
+
+        if (transition.Repeat is { Type: BmRepeatType.Reverse })
+        {
+            blockers.Add("BmRepeat.Reverse has no Web Animations API equivalent");
+            remedies.Add("Use BmRepeat.Mirror, which maps to the browser's alternate direction.");
+        }
+
+        if (transition.Path is not null)
+        {
+            blockers.Add("an arc path couples x and y along a curve, which pre-sampling each property separately would flatten");
+            remedies.Add("Drop the arc path to regain the compositor, or keep it and accept the frame loop.");
+        }
+
+        if (transition.OnUpdate is not null)
+        {
+            blockers.Add("OnUpdate needs a C# callback on every frame, which only the frame loop can give it");
+        }
+
+        var reason = blockers.Count > 0
+            ? $"The engine kept this on the C# frame loop because {string.Join("; and ", blockers)}. On Blazor " +
+              "Server there is no frame loop, so it becomes an instant state change."
+            : "The engine kept this on the C# frame loop. On Blazor Server it becomes an instant state change. " +
+              "None of the usual blockers apply, so this is a combination worth reporting.";
+
+        if (remedies.Count == 0)
+        {
+            remedies.Add("Animate transform components (x, y, scale, rotate) and opacity only, with a plain spring " +
+                         "or tween, to keep an animation on the compositor.");
+        }
+
+        return (reason, [.. remedies]);
+    }
+
+    /// <summary>
+    /// The engine's own rule for what the browser compositor can own: transform components and
+    /// opacity, nothing else. Public because the code review asks the same question of a property
+    /// name it read out of a source file, where there is no engine run to observe.
+    /// </summary>
+    public static bool IsCompositorProperty(string name)
+    {
+        return name.ToLowerInvariant() is "x" or "y" or "z" or "scale" or "scalex" or "scaley"
+            or "rotate" or "rotatex" or "rotatey" or "rotatez" or "skewx" or "skewy"
+            or "perspective" or "opacity";
+    }
+
+    /// <summary>
+    /// Animates each property once, on its own, through a real engine and records which path the
+    /// engine took. Runs once per process, behind the Lazy above.
+    /// </summary>
+    private static async Task<BmotionPropertyDto[]> ProbeAsync()
+    {
+        var results = new List<BmotionPropertyDto>();
+
+        foreach (var (name, property) in _bmPropsByName.Value.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var facts = _facts.GetValueOrDefault(name)
+                ?? new Facts("Other", name, $"{name}: ...");
+
+            var eligible = await ProbeCompositorAsync(name);
+
+            results.Add(new BmotionPropertyDto
+            {
+                Name = name,
+                Category = facts.Category,
+                Css = facts.Css,
+                ValueType = FriendlyValueType(property.PropertyType),
+                CompositorEligible = eligible,
+                OnBlazorServer = eligible ? "Animates" : "Jumps to the target",
+                Example = facts.Example,
+                Notes = facts.Notes
+            });
+        }
+
+        return [.. results
+            .OrderBy(property => CategoryOrder(property.Category))
+            .ThenBy(property => property.Name, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>
+    /// Starts a plain tween on one property and reports whether the engine handed it to the browser.
+    /// The animation is stopped immediately afterwards: the verdict is taken before the first frame,
+    /// and nothing here is waiting for the motion to finish.
+    /// </summary>
+    private static async Task<bool> ProbeCompositorAsync(string name)
+    {
+        var props = BuildTarget([name], out var unknown);
+
+        // A property with no representative value (the dictionary-valued escape hatches) cannot be
+        // probed; it is a CSS write, which is never compositor-eligible.
+        if (unknown.Length > 0) return false;
+
+        var interop = new HeadlessBmotionInterop();
+        await using var engine = new BmotionAnimationEngine(interop);
+        var service = new BmotionAnimateService(engine, interop);
+
+        var controls = await service.AnimateAsync(".bmotion-probe", props, new BmTween { Duration = 0.3 });
+
+        // The hand-off is asynchronous; give its continuations a turn before reading the verdict.
+        await Task.Yield();
+        await Task.Yield();
+
+        controls.Stop();
+
+        return interop.WaapiCalls.Count > 0;
+    }
+
+    /// <summary>
+    /// A value of the right shape for a property. Which value hardly matters - the engine decides on
+    /// the value's <i>kind</i> - but it has to be one the drivers accept, or the probe would report
+    /// "not offloaded" for a property that simply got a malformed target.
+    /// </summary>
+    private static object? SampleValueFor(PropertyInfo property, string name)
+    {
+        if (property.PropertyType == typeof(BmKeyframes))
+        {
+            // Scale and opacity rest at 1, so animating them to 0 is a real change of state; for
+            // everything else any non-zero target moves the element.
+            return (BmKeyframes)(name.StartsWith("scale", StringComparison.OrdinalIgnoreCase) || name is "opacity" ? 0d : 40d);
+        }
+
+        if (property.PropertyType == typeof(BmStringKeyframes))
+        {
+            return (BmStringKeyframes)(_facts.GetValueOrDefault(name)?.Category switch
+            {
+                "SVG" when name is "d" => "M 0 0 L 100 0",
+                "Motion path" when name is "offsetPath" => "path('M 0 0 L 100 0')",
+                "Motion path" => "100%",
+                _ when name.EndsWith("Color", StringComparison.OrdinalIgnoreCase) || name is "fill" or "stroke" => "#FD7F36",
+                _ when name is "clipPath" => "circle(70%)",
+                _ when name is "filter" => "blur(4px)",
+                _ when name is "boxShadow" => "0 8px 30px rgba(0,0,0,0.2)",
+                _ when name is "backgroundPosition" => "100% 50%",
+                _ => "24px"
+            });
+        }
+
+        if (property.PropertyType == typeof(double?)) return 0.5;
+
+        // CssVars and Css are dictionaries: real targets, but not single properties, so they have no
+        // representative single value to probe with.
+        return null;
+    }
+
+    private static string FriendlyValueType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (underlying == typeof(BmKeyframes)) return "BmKeyframes (number or number[])";
+        if (underlying == typeof(BmStringKeyframes)) return "BmStringKeyframes (CSS value or CSS value[])";
+        if (underlying == typeof(double)) return "double";
+        if (underlying == typeof(Dictionary<string, string>)) return "Dictionary<string, string>";
+        if (underlying == typeof(Dictionary<string, BmStringKeyframes>)) return "Dictionary<string, BmStringKeyframes>";
+
+        return underlying.Name;
+    }
+
+    private static int CategoryOrder(string category) => category switch
+    {
+        "Transform" => 0,
+        "Visual" => 1,
+        "Layout" => 2,
+        "Typography" => 3,
+        "Motion path" => 4,
+        "SVG" => 5,
+        "Custom" => 6,
+        _ => 7
+    };
+
+    private static string CamelCase(string name) => char.ToLowerInvariant(name[0]) + name[1..];
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionRecipeCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionRecipeCatalog.cs
@@ -378,7 +378,7 @@ public static class BmotionRecipeCatalog
         },
     ];
 
-    /// <summary>The recipes without their code, for the listing.</summary>
+    /// <summary>The recipes without their code or notes, for the listing.</summary>
     public static BmotionRecipeDto[] Summaries =>
         [.. All.Select(recipe => recipe with { Code = null, Notes = null })];
 

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionRecipeCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionRecipeCatalog.cs
@@ -1,0 +1,396 @@
+using Bit.Bmotion.Demo.Server.Dtos;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// The patterns people actually ask an animation library for, written out in full.
+/// <para>
+/// The API reference answers "what does this parameter do"; a recipe answers "what do I write for
+/// the thing I want", which is the question that arrives. Each one is short, complete and correct
+/// against the current API, and carries the caveat that is not visible in the code - the missing
+/// <c>@key</c>, the <c>position: relative</c> the container needs, the render mode it will not
+/// survive. Those caveats are where hand-written animation code usually goes wrong, and they are
+/// invisible to anyone reading only the parameter table.
+/// </para>
+/// </summary>
+public static class BmotionRecipeCatalog
+{
+    /// <summary>Every recipe, code included.</summary>
+    public static readonly BmotionRecipeDto[] All =
+    [
+        new()
+        {
+            Id = "fade-in-on-mount",
+            Title = "Fade and slide in on mount",
+            Intent = "Make an element appear smoothly when the page or component first renders.",
+            Keywords = "fade in enter mount appear entrance intro initial animate slide up first render",
+            SeeAlso = "/basic",
+            Code = """
+                <Bmotion Initial="Bm.To(opacity: 0, y: 20)"
+                         Animate="Bm.To(opacity: 1, y: 0)"
+                         Transition="Bm.Spring(bounce: 0.2, duration: 0.5)">
+                    <div class="card">Content</div>
+                </Bmotion>
+                """,
+            Notes = "Initial only runs when the element mounts. To replay it, change the element's @key so " +
+                    "Blazor treats it as a new element. Both properties animated here are compositor-eligible, " +
+                    "so this works on Blazor Server as well."
+        },
+        new()
+        {
+            Id = "staggered-list",
+            Title = "Staggered list entrance",
+            Intent = "Make a list of items appear one after another rather than all at once.",
+            Keywords = "stagger list cascade sequence one by one children delay items entrance variants",
+            SeeAlso = "/variants",
+            Code = """
+                <Bmotion Variants="_container" InitialState="hidden" State="visible"
+                         Transition="Bm.Tween(0.3, staggerChildren: 0.06, delayChildren: 0.1)">
+                    <ul class="list">
+                        @foreach (var item in _items)
+                        {
+                            <Bmotion Variants="_item" @key="item.Id">
+                                <li>@item.Title</li>
+                            </Bmotion>
+                        }
+                    </ul>
+                </Bmotion>
+
+                @code {
+                    private readonly BmVariants _container = new()
+                    {
+                        ["hidden"] = Bm.To(opacity: 0),
+                        ["visible"] = Bm.To(opacity: 1),
+                    };
+
+                    private readonly BmVariants _item = new()
+                    {
+                        ["hidden"] = Bm.To(opacity: 0, y: 16),
+                        ["visible"] = Bm.To(opacity: 1, y: 0),
+                    };
+                }
+                """,
+            Notes = "The stagger lives on the CONTAINER's transition, not on the items - each child inherits " +
+                    "the state name and gets its slot in the cascade. Do not also put a Transition on the items " +
+                    "unless you mean to override the timing (a per-variant transition is the tidier way). " +
+                    "Bm.Stagger(..., from: BmStaggerFrom.Center) via childStagger makes the cascade radiate " +
+                    "instead of running first-to-last."
+        },
+        new()
+        {
+            Id = "exit-animation",
+            Title = "Animate an element out before it is removed",
+            Intent = "Fade or slide something away when it disappears, instead of it vanishing instantly.",
+            Keywords = "exit leave remove unmount disappear hide conditional close dismiss animate presence",
+            SeeAlso = "/presence",
+            Code = """
+                <BmotionAnimatePresence IsPresent="_show">
+                    <Bmotion Initial="Bm.To(opacity: 0, scale: 0.95)"
+                             Animate="Bm.To(opacity: 1, scale: 1)"
+                             Exit="Bm.To(opacity: 0, scale: 0.95)"
+                             Transition="Bm.Tween(0.2)">
+                        <div class="panel">Content</div>
+                    </Bmotion>
+                </BmotionAnimatePresence>
+
+                @code {
+                    private bool _show = true;
+                }
+                """,
+            Notes = "Exit does nothing without a presence component around it: Blazor removes the element from " +
+                    "the DOM the moment the condition flips, and there is nothing left to animate. Never wrap " +
+                    "the content in @if - that is exactly what BmotionAnimatePresence replaces. Use " +
+                    "BmotionPresenceGroup for a list, and BmotionPresenceSwitch when one item replaces another."
+        },
+        new()
+        {
+            Id = "modal-dialog",
+            Title = "Modal with a backdrop",
+            Intent = "Open and close a dialog with the backdrop fading and the panel scaling in.",
+            Keywords = "modal dialog popup overlay backdrop scrim open close panel drawer sheet",
+            SeeAlso = "/presence",
+            Code = """
+                <BmotionAnimatePresence IsPresent="_open" Mode="BmPresenceMode.Wait">
+                    <div>
+                        <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)"
+                                 Exit="Bm.To(opacity: 0)" Transition="Bm.Tween(0.15)">
+                            <div class="backdrop" @onclick="Close"></div>
+                        </Bmotion>
+
+                        <Bmotion Initial="Bm.To(opacity: 0, scale: 0.94, y: 12)"
+                                 Animate="Bm.To(opacity: 1, scale: 1, y: 0)"
+                                 Exit="Bm.To(opacity: 0, scale: 0.98, y: 8)"
+                                 Transition="Bm.Spring(bounce: 0.15, duration: 0.35)">
+                            <div class="dialog" role="dialog" aria-modal="true">
+                                <h2>Title</h2>
+                                <button @onclick="Close">Close</button>
+                            </div>
+                        </Bmotion>
+                    </div>
+                </BmotionAnimatePresence>
+
+                @code {
+                    private bool _open;
+
+                    private void Close() => _open = false;
+                }
+                """,
+            Notes = "The exit is deliberately faster and shallower than the enter: a dialog that leaves as " +
+                    "slowly as it arrives feels unresponsive. Keep the accessibility attributes - animation " +
+                    "does not replace role=\"dialog\", aria-modal or focus management."
+        },
+        new()
+        {
+            Id = "hover-and-press",
+            Title = "Hover and press feedback",
+            Intent = "Make a button or card respond to the pointer.",
+            Keywords = "hover press tap click button card interactive feedback scale lift whilehover whiletap",
+            SeeAlso = "/gestures",
+            Code = """
+                <Bmotion WhileHover="Bm.To(scale: 1.04, y: -2)"
+                         WhileTap="Bm.To(scale: 0.97)"
+                         Transition="Bm.Spring(stiffness: 400, damping: 25)">
+                    <button class="card" @onclick="Open">Open</button>
+                </Bmotion>
+                """,
+            Notes = "Gesture overlays revert on their own when the gesture ends - do not write the resting " +
+                    "state into Animate as well. A stiff, well-damped spring is right here: pointer feedback " +
+                    "has to arrive within a frame or two, so bounce reads as lag. Tap is keyboard-accessible " +
+                    "out of the box on a focusable element."
+        },
+        new()
+        {
+            Id = "reveal-on-scroll",
+            Title = "Reveal an element when it scrolls into view",
+            Intent = "Animate a section in the first time the reader scrolls to it.",
+            Keywords = "scroll reveal in view viewport intersection appear on scroll lazy entrance once",
+            SeeAlso = "/scroll",
+            Code = """
+                <Bmotion Initial="Bm.To(opacity: 0, y: 32)"
+                         WhileInView="Bm.To(opacity: 1, y: 0)"
+                         Once="true"
+                         Viewport='new BmViewport { Amount = "0.3" }'
+                         Transition="Bm.Tween(0.5, BmEase.Out)">
+                    <section class="feature">Content</section>
+                </Bmotion>
+                """,
+            Notes = "Once=\"true\" is almost always what is wanted: without it the section re-animates every " +
+                    "time it re-enters the viewport, which is distracting on the way back up. Viewport.Amount " +
+                    "is how much of the element must be visible before it counts as in view."
+        },
+        new()
+        {
+            Id = "scroll-progress-bar",
+            Title = "Reading-progress bar",
+            Intent = "Show how far down the page the reader has scrolled.",
+            Keywords = "scroll progress bar indicator reading position parallax timeline scrolltimeline page",
+            SeeAlso = "/scroll",
+            Code = """
+                <Bmotion Timeline="BmScrollTimeline.Page()" Animate="Bm.To(scaleX: [0, 1])">
+                    <div class="progress-bar" style="transform-origin: 0 50%;" />
+                </Bmotion>
+                """,
+            Notes = "This runs entirely in the browser: the keyframes are pre-sampled once and handed to a " +
+                    "native scroll timeline, so there is no scroll handler, no per-frame interop and nothing " +
+                    "to dispose. Transition does not apply while a Timeline is attached - scroll position IS " +
+                    "the progress. Only transform components and opacity can be scroll-driven."
+        },
+        new()
+        {
+            Id = "layout-animation",
+            Title = "Animate an element between two layouts",
+            Intent = "Make an element glide to its new position or size when the layout changes, without animating any property by hand.",
+            Keywords = "layout flip position size move resize expand collapse accordion reflow rearrange",
+            SeeAlso = "/layout",
+            Code = """
+                <Bmotion Layout="BmLayout.Size"
+                         LayoutAnchor="BmLayoutAnchor.Center"
+                         LayoutDependency="_isOpen"
+                         Transition="Bm.Spring(bounce: 0.15, duration: 0.4)">
+                    <div class="panel">
+                        <h3 @onclick="Toggle">Section</h3>
+                        @if (_isOpen)
+                        {
+                            <p>Body</p>
+                        }
+                    </div>
+                </Bmotion>
+
+                @code {
+                    private bool _isOpen;
+
+                    private void Toggle() => _isOpen = !_isOpen;
+                }
+                """,
+            Notes = "Nothing here animates height - the element is simply re-rendered into its new size and " +
+                    "Bmotion measures the difference (FLIP). Use BmLayout.Position when scaling would distort " +
+                    "text. Add LayoutScroll=\"true\" inside a scrolling container, or the container's own scroll " +
+                    "between the two measurements reads as movement and the element jumps. Layout animations " +
+                    "need the frame loop, so they snap on Blazor Server."
+        },
+        new()
+        {
+            Id = "shared-element",
+            Title = "Shared-element transition between two views",
+            Intent = "Make a thumbnail appear to grow into the full view it opens.",
+            Keywords = "shared element magic move hero transition thumbnail expand detail layoutid morph",
+            SeeAlso = "/layout",
+            Code = """
+                @if (_selected is null)
+                {
+                    <div class="grid">
+                        @foreach (var photo in _photos)
+                        {
+                            <Bmotion LayoutId='@($"photo-{photo.Id}")' @key="photo.Id">
+                                <img src="@photo.Url" @onclick="() => _selected = photo" />
+                            </Bmotion>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <Bmotion LayoutId='@($"photo-{_selected.Id}")'>
+                        <img class="full" src="@_selected.Url" @onclick="() => _selected = null" />
+                    </Bmotion>
+                }
+                """,
+            Notes = "The two elements are matched by LayoutId, so it has to be identical on both sides and " +
+                    "unique on the page. Exactly one element with a given LayoutId may be mounted at a time - " +
+                    "the transition is between the one leaving and the one arriving."
+        },
+        new()
+        {
+            Id = "drag-with-constraints",
+            Title = "Drag an element within bounds",
+            Intent = "Let the user drag something, with edges it cannot be thrown past.",
+            Keywords = "drag draggable pointer move constraints bounds elastic momentum snap back slider",
+            SeeAlso = "/drag",
+            Code = """
+                <Bmotion Drag="BmDrag.Both"
+                         DragConstraints="new BmDragConstraints { Left = -120, Right = 120, Top = -80, Bottom = 80 }"
+                         DragElastic="BmDragElastic.Uniform(0.2)"
+                         DragMomentum="true"
+                         WhileDrag="Bm.To(scale: 1.05)">
+                    <div class="handle" />
+                </Bmotion>
+                """,
+            Notes = "Drag needs the synchronous per-frame loop, so it is WebAssembly-only: on Blazor Server " +
+                    "the element does not move at all. Gate it on BmotionCapabilities.SupportsFrameLoop and " +
+                    "give the server path a non-dragging equivalent. DragElastic controls how far past the " +
+                    "constraint the element can be pulled before it resists."
+        },
+        new()
+        {
+            Id = "loading-spinner",
+            Title = "Continuous loading animation",
+            Intent = "Spin or pulse something forever while work is in progress.",
+            Keywords = "spinner loading loop infinite repeat forever rotate pulse skeleton busy indicator",
+            SeeAlso = "/keyframes",
+            Code = """
+                <Bmotion Animate="Bm.To(rotate: 360)"
+                         Transition="Bm.Tween(1, BmEase.Linear, repeat: BmRepeat.Forever)">
+                    <div class="spinner" />
+                </Bmotion>
+
+                @* a pulse instead: keyframes, mirrored so it breathes rather than snapping back *@
+                <Bmotion Animate="Bm.To(scale: [1, 1.15, 1], opacity: [0.6, 1, 0.6])"
+                         Transition="Bm.Tween(1.4, repeat: BmRepeat.Forever)">
+                    <div class="dot" />
+                </Bmotion>
+                """,
+            Notes = "BmEase.Linear is the one case where linear is correct: a spinner that eases has a visible " +
+                    "stutter every revolution. Keyframe arrays need the per-frame loop, so the pulse above " +
+                    "snaps on Blazor Server while the plain rotation still plays."
+        },
+        new()
+        {
+            Id = "split-text-headline",
+            Title = "Animate a headline word by word",
+            Intent = "Reveal a heading one character, word or line at a time.",
+            Keywords = "split text headline letters characters words lines typography reveal per letter title",
+            SeeAlso = "/split-text",
+            Code = """
+                <BmotionSplitText Text="Motion, written in C#"
+                                  By="BmSplitBy.Words"
+                                  Initial="Bm.To(opacity: 0, y: 24)"
+                                  Animate="Bm.To(opacity: 1, y: 0)"
+                                  Stagger="Bm.Stagger(0.05)"
+                                  Transition="Bm.Spring(bounce: 0.25, duration: 0.6)">
+                </BmotionSplitText>
+                """,
+            Notes = "The text is split in C# and each unit rendered as its own element, so there is no DOM " +
+                    "surgery and no flash of unsplit text. Split by Character for short headings only - a long " +
+                    "sentence becomes a great many animated elements, and screen readers read the whole string " +
+                    "either way."
+        },
+        new()
+        {
+            Id = "programmatic-animation",
+            Title = "Animate from C# code",
+            Intent = "Trigger an animation from an event handler rather than from component state.",
+            Keywords = "programmatic imperative code behind service animate async selector elementreference trigger manual",
+            SeeAlso = "/programmatic",
+            Code = """
+                @inject BmotionAnimateService Motion
+
+                <Bmotion @ref="_box">
+                    <div class="box" />
+                </Bmotion>
+
+                <button @onclick="PulseAsync">Pulse</button>
+
+                @code {
+                    private Bmotion _box = default!;
+
+                    private async Task PulseAsync()
+                    {
+                        // Through the component reference - the element it wraps.
+                        await _box.AnimateAsync(Bm.To(scale: 1.2), Bm.Spring(bounce: 0.5));
+                        await _box.AnimateAsync(Bm.To(scale: 1), Bm.Spring(bounce: 0.2));
+
+                        // Or by selector, across many elements at once, with a stagger.
+                        await Motion.AnimateAsync(".card", Bm.To(y: 0, opacity: 1),
+                                                  Bm.Tween(0.4), Bm.Stagger(0.06));
+                    }
+                }
+                """,
+            Notes = "Prefer declarative Animate for anything that follows component state - it survives " +
+                    "re-renders, and an imperative animation does not. Reach for the service when the " +
+                    "animation is genuinely an event (a pulse on save, a shake on error) or when it has to " +
+                    "span elements the component does not own."
+        },
+        new()
+        {
+            Id = "respect-reduced-motion",
+            Title = "Respect the reduced-motion preference",
+            Intent = "Stop animations from harming users who have asked their operating system for less motion.",
+            Keywords = "accessibility reduced motion prefers-reduced-motion a11y vestibular disable animation policy",
+            SeeAlso = "/accessibility",
+            Code = """
+                // Program.cs - set the policy once, for the whole app.
+                builder.Services.AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMode.User);
+                """,
+            Notes = "The default is IgnoreUnlessConfigured, which is back-compatible rather than correct: it " +
+                    "consults the OS preference only inside a <BmotionConfig>. User respects it everywhere and " +
+                    "is what a new app should set. Reduced motion does not switch animation off - transforms, " +
+                    "layout and dimension changes snap while opacity and colour still animate, so the state " +
+                    "change stays legible. Do not hand-roll this with a media query check of your own."
+        },
+    ];
+
+    /// <summary>The recipes without their code, for the listing.</summary>
+    public static BmotionRecipeDto[] Summaries =>
+        [.. All.Select(recipe => recipe with { Code = null, Notes = null })];
+
+    /// <summary>One recipe by id, matched loosely so "modal" finds "modal-dialog".</summary>
+    public static BmotionRecipeDto? Find(string? id)
+    {
+        var key = (id ?? string.Empty).Trim();
+
+        if (key.Length == 0) return null;
+
+        return All.FirstOrDefault(recipe => string.Equals(recipe.Id, key, StringComparison.OrdinalIgnoreCase))
+            ?? All.FirstOrDefault(recipe => recipe.Id.Contains(key, StringComparison.OrdinalIgnoreCase))
+            ?? All.FirstOrDefault(recipe => recipe.Title.Contains(key, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSearchIndex.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSearchIndex.cs
@@ -1,0 +1,287 @@
+using System.Text;
+using Bit.Bmotion.Demo.Server.Dtos;
+using Bit.Bmotion.Demo.Client.Shared;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// One searchable index over everything this MCP server knows: the guide, every public type and
+/// member, the animatable properties, the easing presets, the recipes, the demo pages and their
+/// sources.
+/// <para>
+/// Without it an agent has to guess which corpus holds the answer and what it is called there.
+/// "How do I make a list appear one item at a time?" is a guide section (Orchestration), a
+/// component parameter (Transition.ChildStagger), a recipe (staggered-list) and a demo page
+/// (/variants) all at once, and none of those contain the word the question was asked with. Each
+/// hit therefore carries the exact follow-up call that returns its full text, so one search is
+/// enough to know what to ask for next.
+/// </para>
+/// </summary>
+public static class BmotionSearchIndex
+{
+    private sealed record Entry(string Kind, string Title, string? Context, string Tool, string Body, string Boosted)
+    {
+        /// <summary>
+        /// The title split into words, camel-case humps included, so "StaggerChildren" is found by
+        /// "stagger" - and so a query word only counts as a title hit when it IS one of those words,
+        /// rather than merely appearing inside one.
+        /// </summary>
+        public string[] TitleWords { get; } = SplitWords(Title);
+    }
+
+    private const int MaxTerms = 16;
+
+    private static readonly Lazy<Task<Entry[]>> _entries = new(BuildAsync);
+
+    private static readonly HashSet<string> _stopWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "how", "the", "and", "for", "with", "from", "that", "this", "what", "when", "where", "which",
+        "does", "did", "are", "was", "you", "your", "than", "then", "its", "but", "any", "some",
+        "please", "help", "about", "into", "way", "make", "want", "need", "would", "should", "could",
+        "there", "here", "have", "has", "get", "got", "let", "one", "two", "per", "via", "onto",
+        // Every entry in this index is about animating something in Bmotion; a query saying so
+        // matches everything and ranks nothing.
+        "bmotion", "animate", "animation", "animated", "animating", "blazor", "element",
+        // The words a problem is reported in. Left in, they outrank the answer: "why does my
+        // animation not run" scores every RunAsync method and every NotFound file in the corpus.
+        "not", "why", "run", "runs", "running", "work", "works", "working", "use", "using",
+        "can", "will", "wont", "isnt", "doesnt", "instead", "still", "just", "only", "even"
+    };
+
+    /// <summary>The best matches for a query, each with the call that returns it in full.</summary>
+    public static async Task<BmotionSearchHitDto[]> SearchAsync(string query, int limit)
+    {
+        var terms = Tokenize(query);
+        if (terms.Length == 0) return [];
+
+        var entries = await _entries.Value;
+
+        return [.. entries
+            .Select(entry => (Entry: entry, Score: Score(entry, terms)))
+            .Where(hit => hit.Score > 0)
+            .OrderByDescending(hit => hit.Score)
+            .ThenBy(hit => hit.Entry.Title, StringComparer.OrdinalIgnoreCase)
+            .Take(Math.Clamp(limit, 1, 50))
+            .Select(hit => new BmotionSearchHitDto
+            {
+                Kind = hit.Entry.Kind,
+                Title = hit.Entry.Title,
+                Context = hit.Entry.Context,
+                Tool = hit.Entry.Tool,
+                Snippet = Snippet(hit.Entry.Body, terms)
+            })];
+    }
+
+    private static int Score(Entry entry, string[] terms)
+    {
+        var score = 0;
+        var matched = 0;
+
+        foreach (var term in terms)
+        {
+            var isTitleWord = entry.TitleWords.Any(word => Equivalent(word, term));
+            var inTitle = isTitleWord ? 0 : Count(entry.Title, term);
+            var inBoosted = Count(entry.Boosted, term);
+            var inBody = Count(entry.Body, term);
+
+            if (isTitleWord is false && inTitle + inBoosted + inBody == 0) continue;
+
+            matched++;
+
+            // A term in a name is worth far more than the same term buried in prose: someone asking
+            // for "StaggerChildren" wants the parameter, not the paragraphs that mention it.
+            score += (isTitleWord ? 12 : 0) + inTitle * 3 + inBoosted * 5 + Math.Min(inBody, 6);
+        }
+
+        // Every term matching is the strongest signal a hit is the right one.
+        return matched == 0 ? 0 : score * matched;
+    }
+
+    /// <summary>
+    /// Same word, plural aside - "spring" has to find the section called "Springs", and nobody
+    /// phrases a question in the number the heading happens to use.
+    /// </summary>
+    private static bool Equivalent(string word, string term)
+    {
+        return string.Equals(word, term, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(word, $"{term}s", StringComparison.OrdinalIgnoreCase)
+            || string.Equals($"{word}s", term, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int Count(string text, string term)
+    {
+        if (text.Length == 0) return 0;
+
+        var count = 0;
+        var index = text.IndexOf(term, StringComparison.OrdinalIgnoreCase);
+
+        while (index >= 0)
+        {
+            count++;
+            index = text.IndexOf(term, index + term.Length, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return count;
+    }
+
+    private static string Snippet(string body, string[] terms)
+    {
+        if (body.Length == 0) return string.Empty;
+
+        var index = -1;
+
+        foreach (var term in terms)
+        {
+            index = body.IndexOf(term, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0) break;
+        }
+
+        if (index < 0) index = 0;
+
+        var start = Math.Max(0, index - 80);
+        var length = Math.Min(240, body.Length - start);
+        var snippet = body.Substring(start, length).Replace('\n', ' ').Replace('\r', ' ').Trim();
+
+        return $"{(start > 0 ? "..." : null)}{snippet}{(start + length < body.Length ? "..." : null)}";
+    }
+
+    /// <summary>Splits a name or heading into words, breaking camel-case humps as well as punctuation.</summary>
+    private static string[] SplitWords(string text)
+    {
+        var words = new List<string>();
+        var current = new StringBuilder();
+
+        foreach (var c in text)
+        {
+            if (char.IsLetterOrDigit(c) is false)
+            {
+                if (current.Length > 0) { words.Add(current.ToString()); current.Clear(); }
+                continue;
+            }
+
+            // A capital after a lowercase letter starts a new word ("StaggerChildren" -> stagger
+            // children), while a run of capitals stays together ("SVG", "CSS").
+            if (char.IsUpper(c) && current.Length > 0 && char.IsLower(current[^1]))
+            {
+                words.Add(current.ToString());
+                current.Clear();
+            }
+
+            current.Append(c);
+        }
+
+        if (current.Length > 0) words.Add(current.ToString());
+
+        return [.. words];
+    }
+
+    private static string[] Tokenize(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return [];
+
+        return [.. query.Split(['.', ',', ';', ':', '?', '!', '"', '\'', '(', ')', '[', ']', '{', '}', '/', '\\', '<', '>', '-', '_', ' ', '\t', '\n', '\r'],
+                              StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            // One- and two-letter words match everything and rank nothing, and the words a question
+            // is phrased with do worse than nothing.
+            .Where(term => term.Length > 2 && _stopWords.Contains(term) is false)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            // Every term is counted in every entry's body, so the work is terms x corpus. No question
+            // is phrased in more words than this, while a pasted file as a query would scan for ages.
+            .Take(MaxTerms)];
+    }
+
+    private static async Task<Entry[]> BuildAsync()
+    {
+        var entries = new List<Entry>(768);
+
+        foreach (var section in BmotionSourceCatalog.GuideSections)
+        {
+            var body = BmotionSourceCatalog.GetGuideSection(section.Heading) ?? string.Empty;
+
+            entries.Add(new Entry("Guide section", section.Heading, section.Parent,
+                $"GetBmotionGuideSection(heading: \"{section.Heading}\")", body, string.Empty));
+        }
+
+        // The setup guides carry the render-mode capability matrices, which is where the answer to
+        // "it works locally but not in production" lives. Without them indexed, a question phrased
+        // as a symptom finds whatever else happens to contain the word "server".
+        foreach (var renderMode in BmotionSetupGuide.RenderModes)
+        {
+            var guide = BmotionSetupGuide.Get(renderMode) ?? string.Empty;
+
+            entries.Add(new Entry("Setup guide", $"Setup for {renderMode}", "Render mode",
+                $"GetBmotionSetupGuide(renderMode: \"{renderMode}\")", guide,
+                $"{renderMode} render mode install register services DI container degrade capability"));
+        }
+
+        // Two entries for the tools that answer by running the engine. They are the right response
+        // to a whole class of question - "will this work on Server", "how long does this spring
+        // take", "why does nothing move" - that names no type, section or recipe, and so would
+        // otherwise match nothing at all.
+        entries.Add(new Entry("Tool", "Check whether an animation works on Blazor Server", "Runs the real engine",
+            "AnalyzeBmotionAnimation(properties: \"...\", transition: \"...\")",
+            "Reports which playback path the engine chose for an animation: the browser compositor, which plays " +
+            "everywhere including Blazor Server, or the C# per-frame loop, which exists only on WebAssembly and " +
+            "collapses to an instant state change on Server. Explains why, and what to change.",
+            "server compositor degrade snap instant jump render mode waapi frame loop production interactive auto"));
+
+        entries.Add(new Entry("Tool", "Measure what a transition feels like", "Runs the real engine",
+            "SimulateBmotionTransition(transition: \"...\")",
+            "Plays a spring, tween or inertia transition off-screen and reports its settle time, overshoot, wobble " +
+            "count and curve shape. A spring has no duration argument, so this is the only way to know how long " +
+            "one takes or how far it overshoots before shipping it.",
+            "spring settle duration overshoot bounce wobble too slow too fast feel tune timing damping stiffness"));
+
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            entries.Add(new Entry("Recipe", recipe.Title, "Copy-pasteable pattern",
+                $"GetBmotionRecipe(id: \"{recipe.Id}\")",
+                $"{recipe.Intent}\n{recipe.Notes}", $"{recipe.Id} {recipe.Keywords}"));
+        }
+
+        foreach (var type in BmotionApiCatalog.Types)
+        {
+            entries.Add(new Entry($"API {type.Kind.ToLowerInvariant()}", type.Name, null,
+                $"GetBmotionApiDetails(typeName: \"{type.Name}\")", type.Summary ?? string.Empty, string.Empty));
+
+            var details = BmotionApiCatalog.GetTypeDetails(type.Name);
+            if (details is null) continue;
+
+            foreach (var member in details.Members)
+            {
+                entries.Add(new Entry($"API {member.Kind.ToLowerInvariant()}", $"{type.Name}.{member.Name}", type.Name,
+                    $"GetBmotionApiDetails(typeName: \"{type.Name}\")",
+                    $"{member.Summary} {member.Remarks}".Trim(),
+                    $"{member.Type} {member.Signature}".Trim()));
+            }
+        }
+
+        foreach (var property in await BmotionPropertyCatalog.GetAsync())
+        {
+            entries.Add(new Entry("Animatable property", property.Name, property.Category,
+                "GetBmotionAnimatableProperties()",
+                $"{property.Notes} Writes {property.Css}. On Blazor Server: {property.OnBlazorServer}.".Trim(),
+                $"{property.Css} {property.Example}"));
+        }
+
+        foreach (var easing in await BmotionEasingCatalog.GetAsync())
+        {
+            entries.Add(new Entry("Easing preset", $"BmEase.{easing.Name}", easing.Family,
+                "GetBmotionEasings()", easing.Feel, $"{easing.Direction} {easing.Family}"));
+        }
+
+        foreach (var page in NavItem.All)
+        {
+            entries.Add(new Entry("Demo page", page.Title, "Live example",
+                $"GetBmotionSourceFile(path: \"{page.SourcePath}\")", page.Description, page.Keywords));
+        }
+
+        foreach (var file in BmotionSourceCatalog.SourceFiles)
+        {
+            entries.Add(new Entry("Source file", file.Path, file.Kind,
+                $"GetBmotionSourceFile(path: \"{file.Path}\")", file.Description ?? string.Empty, string.Empty));
+        }
+
+        return [.. entries];
+    }
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSearchIndex.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSearchIndex.cs
@@ -39,7 +39,9 @@ public static class BmotionSearchIndex
 
     private const int MaxTerms = 16;
 
-    private static readonly Lazy<Task<Entry[]>> _entries = new(BuildAsync);
+    // Not readonly: a Lazy<Task> holds on to a faulted task, which would answer every later search
+    // with the exception the first one hit. Replacing it lets the next search build the index again.
+    private static Lazy<Task<Entry[]>> _entries = new(BuildAsync);
 
     private static readonly HashSet<string> _stopWords = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -62,7 +64,7 @@ public static class BmotionSearchIndex
         var terms = Tokenize(query);
         if (terms.Length == 0) return [];
 
-        var entries = await _entries.Value;
+        var entries = await GetEntriesAsync();
 
         return [.. entries
             .Select(entry => (Entry: entry, Score: Score(entry, terms)))
@@ -78,6 +80,23 @@ public static class BmotionSearchIndex
                 Tool = hit.Entry.Tool,
                 Snippet = Snippet(hit.Entry.Body, terms)
             })];
+    }
+
+    private static async Task<Entry[]> GetEntriesAsync()
+    {
+        var lazy = _entries;
+
+        try
+        {
+            return await lazy.Value;
+        }
+        catch (Exception)
+        {
+            // Whoever loses this race has the winner's fresh Lazy, which is equally unbuilt.
+            Interlocked.CompareExchange(ref _entries, new Lazy<Task<Entry[]>>(BuildAsync), lazy);
+
+            throw;
+        }
     }
 
     private static int Score(Entry entry, string[] terms)

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSearchIndex.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSearchIndex.cs
@@ -27,6 +27,14 @@ public static class BmotionSearchIndex
         /// rather than merely appearing inside one.
         /// </summary>
         public string[] TitleWords { get; } = SplitWords(Title);
+
+        /// <summary>
+        /// The name without the type that owns it: "StaggerChildren" out of
+        /// "BmTransition.StaggerChildren". Splitting the title into humps alone would not match a
+        /// query typed as the whole name - which is how a member is written in code, and therefore
+        /// how it is searched for.
+        /// </summary>
+        public string LocalName { get; } = Title[(Title.LastIndexOf('.') + 1)..];
     }
 
     private const int MaxTerms = 16;
@@ -79,7 +87,8 @@ public static class BmotionSearchIndex
 
         foreach (var term in terms)
         {
-            var isTitleWord = entry.TitleWords.Any(word => Equivalent(word, term));
+            var isTitleWord = Equivalent(entry.LocalName, term)
+                           || entry.TitleWords.Any(word => Equivalent(word, term));
             var inTitle = isTitleWord ? 0 : Count(entry.Title, term);
             var inBoosted = Count(entry.Boosted, term);
             var inBody = Count(entry.Body, term);

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSetupGuide.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSetupGuide.cs
@@ -1,0 +1,368 @@
+using System.Collections.Frozen;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// The complete wiring for adding Bit.Bmotion to a Blazor app, one render mode at a time.
+/// <para>
+/// Render mode is the question an agent gets wrong most expensively here, and it fails silently
+/// twice over. In a Blazor Web App the services have to be registered in <b>both</b> DI containers,
+/// because the prerender pass instantiates the client's components on the server - miss one and the
+/// app throws at prerender, not at compile time. And on Blazor Server half the library degrades to
+/// instant state changes by design, so an animation an agent tested on WebAssembly can arrive
+/// working-but-motionless with nothing in the build output to say why.
+/// </para>
+/// <para>
+/// Each guide therefore states the container list, the capability matrix for that mode, and the
+/// smallest working file set - so the answer is the same shape as the work.
+/// </para>
+/// <para>
+/// The guides are composed from plain (uninterpolated) raw string literals: every one of them is
+/// mostly C# and Razor, and an interpolated literal would mean escaping every brace in every code
+/// sample - which is how a sample ends up shipped with a doubled brace in it.
+/// </para>
+/// </summary>
+public static class BmotionSetupGuide
+{
+    /// <summary>The render modes a guide exists for.</summary>
+    public static readonly string[] RenderModes = ["wasm", "server", "auto", "standalone-wasm"];
+
+    private static readonly FrozenDictionary<string, string> _aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["wasm"] = "wasm",
+        ["webassembly"] = "wasm",
+        ["interactivewebassembly"] = "wasm",
+        ["web app"] = "wasm",
+        ["server"] = "server",
+        ["blazor server"] = "server",
+        ["interactiveserver"] = "server",
+        ["auto"] = "auto",
+        ["interactiveauto"] = "auto",
+        ["standalone-wasm"] = "standalone-wasm",
+        ["standalone"] = "standalone-wasm",
+        ["standalone wasm"] = "standalone-wasm",
+        ["hosted wasm"] = "standalone-wasm",
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The guide for a render mode, or null when the mode is not one of <see cref="RenderModes"/>.</summary>
+    public static string? Get(string renderMode)
+    {
+        if (_aliases.TryGetValue((renderMode ?? string.Empty).Trim(), out var mode) is false) return null;
+
+        return mode switch
+        {
+            "server" => Compose(ServerHeader, Install, ServerRegistration, Imports, FirstAnimation, ServerCapabilities),
+            "auto" => Compose(AutoHeader, Install, AutoRegistration, Imports, FirstAnimation, AutoGuidance),
+            "standalone-wasm" => Compose(StandaloneHeader, Install, StandaloneRegistration, Imports, FirstAnimation, StandaloneCapabilities),
+            _ => Compose(WasmHeader, Install, WasmRegistration, Imports, FirstAnimation, WasmCapabilities)
+        };
+    }
+
+    private static string Compose(params string[] parts) => string.Join("\n\n", parts.Select(part => part.Trim()));
+
+    // -- Shared sections -------------------------------------------------------
+
+    private const string Install = """
+        ## 1. Install
+
+        ```bash
+        dotnet add package Bit.Bmotion
+        ```
+
+        The browser bridge (`bit-bmotion.js`) ships as a static web asset of the package and is imported
+        automatically the first time an animation runs. There is no `<script>` tag to add, and no
+        JavaScript to write.
+
+        Targets .NET 8, 9 and 10.
+        """;
+
+    private const string Imports = """
+        ## 3. Make the components reachable
+
+        Add one line to `_Imports.razor` in every project that renders animations:
+
+        ```razor
+        @using Bit.Bmotion
+        ```
+
+        Without it `<Bmotion>` is not a known component and the build fails with RZ10012 - which is the
+        friendly failure, unlike the DI mistake above, because the compiler catches this one.
+        """;
+
+    private const string FirstAnimation = """
+        ## 4. Check it works
+
+        ```razor
+        <Bmotion Initial="Bm.To(opacity: 0, y: 20)"
+                 Animate="Bm.To(opacity: 1, y: 0)"
+                 Transition="Bm.Spring(bounce: 0.3, duration: 0.5)">
+            <div>Hello, Bmotion!</div>
+        </Bmotion>
+        ```
+
+        The element fades in and slides up on first render. If it appears without moving, the page is
+        still prerendered markup: Bmotion is inert during prerendering by design and starts once the
+        runtime is interactive.
+        """;
+
+    // -- InteractiveWebAssembly ------------------------------------------------
+
+    private const string WasmHeader = """
+        # Bit.Bmotion in a Blazor Web App - InteractiveWebAssembly
+
+        The fully supported configuration: every feature works, because the browser runs .NET and the
+        engine can use the synchronous per-frame loop.
+        """;
+
+    private const string WasmRegistration = """
+        ## 2. Register the services - in BOTH containers
+
+        A Blazor Web App has two DI containers. The client's components are instantiated **twice**: once
+        on the server for the prerender pass, and once in the browser. Anything they inject has to
+        resolve in both places, so both `Program.cs` files call the same method.
+
+        Put the registration in one place so it cannot drift:
+
+        ```csharp
+        // Client/Extensions/IServiceCollectionExtensions.cs
+        using Bit.Bmotion;
+
+        namespace Microsoft.Extensions.DependencyInjection;
+
+        public static class IServiceCollectionExtensions
+        {
+            public static IServiceCollection AddDemoServices(this IServiceCollection services)
+            {
+                services.AddBitBmotionServices();
+
+                return services;
+            }
+        }
+        ```
+
+        ```csharp
+        // Client/Program.cs (WebAssembly)
+        var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+        builder.Services.AddDemoServices();
+
+        await builder.Build().RunAsync();
+        ```
+
+        ```csharp
+        // Server/Program.cs (the host)
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddRazorComponents()
+            .AddInteractiveWebAssemblyComponents();
+
+        // The prerender pass instantiates the client's components in THIS container, so it has to
+        // register the very same services the WebAssembly container does.
+        builder.Services.AddDemoServices();
+
+        var app = builder.Build();
+
+        app.MapStaticAssets();
+
+        app.MapRazorComponents<App>()
+            .AddInteractiveWebAssemblyRenderMode()
+            .AddAdditionalAssemblies(typeof(Client._Imports).Assembly);
+
+        app.Run();
+        ```
+
+        > Registering in only one container is the single most common Bmotion setup bug. It fails at
+        > prerender with a missing-service exception, not at compile time.
+        """;
+
+    private const string WasmCapabilities = """
+        ## What works in this mode
+
+        | Feature | Status |
+        |---|---|
+        | Tweens and springs on transform + opacity | Full - offloaded to the browser compositor |
+        | Colour, dimension and keyframe-array animation | Full - C# per-frame loop |
+        | Drag, inertia, motion values, gestures | Full |
+        | Layout (FLIP) and shared-element transitions | Full |
+        | Scroll timelines | Full |
+
+        Nothing degrades. Call `GetBmotionSetupGuide("server")` before assuming the same of a Server app.
+        """;
+
+    // -- InteractiveServer -----------------------------------------------------
+
+    private const string ServerHeader = """
+        # Bit.Bmotion in a Blazor Web App - InteractiveServer
+
+        **Read the capability table at the bottom before writing any animation for this mode.** Blazor
+        Server has no synchronous JS interop, so the per-frame engine cannot run. Animations the browser
+        compositor can own still play normally; everything else becomes an instant state change -
+        visibly, silently, and only at runtime.
+        """;
+
+    private const string ServerRegistration = """
+        ## 2. Register the services
+
+        One container, because the components only ever run on the server:
+
+        ```csharp
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddRazorComponents()
+            .AddInteractiveServerComponents();
+
+        builder.Services.AddBitBmotionServices();
+
+        var app = builder.Build();
+
+        app.MapStaticAssets();
+
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        app.Run();
+        ```
+        """;
+
+    private const string ServerCapabilities = """
+        ## What works in this mode
+
+        | Feature | Status on Blazor Server |
+        |---|---|
+        | Tweens and zero-velocity springs on transform + opacity | **Full.** Pre-sampled in C# and handed to the Web Animations API over one async call |
+        | Enter, exit, hover, tap and variant animations on those properties | **Full** |
+        | Colour interpolation (backgroundColor, color, fill, ...) | **Jumps to the target** |
+        | Dimension and layout properties (width, height, top, ...) | **Jumps to the target** |
+        | Keyframe arrays, per-property transitions, arc paths | **Jumps to the target** |
+        | Drag, inertia, motion values, `Transition.OnUpdate` | **Not available** - they need the per-frame loop |
+        | Layout (FLIP) and shared-element transitions | **Jumps to the target** |
+
+        ## Writing for this mode
+
+        1. Animate `x`, `y`, `scale`, `rotate` and `opacity`. They cover most interface motion, and they
+           are exactly the properties the compositor can own.
+        2. Replace a `width`/`height` animation with `scale`, and a `top`/`left` animation with `x`/`y`.
+        3. Check any animation you are unsure about with `AnalyzeBmotionAnimation` - it runs the real
+           engine and reports which path it took, rather than guessing from this table.
+        4. Make the degradation visible to the reader rather than mysterious, by injecting the
+           capability flags:
+
+        ```razor
+        @inject BmotionCapabilities Caps
+
+        @if (Caps.SupportsFrameLoop is false)
+        {
+            <p>Drag is disabled here: this page is served over Blazor Server.</p>
+        }
+        ```
+        """;
+
+    // -- InteractiveAuto -------------------------------------------------------
+
+    private const string AutoHeader = """
+        # Bit.Bmotion in a Blazor Web App - InteractiveAuto
+
+        Auto is the hardest mode to write animations for, because **the same component runs in both
+        modes**: Server on the first visit, WebAssembly once the runtime has been downloaded and cached.
+        An animation that needs the per-frame loop therefore works on the second visit and not on the
+        first - which is the worst possible way to find out about it.
+        """;
+
+    private const string AutoRegistration = """
+        ## 2. Register the services - in BOTH containers
+
+        Identical to the WebAssembly guide, and doubly required here: in Auto the server container is not
+        only prerendering, it is running the components interactively until the runtime arrives.
+
+        ```csharp
+        // Server/Program.cs
+        builder.Services.AddRazorComponents()
+            .AddInteractiveServerComponents()
+            .AddInteractiveWebAssemblyComponents();
+
+        builder.Services.AddDemoServices();   // the shared method - see the wasm guide
+
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode()
+            .AddInteractiveWebAssemblyRenderMode()
+            .AddAdditionalAssemblies(typeof(Client._Imports).Assembly);
+        ```
+
+        ```csharp
+        // Client/Program.cs
+        builder.Services.AddDemoServices();
+        ```
+        """;
+
+    private const string AutoGuidance = """
+        ## Writing for this mode
+
+        Design for the Server capability set, and treat everything beyond it as an enhancement:
+
+        1. Build the interface out of `x`, `y`, `scale`, `rotate` and `opacity` animations. Those play in
+           both modes, so the first visit and the second look the same.
+        2. Gate anything that needs the frame loop - drag, inertia, motion values, colour animation - on
+           the capability flag, and give the Server path a static equivalent:
+
+        ```razor
+        @inject BmotionCapabilities Caps
+
+        @if (Caps.SupportsFrameLoop)
+        {
+            <Bmotion Drag="BmDrag.Both">...</Bmotion>
+        }
+        else
+        {
+            <div>...</div>   @* the same content, without the gesture *@
+        }
+        ```
+
+        3. Verify with `AnalyzeBmotionAnimation` before shipping: an animation it reports as running on
+           the C# frame loop is one that behaves differently on the user's first visit.
+        """;
+
+    // -- Standalone WebAssembly ------------------------------------------------
+
+    private const string StandaloneHeader = """
+        # Bit.Bmotion in a standalone Blazor WebAssembly app
+
+        The simplest setup: one project, one DI container, and every feature available.
+        """;
+
+    private const string StandaloneRegistration = """
+        ## 2. Register the services
+
+        ```csharp
+        using Bit.Bmotion;
+
+        var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+        builder.RootComponents.Add<App>("#app");
+        builder.RootComponents.Add<HeadOutlet>("head::after");
+
+        builder.Services.AddBitBmotionServices();
+
+        await builder.Build().RunAsync();
+        ```
+
+        There is no second container and no prerender pass, so the registration mistake that catches out
+        Blazor Web Apps cannot happen here.
+        """;
+
+    private const string StandaloneCapabilities = """
+        ## What works in this mode
+
+        Everything. Compositor-eligible animations offload to the Web Animations API and the rest run on
+        the C# per-frame loop over synchronous interop, which a standalone WebAssembly app always has.
+
+        ## Worth setting while you are here
+
+        ```csharp
+        builder.Services.AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMode.User);
+        ```
+
+        The default is `IgnoreUnlessConfigured`, which is back-compatible rather than correct: it
+        consults the operating system's reduced-motion preference only inside a `<BmotionConfig>`.
+        `User` respects it everywhere, which is the web-platform default and what a new app should do.
+        """;
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSourceCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSourceCatalog.cs
@@ -1,0 +1,313 @@
+using System.Text;
+using System.Reflection;
+using System.Collections.Frozen;
+using Bit.Bmotion.Demo.Server.Dtos;
+using System.Text.RegularExpressions;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Serves the two bodies of hand-written text the MCP tools hand out: the Bit.Bmotion guide (the
+/// library README) and the source of this demo, whose pages are the worked examples.
+/// <para>
+/// Both are embedded into this assembly by the .csproj rather than read from disk, so the tools
+/// keep working from a published, single-folder deployment where the repository is nowhere to be
+/// found.
+/// </para>
+/// </summary>
+public static partial class BmotionSourceCatalog
+{
+    private const string ReadmeResource = "BmotionDocs/README.md";
+    private const string SourcePrefix = "BmotionSource/";
+
+    private static readonly Assembly _assembly = typeof(BmotionSourceCatalog).Assembly;
+
+    private static readonly Lazy<string> _readme = new(() => ReadResource(ReadmeResource) ?? string.Empty);
+    private static readonly Lazy<string[]> _readmeLines = new(() => Readme.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'));
+    private static readonly Lazy<BmotionGuideSectionDto[]> _guideSections = new(BuildGuideSections);
+    private static readonly Lazy<FrozenDictionary<string, string>> _sourceFiles = new(BuildSourceFiles);
+    private static readonly Lazy<BmotionSourceFileDto[]> _sourceFileList = new(BuildSourceFileList);
+
+    /// <summary>The Bit.Bmotion guide, in full.</summary>
+    public static string Readme => _readme.Value;
+
+    /// <summary>Every heading of the guide, in reading order.</summary>
+    public static BmotionGuideSectionDto[] GuideSections => _guideSections.Value;
+
+    /// <summary>Every embedded source file, described.</summary>
+    public static BmotionSourceFileDto[] SourceFiles => _sourceFileList.Value;
+
+    /// <summary>
+    /// The guide text under <paramref name="heading"/>, including its sub-sections. Matching is
+    /// case- and punctuation-insensitive, so "layout shared elements" finds
+    /// "Layout &amp; shared elements".
+    /// </summary>
+    public static string? GetGuideSection(string heading)
+    {
+        if (string.IsNullOrWhiteSpace(heading)) return null;
+
+        var lines = _readmeLines.Value;
+        var normalized = NormalizeHeading(heading);
+
+        int start = -1, level = 0;
+        var fenced = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (IsCodeFence(lines[i]))
+            {
+                fenced = fenced is false;
+                continue;
+            }
+
+            if (fenced) continue;
+
+            if (TryReadHeading(lines[i], out var lineLevel, out var text) is false) continue;
+
+            if (start < 0)
+            {
+                if (NormalizeHeading(text) != normalized) continue;
+
+                start = i;
+                level = lineLevel;
+                continue;
+            }
+
+            // The section ends at the next heading of the same or a higher rank.
+            if (lineLevel > level) continue;
+
+            return string.Join('\n', lines[start..i]).TrimEnd();
+        }
+
+        return start < 0 ? null : string.Join('\n', lines[start..]).TrimEnd();
+    }
+
+    /// <summary>The content of an embedded source file, or null when the path is unknown.</summary>
+    public static string? GetSourceFile(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        return _sourceFiles.Value.GetValueOrDefault(Normalize(path));
+    }
+
+    private static string? ReadResource(string name)
+    {
+        using var stream = _assembly.GetManifestResourceStream(name);
+        if (stream is null) return null;
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+
+        return reader.ReadToEnd();
+    }
+
+    private static BmotionGuideSectionDto[] BuildGuideSections()
+    {
+        var lines = _readmeLines.Value;
+        var headings = new List<(int Index, int Level, string Text)>();
+
+        var fenced = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (IsCodeFence(lines[i]))
+            {
+                fenced = fenced is false;
+                continue;
+            }
+
+            if (fenced) continue;
+
+            if (TryReadHeading(lines[i], out var level, out var text) && level is 2 or 3)
+            {
+                headings.Add((i, level, text));
+            }
+        }
+
+        var sections = new List<BmotionGuideSectionDto>(headings.Count);
+        string? parent = null;
+
+        for (int i = 0; i < headings.Count; i++)
+        {
+            var (index, level, text) = headings[i];
+
+            if (level == 2) parent = text;
+
+            // The section runs until the next heading of the same or a higher rank.
+            var end = lines.Length;
+
+            for (int j = i + 1; j < headings.Count; j++)
+            {
+                if (headings[j].Level > level) continue;
+
+                end = headings[j].Index;
+                break;
+            }
+
+            sections.Add(new BmotionGuideSectionDto
+            {
+                Heading = text,
+                Level = level,
+                Parent = level == 2 ? null : parent,
+                Lines = end - index
+            });
+        }
+
+        // The table of contents is a list of links to the sections below it: as an answer it is
+        // strictly worse than the section it points at, and it outranks real content in search.
+        return [.. sections.Where(section => NormalizeHeading(section.Heading) != "tableofcontents")];
+    }
+
+    private static FrozenDictionary<string, string> BuildSourceFiles()
+    {
+        var files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var resource in _assembly.GetManifestResourceNames())
+        {
+            var normalized = Normalize(resource);
+
+            if (normalized.StartsWith(SourcePrefix, StringComparison.OrdinalIgnoreCase) is false) continue;
+
+            var content = ReadResource(resource);
+            if (content is null) continue;
+
+            files[normalized[SourcePrefix.Length..]] = content;
+        }
+
+        return files.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static BmotionSourceFileDto[] BuildSourceFileList()
+    {
+        return [.. _sourceFiles.Value
+            .Select(file => new BmotionSourceFileDto
+            {
+                Path = file.Key,
+                Kind = file.Key.Contains("/Pages/", StringComparison.OrdinalIgnoreCase) ? "Demo page"
+                     : file.Key.StartsWith("Demo/Server/", StringComparison.OrdinalIgnoreCase) ? "Host"
+                     : "Demo",
+                Description = DescribeSource(file.Value),
+                Lines = CountLines(file.Value)
+            })
+            .OrderBy(file => file.Kind, StringComparer.Ordinal)
+            .ThenBy(file => file.Path, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>
+    /// The number of lines in a file. A trailing newline ends the last line rather than starting
+    /// another one, so a file that has one is not reported a line longer than it is.
+    /// </summary>
+    private static int CountLines(string content)
+    {
+        if (content.Length == 0) return 0;
+
+        var newlines = content.Count(c => c == '\n');
+
+        return content[^1] == '\n' ? newlines : newlines + 1;
+    }
+
+    /// <summary>
+    /// A one-line description of a source file, taken from whatever the file itself already says:
+    /// its leading razor/C# comment, its XML summary, or - for a page - its &lt;PageTitle&gt;.
+    /// </summary>
+    private static string? DescribeSource(string content)
+    {
+        var leadingComment = LeadingRazorCommentRegex().Match(content);
+        if (leadingComment.Success) return Summarize(leadingComment.Groups["text"].Value);
+
+        var summary = XmlSummaryRegex().Match(content);
+        if (summary.Success)
+        {
+            // An XML summary is markup: <paramref name="Slug"/> and friends are noise in a listing.
+            var text = summary.Groups["text"].Value.Replace("///", " ", StringComparison.Ordinal);
+
+            return Summarize(XmlTagRegex().Replace(text, string.Empty));
+        }
+
+        var title = PageTitleRegex().Match(content);
+        if (title.Success) return Summarize(title.Groups["text"].Value);
+
+        var lineComment = LeadingLineCommentRegex().Match(content);
+        if (lineComment.Success) return Summarize(lineComment.Value.Replace("//", " ", StringComparison.Ordinal));
+
+        // Nothing at the top of the file said what it is - the first commentary in it will do.
+        var comment = RazorCommentRegex().Match(content);
+
+        return comment.Success ? Summarize(comment.Groups["text"].Value) : null;
+    }
+
+    private static string? Summarize(string text)
+    {
+        text = WhitespaceRegex().Replace(text, " ").Trim();
+        if (text.Length == 0) return null;
+
+        // The first sentence is the description; the rest is the file's own commentary.
+        var stop = text.IndexOf(". ", StringComparison.Ordinal);
+        if (stop > 0) text = text[..(stop + 1)];
+
+        return text.Length <= 220 ? text : $"{text[..217]}...";
+    }
+
+    /// <summary>
+    /// A Markdown code fence. A '#' line inside one is a shell comment or a C# preprocessor
+    /// directive, not a heading, and must not start or end a guide section.
+    /// </summary>
+    private static bool IsCodeFence(string line)
+    {
+        var text = line.TrimStart();
+
+        return text.StartsWith("```", StringComparison.Ordinal) || text.StartsWith("~~~", StringComparison.Ordinal);
+    }
+
+    private static bool TryReadHeading(string line, out int level, out string text)
+    {
+        level = 0;
+        text = string.Empty;
+
+        while (level < line.Length && line[level] == '#') level++;
+
+        if (level is 0 or > 6 || level >= line.Length || line[level] != ' ') return false;
+
+        text = line[(level + 1)..].Trim();
+
+        return text.Length > 0;
+    }
+
+    /// <summary>
+    /// Reduces a heading to its comparable core, so "Motion values" finds "## Motion values" and
+    /// "layout shared elements" finds "## Layout &amp; shared elements".
+    /// </summary>
+    private static string NormalizeHeading(string heading)
+    {
+        var builder = new StringBuilder(heading.Length);
+
+        foreach (var c in heading)
+        {
+            if (char.IsLetterOrDigit(c)) builder.Append(char.ToLowerInvariant(c));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Normalize(string path) => path.Replace('\\', '/').Trim('/');
+
+    [GeneratedRegex(@"^\s*@\*(?<text>.*?)\*@", RegexOptions.Singleline)]
+    private static partial Regex LeadingRazorCommentRegex();
+
+    [GeneratedRegex(@"@\*(?<text>.*?)\*@", RegexOptions.Singleline)]
+    private static partial Regex RazorCommentRegex();
+
+    [GeneratedRegex(@"<[^>]+>")]
+    private static partial Regex XmlTagRegex();
+
+    [GeneratedRegex(@"///\s*<summary>(?<text>.*?)</summary>", RegexOptions.Singleline)]
+    private static partial Regex XmlSummaryRegex();
+
+    [GeneratedRegex(@"<PageTitle>(?<text>.*?)</PageTitle>", RegexOptions.Singleline | RegexOptions.IgnoreCase)]
+    private static partial Regex PageTitleRegex();
+
+    [GeneratedRegex(@"^\s*(//[^\n]*\n)+")]
+    private static partial Regex LeadingLineCommentRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSourceCatalog.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionSourceCatalog.cs
@@ -117,7 +117,11 @@ public static partial class BmotionSourceCatalog
 
             if (fenced) continue;
 
-            if (TryReadHeading(lines[i], out var level, out var text) && level is 2 or 3)
+            // Every level is collected, not only the two that are reported: a section ends at the
+            // next heading of the same or a higher rank, and a level 1 heading outranks both - so
+            // leaving those out would run a section on into the chapter after it, as GetGuideSection
+            // (which reads all of them) would not.
+            if (TryReadHeading(lines[i], out var level, out var text))
             {
                 headings.Add((i, level, text));
             }
@@ -130,7 +134,9 @@ public static partial class BmotionSourceCatalog
         {
             var (index, level, text) = headings[i];
 
-            if (level == 2) parent = text;
+            if (level <= 2) parent = level == 2 ? text : null;
+
+            if (level is not (2 or 3)) continue;
 
             // The section runs until the next heading of the same or a higher rank.
             var end = lines.Length;

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
@@ -1,0 +1,413 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Turns the way a person (or an agent) writes a transition into the <see cref="BmTransition"/> the
+/// engine runs.
+/// <para>
+/// An MCP client has one string to hand over, and no two of them phrase a spring the same way:
+/// <c>Bm.Spring(stiffness: 260, damping: 12)</c> copied out of a Razor file, <c>spring stiffness=260
+/// damping=12</c> typed from memory, <c>spring(0.4 bounce)</c> half-remembered. Rejecting all but one
+/// spelling would mean an agent spends its turns guessing at syntax instead of at motion, so this
+/// parser accepts the family and reports what it understood - including the canonical C# call, which
+/// is what the agent should actually write into the code.
+/// </para>
+/// <para>
+/// It is deliberately not a C# parser. It recognises the three transition kinds and their named
+/// arguments; anything it does not recognise comes back as a warning rather than being silently
+/// dropped, so a misspelled argument is visible instead of quietly becoming a default.
+/// </para>
+/// </summary>
+public static partial class BmotionTransitionSpec
+{
+    /// <summary>What a spec string parsed into.</summary>
+    /// <param name="Transition">The transition to run, or null when the spec could not be read.</param>
+    /// <param name="Canonical">The C# call that produces it - what to write in the code.</param>
+    /// <param name="Warnings">Arguments that were not recognised, and assumptions that were made.</param>
+    /// <param name="Error">Why the spec could not be read, when it could not.</param>
+    public sealed record Result(BmTransition? Transition, string Canonical, string[] Warnings, string? Error);
+
+    /// <summary>The transition kinds a spec can name, for error messages and tool descriptions.</summary>
+    public static readonly string[] Kinds = ["spring", "tween", "inertia"];
+
+    /// <summary>
+    /// Reads a transition spec. Accepts <c>spring</c>, <c>tween</c> and <c>inertia</c>, with or
+    /// without a <c>Bm.</c> prefix, parentheses, named arguments (<c>name: value</c> or
+    /// <c>name=value</c>) and positional arguments in the order the <c>Bm</c> factory declares them.
+    /// An empty spec is a default tween, which is what the library itself falls back to.
+    /// </summary>
+    public static Result Parse(string? spec)
+    {
+        var text = (spec ?? string.Empty).Trim();
+
+        if (text.Length == 0) return Build("tween", [], []);
+
+        // "Bm.Spring(...)", "Motion.Spring(...)" and a bare "Spring(...)" are the same request.
+        text = QualifierRegex().Replace(text, string.Empty);
+
+        var open = text.IndexOf('(');
+        var kindText = (open < 0 ? FirstWord(text) : text[..open]).Trim();
+        var kind = kindText.ToLowerInvariant();
+
+        var warnings = new List<string>();
+
+        // A spec that opens with a number is a duration: "0.4" and "0.4, InOut" are tweens.
+        if (kind.Length == 0 || double.TryParse(kindText, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+        {
+            kind = "tween";
+            warnings.Add("No transition kind was named, so this was read as a tween. Write 'spring', 'tween' or 'inertia' to be explicit.");
+            return Build(kind, SplitArguments(text), warnings);
+        }
+
+        if (Kinds.Contains(kind) is false)
+        {
+            return new Result(null, string.Empty, [],
+                $"'{kindText}' is not a Bit.Bmotion transition kind. Use one of: {string.Join(", ", Kinds)} - " +
+                "for example 'spring(stiffness: 260, damping: 12)', 'tween(0.4, InOut)' or 'inertia(velocity: 500)'.");
+        }
+
+        // Arguments are whatever sits inside the parentheses, or everything after the kind when the
+        // spec was written without them.
+        var close = text.LastIndexOf(')');
+        var arguments = open >= 0 && close > open
+            ? text[(open + 1)..close]
+            : text[kindText.Length..];
+
+        return Build(kind, SplitArguments(arguments), warnings);
+    }
+
+    private static Result Build(string kind, string[] arguments, List<string> warnings)
+    {
+        // Positional arguments follow the Bm factory signatures, so a spec copied out of Razor
+        // means here what it means there.
+        string[] positional = kind switch
+        {
+            "spring" => ["stiffness", "damping", "mass"],
+            "inertia" => ["velocity", "timeconstant", "power"],
+            _ => ["duration", "ease"]
+        };
+
+        var named = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var index = 0;
+
+        foreach (var argument in arguments)
+        {
+            var separator = argument.IndexOfAny([':', '=']);
+
+            if (separator > 0)
+            {
+                var name = argument[..separator].Trim();
+                var value = argument[(separator + 1)..].Trim();
+
+                if (name.Length > 0) named[name] = value;
+
+                continue;
+            }
+
+            // A positional argument only has meaning while the signature still has a slot for it.
+            if (index < positional.Length)
+            {
+                named[positional[index++]] = argument.Trim();
+                continue;
+            }
+
+            warnings.Add($"'{argument.Trim()}' was ignored: it is past the last positional argument of a {kind}.");
+        }
+
+        return kind switch
+        {
+            "spring" => BuildSpring(named, warnings),
+            "inertia" => BuildInertia(named, warnings),
+            _ => BuildTween(named, warnings)
+        };
+    }
+
+    private static Result BuildSpring(Dictionary<string, string> named, List<string> warnings)
+    {
+        var spring = new BmSpring();
+        var written = new List<string>();
+
+        // Bounce and duration derive stiffness and damping, so a spec that sets both forms would
+        // silently have half of it ignored by the engine. Say so rather than letting it look applied.
+        var hasPhysics = named.ContainsKey("stiffness") || named.ContainsKey("damping");
+        var hasFeel = named.ContainsKey("bounce");
+
+        if (hasPhysics && hasFeel)
+        {
+            warnings.Add("Both 'bounce' and 'stiffness'/'damping' were given. Bounce wins: the engine derives " +
+                         "stiffness and damping from bounce and duration, so the explicit values are unused.");
+        }
+
+        foreach (var (name, value) in named)
+        {
+            switch (name.ToLowerInvariant())
+            {
+                case "stiffness" when TryNumber(name, value, warnings, out var stiffness):
+                    spring.Stiffness = stiffness;
+                    written.Add($"stiffness: {Number(stiffness)}");
+                    break;
+
+                case "damping" when TryNumber(name, value, warnings, out var damping):
+                    spring.Damping = damping;
+                    written.Add($"damping: {Number(damping)}");
+                    break;
+
+                case "mass" when TryNumber(name, value, warnings, out var mass):
+                    spring.Mass = mass;
+                    written.Add($"mass: {Number(mass)}");
+                    break;
+
+                case "bounce" when TryNumber(name, value, warnings, out var bounce):
+                    spring.Bounce = bounce;
+                    written.Add($"bounce: {Number(bounce)}");
+                    break;
+
+                case "duration" or "visualduration" when TryNumber(name, value, warnings, out var duration):
+                    spring.Duration = duration;
+                    written.Add($"duration: {Number(duration)}");
+                    break;
+
+                case "velocity" when TryNumber(name, value, warnings, out var velocity):
+                    spring.Velocity = velocity;
+                    written.Add($"velocity: {Number(velocity)}");
+                    break;
+
+                case "restspeed" when TryNumber(name, value, warnings, out var restSpeed):
+                    spring.RestSpeed = restSpeed;
+                    break;
+
+                case "restdelta" when TryNumber(name, value, warnings, out var restDelta):
+                    spring.RestDelta = restDelta;
+                    break;
+
+                case "delay" when TryNumber(name, value, warnings, out var delay):
+                    spring.Delay = delay;
+                    written.Add($"delay: {Number(delay)}");
+                    break;
+
+                default:
+                    Unknown(name, "spring", "stiffness, damping, mass, bounce, duration, velocity, restSpeed, restDelta, delay", warnings);
+                    break;
+            }
+        }
+
+        // A bounce spring with no duration is the library's own default visual duration; stating it
+        // keeps the canonical call runnable as written.
+        if (spring.Bounce.HasValue && spring.Duration.HasValue is false)
+        {
+            warnings.Add("'bounce' was given without a 'duration'; the spring uses its Duration default. " +
+                         "Pass both for the motion.dev-style pairing, e.g. spring(bounce: 0.4, duration: 0.6).");
+        }
+
+        return new Result(spring, $"Bm.Spring({string.Join(", ", written)})", [.. warnings], null);
+    }
+
+    private static Result BuildTween(Dictionary<string, string> named, List<string> warnings)
+    {
+        var tween = new BmTween();
+        var written = new List<string>();
+
+        foreach (var (name, value) in named)
+        {
+            switch (name.ToLowerInvariant())
+            {
+                case "duration" when TryNumber(name, value, warnings, out var duration):
+                    tween.Duration = duration;
+                    written.Insert(0, Number(duration));
+                    break;
+
+                case "ease" or "easing":
+                    if (TryEase(value, out var ease))
+                    {
+                        tween.Ease = ease;
+                        written.Add($"BmEase.{ease}");
+                    }
+                    else
+                    {
+                        warnings.Add($"'{value}' is not a BmEase value; the tween kept BmEase.{tween.Ease}. " +
+                                     "Call GetBmotionEasings for the full list.");
+                    }
+                    break;
+
+                case "delay" when TryNumber(name, value, warnings, out var delay):
+                    tween.Delay = delay;
+                    written.Add($"delay: {Number(delay)}");
+                    break;
+
+                case "steps" when TryNumber(name, value, warnings, out var steps):
+                    tween.Steps = (int)steps;
+                    written.Add($"steps: {(int)steps}");
+                    break;
+
+                case "bezier":
+                    var bezier = Numbers(value);
+                    if (bezier.Length == 4)
+                    {
+                        tween.Bezier = bezier;
+                        written.Add($"bezier: [{string.Join(", ", bezier.Select(Number))}]");
+                    }
+                    else
+                    {
+                        warnings.Add("'bezier' needs exactly four numbers, e.g. bezier: [0.42, 0, 0.58, 1].");
+                    }
+                    break;
+
+                default:
+                    Unknown(name, "tween", "duration, ease, delay, steps, bezier", warnings);
+                    break;
+            }
+        }
+
+        return new Result(tween, $"Bm.Tween({string.Join(", ", written)})", [.. warnings], null);
+    }
+
+    private static Result BuildInertia(Dictionary<string, string> named, List<string> warnings)
+    {
+        var inertia = new BmInertia();
+        var written = new List<string>();
+
+        foreach (var (name, value) in named)
+        {
+            switch (name.ToLowerInvariant())
+            {
+                case "velocity" when TryNumber(name, value, warnings, out var velocity):
+                    inertia.Velocity = velocity;
+                    written.Add($"velocity: {Number(velocity)}");
+                    break;
+
+                case "timeconstant" when TryNumber(name, value, warnings, out var timeConstant):
+                    inertia.TimeConstant = timeConstant;
+                    written.Add($"timeConstant: {Number(timeConstant)}");
+                    break;
+
+                case "power" when TryNumber(name, value, warnings, out var power):
+                    inertia.Power = power;
+                    written.Add($"power: {Number(power)}");
+                    break;
+
+                case "min" when TryNumber(name, value, warnings, out var min):
+                    inertia.Min = min;
+                    written.Add($"min: {Number(min)}");
+                    break;
+
+                case "max" when TryNumber(name, value, warnings, out var max):
+                    inertia.Max = max;
+                    written.Add($"max: {Number(max)}");
+                    break;
+
+                case "restdelta" when TryNumber(name, value, warnings, out var restDelta):
+                    inertia.RestDelta = restDelta;
+                    break;
+
+                case "delay" when TryNumber(name, value, warnings, out var delay):
+                    inertia.Delay = delay;
+                    written.Add($"delay: {Number(delay)}");
+                    break;
+
+                default:
+                    Unknown(name, "inertia", "velocity, timeConstant, power, min, max, restDelta, delay", warnings);
+                    break;
+            }
+        }
+
+        return new Result(inertia, $"Bm.Inertia({string.Join(", ", written)})", [.. warnings], null);
+    }
+
+    /// <summary>Resolves a <see cref="BmEase"/> by name, with or without its enum qualifier.</summary>
+    public static bool TryEase(string? text, out BmEase ease)
+    {
+        ease = BmEase.Out;
+
+        var name = (text ?? string.Empty).Trim();
+        if (name.Length == 0) return false;
+
+        // "BmEase.InOut", "ease.InOut" and "easeInOut" all name the same member.
+        var dot = name.LastIndexOf('.');
+        if (dot >= 0) name = name[(dot + 1)..];
+        if (name.StartsWith("ease", StringComparison.OrdinalIgnoreCase) && name.Length > 4) name = name[4..];
+
+        return Enum.TryParse(name, ignoreCase: true, out ease);
+    }
+
+    private static void Unknown(string name, string kind, string known, List<string> warnings)
+    {
+        warnings.Add($"'{name}' is not an argument of a {kind} and was ignored. A {kind} takes: {known}.");
+    }
+
+    private static bool TryNumber(string name, string value, List<string> warnings, out double number)
+    {
+        // Units are how a person writes seconds; the library takes plain numbers.
+        var text = value.Trim().TrimEnd('s', 'S').Trim();
+
+        if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out number)) return true;
+
+        warnings.Add($"'{value}' is not a number, so '{name}' was ignored.");
+
+        return false;
+    }
+
+    private static double[] Numbers(string value)
+    {
+        return [.. value.Split(['[', ']', ',', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(part => double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var number)
+                ? number
+                : double.NaN)
+            .Where(double.IsFinite)];
+    }
+
+    /// <summary>
+    /// Splits an argument list on commas, falling back to whitespace when it was written without
+    /// any - which is how a spec typed by hand usually arrives.
+    /// </summary>
+    private static string[] SplitArguments(string arguments)
+    {
+        var text = arguments.Trim().Trim('(', ')');
+        if (text.Length == 0) return [];
+
+        // A bezier argument carries its own commas inside its brackets, so the comma split has to
+        // respect nesting; a spec written without commas at all is split on whitespace instead.
+        var parts = text.Contains(',')
+            ? SplitOutsideBrackets(text)
+            : text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return [.. parts.Where(part => part.Length > 0)];
+    }
+
+    private static string[] SplitOutsideBrackets(string text)
+    {
+        var parts = new List<string>();
+        var depth = 0;
+        var start = 0;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            if (c is '[' or '(') depth++;
+            else if (c is ']' or ')') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                parts.Add(text[start..i].Trim());
+                start = i + 1;
+            }
+        }
+
+        parts.Add(text[start..].Trim());
+
+        return [.. parts];
+    }
+
+    private static string FirstWord(string text)
+    {
+        var space = text.IndexOfAny([' ', '\t']);
+
+        return space < 0 ? text : text[..space];
+    }
+
+    private static string Number(double value) => value.ToString("0.####", CultureInfo.InvariantCulture);
+
+    [GeneratedRegex(@"^\s*(Bm|Motion|BmTransition)\s*\.\s*", RegexOptions.IgnoreCase)]
+    private static partial Regex QualifierRegex();
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
@@ -399,11 +399,16 @@ public static partial class BmotionTransitionSpec
         return [.. parts];
     }
 
+    /// <summary>
+    /// The leading token of a spec written without parentheses. A comma ends it as surely as a
+    /// space does: "0.4, InOut" names a duration followed by an easing, and reading "0.4," as the
+    /// kind would leave a plain tween spec unparseable.
+    /// </summary>
     private static string FirstWord(string text)
     {
-        var space = text.IndexOfAny([' ', '\t']);
+        var end = text.IndexOfAny([' ', '\t', ',']);
 
-        return space < 0 ? text : text[..space];
+        return end < 0 ? text : text[..end];
     }
 
     private static string Number(double value) => value.ToString("0.####", CultureInfo.InvariantCulture);

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
@@ -32,6 +32,16 @@ public static partial class BmotionTransitionSpec
     /// <summary>The transition kinds a spec can name, for error messages and tool descriptions.</summary>
     public static readonly string[] Kinds = ["spring", "tween", "inertia"];
 
+    // The numeric arguments of each kind, lower-cased. Matching the name before reading the value is
+    // what keeps an unreadable value from being reported as an argument the kind does not have.
+    private static readonly string[] _springArguments =
+        ["stiffness", "damping", "mass", "bounce", "duration", "visualduration", "velocity", "restspeed", "restdelta", "delay"];
+
+    private static readonly string[] _tweenArguments = ["duration", "delay", "steps"];
+
+    private static readonly string[] _inertiaArguments =
+        ["velocity", "timeconstant", "power", "min", "max", "restdelta", "delay"];
+
     /// <summary>
     /// Reads a transition spec. Accepts <c>spring</c>, <c>tween</c> and <c>inertia</c>, with or
     /// without a <c>Bm.</c> prefix, parentheses, named arguments (<c>name: value</c> or
@@ -142,53 +152,62 @@ public static partial class BmotionTransitionSpec
 
         foreach (var (name, value) in named)
         {
-            switch (name.ToLowerInvariant())
+            var argument = name.ToLowerInvariant();
+
+            // Whether the name is one a spring takes and whether its value reads as a number are two
+            // separate questions. Asked as one, "stiffness: fast" comes back as an argument a spring
+            // does not have - which sends the caller off renaming an argument that was already right.
+            if (_springArguments.Contains(argument) is false)
             {
-                case "stiffness" when TryNumber(name, value, warnings, out var stiffness):
-                    spring.Stiffness = stiffness;
-                    written.Add($"stiffness: {Number(stiffness)}");
+                Unknown(name, "spring", "stiffness, damping, mass, bounce, duration, velocity, restSpeed, restDelta, delay", warnings);
+                continue;
+            }
+
+            if (TryNumber(name, value, warnings, out var number) is false) continue;
+
+            switch (argument)
+            {
+                case "stiffness":
+                    spring.Stiffness = number;
+                    written.Add($"stiffness: {Number(number)}");
                     break;
 
-                case "damping" when TryNumber(name, value, warnings, out var damping):
-                    spring.Damping = damping;
-                    written.Add($"damping: {Number(damping)}");
+                case "damping":
+                    spring.Damping = number;
+                    written.Add($"damping: {Number(number)}");
                     break;
 
-                case "mass" when TryNumber(name, value, warnings, out var mass):
-                    spring.Mass = mass;
-                    written.Add($"mass: {Number(mass)}");
+                case "mass":
+                    spring.Mass = number;
+                    written.Add($"mass: {Number(number)}");
                     break;
 
-                case "bounce" when TryNumber(name, value, warnings, out var bounce):
-                    spring.Bounce = bounce;
-                    written.Add($"bounce: {Number(bounce)}");
+                case "bounce":
+                    spring.Bounce = number;
+                    written.Add($"bounce: {Number(number)}");
                     break;
 
-                case "duration" or "visualduration" when TryNumber(name, value, warnings, out var duration):
-                    spring.Duration = duration;
-                    written.Add($"duration: {Number(duration)}");
+                case "duration" or "visualduration":
+                    spring.Duration = number;
+                    written.Add($"duration: {Number(number)}");
                     break;
 
-                case "velocity" when TryNumber(name, value, warnings, out var velocity):
-                    spring.Velocity = velocity;
-                    written.Add($"velocity: {Number(velocity)}");
+                case "velocity":
+                    spring.Velocity = number;
+                    written.Add($"velocity: {Number(number)}");
                     break;
 
-                case "restspeed" when TryNumber(name, value, warnings, out var restSpeed):
-                    spring.RestSpeed = restSpeed;
+                case "restspeed":
+                    spring.RestSpeed = number;
                     break;
 
-                case "restdelta" when TryNumber(name, value, warnings, out var restDelta):
-                    spring.RestDelta = restDelta;
+                case "restdelta":
+                    spring.RestDelta = number;
                     break;
 
-                case "delay" when TryNumber(name, value, warnings, out var delay):
-                    spring.Delay = delay;
-                    written.Add($"delay: {Number(delay)}");
-                    break;
-
-                default:
-                    Unknown(name, "spring", "stiffness, damping, mass, bounce, duration, velocity, restSpeed, restDelta, delay", warnings);
+                case "delay":
+                    spring.Delay = number;
+                    written.Add($"delay: {Number(number)}");
                     break;
             }
         }
@@ -211,51 +230,65 @@ public static partial class BmotionTransitionSpec
 
         foreach (var (name, value) in named)
         {
-            switch (name.ToLowerInvariant())
+            var argument = name.ToLowerInvariant();
+
+            if (argument is "ease" or "easing")
             {
-                case "duration" when TryNumber(name, value, warnings, out var duration):
-                    tween.Duration = duration;
-                    written.Insert(0, Number(duration));
+                if (TryEase(value, out var ease))
+                {
+                    tween.Ease = ease;
+                    written.Add($"BmEase.{ease}");
+                }
+                else
+                {
+                    warnings.Add($"'{value}' is not a BmEase value; the tween kept BmEase.{tween.Ease}. " +
+                                 "Call GetBmotionEasings for the full list.");
+                }
+
+                continue;
+            }
+
+            if (argument is "bezier")
+            {
+                var bezier = Numbers(value);
+
+                if (bezier.Length == 4)
+                {
+                    tween.Bezier = bezier;
+                    written.Add($"bezier: [{string.Join(", ", bezier.Select(Number))}]");
+                }
+                else
+                {
+                    warnings.Add("'bezier' needs exactly four numbers, e.g. bezier: [0.42, 0, 0.58, 1].");
+                }
+
+                continue;
+            }
+
+            // A value that is not a number is reported as that, not as an unknown name: see BuildSpring.
+            if (_tweenArguments.Contains(argument) is false)
+            {
+                Unknown(name, "tween", "duration, ease, delay, steps, bezier", warnings);
+                continue;
+            }
+
+            if (TryNumber(name, value, warnings, out var number) is false) continue;
+
+            switch (argument)
+            {
+                case "duration":
+                    tween.Duration = number;
+                    written.Insert(0, Number(number));
                     break;
 
-                case "ease" or "easing":
-                    if (TryEase(value, out var ease))
-                    {
-                        tween.Ease = ease;
-                        written.Add($"BmEase.{ease}");
-                    }
-                    else
-                    {
-                        warnings.Add($"'{value}' is not a BmEase value; the tween kept BmEase.{tween.Ease}. " +
-                                     "Call GetBmotionEasings for the full list.");
-                    }
+                case "delay":
+                    tween.Delay = number;
+                    written.Add($"delay: {Number(number)}");
                     break;
 
-                case "delay" when TryNumber(name, value, warnings, out var delay):
-                    tween.Delay = delay;
-                    written.Add($"delay: {Number(delay)}");
-                    break;
-
-                case "steps" when TryNumber(name, value, warnings, out var steps):
-                    tween.Steps = (int)steps;
-                    written.Add($"steps: {(int)steps}");
-                    break;
-
-                case "bezier":
-                    var bezier = Numbers(value);
-                    if (bezier.Length == 4)
-                    {
-                        tween.Bezier = bezier;
-                        written.Add($"bezier: [{string.Join(", ", bezier.Select(Number))}]");
-                    }
-                    else
-                    {
-                        warnings.Add("'bezier' needs exactly four numbers, e.g. bezier: [0.42, 0, 0.58, 1].");
-                    }
-                    break;
-
-                default:
-                    Unknown(name, "tween", "duration, ease, delay, steps, bezier", warnings);
+                case "steps":
+                    tween.Steps = (int)number;
+                    written.Add($"steps: {(int)number}");
                     break;
             }
         }
@@ -270,44 +303,51 @@ public static partial class BmotionTransitionSpec
 
         foreach (var (name, value) in named)
         {
-            switch (name.ToLowerInvariant())
+            var argument = name.ToLowerInvariant();
+
+            // A value that is not a number is reported as that, not as an unknown name: see BuildSpring.
+            if (_inertiaArguments.Contains(argument) is false)
             {
-                case "velocity" when TryNumber(name, value, warnings, out var velocity):
-                    inertia.Velocity = velocity;
-                    written.Add($"velocity: {Number(velocity)}");
+                Unknown(name, "inertia", "velocity, timeConstant, power, min, max, restDelta, delay", warnings);
+                continue;
+            }
+
+            if (TryNumber(name, value, warnings, out var number) is false) continue;
+
+            switch (argument)
+            {
+                case "velocity":
+                    inertia.Velocity = number;
+                    written.Add($"velocity: {Number(number)}");
                     break;
 
-                case "timeconstant" when TryNumber(name, value, warnings, out var timeConstant):
-                    inertia.TimeConstant = timeConstant;
-                    written.Add($"timeConstant: {Number(timeConstant)}");
+                case "timeconstant":
+                    inertia.TimeConstant = number;
+                    written.Add($"timeConstant: {Number(number)}");
                     break;
 
-                case "power" when TryNumber(name, value, warnings, out var power):
-                    inertia.Power = power;
-                    written.Add($"power: {Number(power)}");
+                case "power":
+                    inertia.Power = number;
+                    written.Add($"power: {Number(number)}");
                     break;
 
-                case "min" when TryNumber(name, value, warnings, out var min):
-                    inertia.Min = min;
-                    written.Add($"min: {Number(min)}");
+                case "min":
+                    inertia.Min = number;
+                    written.Add($"min: {Number(number)}");
                     break;
 
-                case "max" when TryNumber(name, value, warnings, out var max):
-                    inertia.Max = max;
-                    written.Add($"max: {Number(max)}");
+                case "max":
+                    inertia.Max = number;
+                    written.Add($"max: {Number(number)}");
                     break;
 
-                case "restdelta" when TryNumber(name, value, warnings, out var restDelta):
-                    inertia.RestDelta = restDelta;
+                case "restdelta":
+                    inertia.RestDelta = number;
                     break;
 
-                case "delay" when TryNumber(name, value, warnings, out var delay):
-                    inertia.Delay = delay;
-                    written.Add($"delay: {Number(delay)}");
-                    break;
-
-                default:
-                    Unknown(name, "inertia", "velocity, timeConstant, power, min, max, restDelta, delay", warnings);
+                case "delay":
+                    inertia.Delay = number;
+                    written.Add($"delay: {Number(number)}");
                     break;
             }
         }

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionTransitionSpec.cs
@@ -119,7 +119,19 @@ public static partial class BmotionTransitionSpec
             // A positional argument only has meaning while the signature still has a slot for it.
             if (index < positional.Length)
             {
-                named[positional[index++]] = argument.Trim();
+                var slot = positional[index++];
+                var text = argument.Trim();
+
+                // Bm.Tween takes the duration first, but "tween(BackOut)" is how an easing-only tween
+                // is written, and reading that as a duration would reject the one thing it says. The
+                // number test comes first: Enum.TryParse reads a bare number as a BmEase.
+                if (slot is "duration" && TryParseNumber(text, out _) is false && TryEase(text, out _))
+                {
+                    slot = "ease";
+                    index = Array.IndexOf(positional, "ease") + 1;
+                }
+
+                named[slot] = text;
                 continue;
             }
 
@@ -378,14 +390,30 @@ public static partial class BmotionTransitionSpec
 
     private static bool TryNumber(string name, string value, List<string> warnings, out double number)
     {
-        // Units are how a person writes seconds; the library takes plain numbers.
-        var text = value.Trim().TrimEnd('s', 'S').Trim();
-
-        if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out number)) return true;
+        if (TryParseNumber(value, out number)) return true;
 
         warnings.Add($"'{value}' is not a number, so '{name}' was ignored.");
 
         return false;
+    }
+
+    /// <summary>
+    /// Units are how a person writes a time; the library takes plain seconds. The "ms" has to be read
+    /// before it is dropped: trimming the trailing s off "300ms" leaves "300m", and dropping the unit
+    /// without converting leaves 300 seconds - a thousand times the motion that was asked for.
+    /// </summary>
+    private static bool TryParseNumber(string value, out double number)
+    {
+        var text = value.Trim();
+        var milliseconds = text.EndsWith("ms", StringComparison.OrdinalIgnoreCase);
+
+        text = (milliseconds ? text[..^2] : text.TrimEnd('s', 'S')).Trim();
+
+        if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out number) is false) return false;
+
+        if (milliseconds) number /= 1000;
+
+        return true;
     }
 
     private static double[] Numbers(string value)

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionXmlDocs.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionXmlDocs.cs
@@ -1,0 +1,187 @@
+using System.Text;
+using System.Xml.Linq;
+using System.Collections.Frozen;
+using System.Text.RegularExpressions;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// Reads the XML documentation the Bit.Bmotion build emits next to its assembly and flattens each
+/// entry into plain text: <c>&lt;see cref="T:Bit.Bmotion.BmSpring"/&gt;</c> becomes
+/// <c>BmSpring</c>, <c>&lt;c&gt;</c> spans become their content, and paragraphs become blank
+/// lines. That text is the same prose a developer reads in IntelliSense, which makes it the most
+/// accurate answer an MCP client can get about a member - there is no second copy to keep in sync.
+/// </summary>
+public static partial class BmotionXmlDocs
+{
+    private const char CodeMarker = (char)1;
+
+    private static readonly Lazy<FrozenDictionary<string, XElement>> _members = new(Load);
+    private static readonly Lazy<FrozenDictionary<string, XElement>> _overloads = new(BuildOverloads);
+
+    /// <summary>The flattened &lt;summary&gt; of a documented member, or null.</summary>
+    public static string? GetSummary(string documentationId) => GetSection(documentationId, "summary");
+
+    /// <summary>The flattened &lt;remarks&gt; of a documented member, or null.</summary>
+    public static string? GetRemarks(string documentationId) => GetSection(documentationId, "remarks");
+
+    private static string? GetSection(string documentationId, string section)
+    {
+        // Overloads are told apart by their parameter list; when building it did not produce an
+        // exact hit (generics, modifiers), one overload's documentation still beats none.
+        if (_members.Value.TryGetValue(documentationId, out var member) is false &&
+            _overloads.Value.TryGetValue(documentationId, out member) is false) return null;
+
+        var element = member.Element(section);
+
+        return element is null ? null : Flatten(element);
+    }
+
+    /// <summary>
+    /// Every documented method by its id without the parameter list, so an inexact id still finds an
+    /// overload without walking the whole table. Which overload is decided by ordering the
+    /// candidates - a FrozenDictionary enumerates in whatever order it hashed into, so taking one
+    /// off it directly would answer differently per build.
+    /// </summary>
+    private static FrozenDictionary<string, XElement> BuildOverloads()
+    {
+        return _members.Value.Where(member => member.Key.Contains('(', StringComparison.Ordinal))
+                             .OrderBy(member => member.Key, StringComparer.Ordinal)
+                             .GroupBy(member => member.Key[..member.Key.IndexOf('(', StringComparison.Ordinal)], StringComparer.Ordinal)
+                             .ToFrozenDictionary(group => group.Key, group => group.First().Value, StringComparer.Ordinal);
+    }
+
+    private static FrozenDictionary<string, XElement> Load()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, $"{typeof(Bm).Assembly.GetName().Name}.xml");
+
+        if (File.Exists(path) is false) return FrozenDictionary<string, XElement>.Empty;
+
+        try
+        {
+            var document = XDocument.Load(path);
+
+            return document.Descendants("member")
+                           .Where(member => member.Attribute("name") is not null)
+                           .GroupBy(member => member.Attribute("name")!.Value, StringComparer.Ordinal)
+                           .ToFrozenDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        }
+        catch (Exception)
+        {
+            // Documentation is a nicety: a malformed or half-written file must not take the tools down.
+            return FrozenDictionary<string, XElement>.Empty;
+        }
+    }
+
+    private static string Flatten(XElement element)
+    {
+        var builder = new StringBuilder();
+        var codeSamples = new List<string>();
+
+        Write(element, builder, codeSamples);
+
+        var text = builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        // The source wraps its prose across lines, so a single newline is just a space - while the
+        // blank line a <para> emits is a real paragraph break and has to survive.
+        text = WrappedLineRegex().Replace(text, " ");
+        text = ParagraphBreakRegex().Replace(text, "\n\n");
+        text = RepeatedSpaceRegex().Replace(text, " ");
+
+        // A code sample only stood in as a placeholder while the prose was unwrapped: its own line
+        // breaks and indentation are the sample, not source wrapping, and go back in verbatim.
+        for (int i = 0; i < codeSamples.Count; i++)
+        {
+            text = text.Replace(CodePlaceholder(i), codeSamples[i], StringComparison.Ordinal);
+        }
+
+        return text.Trim();
+    }
+
+    /// <summary>
+    /// Stands in for a code sample while the prose is unwrapped. U+0001 never occurs in
+    /// documentation text, and none of the whitespace passes above can touch it.
+    /// </summary>
+    private static string CodePlaceholder(int index) => $"{CodeMarker}{index}{CodeMarker}";
+
+    private static void Write(XNode node, StringBuilder builder, List<string> codeSamples)
+    {
+        switch (node)
+        {
+            case XText text:
+                builder.Append(text.Value);
+                return;
+
+            case XElement element:
+                switch (element.Name.LocalName)
+                {
+                    case "see" or "seealso":
+                        builder.Append(Reference(element));
+                        return;
+
+                    case "paramref" or "typeparamref":
+                        builder.Append(element.Attribute("name")?.Value);
+                        return;
+
+                    case "para":
+                        builder.Append('\n');
+                        foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
+                        builder.Append('\n');
+                        return;
+
+                    case "code":
+                        // Blank lines on both sides, so the sample is a block of its own rather than
+                        // a sentence that happens to continue in code.
+                        builder.Append("\n\n").Append(CodePlaceholder(codeSamples.Count)).Append("\n\n");
+                        codeSamples.Add(element.Value.Trim());
+                        return;
+
+                    case "param" or "typeparam":
+                        builder.Append('\n').Append(element.Attribute("name")?.Value).Append(": ");
+                        foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
+                        return;
+
+                    default:
+                        foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
+                        return;
+                }
+        }
+    }
+
+    /// <summary>Turns a cref such as "T:Bit.Bmotion.BmSpring.Stiffness" into "BmSpring.Stiffness".</summary>
+    private static string Reference(XElement element)
+    {
+        var target = element.Attribute("cref")?.Value ?? element.Attribute("langword")?.Value ?? element.Value;
+
+        if (string.IsNullOrEmpty(target)) return string.Empty;
+
+        var kind = target.Length > 2 && target[1] == ':' ? target[0] : '\0';
+        if (kind != '\0') target = target[2..];
+
+        // A method cref carries its parameter list. Fully qualified argument types read as noise in
+        // prose, and the '.'s inside them would otherwise be split on below - which would keep the
+        // arguments and drop the owning type.
+        var arguments = target.IndexOf('(', StringComparison.Ordinal);
+        if (arguments > 0) target = target[..arguments];
+
+        // Drop the arity marker of a generic type ("BmValue`1").
+        var arity = target.IndexOf('`', StringComparison.Ordinal);
+        if (arity > 0) target = target[..arity];
+
+        var parts = target.Split('.');
+
+        // A type reads best on its own; a member keeps the type it belongs to.
+        var keep = kind is 'T' or 'N' ? 1 : 2;
+
+        return parts.Length <= keep ? target : string.Join('.', parts[^keep..]);
+    }
+
+    [GeneratedRegex(@"(?<!\n)[ \t]*\n[ \t]*(?!\n)")]
+    private static partial Regex WrappedLineRegex();
+
+    [GeneratedRegex(@"[ \t]*\n[ \t\n]*")]
+    private static partial Regex ParagraphBreakRegex();
+
+    [GeneratedRegex(@"[ \t]{2,}")]
+    private static partial Regex RepeatedSpaceRegex();
+}

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionXmlDocs.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/BmotionXmlDocs.cs
@@ -124,9 +124,13 @@ public static partial class BmotionXmlDocs
                         return;
 
                     case "para":
-                        builder.Append('\n');
+                        // A blank line on either side, as the code case does. A single newline is how
+                        // the source wraps its prose, and the unwrapping pass turns one of those back
+                        // into a space: the break would survive only for as long as every <para> in the
+                        // library keeps being written on a line of its own.
+                        builder.Append("\n\n");
                         foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
-                        builder.Append('\n');
+                        builder.Append("\n\n");
                         return;
 
                     case "code":
@@ -137,8 +141,11 @@ public static partial class BmotionXmlDocs
                         return;
 
                     case "param" or "typeparam":
-                        builder.Append('\n').Append(element.Attribute("name")?.Value).Append(": ");
+                        // Each parameter is a paragraph of its own, for the same reason - and the
+                        // trailing break is what separates the last one from prose that follows it.
+                        builder.Append("\n\n").Append(element.Attribute("name")?.Value).Append(": ");
                         foreach (var child in element.Nodes()) Write(child, builder, codeSamples);
+                        builder.Append("\n\n");
                         return;
 
                     default:

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Services/HeadlessBmotionInterop.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Services/HeadlessBmotionInterop.cs
@@ -1,0 +1,173 @@
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bit.Bmotion.Demo.Server.Services;
+
+/// <summary>
+/// A browser-free <see cref="IBmotionInterop"/> that lets the MCP tools run the real Bit.Bmotion
+/// engine on the server, with no DOM anywhere.
+/// <para>
+/// It is the reason <c>SimulateBmotionTransition</c> and <c>AnalyzeBmotionAnimation</c> can answer
+/// with numbers instead of adjectives: the engine takes exactly the decisions it takes in a
+/// browser - whether an animation can be handed to the compositor, how a spring is sampled, how
+/// long it keeps ticking - and this fake records them rather than forwarding them to JavaScript.
+/// The alternative would be a second implementation of the physics living in the demo, which is
+/// the one thing guaranteed to drift away from the library it documents.
+/// </para>
+/// <para>
+/// <see cref="IsInProcess"/> reports <c>true</c>, which is what the engine reads to decide that a
+/// per-frame loop exists (Blazor WebAssembly). Frames are then advanced by calling the engine's
+/// <c>ComputeFrame</c> directly - see <see cref="BmotionMotionLab"/> - instead of by a real
+/// <c>requestAnimationFrame</c> ticker, so a simulation runs as fast as the CPU allows rather than
+/// in real time.
+/// </para>
+/// </summary>
+internal sealed class HeadlessBmotionInterop : IBmotionInterop
+{
+    /// <summary>One compositor (Web Animations API) hand-off the engine attempted.</summary>
+    /// <param name="ElementId">The element the engine offloaded.</param>
+    /// <param name="Keyframes">The pre-sampled CSS keyframes, as handed to the browser.</param>
+    /// <param name="Timing">The WAAPI timing object: duration, delay, easing, iterations, direction.</param>
+    internal sealed record WaapiCall(string ElementId, object Keyframes, object Timing);
+
+    private readonly List<WaapiCall> _waapiCalls = [];
+    private int _elementSeq;
+
+    /// <summary>Every compositor offload the engine asked for, in order. Empty means it stayed on the frame loop.</summary>
+    public IReadOnlyList<WaapiCall> WaapiCalls => _waapiCalls;
+
+    /// <summary>
+    /// Whether the browser is pretended to support CSS <c>linear()</c> easing. Springs can only be
+    /// offloaded to the compositor when it does, so turning this off is how a simulation asks what
+    /// happens on a browser that lacks it.
+    /// </summary>
+    public bool SupportsLinearEasing { get; init; } = true;
+
+    /// <summary>What <see cref="PrefersReducedMotionAsync"/> answers - the OS accessibility setting.</summary>
+    public bool PrefersReducedMotion { get; init; }
+
+    /// <summary>
+    /// <c>true</c>: the engine believes a synchronous per-frame loop is available, as on Blazor
+    /// WebAssembly. Set it to <c>false</c> to observe the Blazor Server behaviour instead, where
+    /// everything that needs the loop collapses to an instant state change.
+    /// </summary>
+    public bool IsInProcess { get; init; } = true;
+
+    // -- The frame loop --------------------------------------------------------
+    // Deliberately inert: a real ticker would race the simulation, which advances the clock itself
+    // so it can sample at a chosen resolution and stop the moment the animation settles.
+
+    public ValueTask StartRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
+        => ValueTask.CompletedTask;
+
+    public ValueTask StopRafLoopAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T>? dotnetRef = null) where T : class
+        => ValueTask.CompletedTask;
+
+    // -- Reduced motion --------------------------------------------------------
+
+    public ValueTask<bool> PrefersReducedMotionAsync() => ValueTask.FromResult(PrefersReducedMotion);
+
+    public ValueTask WatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
+        => ValueTask.CompletedTask;
+
+    public ValueTask UnwatchReducedMotionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef) where T : class
+        => ValueTask.CompletedTask;
+
+    // -- Styles and elements ---------------------------------------------------
+    // The engine also returns each frame's styles from ComputeFrame, which is where the simulation
+    // reads them; there is nothing for this method to write them to.
+
+    public ValueTask ApplyStylesAsync(string elementId, object styles) => ValueTask.CompletedTask;
+
+    public ValueTask PopLayoutAsync(string elementId, double currentX, double currentY) => ValueTask.CompletedTask;
+
+    public ValueTask UnpopLayoutAsync(string elementId) => ValueTask.CompletedTask;
+
+    public ValueTask<bool> RegisterElementAsync(string elementId) => ValueTask.FromResult(true);
+
+    public ValueTask UnregisterElementAsync(string elementId) => ValueTask.CompletedTask;
+
+    // -- Gestures and observers ------------------------------------------------
+    // Nothing here can fire without a pointer, a viewport or a scroll container, none of which
+    // exist on the server. They are inert rather than throwing, so an animation that merely
+    // declares a gesture can still be analysed.
+
+    public ValueTask AttachEventListenersAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, object events, DotNetObjectReference<T> dotnetRef) where T : class
+        => ValueTask.CompletedTask;
+
+    public ValueTask StartDragAsync(string elementId, long pointerId, double clientX, double clientY)
+        => ValueTask.CompletedTask;
+
+    public ValueTask ObserveViewportAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, DotNetObjectReference<T> dotnetRef, bool once) where T : class
+        => ValueTask.CompletedTask;
+
+    public ValueTask ObserveViewportWithOptionsAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string elementId, DotNetObjectReference<T> dotnetRef, BmViewport options) where T : class
+        => ValueTask.CompletedTask;
+
+    public ValueTask UnobserveViewportAsync(string elementId) => ValueTask.CompletedTask;
+
+    // -- Layout (FLIP) ---------------------------------------------------------
+    // No element has a box on the server, so a FLIP measurement has no answer. Null is what the
+    // real bridge reports for an element that is not in the document.
+
+    public ValueTask<BmotionBoundingRect?> GetBoundingRectAsync(string elementId, BmotionMeasureOptions options = default)
+        => ValueTask.FromResult<BmotionBoundingRect?>(null);
+
+    public ValueTask PlayWaapiFlipAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        string elementId, double dx, double dy, double sx, double sy, double durationMs, string easingStr,
+        string? finalTransform, double originX, double originY, DotNetObjectReference<T>? dotnetRef) where T : class
+        => ValueTask.CompletedTask;
+
+    // -- Compositor offload ----------------------------------------------------
+
+    public ValueTask<bool> SupportsLinearEasingAsync() => ValueTask.FromResult(SupportsLinearEasing);
+
+    /// <summary>
+    /// Records the hand-off and reports it as played. That the engine called this at all is the
+    /// answer <c>AnalyzeBmotionAnimation</c> is after: an animation the compositor can own plays on
+    /// Blazor Server too, because it needs one async interop call and no frame loop.
+    /// </summary>
+    public ValueTask<bool> PlayWaapiAnimationAsync(string elementId, int token, object keyframes, object timing)
+    {
+        _waapiCalls.Add(new WaapiCall(elementId, keyframes, timing));
+
+        return ValueTask.FromResult(true);
+    }
+
+    public ValueTask CancelWaapiAnimationAsync(string elementId, int token, bool commit) => ValueTask.CompletedTask;
+
+    // -- Scroll ----------------------------------------------------------------
+
+    public ValueTask<bool?> PlayScrollTimelineAsync(string elementId, int token, object keyframes, object timeline)
+        => ValueTask.FromResult<bool?>(true);
+
+    public ValueTask CancelScrollTimelineAsync(string elementId, int token) => ValueTask.CompletedTask;
+
+    public ValueTask<string?> ObserveScrollAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string? containerId, DotNetObjectReference<T> dotnetRef, object? options = null) where T : class
+        => ValueTask.FromResult<string?>(null);
+
+    public ValueTask UnobserveScrollAsync(string key) => ValueTask.CompletedTask;
+
+    // -- Element resolution ----------------------------------------------------
+
+    /// <summary>
+    /// Hands out a fresh synthetic id per call. A selector matches nothing on the server, and
+    /// returning no ids would make every programmatic animation a no-op - which would look
+    /// identical to an animation the engine decided not to run, and defeat the whole simulation.
+    /// </summary>
+    public ValueTask<string[]> ResolveOrRegisterBySelectorAsync(string selector)
+        => ValueTask.FromResult<string[]>([NextElementId()]);
+
+    public ValueTask<string> ResolveOrRegisterByRefAsync(ElementReference elementReference)
+        => ValueTask.FromResult(NextElementId());
+
+    // -- View transitions ------------------------------------------------------
+
+    public ValueTask<bool> StartViewTransitionAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(DotNetObjectReference<T> dotnetRef, string callbackName) where T : class
+        => ValueTask.FromResult(false);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private string NextElementId() => $"bm-headless-{++_elementSeq}";
+}

--- a/src/Bmotion/Bit.Bmotion.slnx
+++ b/src/Bmotion/Bit.Bmotion.slnx
@@ -12,6 +12,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="Tests/Bit.Bmotion.Tests/Bit.Bmotion.Tests.csproj" />
+    <Project Path="Tests/Bit.Bmotion.Tests.Mcp/Bit.Bmotion.Tests.Mcp.csproj" />
   </Folder>
   <Project Path="Bit.Bmotion/Bit.Bmotion.csproj" />
 </Solution>

--- a/src/Bmotion/README.md
+++ b/src/Bmotion/README.md
@@ -912,8 +912,8 @@ drag, variants & stagger, keyframes, enter/exit transitions, presence switching,
 
 The demo hosts an **MCP server** at `/mcp`, so an AI agent can write Bmotion code from what the
 library actually is rather than from what it remembers. Point an MCP client at
-`https://localhost:5001/mcp`; every tool is also a plain HTTP GET under `/api/mcp/...` if you just
-want to look, and the demo's own `/mcp` page documents and exercises all of them.
+`https://localhost:5071/mcp`; every tool is also a plain HTTP GET under `/api/mcp/...` if you just
+want to look, and the demo's own `/mcp-server` page documents and exercises all of them.
 
 What sets it apart from a documentation server is that half of its tools **answer by running the
 real animation engine off-screen** - a headless `IBmotionInterop` lets it construct a genuine

--- a/src/Bmotion/README.md
+++ b/src/Bmotion/README.md
@@ -29,6 +29,7 @@ A Blazor-native animation library inspired by [Motion](https://motion.dev) (Fram
 - [Scroll timelines](#scroll-timelines)
 - [Programmatic API](#programmatic-api)
 - [Motion values](#motion-values)
+- [MCP server (for AI agents)](#mcp-server-for-ai-agents)
 - [Accessibility](#accessibility)
 
 ---
@@ -904,6 +905,46 @@ Scroll-linked animations compose end-to-end:
 See the `Demo` samples app for runnable examples of basic animations, gestures, springs,
 drag, variants & stagger, keyframes, enter/exit transitions, presence switching, layout
 (FLIP) animations, scroll-linked motion values and programmatic control.
+
+---
+
+## MCP server (for AI agents)
+
+The demo hosts an **MCP server** at `/mcp`, so an AI agent can write Bmotion code from what the
+library actually is rather than from what it remembers. Point an MCP client at
+`https://localhost:5001/mcp`; every tool is also a plain HTTP GET under `/api/mcp/...` if you just
+want to look, and the demo's own `/mcp` page documents and exercises all of them.
+
+What sets it apart from a documentation server is that half of its tools **answer by running the
+real animation engine off-screen** - a headless `IBmotionInterop` lets it construct a genuine
+`BmotionAnimationEngine` with no DOM and advance the frame clock itself, so a three-second spring
+is measured in microseconds:
+
+- **`SimulateBmotionTransition`** plays a transition and reports how long it takes to settle, how
+  far it overshoots and what the curve looks like. A spring has no duration argument, so this is
+  the only way to know what one does before shipping it. `CompareBmotionTransitions` ranks several.
+- **`AnalyzeBmotionAnimation`** starts an animation and reports which playback path the engine
+  chose - the browser compositor, or the C# frame loop. That choice is exactly what decides whether
+  the animation plays or silently snaps on Blazor Server, and nothing in a build log says which.
+- **`ReviewBmotionCode`** checks written markup for the mistakes that compile cleanly and then do
+  nothing: an `Exit` with no presence component, a `@foreach` with no `@key`, a spring whose
+  duration the engine ignores.
+- **`GetBmotionRecipes`** / **`GetBmotionRecipe`** hand over complete, copy-pasteable patterns - a
+  staggered list, a modal, a scroll reveal, a shared-element transition - each with the caveat that
+  is not visible in the code.
+- **`SearchBmotion`** covers this guide, every public member, the animatable properties, the easing
+  presets, the recipes, the setup guides and the demo's sources at once, with the exact follow-up
+  call on each hit.
+- **The exact API** (`GetBmotionApiList` / `GetBmotionApiDetails`) is reflected out of the shipped
+  assembly, with every parameter's type, XML documentation and **real default value** - which in an
+  animation library is the behaviour.
+- **Resources** (`bmotion://guide/...`, `bmotion://api/...`, `bmotion://recipes`) and **prompts**
+  for the four common jobs: building an animation, adding Bmotion to an app, tuning how something
+  feels, and debugging an animation that does not move.
+
+Start with the `GetBmotionOverview` tool. See
+[McpController](Bit.Bmotion.Demo/Server/Controllers/McpController.cs) and
+[BmotionMotionLab](Bit.Bmotion.Demo/Server/Services/BmotionMotionLab.cs).
 
 ---
 

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Bit.Bmotion.Tests.Mcp.csproj
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Bit.Bmotion.Tests.Mcp.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!-- Separate from Bit.Bmotion.Tests because the subject is the demo's ASP.NET Core host, which
+         only exists on net10.0, while the library's own tests multi-target back to net8.0. -->
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <!-- A ProjectReference to a Web SDK project leaves OutputType at Library, and the MSTest
+             runner needs an entry point of its own. -->
+        <OutputType>Exe</OutputType>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <EnableMSTestRunner>true</EnableMSTestRunner>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MSTest" Version="4.3.3" />
+        <!-- Hosts the real Program.cs in-memory, so the protocol tests exercise the wiring that
+             ships rather than a second registration written for the tests. -->
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+        <!-- The MCP client half of the same library the server is built on: the protocol tests talk
+             to the server the way an agent does, not by calling the C# methods directly. -->
+        <PackageReference Include="ModelContextProtocol" Version="2.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Bit.Bmotion.Demo\Server\Bit.Bmotion.Demo.Server.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpControllerTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpControllerTests.cs
@@ -80,7 +80,7 @@ public class McpControllerTests
     [TestMethod]
     public void GetBmotionRecipe_AKnownId_ReturnsTheRecipeWithItsCode()
     {
-        var recipe = _controller.GetBmotionRecipe("staggered-list") as BmotionRecipeDto;
+        var recipe = _controller.GetBmotionRecipe("staggered-list").Recipe;
 
         Assert.IsNotNull(recipe, "A known id did not come back as a recipe.");
         Assert.AreEqual("staggered-list", recipe.Id);
@@ -91,7 +91,7 @@ public class McpControllerTests
     [TestMethod]
     public void GetBmotionRecipe_AnUnknownId_NamesEveryIdThatExists()
     {
-        var answer = _controller.GetBmotionRecipe("teleport") as string;
+        var answer = _controller.GetBmotionRecipe("teleport").Message;
 
         Assert.IsNotNull(answer, "An unknown id did not come back as an explanation.");
 
@@ -309,6 +309,29 @@ public class McpControllerTests
 
         // GetMcpCatalog is deliberately not a tool: an agent gets this from tools/list.
         Assert.IsFalse(catalog.Tools.Any(tool => tool.Name == nameof(McpController.GetMcpCatalog)));
+    }
+
+    /// <summary>
+    /// The reviewed body is bounded like every other document this server hands out, and what was cut
+    /// is said out loud: a review that silently covered the first half of a file would read as a clean
+    /// bill of health for the second.
+    /// </summary>
+    [TestMethod]
+    public void ReviewBmotionCode_CodeLongerThanTheLimit_ReviewsWhatFitsAndNamesWhatDidNot()
+    {
+        const string Markup =
+            "<Bmotion Animate=\"Bm.To(opacity: 1)\" Transition=\"Bm.Spring(duration: 0.5)\"><div /></Bmotion>";
+
+        var review = _controller.ReviewBmotionCode(Markup + new string('\n', 60_000) + Markup);
+
+        Assert.IsFalse(review.Passed);
+
+        Assert.IsTrue(review.Findings.Any(finding => finding.Rule == "code-too-long"),
+                      "Nothing said the code was cut short.");
+
+        // And the rules still ran over the part that fit.
+        Assert.IsTrue(review.Findings.Any(finding => finding.Rule == "spring-duration-without-bounce"),
+                      "The head of the code was not reviewed.");
     }
 
     [TestMethod]

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpControllerTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpControllerTests.cs
@@ -1,0 +1,345 @@
+using Bit.Bmotion.Demo.Client.Shared;
+
+namespace Bit.Bmotion.Tests.Mcp.Controllers;
+
+/// <summary>
+/// The tool methods themselves.
+/// <para>
+/// The theme here is what happens when an agent asks for something that is not there. Over MCP a
+/// thrown exception is reduced to "an error occurred invoking X", which teaches the caller nothing
+/// and costs it a turn; every miss in this controller therefore has to come back as text that names
+/// what does exist. These tests hold each of them to that, and check the answers a caller acts on
+/// without reading - the overview an agent starts from, and the catalog the demo page renders.
+/// </para>
+/// </summary>
+[TestClass]
+public class McpControllerTests
+{
+    private readonly McpController _controller = new();
+
+    [TestMethod]
+    public void GetBmotionOverview_IsTheBriefingAnAgentCanStartFrom()
+    {
+        var overview = _controller.GetBmotionOverview();
+
+        Assert.IsTrue(overview.Length > 2_000, $"The overview is only {overview.Length} characters.");
+
+        // The three things it promises: what the library is, how to wire it, and what to call next.
+        StringAssert.Contains(overview, "## Installation");
+        StringAssert.Contains(overview, "## Quick Start");
+        StringAssert.Contains(overview, "## Which tool to call");
+        StringAssert.Contains(overview, "## Rules of thumb when writing Bmotion code");
+
+        // The rule that decides whether an animation works at all in production.
+        StringAssert.Contains(overview, "Blazor Server");
+        StringAssert.Contains(overview, "compositor");
+
+        // A section the guide no longer has must be reported, not left as a silent gap.
+        Assert.IsFalse(overview.Contains("was not found in this build", StringComparison.Ordinal),
+                       "The overview is quoting a guide section that no longer exists.");
+    }
+
+    /// <summary>
+    /// Which build the answers come from. An agent holding a remembered version of the library
+    /// otherwise has no way to tell that this server is answering about a different one.
+    /// </summary>
+    [TestMethod]
+    public void GetBmotionOverview_NamesTheVersionItIsAnsweringFor()
+    {
+        var overview = _controller.GetBmotionOverview();
+
+        StringAssert.Contains(overview, "These tools answer from Bit.Bmotion");
+        Assert.IsFalse(overview.Contains("Bit.Bmotion unknown", StringComparison.Ordinal),
+                       "The assembly version could not be read.");
+    }
+
+    [TestMethod]
+    public void GetBmotionSetupGuide_AnUnknownRenderMode_NamesTheOnesThatExist()
+    {
+        var answer = _controller.GetBmotionSetupGuide("maui");
+
+        foreach (var mode in BmotionSetupGuide.RenderModes)
+        {
+            StringAssert.Contains(answer, mode, $"The answer does not offer '{mode}'.");
+        }
+    }
+
+    [TestMethod]
+    public void GetBmotionGuideSection_AnUnknownHeading_NamesTheOnesThatExist()
+    {
+        var answer = _controller.GetBmotionGuideSection("Teleportation");
+
+        StringAssert.Contains(answer, "no section called 'Teleportation'");
+
+        foreach (var section in BmotionSourceCatalog.GuideSections.Take(3))
+        {
+            StringAssert.Contains(answer, section.Heading);
+        }
+    }
+
+    [TestMethod]
+    public void GetBmotionRecipe_AKnownId_ReturnsTheRecipeWithItsCode()
+    {
+        var recipe = _controller.GetBmotionRecipe("staggered-list") as BmotionRecipeDto;
+
+        Assert.IsNotNull(recipe, "A known id did not come back as a recipe.");
+        Assert.AreEqual("staggered-list", recipe.Id);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(recipe.Code));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(recipe.Notes));
+    }
+
+    [TestMethod]
+    public void GetBmotionRecipe_AnUnknownId_NamesEveryIdThatExists()
+    {
+        var answer = _controller.GetBmotionRecipe("teleport") as string;
+
+        Assert.IsNotNull(answer, "An unknown id did not come back as an explanation.");
+
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            StringAssert.Contains(answer, recipe.Id);
+        }
+
+        StringAssert.Contains(answer, nameof(McpController.SearchBmotion));
+    }
+
+    [TestMethod]
+    public void GetBmotionApiDetails_AKnownType_ReturnsDetailsAndNoMessage()
+    {
+        var result = _controller.GetBmotionApiDetails("BmSpring");
+
+        Assert.IsNotNull(result.Details);
+        Assert.IsNull(result.Message);
+        Assert.AreEqual("BmSpring", result.Details.Name);
+    }
+
+    /// <summary>A near miss is the common case, and the near misses are the useful part of the answer.</summary>
+    [TestMethod]
+    public void GetBmotionApiDetails_AnAlmostRightName_SuggestsTheTypesItCouldMean()
+    {
+        var result = _controller.GetBmotionApiDetails("Spring");
+
+        Assert.IsNull(result.Details);
+        Assert.IsNotNull(result.Message);
+        StringAssert.Contains(result.Message, "BmSpring");
+    }
+
+    [TestMethod]
+    public void GetBmotionApiDetails_ANameLikeNothingAtAll_PointsAtTheListing()
+    {
+        var result = _controller.GetBmotionApiDetails("Teleporter");
+
+        Assert.IsNull(result.Details);
+        StringAssert.Contains(result.Message!, nameof(McpController.GetBmotionApiList));
+    }
+
+    [TestMethod]
+    public void GetBmotionSourceFile_AKnownPath_ReturnsItVerbatim()
+    {
+        var content = _controller.GetBmotionSourceFile("Demo/Server/Program.cs");
+
+        StringAssert.Contains(content, "MapMcp");
+        Assert.AreEqual(BmotionSourceCatalog.GetSourceFile("Demo/Server/Program.cs"), content);
+    }
+
+    [TestMethod]
+    public void GetBmotionSourceFile_AnAlmostRightPath_SuggestsTheFilesItCouldMean()
+    {
+        var answer = _controller.GetBmotionSourceFile("Springs.razor");
+
+        StringAssert.Contains(answer, "Did you mean");
+        StringAssert.Contains(answer, "Springs.razor");
+    }
+
+    [TestMethod]
+    public void GetBmotionSourceFile_APathLikeNothingAtAll_PointsAtTheListing()
+    {
+        StringAssert.Contains(_controller.GetBmotionSourceFile("nowhere/at/all.txt"),
+                              nameof(McpController.GetBmotionSourceFiles));
+    }
+
+    /// <summary>
+    /// A couple of tool calls must not be able to crowd out a client's context window, so the long
+    /// documents are cut - and say that they were, rather than ending mid-sentence.
+    /// </summary>
+    [TestMethod]
+    public void GetBmotionSourceFile_AVeryLongFile_IsCutAndSaysSo()
+    {
+        var longest = BmotionSourceCatalog.SourceFiles
+            .OrderByDescending(file => BmotionSourceCatalog.GetSourceFile(file.Path)!.Length)
+            .First();
+
+        var content = BmotionSourceCatalog.GetSourceFile(longest.Path)!;
+        var answer = _controller.GetBmotionSourceFile(longest.Path);
+
+        if (content.Length <= 40_000)
+        {
+            Assert.AreEqual(content, answer, "A file inside the limit was altered.");
+
+            return;
+        }
+
+        StringAssert.Contains(answer, "[truncated");
+        Assert.IsTrue(answer.Length < content.Length);
+    }
+
+    [TestMethod]
+    public async Task CompareBmotionTransitions_MeasuresEachCandidateSeparately()
+    {
+        var results = await _controller.CompareBmotionTransitions(
+            "spring(stiffness: 260, damping: 12); spring(stiffness: 260, damping: 30); tween(0.3, BackOut)");
+
+        Assert.AreEqual(3, results.Length);
+        Assert.IsTrue(results.All(result => result.Error is null));
+
+        // The comparison is only useful if the numbers actually differ between candidates.
+        Assert.AreEqual(3, results.Select(result => result.Transition).Distinct().Count());
+        Assert.IsTrue(results[0].OvershootPercent > results[1].OvershootPercent,
+                      "The lighter-damped spring did not measure as bouncier.");
+    }
+
+    [TestMethod]
+    public async Task CompareBmotionTransitions_AcceptsNewlinesAsWellAsSemicolons()
+    {
+        var results = await _controller.CompareBmotionTransitions("spring(stiffness: 200, damping: 20)\ntween(0.4)\r\ninertia(velocity: 300)");
+
+        Assert.AreEqual(3, results.Length);
+        CollectionAssert.AreEqual(new[] { "Spring", "Tween", "Inertia" }, results.Select(result => result.Kind).ToArray());
+    }
+
+    /// <summary>
+    /// Simulating dozens at once would spend more of a client's context than any comparison is read
+    /// with, and the interesting comparisons are between two and four candidates.
+    /// </summary>
+    [TestMethod]
+    public async Task CompareBmotionTransitions_IsCappedRatherThanRunningWhateverArrives()
+    {
+        var many = string.Join("; ", Enumerable.Range(1, 40).Select(i => $"tween({i / 100.0})"));
+
+        var results = await _controller.CompareBmotionTransitions(many);
+
+        Assert.AreEqual(8, results.Length);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(";;;")]
+    [DataRow(null)]
+    public async Task CompareBmotionTransitions_NothingToCompare_IsAnEmptyAnswerRatherThanAThrow(string? transitions)
+    {
+        Assert.AreEqual(0, (await _controller.CompareBmotionTransitions(transitions!)).Length);
+    }
+
+    [TestMethod]
+    public async Task CompareBmotionTransitions_OneUnreadableCandidate_DoesNotCostTheOthers()
+    {
+        var results = await _controller.CompareBmotionTransitions("spring(stiffness: 200, damping: 20); swoosh(1); tween(0.4)");
+
+        Assert.AreEqual(3, results.Length);
+        Assert.IsNull(results[0].Error);
+        Assert.IsNotNull(results[1].Error);
+        Assert.IsNull(results[2].Error);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeBmotionAnimation_ReadsThePropertyListHoweverItIsWritten()
+    {
+        foreach (var written in new[] { "x, opacity", "x;opacity", "x opacity", " x ,  opacity " })
+        {
+            var result = await _controller.AnalyzeBmotionAnimation(written, "tween(0.4)");
+
+            CollectionAssert.AreEqual(new[] { "x", "opacity" }, result.Properties, $"'{written}' was read as something else.");
+            Assert.IsTrue(result.WorksOnBlazorServer);
+        }
+    }
+
+    [TestMethod]
+    public async Task AnalyzeBmotionAnimation_NoTransitionGiven_FallsBackToAPlainTween()
+    {
+        var result = await _controller.AnalyzeBmotionAnimation("x", transition: null);
+
+        Assert.IsNull(result.Error);
+        StringAssert.Contains(result.Transition, "Bm.Tween");
+    }
+
+    [TestMethod]
+    public void GetBmotionDemoPages_ListsEveryPage_WithASourceFileThatResolves()
+    {
+        var pages = _controller.GetBmotionDemoPages();
+
+        Assert.AreEqual(NavItem.All.Length, pages.Length);
+
+        foreach (var page in pages)
+        {
+            Assert.AreNotEqual(string.Empty, page.Title.Trim());
+            Assert.AreNotEqual(string.Empty, page.Description.Trim());
+            Assert.AreNotEqual(string.Empty, page.Keywords.Trim());
+            Assert.IsNotNull(BmotionSourceCatalog.GetSourceFile(page.SourcePath),
+                             $"'{page.Title}' points at '{page.SourcePath}', which is not embedded.");
+        }
+    }
+
+    [TestMethod]
+    public async Task SearchBmotion_DefaultsToAReadableNumberOfHits()
+    {
+        Assert.IsTrue((await _controller.SearchBmotion("spring")).Length <= 12);
+    }
+
+    /// <summary>
+    /// The catalog is reflected off the attributes rather than restated, so the demo page that
+    /// documents this server cannot describe a tool that no longer exists or miss one just added.
+    /// </summary>
+    [TestMethod]
+    public void GetMcpCatalog_ReportsTheServersRealSurface()
+    {
+        var catalog = _controller.GetMcpCatalog();
+
+        Assert.IsTrue(catalog.Tools.Length >= 15, $"Only {catalog.Tools.Length} tools were found.");
+        Assert.AreNotEqual(0, catalog.Prompts.Length);
+        Assert.AreNotEqual(0, catalog.Resources.Length);
+
+        foreach (var member in catalog.Tools.Concat(catalog.Prompts).Concat(catalog.Resources))
+        {
+            Assert.AreNotEqual(string.Empty, member.Name.Trim());
+            Assert.AreNotEqual(string.Empty, member.Description.Trim(),
+                               $"'{member.Name}' has no description, which is all a client has to choose it by.");
+            Assert.IsNotNull(member.Parameters);
+        }
+
+        // GetMcpCatalog is deliberately not a tool: an agent gets this from tools/list.
+        Assert.IsFalse(catalog.Tools.Any(tool => tool.Name == nameof(McpController.GetMcpCatalog)));
+    }
+
+    [TestMethod]
+    public void GetMcpCatalog_IsSortedSoThePageDoesNotReshuffleBetweenBuilds()
+    {
+        var catalog = _controller.GetMcpCatalog();
+
+        foreach (var names in new[]
+        {
+            catalog.Tools.Select(tool => tool.Name).ToArray(),
+            catalog.Prompts.Select(prompt => prompt.Name).ToArray(),
+            catalog.Resources.Select(resource => resource.Name).ToArray(),
+        })
+        {
+            CollectionAssert.AreEqual(names.OrderBy(name => name, StringComparer.Ordinal).ToArray(), names);
+        }
+    }
+
+    [TestMethod]
+    public void GetMcpCatalog_MarksTheOptionalParameters()
+    {
+        var catalog = _controller.GetMcpCatalog();
+
+        var search = catalog.Tools.Single(tool => tool.Name == nameof(McpController.SearchBmotion));
+
+        CollectionAssert.Contains(search.Parameters, "query: string");
+        CollectionAssert.Contains(search.Parameters, "limit?: int");
+
+        var simulate = catalog.Tools.Single(tool => tool.Name == nameof(McpController.SimulateBmotionTransition));
+
+        CollectionAssert.Contains(simulate.Parameters, "transition: string");
+        CollectionAssert.Contains(simulate.Parameters, "from?: double");
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpSurfaceTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpSurfaceTests.cs
@@ -169,7 +169,8 @@ public class McpSurfaceTests
 
         foreach (var file in BmotionSourceCatalog.SourceFiles)
         {
-            Assert.AreEqual(BmotionSourceCatalog.GetSourceFile(file.Path), McpResources.Source(file.Path));
+            Assert.AreEqual(controller.GetBmotionSourceFile(file.Path), McpResources.Source(file.Path),
+                            $"The source file '{file.Path}' reads differently through the resource.");
         }
     }
 

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpSurfaceTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Controllers/McpSurfaceTests.cs
@@ -1,0 +1,308 @@
+using System.Reflection;
+
+using ModelContextProtocol.Server;
+using System.Text.RegularExpressions;
+
+namespace Bit.Bmotion.Tests.Mcp.Controllers;
+
+/// <summary>
+/// The server's surface as a whole - the tools, the prompts and the resources - and the
+/// cross-references between them.
+/// <para>
+/// Nearly every word this server hands out tells an agent what to call next: the overview lists the
+/// tools, each tool's description names the others, and every prompt is a numbered sequence of
+/// calls. Renaming one tool therefore breaks instructions in a dozen places, and nothing about that
+/// fails to compile - the server keeps working, and starts telling agents to call something that
+/// does not exist. The tests here are mostly one idea applied everywhere: every tool named in prose
+/// has to be a tool this server actually exposes.
+/// </para>
+/// </summary>
+[TestClass]
+public class McpSurfaceTests
+{
+    /// <summary>Anything shaped like one of this server's tool names, wherever it appears in prose.</summary>
+    private static readonly Regex ToolReference = new(@"\b(?:Get|Search|Simulate|Compare|Analyze|Review|List)Bmotion[A-Za-z]*\b");
+
+    private static readonly BmotionMcpCatalogDto Catalog = new McpController().GetMcpCatalog();
+
+    private static string[] ToolNames => [.. Catalog.Tools.Select(tool => tool.Name)];
+
+    [TestMethod]
+    public void Tools_EveryOne_IsNamedLegallyAndDescribedOnce()
+    {
+        var names = ToolNames;
+
+        CollectionAssert.AreEquivalent(names.Distinct().ToArray(), names, "A tool name is registered twice.");
+
+        foreach (var tool in Catalog.Tools)
+        {
+            // The MCP name grammar: what a client is allowed to send back as tools/call.
+            Assert.IsTrue(Regex.IsMatch(tool.Name, "^[A-Za-z0-9_-]{1,64}$"), $"'{tool.Name}' is not a legal MCP tool name.");
+
+            // The description is the entire basis on which a model chooses a tool.
+            Assert.IsTrue(tool.Description.Length > 60,
+                          $"'{tool.Name}' has a {tool.Description.Length}-character description, which is too little to choose it by.");
+        }
+    }
+
+    /// <summary>
+    /// The overview is the tool an agent is told to start with, and its "Which tool to call" section
+    /// is the map it navigates by. A name that has drifted there sends it to a tool that is not here.
+    /// </summary>
+    [TestMethod]
+    public void Overview_EveryToolItSendsAnAgentTo_Exists()
+    {
+        AssertEveryToolReferenceResolves(new McpController().GetBmotionOverview(), "the overview");
+    }
+
+    /// <summary>
+    /// The map has to be complete as well as correct: a tool listed nowhere in the overview is one
+    /// an agent that read the overview has no reason to call. The overview does not list itself,
+    /// which is the one omission that costs nothing - it is already being read.
+    /// </summary>
+    [TestMethod]
+    public void Overview_MentionsEveryOtherToolTheServerExposes()
+    {
+        var overview = new McpController().GetBmotionOverview();
+
+        var unmentioned = ToolNames
+            .Where(name => name != nameof(McpController.GetBmotionOverview))
+            .Where(name => overview.Contains(name, StringComparison.Ordinal) is false)
+            .ToArray();
+
+        Assert.AreEqual(0, unmentioned.Length, $"Exposed but never mentioned in the overview: {string.Join(", ", unmentioned)}.");
+    }
+
+    [TestMethod]
+    public void Tools_EveryToolTheDescriptionsCrossReference_Exists()
+    {
+        foreach (var tool in Catalog.Tools)
+        {
+            AssertEveryToolReferenceResolves(tool.Description, $"the description of {tool.Name}");
+        }
+    }
+
+    [TestMethod]
+    public void Prompts_EveryToolTheyInstructAnAgentToCall_Exists()
+    {
+        foreach (var (name, text) in RenderEveryPrompt())
+        {
+            AssertEveryToolReferenceResolves(text, $"the '{name}' prompt");
+        }
+    }
+
+    [TestMethod]
+    public void Prompts_EachOne_RendersAWorkflowRatherThanARestatementOfTheRequest()
+    {
+        var prompts = RenderEveryPrompt();
+
+        Assert.AreEqual(Catalog.Prompts.Length, prompts.Count);
+        Assert.AreNotEqual(0, prompts.Count);
+
+        foreach (var (name, text) in prompts)
+        {
+            Assert.IsTrue(text.Length > 500, $"The '{name}' prompt is only {text.Length} characters.");
+
+            // A workflow is an order of calls; a prompt that names no tool is just prose.
+            Assert.IsTrue(ToolReference.IsMatch(text), $"The '{name}' prompt names no tool to call.");
+
+            // The argument it was given has to reach the text, or the prompt ignores its input.
+            StringAssert.Contains(text, "SENTINEL", $"The '{name}' prompt dropped one of its arguments.");
+        }
+    }
+
+    /// <summary>
+    /// The workflows that write or change motion end by running the code back through the engine
+    /// rather than by declaring victory when it builds - which is the one habit that catches the
+    /// failures this library has. 'add-bmotion-to-app' is exempt: it wires a project up, and its
+    /// proof is that the app builds and the sample animation moves.
+    /// </summary>
+    [TestMethod]
+    public void Prompts_TheOnesThatWriteMotion_EndByVerifyingIt()
+    {
+        var wiringOnly = new[] { "add-bmotion-to-app" };
+
+        foreach (var (name, text) in RenderEveryPrompt().Where(prompt => wiringOnly.Contains(prompt.Name) is false))
+        {
+            Assert.IsTrue(text.Contains(nameof(McpController.AnalyzeBmotionAnimation), StringComparison.Ordinal) ||
+                          text.Contains(nameof(McpController.ReviewBmotionCode), StringComparison.Ordinal) ||
+                          text.Contains(nameof(McpController.SimulateBmotionTransition), StringComparison.Ordinal),
+                          $"The '{name}' prompt never has the agent check its own work.");
+        }
+    }
+
+    [TestMethod]
+    public void Resources_EveryUriTemplate_IsWellFormedAndUnique()
+    {
+        var uris = Catalog.Resources.Select(resource => resource.Name).ToArray();
+
+        CollectionAssert.AreEquivalent(uris.Distinct().ToArray(), uris, "A resource URI is registered twice.");
+
+        foreach (var uri in uris)
+        {
+            StringAssert.StartsWith(uri, "bmotion://", $"'{uri}' is not under this server's scheme.");
+        }
+    }
+
+    /// <summary>
+    /// Tools and resources are two doors onto the same catalogs. A client that pins the resource has
+    /// to be reading what a client that called the tool would get, or the two answers drift apart
+    /// and only one of them is ever checked.
+    /// </summary>
+    [TestMethod]
+    public void Resources_AnswerTheSameAsTheToolsOverTheSameCatalogs()
+    {
+        var controller = new McpController();
+
+        Assert.AreEqual(BmotionSourceCatalog.Readme, McpResources.Guide());
+
+        foreach (var section in BmotionSourceCatalog.GuideSections)
+        {
+            Assert.AreEqual(controller.GetBmotionGuideSection(section.Heading), McpResources.GuideSection(section.Heading),
+                            $"The guide section '{section.Heading}' reads differently through the resource.");
+        }
+
+        foreach (var mode in BmotionSetupGuide.RenderModes)
+        {
+            Assert.AreEqual(controller.GetBmotionSetupGuide(mode), McpResources.Setup(mode));
+        }
+
+        foreach (var file in BmotionSourceCatalog.SourceFiles)
+        {
+            Assert.AreEqual(BmotionSourceCatalog.GetSourceFile(file.Path), McpResources.Source(file.Path));
+        }
+    }
+
+    [TestMethod]
+    public async Task Resources_EachOne_RendersSomethingReadable()
+    {
+        Assert.IsTrue(McpResources.ApiList().Length > 500);
+        StringAssert.StartsWith(McpResources.ApiList(), "# Bit.Bmotion public API");
+
+        StringAssert.Contains(McpResources.ApiType("BmSpring"), "# BmSpring");
+        StringAssert.Contains(McpResources.ApiType("BmSpring"), "Stiffness");
+
+        var properties = await McpResources.Properties();
+
+        StringAssert.Contains(properties, "| Property | Category |");
+        StringAssert.Contains(properties, "`opacity`");
+
+        var easings = await McpResources.Easings();
+
+        StringAssert.Contains(easings, "`BmEase.Linear`");
+
+        var recipes = McpResources.Recipes();
+
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            StringAssert.Contains(recipes, recipe.Title, $"The recipes resource omits '{recipe.Id}'.");
+        }
+    }
+
+    /// <summary>
+    /// A resource asked for something that is not there answers in text as well: a client browsing
+    /// them cannot be handed a stack trace.
+    /// </summary>
+    [TestMethod]
+    public void Resources_AskedForWhatIsNotThere_ExplainRatherThanThrow()
+    {
+        StringAssert.Contains(McpResources.GuideSection("Teleportation"), "no section called");
+        StringAssert.Contains(McpResources.ApiType("Teleporter"), "no public type called");
+        StringAssert.Contains(McpResources.Source("nowhere.razor"), "No source file at");
+
+        var setup = McpResources.Setup("maui");
+
+        foreach (var mode in BmotionSetupGuide.RenderModes)
+        {
+            StringAssert.Contains(setup, mode);
+        }
+    }
+
+    /// <summary>
+    /// Every tool method is also a plain HTTP GET, which is what the demo's own MCP page calls to
+    /// show the tools working. A tool that loses its route disappears from that page silently.
+    /// </summary>
+    [TestMethod]
+    public void Tools_AreAlsoReachableAsPlainHttpEndpoints()
+    {
+        foreach (var method in typeof(McpController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => method.IsDefined(typeof(McpServerToolAttribute))))
+        {
+            Assert.IsTrue(method.IsDefined(typeof(Microsoft.AspNetCore.Mvc.HttpGetAttribute)),
+                          $"'{method.Name}' is an MCP tool but not an HTTP endpoint.");
+        }
+    }
+
+    /// <summary>
+    /// A tool taking free text has to show what that text looks like, in its own description or on
+    /// the parameter. Without an example the model invents a syntax, and the tool answers about a
+    /// spec it half-understood rather than refusing one it did not.
+    /// </summary>
+    [TestMethod]
+    public void Tools_TheOnesTakingFreeText_ShowAnExampleOfWhatToWrite()
+    {
+        foreach (var method in typeof(McpController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => method.IsDefined(typeof(McpServerToolAttribute)))
+            .Where(method => method.GetParameters().Any(parameter => parameter.ParameterType == typeof(string))))
+        {
+            // Either every free-text argument carries its own description...
+            var described = method.GetParameters()
+                .Where(parameter => parameter.ParameterType == typeof(string))
+                .All(parameter => parameter.IsDefined(typeof(System.ComponentModel.DescriptionAttribute)));
+
+            // ...or the tool's own description shows what to write, which is enough for the ones
+            // whose single argument is an id, a path or a heading.
+            var description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description ?? string.Empty;
+
+            var shown = description.Contains("e.g.", StringComparison.OrdinalIgnoreCase) ||
+                        description.Contains("for example", StringComparison.OrdinalIgnoreCase) ||
+                        description.Contains('\'');
+
+            Assert.IsTrue(described || shown,
+                          $"'{method.Name}' takes free text and never shows what it should look like.");
+        }
+    }
+
+    private static void AssertEveryToolReferenceResolves(string text, string where)
+    {
+        var names = ToolNames;
+
+        var dangling = ToolReference.Matches(text)
+            .Select(match => match.Value)
+            .Distinct(StringComparer.Ordinal)
+            .Where(name => names.Contains(name) is false)
+            .ToArray();
+
+        Assert.AreEqual(0, dangling.Length, $"{where} names tools this server does not expose: {string.Join(", ", dangling)}.");
+    }
+
+    /// <summary>
+    /// Every prompt, rendered with a recognisable marker in each of its arguments - so a prompt that
+    /// quietly drops one of them is visible.
+    /// </summary>
+    private static List<(string Name, string Text)> RenderEveryPrompt()
+    {
+        var rendered = new List<(string, string)>();
+
+        foreach (var method in typeof(McpPrompts).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+        {
+            var prompt = method.GetCustomAttribute<McpServerPromptAttribute>();
+
+            if (prompt is null) continue;
+
+            var arguments = method.GetParameters()
+                .Select(parameter => (object?)$"SENTINEL-{parameter.Name}")
+                .ToArray();
+
+            var text = method.Invoke(null, arguments) as string;
+
+            Assert.IsNotNull(text, $"The '{prompt.Name ?? method.Name}' prompt rendered nothing.");
+
+            rendered.Add((prompt.Name ?? method.Name, text));
+        }
+
+        return rendered;
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/GlobalUsings.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+global using Bit.Bmotion;
+global using Bit.Bmotion.Demo.Server.Dtos;
+global using Bit.Bmotion.Demo.Server.Services;
+global using Bit.Bmotion.Demo.Server.Controllers;

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Protocol/McpServerIntegrationTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Protocol/McpServerIntegrationTests.cs
@@ -390,14 +390,14 @@ public class McpServerIntegrationTests
     }
 
     /// <summary>
-    /// The tools are also plain HTTP GETs, which is what the demo's own /mcp page calls to show them
-    /// working. That route is separate wiring from the MCP transport and fails separately.
+    /// The tools are also plain HTTP GETs, which is what the demo's own /mcp-server page calls to
+    /// show them working. That route is separate wiring from the MCP transport and fails separately -
+    /// but it is the same host, so it is reached through the fixture rather than a second startup.
     /// </summary>
     [TestMethod]
     public async Task Server_TheSameToolsAreAlsoReachableOverPlainHttp()
     {
-        using var factory = new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>();
-        using var http = factory.CreateClient();
+        var http = _server.Http;
 
         var catalog = await http.GetFromJsonAsync<BmotionMcpCatalogDto>("/api/Mcp/GetMcpCatalog");
 

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Protocol/McpServerIntegrationTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Protocol/McpServerIntegrationTests.cs
@@ -1,0 +1,437 @@
+using System.Text.Json;
+using System.Net.Http.Json;
+using ModelContextProtocol.Protocol;
+using Bit.Bmotion.Tests.Mcp.TestInfra;
+
+namespace Bit.Bmotion.Tests.Mcp.Protocol;
+
+/// <summary>
+/// The server as an agent meets it: the real <c>Program.cs</c> hosted in memory, spoken to over the
+/// MCP HTTP transport by the real client.
+/// <para>
+/// This is the layer where production failures actually live. A tool that is not decorated is not
+/// registered; a DTO the schema generator cannot describe fails at <c>tools/list</c>; an argument
+/// name that differs from the parameter name arrives as null; a returned object that will not
+/// serialise fails inside the call rather than in the method. Every one of those passes the
+/// method-level tests in this suite and breaks the server for every client.
+/// </para>
+/// </summary>
+[TestClass]
+public class McpServerIntegrationTests
+{
+    private static BmotionMcpServerFixture _server = null!;
+
+    [ClassInitialize]
+    public static async Task StartServerAsync(TestContext _) => _server = await BmotionMcpServerFixture.StartAsync();
+
+    [ClassCleanup]
+    public static async Task StopServerAsync() => await _server.DisposeAsync();
+
+    /// <summary>
+    /// That the client connected at all is the handshake. What it negotiated is the interesting
+    /// part: a server advertising no capability for one of the three halves has that half wired but
+    /// unreachable, which looks from the outside like the feature simply not existing.
+    /// </summary>
+    [TestMethod]
+    public void Server_CompletesTheHandshake_AdvertisingAllThreeHalvesOfItsSurface()
+    {
+        Assert.IsNotNull(_server.Client.ServerInfo);
+        Assert.IsNotNull(_server.Client.ServerCapabilities);
+
+        Assert.IsNotNull(_server.Client.ServerCapabilities.Tools, "The server does not advertise tools.");
+        Assert.IsNotNull(_server.Client.ServerCapabilities.Prompts, "The server does not advertise prompts.");
+        Assert.IsNotNull(_server.Client.ServerCapabilities.Resources, "The server does not advertise resources.");
+    }
+
+    /// <summary>
+    /// What the server registers over the protocol has to be what the demo page - and this suite -
+    /// reads off the attributes. A tool missing its registration is invisible here and present
+    /// everywhere else.
+    /// </summary>
+    [TestMethod]
+    public async Task ListTools_ExposesExactlyTheToolsTheAttributesDeclare()
+    {
+        var overTheWire = (await _server.Client.ListToolsAsync()).Select(tool => tool.Name).ToArray();
+        var declared = new McpController().GetMcpCatalog().Tools.Select(tool => tool.Name).ToArray();
+
+        CollectionAssert.AreEquivalent(declared, overTheWire,
+                                       $"Over the wire: {string.Join(", ", overTheWire.Order())}.");
+    }
+
+    /// <summary>
+    /// The description and the input schema are the entire basis on which a model chooses a tool and
+    /// fills in its arguments. A DTO the generator cannot describe shows up as a missing schema here.
+    /// </summary>
+    [TestMethod]
+    public async Task ListTools_EveryTool_ArrivesWithADescriptionAndAnInputSchema()
+    {
+        foreach (var tool in await _server.Client.ListToolsAsync())
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(tool.Description), $"'{tool.Name}' arrived with no description.");
+
+            var schema = tool.ProtocolTool.InputSchema;
+
+            Assert.AreEqual(JsonValueKind.Object, schema.ValueKind, $"'{tool.Name}' has no input schema.");
+            Assert.AreEqual("object", schema.GetProperty("type").GetString());
+        }
+    }
+
+    [TestMethod]
+    public async Task ListTools_TheArgumentNames_AreTheOnesTheMethodsDeclare()
+    {
+        var tools = (await _server.Client.ListToolsAsync()).ToDictionary(tool => tool.Name, StringComparer.Ordinal);
+
+        foreach (var (name, expected) in new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            [nameof(McpController.SearchBmotion)] = ["query", "limit"],
+            [nameof(McpController.GetBmotionSetupGuide)] = ["renderMode"],
+            [nameof(McpController.GetBmotionRecipe)] = ["id"],
+            [nameof(McpController.SimulateBmotionTransition)] = ["transition", "from", "to"],
+            [nameof(McpController.AnalyzeBmotionAnimation)] = ["properties", "transition"],
+            [nameof(McpController.ReviewBmotionCode)] = ["code"],
+            [nameof(McpController.GetBmotionGuideSection)] = ["heading"],
+            [nameof(McpController.GetBmotionApiDetails)] = ["typeName"],
+            [nameof(McpController.GetBmotionSourceFile)] = ["path"],
+        })
+        {
+            var properties = tools[name].ProtocolTool.InputSchema.GetProperty("properties");
+
+            foreach (var argument in expected)
+            {
+                Assert.IsTrue(properties.TryGetProperty(argument, out _),
+                              $"'{name}' has no '{argument}' argument in its schema.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every tool, called for real. Serialisation of the answer happens inside the call, so a DTO
+    /// that will not round-trip fails here and nowhere else in this suite.
+    /// </summary>
+    [TestMethod]
+    public async Task CallTool_EveryToolTheServerExposes_AnswersWithoutAnError()
+    {
+        var arguments = new Dictionary<string, IReadOnlyDictionary<string, object?>>(StringComparer.Ordinal)
+        {
+            [nameof(McpController.SearchBmotion)] = new Dictionary<string, object?> { ["query"] = "staggered list", ["limit"] = 5 },
+            [nameof(McpController.GetBmotionSetupGuide)] = new Dictionary<string, object?> { ["renderMode"] = "wasm" },
+            [nameof(McpController.GetBmotionRecipe)] = new Dictionary<string, object?> { ["id"] = "staggered-list" },
+            [nameof(McpController.SimulateBmotionTransition)] = new Dictionary<string, object?> { ["transition"] = "spring(stiffness: 260, damping: 12)" },
+            [nameof(McpController.CompareBmotionTransitions)] = new Dictionary<string, object?> { ["transitions"] = "tween(0.3); spring(bounce: 0.2, duration: 0.4)" },
+            [nameof(McpController.AnalyzeBmotionAnimation)] = new Dictionary<string, object?> { ["properties"] = "x, opacity", ["transition"] = "tween(0.4)" },
+            [nameof(McpController.ReviewBmotionCode)] = new Dictionary<string, object?> { ["code"] = "<Bmotion Animate=\"Bm.To(x: 100)\"><div /></Bmotion>" },
+            [nameof(McpController.GetBmotionGuideSection)] = new Dictionary<string, object?> { ["heading"] = "Installation" },
+            [nameof(McpController.GetBmotionApiDetails)] = new Dictionary<string, object?> { ["typeName"] = "BmSpring" },
+            [nameof(McpController.GetBmotionSourceFile)] = new Dictionary<string, object?> { ["path"] = "Demo/Server/Program.cs" },
+        };
+
+        var called = 0;
+
+        foreach (var tool in await _server.Client.ListToolsAsync())
+        {
+            var result = await _server.Client.CallToolAsync(
+                tool.Name,
+                arguments.GetValueOrDefault(tool.Name) ?? new Dictionary<string, object?>());
+
+            Assert.IsFalse(result.IsError is true, $"'{tool.Name}' answered with an error: {Render(result)}");
+            Assert.AreNotEqual(0, result.Content.Count, $"'{tool.Name}' answered with nothing at all.");
+            Assert.AreNotEqual(string.Empty, Render(result).Trim(), $"'{tool.Name}' answered with empty content.");
+
+            called++;
+        }
+
+        Assert.IsTrue(called >= 15, $"Only {called} tools were called.");
+    }
+
+    /// <summary>
+    /// The answers that are objects come back as structured content, not only as a rendered string -
+    /// which is what lets a client read SettleSeconds as a number rather than parsing prose.
+    /// </summary>
+    [TestMethod]
+    public async Task CallTool_AMeasuringTool_ReturnsItsNumbersAsStructuredData()
+    {
+        var result = await _server.Client.CallToolAsync(
+            nameof(McpController.SimulateBmotionTransition),
+            new Dictionary<string, object?> { ["transition"] = "spring(stiffness: 100, damping: 20)", ["from"] = 0, ["to"] = 100 });
+
+        Assert.IsFalse(result.IsError is true, Render(result));
+
+        var payload = Payload(result);
+
+        Assert.AreEqual("Spring", payload.GetProperty("kind").GetString());
+        Assert.IsTrue(payload.GetProperty("settleSeconds").GetDouble() > 0);
+        Assert.IsTrue(payload.GetProperty("overshootPercent").GetDouble() < 0.5, "A critically damped spring measured as overshooting.");
+        Assert.AreNotEqual(0, payload.GetProperty("samples").GetArrayLength());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(payload.GetProperty("reading").GetString()));
+    }
+
+    [TestMethod]
+    public async Task CallTool_TheDoubleArguments_SurviveTheJsonRoundTrip()
+    {
+        var result = await _server.Client.CallToolAsync(
+            nameof(McpController.SimulateBmotionTransition),
+            new Dictionary<string, object?> { ["transition"] = "tween(0.5, Linear)", ["from"] = 12.5, ["to"] = 87.5 });
+
+        var payload = Payload(result);
+
+        Assert.AreEqual(12.5, payload.GetProperty("from").GetDouble());
+        Assert.AreEqual(87.5, payload.GetProperty("to").GetDouble());
+    }
+
+    [TestMethod]
+    public async Task CallTool_TheCodeReview_ReturnsItsFindingsAsData()
+    {
+        var result = await _server.Client.CallToolAsync(
+            nameof(McpController.ReviewBmotionCode),
+            new Dictionary<string, object?>
+            {
+                ["code"] = "@if (show)\n{\n    <Bmotion Exit=\"Bm.To(opacity: 0)\">\n        <div />\n    </Bmotion>\n}",
+            });
+
+        var payload = Payload(result);
+
+        Assert.IsFalse(payload.GetProperty("passed").GetBoolean());
+
+        var findings = payload.GetProperty("findings");
+
+        Assert.AreNotEqual(0, findings.GetArrayLength());
+        Assert.AreEqual("exit-without-presence", findings[0].GetProperty("rule").GetString());
+        Assert.AreEqual(3, findings[0].GetProperty("line").GetInt32());
+    }
+
+    /// <summary>
+    /// An unreadable transition is a correctable mistake, not a failed call. Thrown, the protocol
+    /// reduces it to "an error occurred invoking SimulateBmotionTransition" and the caller learns
+    /// nothing; returned as data, the explanation survives.
+    /// </summary>
+    [TestMethod]
+    public async Task CallTool_AnUnreadableArgument_ComesBackAsAnExplanation_NotAsAProtocolError()
+    {
+        var result = await _server.Client.CallToolAsync(
+            nameof(McpController.SimulateBmotionTransition),
+            new Dictionary<string, object?> { ["transition"] = "swoosh(0.4)" });
+
+        Assert.IsFalse(result.IsError is true, "A correctable mistake was reported as a failed call.");
+
+        var payload = Payload(result);
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(payload.GetProperty("error").GetString()));
+        StringAssert.Contains(payload.GetProperty("error").GetString()!, "spring");
+    }
+
+    [TestMethod]
+    public async Task CallTool_AMissingId_NamesWhatDoesExist()
+    {
+        var result = await _server.Client.CallToolAsync(
+            nameof(McpController.GetBmotionRecipe),
+            new Dictionary<string, object?> { ["id"] = "teleport" });
+
+        Assert.IsFalse(result.IsError is true);
+        StringAssert.Contains(Render(result), "staggered-list");
+    }
+
+    [TestMethod]
+    public async Task CallTool_AnOptionalArgumentOmitted_UsesTheDeclaredDefault()
+    {
+        var result = await _server.Client.CallToolAsync(
+            nameof(McpController.SimulateBmotionTransition),
+            new Dictionary<string, object?> { ["transition"] = "tween(0.3)" });
+
+        var payload = Payload(result);
+
+        Assert.AreEqual(0, payload.GetProperty("from").GetDouble());
+        Assert.AreEqual(100, payload.GetProperty("to").GetDouble());
+    }
+
+    [TestMethod]
+    public async Task CallTool_AToolThatDoesNotExist_Fails_WithoutTakingTheSessionDown()
+    {
+        var error = await Assert.ThrowsAsync<ModelContextProtocol.McpException>(
+            () => _server.Client.CallToolAsync("GetBmotionNothing", new Dictionary<string, object?>()).AsTask());
+
+        StringAssert.Contains(error.Message, "GetBmotionNothing");
+
+        // The session is still usable afterwards, which is what makes a bad call recoverable.
+        Assert.AreNotEqual(0, (await _server.Client.ListToolsAsync()).Count);
+    }
+
+    [TestMethod]
+    public async Task ListPrompts_ExposesEveryWorkflow_WithItsArguments()
+    {
+        var prompts = await _server.Client.ListPromptsAsync();
+
+        var declared = new McpController().GetMcpCatalog().Prompts.Select(prompt => prompt.Name).ToArray();
+
+        CollectionAssert.AreEquivalent(declared, prompts.Select(prompt => prompt.Name).ToArray());
+
+        foreach (var prompt in prompts)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(prompt.Description), $"'{prompt.Name}' has no description.");
+        }
+    }
+
+    [TestMethod]
+    public async Task GetPrompt_RendersTheWorkflowWithTheArgumentsItWasGiven()
+    {
+        var result = await _server.Client.GetPromptAsync(
+            "animate-with-bmotion",
+            new Dictionary<string, object?>
+            {
+                ["request"] = "the cards should appear one after another",
+                ["renderMode"] = "server",
+            });
+
+        Assert.AreNotEqual(0, result.Messages.Count);
+
+        var text = string.Join('\n', result.Messages.Select(message => (message.Content as TextContentBlock)?.Text));
+
+        StringAssert.Contains(text, "the cards should appear one after another");
+        StringAssert.Contains(text, "server");
+        StringAssert.Contains(text, nameof(McpController.AnalyzeBmotionAnimation));
+    }
+
+    [TestMethod]
+    public async Task ListResources_ExposesTheFixedOnes_AndTheTemplatedOnes()
+    {
+        var resources = await _server.Client.ListResourcesAsync();
+        var templates = await _server.Client.ListResourceTemplatesAsync();
+
+        var uris = resources.Select(resource => resource.Uri)
+            .Concat(templates.Select(template => template.UriTemplate))
+            .ToArray();
+
+        var declared = new McpController().GetMcpCatalog().Resources.Select(resource => resource.Name).ToArray();
+
+        CollectionAssert.AreEquivalent(declared, uris, $"Over the wire: {string.Join(", ", uris.Order())}.");
+    }
+
+    [TestMethod]
+    public async Task ReadResource_TheFixedResources_ReturnTheirDocuments()
+    {
+        foreach (var resource in await _server.Client.ListResourcesAsync())
+        {
+            var result = await resource.ReadAsync();
+
+            Assert.AreNotEqual(0, result.Contents.Count, $"'{resource.Uri}' returned nothing.");
+
+            var text = (result.Contents[0] as TextResourceContents)?.Text;
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(text), $"'{resource.Uri}' returned empty text.");
+        }
+    }
+
+    [TestMethod]
+    public async Task ReadResource_ATemplatedResource_ResolvesItsArgument()
+    {
+        var guide = await _server.Client.ReadResourceAsync("bmotion://guide/Installation");
+
+        StringAssert.Contains(((TextResourceContents)guide.Contents[0]).Text!, "## Installation");
+
+        var type = await _server.Client.ReadResourceAsync("bmotion://api/BmSpring");
+
+        StringAssert.Contains(((TextResourceContents)type.Contents[0]).Text!, "Stiffness");
+
+        var setup = await _server.Client.ReadResourceAsync("bmotion://setup/server");
+
+        StringAssert.Contains(((TextResourceContents)setup.Contents[0]).Text!, "Blazor Server");
+    }
+
+    /// <summary>
+    /// A path is a URI segment here, so the slashes in it have to be escaped and unescaped again.
+    /// Getting that wrong makes every demo page unreadable through the resource while every one of
+    /// them stays readable through the tool.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadResource_ASourceFilePath_SurvivesUriEscaping()
+    {
+        var result = await _server.Client.ReadResourceAsync($"bmotion://source/{Uri.EscapeDataString("Demo/Server/Program.cs")}");
+
+        var text = ((TextResourceContents)result.Contents[0]).Text!;
+
+        StringAssert.Contains(text, "MapMcp");
+        Assert.AreEqual(BmotionSourceCatalog.GetSourceFile("Demo/Server/Program.cs"), text);
+    }
+
+    /// <summary>
+    /// Several agents share one server. The catalogs are built lazily and once, and the simulations
+    /// each build their own engine; nothing here may serialise on the others or answer differently
+    /// because it was asked at the same time as something else.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_AnswersConcurrentCalls_Independently()
+    {
+        var calls = new (string Tool, Dictionary<string, object?> Arguments)[]
+        {
+            (nameof(McpController.SimulateBmotionTransition), new() { ["transition"] = "spring(stiffness: 260, damping: 12)" }),
+            (nameof(McpController.SearchBmotion), new() { ["query"] = "drag constraints" }),
+            (nameof(McpController.GetBmotionEasings), new()),
+            (nameof(McpController.GetBmotionAnimatableProperties), new()),
+            (nameof(McpController.AnalyzeBmotionAnimation), new() { ["properties"] = "width" }),
+            (nameof(McpController.GetBmotionApiList), new()),
+            (nameof(McpController.SimulateBmotionTransition), new() { ["transition"] = "tween(0.4, BackOut)" }),
+            (nameof(McpController.GetBmotionRecipes), new()),
+        };
+
+        var results = await Task.WhenAll(calls.Select(call =>
+            _server.Client.CallToolAsync(call.Tool, call.Arguments).AsTask()));
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            Assert.IsFalse(results[i].IsError is true, $"'{calls[i].Tool}' failed under concurrency: {Render(results[i])}");
+        }
+
+        // And the same question asked in that crowd still gives the answer it gives alone.
+        var alone = await _server.Client.CallToolAsync(
+            nameof(McpController.SimulateBmotionTransition),
+            new Dictionary<string, object?> { ["transition"] = "spring(stiffness: 260, damping: 12)" });
+
+        Assert.AreEqual(Payload(results[0]).GetProperty("settleSeconds").GetDouble(),
+                        Payload(alone).GetProperty("settleSeconds").GetDouble());
+    }
+
+    /// <summary>
+    /// The tools are also plain HTTP GETs, which is what the demo's own /mcp page calls to show them
+    /// working. That route is separate wiring from the MCP transport and fails separately.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_TheSameToolsAreAlsoReachableOverPlainHttp()
+    {
+        using var factory = new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>();
+        using var http = factory.CreateClient();
+
+        var catalog = await http.GetFromJsonAsync<BmotionMcpCatalogDto>("/api/Mcp/GetMcpCatalog");
+
+        Assert.IsNotNull(catalog);
+        Assert.AreNotEqual(0, catalog.Tools.Length);
+
+        var simulation = await http.GetFromJsonAsync<BmotionSimulationDto>(
+            "/api/Mcp/SimulateBmotionTransition?transition=spring(stiffness:%20260,%20damping:%2012)");
+
+        Assert.IsNotNull(simulation);
+        Assert.AreEqual("Spring", simulation.Kind);
+        Assert.IsTrue(simulation.SettleSeconds > 0);
+    }
+
+    /// <summary>The answer as a client renders it: every text block the call returned.</summary>
+    private static string Render(CallToolResult result)
+    {
+        return string.Join('\n', result.Content.OfType<TextContentBlock>().Select(block => block.Text));
+    }
+
+    /// <summary>
+    /// The object a tool returned. Structured content when the server sent it, and otherwise the
+    /// JSON in the text block - which is how a tool returning a bare object arrives.
+    /// </summary>
+    private static JsonElement Payload(CallToolResult result)
+    {
+        if (result.StructuredContent is JsonElement structured && structured.ValueKind is not JsonValueKind.Undefined)
+        {
+            // A tool returning a single value is wrapped under "result" by the schema generator.
+            return structured.ValueKind == JsonValueKind.Object && structured.TryGetProperty("result", out var wrapped)
+                ? wrapped
+                : structured;
+        }
+
+        return JsonDocument.Parse(Render(result)).RootElement;
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/ApiCatalogTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/ApiCatalogTests.cs
@@ -1,0 +1,315 @@
+using System.Reflection;
+
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The API reference, reflected off the shipped Bit.Bmotion assembly.
+/// <para>
+/// Its whole claim is that it cannot drift from the library, so the tests are about the mechanism
+/// rather than the contents: every listed type must be fetchable, the default values must be read
+/// off real instances (in an animation library the defaults <i>are</i> the behaviour), and the
+/// documentation must actually be there. That last one is a deployment property, not a code one -
+/// the XML file lives next to the assembly, and a publish profile that drops it turns every summary
+/// in the reference into null without failing anything.
+/// </para>
+/// </summary>
+[TestClass]
+public class ApiCatalogTests
+{
+    private static readonly string[] KnownKinds =
+        ["Component", "Interface", "Enum", "Delegate", "Static class", "Class", "Struct", "Record", "Attribute"];
+
+    [TestMethod]
+    public void Types_ListsThePublicSurfaceOfTheLibrary()
+    {
+        var types = BmotionApiCatalog.Types;
+
+        Assert.IsTrue(types.Length >= 20, $"Only {types.Length} public types were found.");
+
+        foreach (var type in types)
+        {
+            Assert.AreNotEqual(string.Empty, type.Name.Trim());
+            CollectionAssert.Contains(KnownKinds, type.Kind, $"'{type.Name}' is a '{type.Kind}'.");
+            // Compiler-generated names and raw arity markers would be noise in a reference an agent
+            // reads; a generic spelled out as BmotionPresenceGroup<TItem> is exactly right.
+            Assert.IsFalse(type.Name.Contains('`'), $"'{type.Name}' still carries its arity marker.");
+            Assert.IsFalse(type.Name.Contains("<>", StringComparison.Ordinal), $"'{type.Name}' is compiler-generated.");
+        }
+
+        var names = types.Select(type => type.Name).ToArray();
+
+        CollectionAssert.AreEquivalent(names.Distinct().ToArray(), names, "A type is listed twice.");
+    }
+
+    [TestMethod]
+    [DataRow("Bm")]
+    [DataRow("Bmotion")]
+    [DataRow("BmSpring")]
+    [DataRow("BmTween")]
+    [DataRow("BmInertia")]
+    [DataRow("BmotionAnimatePresence")]
+    [DataRow("BmVariants")]
+    [DataRow("BmDrag")]
+    [DataRow("BmScrollTimeline")]
+    [DataRow("BmotionAnimateService")]
+    public void Types_IncludeEveryTypeTheToolDescriptionsTellAnAgentToAskFor(string name)
+    {
+        Assert.IsTrue(BmotionApiCatalog.Types.Any(type => type.Name == name),
+                      $"GetBmotionApiDetails advertises '{name}', which is not in the list.");
+    }
+
+    /// <summary>
+    /// The listing exists to pick a name to fetch with. A name it offers that the fetch cannot
+    /// resolve sends an agent round a loop with no way out.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_AnswersForEveryTypeTheListingOffers()
+    {
+        var unfetchable = BmotionApiCatalog.Types
+            .Where(type => BmotionApiCatalog.GetTypeDetails(type.Name) is null)
+            .Select(type => type.Name)
+            .ToArray();
+
+        Assert.AreEqual(0, unfetchable.Length, $"Listed but not fetchable: {string.Join(", ", unfetchable)}.");
+    }
+
+    [TestMethod]
+    public void GetTypeDetails_ResolvesTheNameHoweverItIsWritten()
+    {
+        var canonical = BmotionApiCatalog.GetTypeDetails("BmSpring");
+
+        Assert.IsNotNull(canonical);
+        Assert.AreSame(canonical, BmotionApiCatalog.GetTypeDetails("bmspring"));
+        Assert.AreSame(canonical, BmotionApiCatalog.GetTypeDetails("  BmSpring  "));
+        Assert.AreSame(canonical, BmotionApiCatalog.GetTypeDetails("Bit.Bmotion.BmSpring"));
+    }
+
+    [TestMethod]
+    [DataRow("Nonexistent")]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    public void GetTypeDetails_WhatIsNotAPublicType_IsNull(string? name)
+    {
+        Assert.IsNull(BmotionApiCatalog.GetTypeDetails(name!));
+    }
+
+    /// <summary>
+    /// The reason the reference is reflected rather than written down: whether Damping is 10 or 20
+    /// is the difference between the motion an agent wrote and the motion it meant.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_ReadsDefaultValuesOffARealInstance()
+    {
+        var spring = BmotionApiCatalog.GetTypeDetails("BmSpring")!;
+
+        var actual = new BmSpring();
+
+        foreach (var (name, expected) in new[]
+        {
+            (nameof(BmSpring.Stiffness), actual.Stiffness),
+            (nameof(BmSpring.Damping), actual.Damping),
+            (nameof(BmSpring.Mass), actual.Mass),
+        })
+        {
+            var member = spring.Members.Single(entry => entry.Name == name);
+
+            Assert.AreEqual(expected.ToString(System.Globalization.CultureInfo.InvariantCulture), member.Default,
+                            $"BmSpring.{name} is documented as defaulting to '{member.Default}'.");
+        }
+
+        // A tween's duration is the one number people assume; it has to be the library's own.
+        Assert.AreEqual(new BmTween().Duration.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        BmotionApiCatalog.GetTypeDetails("BmTween")!.Members.Single(member => member.Name == "Duration").Default);
+    }
+
+    [TestMethod]
+    public void GetTypeDetails_AComponent_ListsItsBlazorParameters()
+    {
+        var component = BmotionApiCatalog.GetTypeDetails("Bmotion")!;
+
+        Assert.AreEqual("Component", component.Kind);
+
+        var parameters = component.Members.Where(member => member.Kind == "Parameter").Select(member => member.Name).ToArray();
+
+        foreach (var expected in new[] { "Initial", "Animate", "Exit", "Transition", "ChildContent" })
+        {
+            CollectionAssert.Contains(parameters, expected, $"<Bmotion> has no '{expected}' parameter in the reference.");
+        }
+
+        // Parameters come first: they are what a caller writes, and the rest is implementation.
+        Assert.AreEqual("Parameter", component.Members[0].Kind);
+    }
+
+    /// <summary>
+    /// A component's inherited Bmotion parameters belong in its reference; the members it gets from
+    /// ComponentBase do not - they are noise an agent has to read past.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_AComponent_DoesNotCarryTheFrameworksOwnMembers()
+    {
+        var component = BmotionApiCatalog.GetTypeDetails("Bmotion")!;
+
+        foreach (var framework in new[] { "SetParametersAsync", "StateHasChanged", "OnInitialized", "InvokeAsync" })
+        {
+            Assert.IsFalse(component.Members.Any(member => member.Name == framework),
+                           $"'{framework}' comes from ComponentBase and does not belong in the reference.");
+        }
+    }
+
+    [TestMethod]
+    public void GetTypeDetails_AnEnum_ListsEveryMemberAsAnEnumValue()
+    {
+        var ease = BmotionApiCatalog.GetTypeDetails("BmEase")!;
+
+        Assert.AreEqual("Enum", ease.Kind);
+        Assert.IsTrue(ease.Members.All(member => member.Kind == "EnumValue"));
+
+        CollectionAssert.AreEquivalent(Enum.GetNames<BmEase>(), ease.Members.Select(member => member.Name).ToArray());
+
+        // The underlying constant is reported, so BmEase.Linear can be told from BmEase.Out.
+        Assert.IsTrue(ease.Members.All(member => member.Default is not null));
+    }
+
+    [TestMethod]
+    public void GetTypeDetails_AStaticFacade_ListsItsFactoryMethodsWithSignatures()
+    {
+        var bm = BmotionApiCatalog.GetTypeDetails("Bm")!;
+
+        Assert.AreEqual("Static class", bm.Kind);
+
+        foreach (var factory in new[] { "To", "Spring", "Tween" })
+        {
+            var methods = bm.Members.Where(member => member.Kind == "Method" && member.Name == factory).ToArray();
+
+            Assert.AreNotEqual(0, methods.Length, $"Bm.{factory} is missing from the reference.");
+            Assert.IsTrue(methods.All(method => method.Signature is not null && method.Signature.StartsWith('(')),
+                          $"Bm.{factory} is listed without a parameter list.");
+        }
+    }
+
+    /// <summary>
+    /// The documentation comes from the XML file the library build emits next to the assembly. If a
+    /// publish drops it, every summary here becomes null and the reference degrades to bare names
+    /// without anything failing.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_TheXmlDocumentation_IsDeployedAlongsideTheAssembly()
+    {
+        Assert.IsTrue(File.Exists(Path.Combine(AppContext.BaseDirectory, "Bit.Bmotion.xml")),
+                      "Bit.Bmotion.xml is not next to the assembly, so the reference has no prose at all.");
+
+        var documented = BmotionApiCatalog.Types.Count(type => string.IsNullOrWhiteSpace(type.Summary) is false);
+
+        Assert.IsTrue(documented > BmotionApiCatalog.Types.Length / 2,
+                      $"Only {documented} of {BmotionApiCatalog.Types.Length} types carry a summary.");
+
+        StringAssert.Contains(BmotionApiCatalog.GetTypeDetails("BmSpring")!.Summary ?? string.Empty, "spring",
+                              StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Every hit costs a reflection walk plus an XML lookup per member, and the search index asks
+    /// for all of them at once.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_IsCachedPerType()
+    {
+        Assert.AreSame(BmotionApiCatalog.GetTypeDetails("Bmotion"), BmotionApiCatalog.GetTypeDetails("Bmotion"));
+    }
+
+    [TestMethod]
+    public void GetTypeDetails_IsSafeToAskForFromManyThreadsAtOnce()
+    {
+        var names = BmotionApiCatalog.Types.Select(type => type.Name).ToArray();
+
+        var results = names.AsParallel().WithDegreeOfParallelism(8)
+            .Select(name => BmotionApiCatalog.GetTypeDetails(name))
+            .ToArray();
+
+        Assert.IsTrue(results.All(details => details is not null));
+    }
+
+    [TestMethod]
+    public void FriendlyName_SpellsTypesTheWayCSharpDoes()
+    {
+        Assert.AreEqual("double?", BmotionApiCatalog.FriendlyName(typeof(double?)));
+        Assert.AreEqual("string[]", BmotionApiCatalog.FriendlyName(typeof(string[])));
+        Assert.AreEqual("void", BmotionApiCatalog.FriendlyName(typeof(void)));
+        Assert.AreEqual("bool", BmotionApiCatalog.FriendlyName(typeof(bool)));
+        Assert.AreEqual("int", BmotionApiCatalog.FriendlyName(typeof(int)));
+        Assert.AreEqual("object", BmotionApiCatalog.FriendlyName(typeof(object)));
+        Assert.AreEqual("Dictionary<string, int>", BmotionApiCatalog.FriendlyName(typeof(Dictionary<string, int>)));
+        Assert.AreEqual("Task<string[]>", BmotionApiCatalog.FriendlyName(typeof(Task<string[]>)));
+    }
+
+    /// <summary>
+    /// Every member of every type, walked once. A reflection or documentation-id mistake on one
+    /// exotic member (a generic method, an operator, a ref parameter) throws rather than degrading,
+    /// and would take the whole tool down for the type it is on.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_EveryMemberOfEveryType_IsDescribedWithoutThrowing()
+    {
+        foreach (var type in BmotionApiCatalog.Types)
+        {
+            var details = BmotionApiCatalog.GetTypeDetails(type.Name)!;
+
+            Assert.AreEqual(type.Name, details.Name);
+            Assert.AreEqual(type.Kind, details.Kind);
+            Assert.IsNotNull(details.FullName);
+            Assert.IsNotNull(details.Implements);
+
+            foreach (var member in details.Members)
+            {
+                Assert.AreNotEqual(string.Empty, member.Name.Trim(), $"{type.Name} has an unnamed member.");
+                Assert.IsFalse(member.Name.Contains('<'), $"{type.Name}.{member.Name} is compiler-generated.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The reference is prose an agent reads, not markup. Flattening that leaves tags behind would
+    /// put "&lt;see cref=..." into the middle of a sentence.
+    /// </summary>
+    [TestMethod]
+    public void GetTypeDetails_TheDocumentation_IsFlattenedToProse()
+    {
+        foreach (var type in BmotionApiCatalog.Types)
+        {
+            var details = BmotionApiCatalog.GetTypeDetails(type.Name)!;
+
+            foreach (var text in details.Members.Select(member => member.Summary)
+                                        .Concat([details.Summary, details.Remarks])
+                                        .Where(text => text is not null))
+            {
+                foreach (var tag in new[] { "<see ", "<paramref", "<para>", "<c>", "<summary>", "</summary>" })
+                {
+                    Assert.IsFalse(text!.Contains(tag, StringComparison.Ordinal),
+                                   $"{type.Name} carries raw '{tag}' into its documentation: {text}");
+                }
+            }
+        }
+    }
+
+    [TestMethod]
+    public void GetTypeDetails_MarksTheEditorRequiredParameters()
+    {
+        // Not every version of the library has one; when it does, the flag has to survive.
+        var required = BmotionApiCatalog.Types
+            .Select(type => BmotionApiCatalog.GetTypeDetails(type.Name)!)
+            .SelectMany(details => details.Members.Select(member => (details.Name, Member: member)))
+            .Where(entry => entry.Member.Required)
+            .ToArray();
+
+        foreach (var (owner, member) in required)
+        {
+            var property = Type.GetType($"Bit.Bmotion.{owner}, Bit.Bmotion")?.GetProperty(member.Name);
+
+            if (property is null) continue;
+
+            Assert.IsTrue(property.IsDefined(typeof(Microsoft.AspNetCore.Components.EditorRequiredAttribute), inherit: true),
+                          $"{owner}.{member.Name} is marked required but is not [EditorRequired].");
+        }
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/CodeReviewTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/CodeReviewTests.cs
@@ -167,6 +167,17 @@ public class CodeReviewTests
                 </Bmotion>
                 """,
 
+            ["animate-without-initial"] = """
+                <Bmotion Animate="_open ? Bm.To(opacity: 1) : Bm.To(opacity: 0)">
+                    <div class="card">Content</div>
+                </Bmotion>
+                """,
+
+            ["empty-bmotion"] = """
+                <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)">
+                    <div class="card">Content</div>
+                </Bmotion>
+                """,
             ["missing-key-in-loop"] = """
                 @foreach (var item in Items)
                 {
@@ -221,6 +232,10 @@ public class CodeReviewTests
                 """,
         };
 
+        CollectionAssert.AreEquivalent(Offenders.Keys.ToArray(), clean.Keys.ToArray(),
+                                       "Every rule needs a correct form here as well as an offender: a rule with " +
+                                       "no false-positive case is a rule nothing keeps honest.");
+
         foreach (var (rule, code) in clean)
         {
             var review = BmotionCodeReview.Review(code);
@@ -228,6 +243,24 @@ public class CodeReviewTests
             Assert.IsFalse(review.Findings.Any(finding => finding.Rule == rule),
                            $"'{rule}' fired on markup that gets it right:\n{code}");
         }
+    }
+
+    /// <summary>
+    /// Only the bound Animate value tells an entrance apart from a state change. An underscore
+    /// anywhere else on the tag - a BEM class, an id, some unrelated attribute - is not state, and a
+    /// rule that reads it as state goes quiet on exactly the markup it exists to catch.
+    /// </summary>
+    [TestMethod]
+    public void Review_AnimateWithoutInitial_IsStillReportedWhenTheUnderscoreIsNotInAnimate()
+    {
+        var code = """
+            <Bmotion Animate="Bm.To(opacity: 1)" class="card_body" id="hero_panel">
+                <div class="card">Content</div>
+            </Bmotion>
+            """;
+
+        Assert.IsTrue(BmotionCodeReview.Review(code).Findings.Any(finding => finding.Rule == "animate-without-initial"),
+                      "An underscore outside the Animate value silenced the rule.");
     }
 
     [TestMethod]

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/CodeReviewTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/CodeReviewTests.cs
@@ -1,0 +1,428 @@
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The review pass that closes the loop after an agent writes Bmotion markup.
+/// <para>
+/// Every rule it applies exists because the mistake it catches is silent - it compiles, deploys and
+/// renders, and then does nothing. So the tests come in pairs: each rule has to fire on markup that
+/// makes the mistake, and stay quiet on markup that does not. The second half is what keeps the
+/// review usable at all; a rule that fires on correct code teaches an agent to ignore the review,
+/// which costs more than never having run it.
+/// </para>
+/// </summary>
+[TestClass]
+public class CodeReviewTests
+{
+    /// <summary>
+    /// One piece of markup per rule, each making exactly the mistake the rule is named after. It
+    /// doubles as the coverage check below: a rule with no offender here is a rule nothing proves
+    /// still fires.
+    /// </summary>
+    private static readonly Dictionary<string, string> Offenders = new(StringComparer.Ordinal)
+    {
+        ["exit-without-presence"] = """
+            @if (show)
+            {
+                <Bmotion Initial="Bm.To(opacity: 0)"
+                         Animate="Bm.To(opacity: 1)"
+                         Exit="Bm.To(opacity: 0)">
+                    <div class="panel">Content</div>
+                </Bmotion>
+            }
+            """,
+
+        ["spring-duration-without-bounce"] = """
+            <Bmotion Animate="Bm.To(x: 100)" Transition="Bm.Spring(duration: 0.5)">
+                <div class="box" />
+            </Bmotion>
+            """,
+
+        ["animate-without-initial"] = """
+            <Bmotion Animate="Bm.To(opacity: 1)">
+                <div class="card">Content</div>
+            </Bmotion>
+            """,
+
+        ["missing-key-in-loop"] = """
+            @foreach (var item in Items)
+            {
+                <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)">
+                    <li>@item.Title</li>
+                </Bmotion>
+            }
+            """,
+
+        ["nested-quotes-in-attribute"] = """
+            <Bmotion Animate="Bm.To(backgroundColor: "#FD7F36")">
+                <div class="box" />
+            </Bmotion>
+            """,
+
+        ["component-as-animated-root"] = """
+            <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)">
+                <ProductCard Product="Product" />
+            </Bmotion>
+            """,
+
+        ["empty-bmotion"] = """
+            <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)" />
+            """,
+
+        ["frame-loop-only-properties"] = """
+            <Bmotion Initial='Bm.To(height: "0px")' Animate='Bm.To(height: "320px")'>
+                <div class="drawer" />
+            </Bmotion>
+            """,
+
+        ["drag-without-capability-guard"] = """
+            <Bmotion Drag="true" DragConstraints="new BmDragConstraints { Left = -100, Right = 100 }">
+                <div class="handle" />
+            </Bmotion>
+            """,
+
+        ["eased-infinite-rotation"] = """
+            <Bmotion Animate="Bm.To(rotate: 360)"
+                     Transition="Bm.Tween(1, repeat: BmRepeat.Forever)">
+                <div class="spinner" />
+            </Bmotion>
+            """,
+
+        ["resting-state-in-gesture"] = """
+            <Bmotion WhileHover="Bm.To(scale: 1)" WhileTap="Bm.To(scale: 0.97)">
+                <button class="card">Open</button>
+            </Bmotion>
+            """,
+
+        ["reduced-motion-not-configured"] = """
+            builder.Services.AddBitBmotionServices();
+            """,
+    };
+
+    /// <summary>
+    /// A rule listed in RulesApplied but unreachable is worse than no rule: the report says it was
+    /// checked. Every declared rule needs markup here that provokes it.
+    /// </summary>
+    [TestMethod]
+    public void Review_EveryDeclaredRule_HasMarkupThatProvokesIt()
+    {
+        CollectionAssert.AreEquivalent(BmotionCodeReview.Rules, Offenders.Keys.ToArray(),
+                                       "The rule list and the offending samples have drifted apart.");
+    }
+
+    [TestMethod]
+    public void Review_EachRule_FiresOnTheMistakeItIsNamedAfter()
+    {
+        foreach (var (rule, code) in Offenders)
+        {
+            var review = BmotionCodeReview.Review(code);
+
+            Assert.IsTrue(review.Findings.Any(finding => finding.Rule == rule),
+                          $"'{rule}' did not fire. It reported instead: " +
+                          $"{string.Join(", ", review.Findings.Select(finding => finding.Rule).DefaultIfEmpty("nothing"))}.");
+        }
+    }
+
+    [TestMethod]
+    public void Review_EveryFinding_NamesALine_AndSaysWhatToDo()
+    {
+        foreach (var (rule, code) in Offenders)
+        {
+            var lineCount = code.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n').Length;
+
+            foreach (var finding in BmotionCodeReview.Review(code).Findings)
+            {
+                Assert.AreNotEqual(string.Empty, finding.Message.Trim(), $"'{finding.Rule}' reported an empty message.");
+                Assert.AreNotEqual(string.Empty, finding.Fix.Trim(), $"'{finding.Rule}' reported no correction.");
+                CollectionAssert.Contains(new[] { "Error", "Warning", "Suggestion" }, finding.Severity);
+
+                Assert.IsNotNull(finding.Line, $"'{finding.Rule}' (on the '{rule}' sample) mapped to no line.");
+                Assert.IsTrue(finding.Line >= 1 && finding.Line <= lineCount,
+                              $"'{finding.Rule}' points at line {finding.Line} of a {lineCount}-line sample.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The correct forms of the same markup. A rule that also fires on these is a rule an agent
+    /// learns to ignore.
+    /// </summary>
+    [TestMethod]
+    public void Review_TheCorrectFormOfEachMistake_IsNotReported()
+    {
+        var clean = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["exit-without-presence"] = """
+                <BmotionAnimatePresence IsPresent="show">
+                    <Bmotion Initial="Bm.To(opacity: 0)"
+                             Animate="Bm.To(opacity: 1)"
+                             Exit="Bm.To(opacity: 0)">
+                        <div class="panel">Content</div>
+                    </Bmotion>
+                </BmotionAnimatePresence>
+                """,
+
+            ["spring-duration-without-bounce"] = """
+                <Bmotion Animate="Bm.To(x: 100)" Transition="Bm.Spring(bounce: 0.2, duration: 0.5)">
+                    <div class="box" />
+                </Bmotion>
+                """,
+
+            ["missing-key-in-loop"] = """
+                @foreach (var item in Items)
+                {
+                    <Bmotion @key="item.Id" Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)">
+                        <li>@item.Title</li>
+                    </Bmotion>
+                }
+                """,
+
+            ["nested-quotes-in-attribute"] = """
+                <Bmotion Animate='Bm.To(backgroundColor: "#FD7F36")'>
+                    <div class="box" />
+                </Bmotion>
+                """,
+
+            ["component-as-animated-root"] = """
+                <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)">
+                    <div class="wrapper"><ProductCard Product="Product" /></div>
+                </Bmotion>
+                """,
+
+            ["frame-loop-only-properties"] = """
+                <Bmotion Initial="Bm.To(opacity: 0, y: 20)" Animate="Bm.To(opacity: 1, y: 0)">
+                    <div class="card" />
+                </Bmotion>
+                """,
+
+            ["eased-infinite-rotation"] = """
+                <Bmotion Animate="Bm.To(rotate: 360)"
+                         Transition="Bm.Tween(1, BmEase.Linear, repeat: BmRepeat.Forever)">
+                    <div class="spinner" />
+                </Bmotion>
+                """,
+
+            ["resting-state-in-gesture"] = """
+                <Bmotion WhileHover="Bm.To(scale: 1.04)" WhileTap="Bm.To(scale: 0.97)">
+                    <button class="card">Open</button>
+                </Bmotion>
+                """,
+
+            ["reduced-motion-not-configured"] = """
+                builder.Services.AddBitBmotionServices(o => o.ReducedMotion = BmReducedMotionMode.User);
+                """,
+
+            ["drag-without-capability-guard"] = """
+                @if (Caps.SupportsFrameLoop)
+                {
+                    <Bmotion Drag="true">
+                        <div class="handle" />
+                    </Bmotion>
+                }
+                """,
+        };
+
+        foreach (var (rule, code) in clean)
+        {
+            var review = BmotionCodeReview.Review(code);
+
+            Assert.IsFalse(review.Findings.Any(finding => finding.Rule == rule),
+                           $"'{rule}' fired on markup that gets it right:\n{code}");
+        }
+    }
+
+    [TestMethod]
+    public void Review_PointsAtTheLineTheMistakeIsOn()
+    {
+        var code = """
+            <div class="wrapper">
+                <Bmotion Animate="Bm.To(x: 100)" Transition="Bm.Spring(duration: 0.5)">
+                    <div class="box" />
+                </Bmotion>
+            </div>
+            """;
+
+        var finding = BmotionCodeReview.Review(code).Findings.Single(entry => entry.Rule == "spring-duration-without-bounce");
+
+        Assert.AreEqual(2, finding.Line);
+    }
+
+    [TestMethod]
+    public void Review_TheMostSeriousFindingsComeFirst()
+    {
+        // One markup, three mistakes at three severities: a self-closed Bmotion (Error), a spring
+        // duration with no bounce (Warning) and a frame-loop-only property (Suggestion).
+        var code = """
+            <Bmotion Animate="Bm.To(height: "0px")" Transition="Bm.Spring(duration: 0.5)" />
+            """;
+
+        var findings = BmotionCodeReview.Review(code).Findings;
+
+        var order = findings.Select(finding => finding.Severity switch
+        {
+            "Error" => 0,
+            "Warning" => 1,
+            _ => 2
+        }).ToArray();
+
+        CollectionAssert.AreEqual(order.OrderBy(rank => rank).ToArray(), order,
+                                  $"Reported in the order: {string.Join(", ", findings.Select(f => f.Severity))}.");
+    }
+
+    [TestMethod]
+    public void Review_Passed_MeansNothingAboveASuggestionWasFound()
+    {
+        // An Error fails the review.
+        Assert.IsFalse(BmotionCodeReview.Review("""<Bmotion Animate="Bm.To(x: 100)" />""").Passed);
+
+        // A Warning fails it too.
+        var warning = BmotionCodeReview.Review("""
+            <Bmotion Animate="Bm.To(x: 100)" Transition="Bm.Spring(duration: 0.5)">
+                <div class="box" />
+            </Bmotion>
+            """);
+
+        Assert.IsTrue(warning.Findings.All(finding => finding.Severity != "Error"));
+        Assert.IsFalse(warning.Passed);
+
+        // A Suggestion alone does not.
+        var suggestion = BmotionCodeReview.Review("""
+            <Bmotion Initial='Bm.To(height: "0px")' Animate='Bm.To(height: "320px")'>
+                <div class="drawer" />
+            </Bmotion>
+            """);
+
+        Assert.IsTrue(suggestion.Findings.All(finding => finding.Severity == "Suggestion"));
+        Assert.IsTrue(suggestion.Passed);
+    }
+
+    [TestMethod]
+    public void Review_CleanMarkup_PassesWithNothingToReport()
+    {
+        var code = """
+            <BmotionAnimatePresence IsPresent="show">
+                <Bmotion Initial="Bm.To(opacity: 0, scale: 0.95)"
+                         Animate="Bm.To(opacity: 1, scale: 1)"
+                         Exit="Bm.To(opacity: 0, scale: 0.95)"
+                         Transition="Bm.Spring(bounce: 0.15, duration: 0.35)">
+                    <div class="dialog">Content</div>
+                </Bmotion>
+            </BmotionAnimatePresence>
+            """;
+
+        var review = BmotionCodeReview.Review(code);
+
+        Assert.AreEqual(0, review.Findings.Length,
+                        $"Reported: {string.Join(", ", review.Findings.Select(finding => $"{finding.Rule}@{finding.Line}"))}.");
+        Assert.IsTrue(review.Passed);
+    }
+
+    /// <summary>
+    /// An empty result has to be distinguishable from an unchecked one, which is what RulesApplied
+    /// is for - so it is present even when nothing was reviewed.
+    /// </summary>
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   \n  \t ")]
+    public void Review_NothingToReview_PassesAndStillSaysWhatWouldHaveBeenChecked(string? code)
+    {
+        var review = BmotionCodeReview.Review(code);
+
+        Assert.IsTrue(review.Passed);
+        Assert.AreEqual(0, review.Findings.Length);
+        CollectionAssert.AreEqual(BmotionCodeReview.Rules, review.RulesApplied);
+    }
+
+    [TestMethod]
+    public void Review_AlwaysReportsTheRulesItApplied()
+    {
+        foreach (var code in Offenders.Values)
+        {
+            CollectionAssert.AreEqual(BmotionCodeReview.Rules, BmotionCodeReview.Review(code).RulesApplied);
+        }
+    }
+
+    [TestMethod]
+    public void Review_TheSameFrameLoopProperty_IsReportedOnceRatherThanPerOccurrence()
+    {
+        var code = """
+            <Bmotion Initial='Bm.To(height: "0px")' Animate='Bm.To(height: "320px")'>
+                <div class="drawer" />
+            </Bmotion>
+            """;
+
+        var findings = BmotionCodeReview.Review(code)
+            .Findings.Where(finding => finding.Rule == "frame-loop-only-properties")
+            .ToArray();
+
+        Assert.AreEqual(1, findings.Length, "The same property was reported for both ends of the animation.");
+    }
+
+    /// <summary>
+    /// Variant-driven and timeline-driven markup animates on a state change rather than on mount,
+    /// so the missing-Initial rule has to hold its tongue there.
+    /// </summary>
+    [TestMethod]
+    public void Review_VariantAndTimelineDrivenMarkup_IsNotAskedForAnInitial()
+    {
+        foreach (var code in new[]
+        {
+            """
+            <Bmotion Variants="Container" State="visible">
+                <div class="list" />
+            </Bmotion>
+            """,
+            """
+            <Bmotion Timeline="BmScrollTimeline.Page()" Animate="Bm.To(scaleX: [0, 1])">
+                <div class="progress-bar" />
+            </Bmotion>
+            """,
+        })
+        {
+            Assert.IsFalse(BmotionCodeReview.Review(code).Findings.Any(finding => finding.Rule == "animate-without-initial"),
+                           $"An Initial was demanded of:\n{code}");
+        }
+    }
+
+    /// <summary>Nesting Bmotion's own components is normal; only a foreign component is a finding.</summary>
+    [TestMethod]
+    public void Review_ANestedBmotionComponent_IsNotMistakenForAnUnanimatableRoot()
+    {
+        var code = """
+            <Bmotion Initial="Bm.To(opacity: 0)" Animate="Bm.To(opacity: 1)">
+                <BmotionSplitText Text="Hello" />
+            </Bmotion>
+            """;
+
+        Assert.IsFalse(BmotionCodeReview.Review(code).Findings.Any(finding => finding.Rule == "component-as-animated-root"));
+    }
+
+    [TestMethod]
+    public void Review_IsTotal_NoInputThrows()
+    {
+        foreach (var code in new[]
+        {
+            "<Bmotion", "<<<<", "\"\"\"", "Bm.To(", "@foreach (", new string('<', 2_000),
+            "<Bmotion Animate=\"Bm.To(x: 1)\">\n" + string.Join('\n', Enumerable.Repeat("<div />", 500)),
+        })
+        {
+            var review = BmotionCodeReview.Review(code);
+
+            Assert.IsNotNull(review.Findings);
+            CollectionAssert.AreEqual(BmotionCodeReview.Rules, review.RulesApplied);
+        }
+    }
+
+    [TestMethod]
+    public void Review_ReadsBothLineEndings()
+    {
+        var windows = "<Bmotion Animate=\"Bm.To(x: 100)\" Transition=\"Bm.Spring(duration: 0.5)\">\r\n    <div />\r\n</Bmotion>";
+        var unix = windows.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        var fromWindows = BmotionCodeReview.Review(windows);
+        var fromUnix = BmotionCodeReview.Review(unix);
+
+        CollectionAssert.AreEqual(fromUnix.Findings.Select(finding => $"{finding.Rule}@{finding.Line}").ToArray(),
+                                  fromWindows.Findings.Select(finding => $"{finding.Rule}@{finding.Line}").ToArray());
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/EasingCatalogTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/EasingCatalogTests.cs
@@ -1,0 +1,162 @@
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The easing catalog turns preset names into numbers by sampling the library's own easing
+/// implementation. The one fact it exists to publish is <c>Overshoots</c> - whether the curve
+/// leaves the 0-1 range and so carries the element past its target - because that is what decides
+/// whether a preset can be used on a drawer, a modal or anything else with a hard edge. These tests
+/// hold that flag to the curve it is derived from, and pin the families whose answer is known.
+/// </summary>
+[TestClass]
+public class EasingCatalogTests
+{
+    [TestMethod]
+    public async Task Get_ListsEveryBmEasePreset_Once()
+    {
+        var catalog = await BmotionEasingCatalog.GetAsync();
+
+        CollectionAssert.AreEquivalent(Enum.GetNames<BmEase>(), catalog.Select(easing => easing.Name).ToArray());
+        Assert.AreEqual(catalog.Length, catalog.Select(easing => easing.Name).Distinct().Count());
+    }
+
+    [TestMethod]
+    public async Task Get_EveryEntry_IsFullyPopulated()
+    {
+        foreach (var easing in await BmotionEasingCatalog.GetAsync())
+        {
+            Assert.AreEqual(11, easing.Curve.Length, $"BmEase.{easing.Name} was sampled at {easing.Curve.Length} points.");
+            Assert.AreEqual(easing.Curve.Length, easing.Sparkline.Length,
+                            $"BmEase.{easing.Name}'s sparkline does not match its curve.");
+            Assert.AreNotEqual(string.Empty, easing.Feel.Trim(), $"BmEase.{easing.Name} has no guidance.");
+            Assert.AreNotEqual(string.Empty, easing.Family.Trim());
+            Assert.AreNotEqual(string.Empty, easing.Direction.Trim());
+
+            foreach (var value in easing.Curve)
+            {
+                Assert.IsTrue(double.IsFinite(value), $"BmEase.{easing.Name} sampled a non-finite value.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task Get_EveryCurve_RunsFromZeroToOne()
+    {
+        foreach (var easing in await BmotionEasingCatalog.GetAsync())
+        {
+            Assert.AreEqual(0, easing.Curve[0], 0.02, $"BmEase.{easing.Name} does not start at rest.");
+            Assert.AreEqual(1, easing.Curve[^1], 0.02, $"BmEase.{easing.Name} does not arrive at the target.");
+        }
+    }
+
+    /// <summary>
+    /// The published flag has to be the curve's own property, not an opinion about the name - a
+    /// preset renamed or re-tuned in the library must move the flag with it.
+    /// </summary>
+    [TestMethod]
+    public async Task Get_TheOvershootFlag_IsDerivedFromTheCurveItPublishes()
+    {
+        foreach (var easing in await BmotionEasingCatalog.GetAsync())
+        {
+            var leavesRange = easing.Curve.Any(value => value < -0.001 || value > 1.001);
+
+            Assert.AreEqual(leavesRange, easing.Overshoots,
+                            $"BmEase.{easing.Name}: Overshoots={easing.Overshoots} but the curve " +
+                            $"[{string.Join(", ", easing.Curve)}] says {leavesRange}.");
+        }
+    }
+
+    /// <summary>
+    /// Anticipate is deliberately not in this list: its wind-up is a shallow bezier dip of about
+    /// one percent, which eleven samples do not reliably land on - so the catalog reports it as not
+    /// overshooting, and that is the honest answer at this resolution.
+    /// </summary>
+    [TestMethod]
+    [DataRow("BackOut")]
+    [DataRow("BackIn")]
+    [DataRow("BackInOut")]
+    [DataRow("ElasticOut")]
+    [DataRow("ElasticIn")]
+    public async Task Get_ThePresetsWithAHardEdgeProblem_AreFlaggedAsOvershooting(string name)
+    {
+        var easing = (await BmotionEasingCatalog.GetAsync()).Single(entry => entry.Name == name);
+
+        Assert.IsTrue(easing.Overshoots,
+                      $"BmEase.{name} is not flagged, so it reads as safe on a drawer. " +
+                      $"Curve: [{string.Join(", ", easing.Curve)}]");
+    }
+
+    [TestMethod]
+    [DataRow("Linear")]
+    [DataRow("In")]
+    [DataRow("Out")]
+    [DataRow("InOut")]
+    [DataRow("QuadOut")]
+    [DataRow("ExpoOut")]
+    [DataRow("SineInOut")]
+    public async Task Get_ThePresetsThatStayInsideTheirBounds_AreNotFlagged(string name)
+    {
+        var easing = (await BmotionEasingCatalog.GetAsync()).Single(entry => entry.Name == name);
+
+        Assert.IsFalse(easing.Overshoots, $"BmEase.{name} was flagged as overshooting, which rules it out needlessly.");
+    }
+
+    [TestMethod]
+    public async Task Get_Linear_IsSampledAsTheStraightLineItIs()
+    {
+        var linear = (await BmotionEasingCatalog.GetAsync()).Single(entry => entry.Name == "Linear");
+
+        Assert.AreEqual("Linear", linear.Direction);
+        Assert.AreEqual("Linear", linear.Family);
+
+        for (int i = 0; i < linear.Curve.Length; i++)
+        {
+            Assert.AreEqual(i / 10.0, linear.Curve[i], 0.02);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("QuadIn", "Quad", "In")]
+    [DataRow("QuadOut", "Quad", "Out")]
+    [DataRow("QuadInOut", "Quad", "InOut")]
+    [DataRow("BackOut", "Back", "Out")]
+    [DataRow("ExpoInOut", "Expo", "InOut")]
+    [DataRow("Anticipate", "Anticipate", "Custom")]
+    public async Task Get_TheFamilyAndDirection_AreReadOffThePresetName(string name, string family, string direction)
+    {
+        var easing = (await BmotionEasingCatalog.GetAsync()).Single(entry => entry.Name == name);
+
+        Assert.AreEqual(family, easing.Family);
+        Assert.AreEqual(direction, easing.Direction);
+    }
+
+    /// <summary>The bare In/Out/InOut members are the library's default cubic curves, not a family of their own.</summary>
+    [TestMethod]
+    [DataRow("In")]
+    [DataRow("Out")]
+    [DataRow("InOut")]
+    public async Task Get_TheBareDirections_AreReportedAsTheCubicFamily(string name)
+    {
+        var easing = (await BmotionEasingCatalog.GetAsync()).Single(entry => entry.Name == name);
+
+        Assert.AreEqual("Cubic", easing.Family);
+    }
+
+    [TestMethod]
+    public async Task Get_AnEaseOut_CoversMoreGroundEarlyThanAnEaseIn()
+    {
+        var catalog = await BmotionEasingCatalog.GetAsync();
+
+        var quadOut = catalog.Single(entry => entry.Name == "QuadOut").Curve;
+        var quadIn = catalog.Single(entry => entry.Name == "QuadIn").Curve;
+
+        // At a quarter of the way through: decelerating is ahead, accelerating is behind.
+        Assert.IsTrue(quadOut[3] > 0.3, $"QuadOut at t=0.3 is {quadOut[3]}.");
+        Assert.IsTrue(quadIn[3] < 0.3, $"QuadIn at t=0.3 is {quadIn[3]}.");
+    }
+
+    [TestMethod]
+    public async Task Get_IsCachedRatherThanReSampledPerCall()
+    {
+        Assert.AreSame(await BmotionEasingCatalog.GetAsync(), await BmotionEasingCatalog.GetAsync());
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/MotionLabTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/MotionLabTests.cs
@@ -1,0 +1,318 @@
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The half of the MCP server that answers by running the real engine rather than by quoting text.
+/// <para>
+/// These are the tools whose answers an agent cannot sanity-check: nobody can tell by reading that
+/// a settle time of 1.4s is wrong. So the tests assert the properties that make the measurements
+/// trustworthy - a critically damped spring must measure as not overshooting, a bouncy one must
+/// measure as overshooting, a tween must settle at the duration it was given - and the invariants
+/// that keep a bad answer from looking like a good one: an unreadable spec must come back as an
+/// error rather than as zeroes, and a motion that never rests must say so rather than reporting
+/// the frame cap as its settle time.
+/// </para>
+/// </summary>
+[TestClass]
+public class MotionLabTests
+{
+    [TestMethod]
+    public async Task Simulate_ATween_SettlesAtTheDurationItWasGiven()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("tween(0.4, Linear)", 0, 100);
+
+        Assert.IsNull(result.Error);
+        Assert.AreEqual("Tween", result.Kind);
+        // One frame of tolerance: the engine samples on the 60 fps grid, so it lands on or just past
+        // the duration, never before it.
+        Assert.AreEqual(0.4, result.SettleSeconds, 0.02, $"Settled at {result.SettleSeconds}s.");
+        Assert.AreEqual(0, result.OvershootPercent, 0.001, "A linear tween cannot pass its target.");
+        Assert.AreEqual(0, result.TargetCrossings);
+    }
+
+    [TestMethod]
+    public async Task Simulate_ACriticallyDampedSpring_MeasuresAsNotOvershooting()
+    {
+        // Damping at 2*sqrt(stiffness*mass) is exactly critical: it eases in and stops dead.
+        var result = await BmotionMotionLab.SimulateAsync("spring(stiffness: 100, damping: 20)", 0, 100);
+
+        Assert.AreEqual("Spring", result.Kind);
+        Assert.IsTrue(result.OvershootPercent < 0.5, $"Overshot by {result.OvershootPercent}%.");
+        Assert.AreEqual(0, result.TargetCrossings);
+        StringAssert.Contains(result.Reading, "critically damped");
+    }
+
+    [TestMethod]
+    public async Task Simulate_AnUnderdampedSpring_MeasuresTheOvershootAndTheWobble()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("spring(stiffness: 300, damping: 8)", 0, 100);
+
+        Assert.IsTrue(result.OvershootPercent > 5, $"A spring this lightly damped must overshoot; it measured {result.OvershootPercent}%.");
+        Assert.IsTrue(result.TargetCrossings >= 2, $"It crossed the target {result.TargetCrossings} times.");
+        Assert.IsTrue(result.PeakVelocity > 0);
+    }
+
+    /// <summary>
+    /// The relationship the whole tool exists to expose: damping is the only lever between these
+    /// two, and more of it must measure as less bounce and a shorter settle.
+    /// </summary>
+    [TestMethod]
+    public async Task Simulate_MoreDamping_MeansLessOvershoot()
+    {
+        var loose = await BmotionMotionLab.SimulateAsync("spring(stiffness: 260, damping: 8)");
+        var tight = await BmotionMotionLab.SimulateAsync("spring(stiffness: 260, damping: 26)");
+
+        Assert.IsTrue(tight.OvershootPercent < loose.OvershootPercent,
+                      $"Damping 26 overshot {tight.OvershootPercent}%, damping 8 overshot {loose.OvershootPercent}%.");
+        Assert.IsTrue(tight.TargetCrossings <= loose.TargetCrossings);
+    }
+
+    [TestMethod]
+    public async Task Simulate_TheSamples_StartAtTheSourceAndEndAtTheTarget()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("tween(0.5, InOut)", 20, 180);
+
+        Assert.AreNotEqual(0, result.Samples.Length);
+        Assert.IsTrue(result.Samples.Length <= 24, $"{result.Samples.Length} samples is more than a client should be handed.");
+
+        Assert.AreEqual(20, result.Samples[0].Value, 5, "The first sample is not near the starting value.");
+        Assert.AreEqual(180, result.Samples[^1].Value, 1, "The last sample is not the resting value.");
+
+        // Time only moves forwards, and the pinned last sample is the end of the motion.
+        for (int i = 1; i < result.Samples.Length; i++)
+        {
+            Assert.IsTrue(result.Samples[i].Seconds >= result.Samples[i - 1].Seconds,
+                          $"Sample {i} goes backwards in time.");
+        }
+
+        Assert.AreEqual(result.SettleSeconds, result.Samples[^1].Seconds, 1e-6);
+    }
+
+    [TestMethod]
+    public async Task Simulate_TheSparkline_IsDrawnAndBounded()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("spring(stiffness: 260, damping: 12)");
+
+        Assert.AreNotEqual(string.Empty, result.Sparkline);
+        Assert.IsTrue(result.Sparkline.Length <= 48, $"A {result.Sparkline.Length}-character sparkline does not fit a terminal.");
+    }
+
+    [TestMethod]
+    public async Task Simulate_ADescendingMotion_MeasuresOvershootInTheDirectionOfTravel()
+    {
+        // Travelling downwards, "past the target" means below it. A sign error here would report a
+        // bouncy spring as perfectly damped.
+        var result = await BmotionMotionLab.SimulateAsync("spring(stiffness: 300, damping: 8)", 100, 0);
+
+        Assert.IsTrue(result.OvershootPercent > 5, $"Measured {result.OvershootPercent}% travelling downwards.");
+        Assert.AreEqual(100, result.From);
+        Assert.AreEqual(0, result.To);
+    }
+
+    [TestMethod]
+    public async Task Simulate_AZeroLengthMotion_ReportsNothingRatherThanDividingByIt()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("tween(0.3)", 50, 50);
+
+        Assert.IsNull(result.Error);
+        Assert.AreEqual(0, result.OvershootPercent);
+        Assert.IsFalse(double.IsNaN(result.OvershootPercent) || double.IsInfinity(result.OvershootPercent));
+    }
+
+    [TestMethod]
+    public async Task Simulate_Inertia_RetargetsTheMeasurementAtWhereItActuallyStops()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("inertia(velocity: 500)", 0, 100);
+
+        Assert.AreEqual("Inertia", result.Kind);
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("ignores the target", StringComparison.OrdinalIgnoreCase)),
+                      $"Warnings: {string.Join(" | ", result.Warnings)}");
+
+        // Reported against the resting point, not against the caller's 100 - otherwise the overshoot
+        // would be an artefact of a target inertia never had.
+        Assert.AreNotEqual(100, result.To);
+        Assert.AreEqual(result.To, result.Samples[^1].Value, 0.5);
+        StringAssert.Contains(result.Reading, "glide");
+    }
+
+    [TestMethod]
+    public async Task Simulate_ASpringThatNeverSettles_SaysSoInsteadOfReportingTheFrameCap()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("spring(stiffness: 400, damping: 0.05)", 0, 100);
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("come to rest", StringComparison.OrdinalIgnoreCase)),
+                      $"A ringing spring reported no warning. Warnings: {string.Join(" | ", result.Warnings)}");
+        // And the advice names the lever, rather than only the symptom.
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("damping", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public async Task Simulate_AnUnreadableSpec_IsDataTheCallerCanAct_Not_AThrownCall()
+    {
+        var result = await BmotionMotionLab.SimulateAsync("swoosh(0.4)", 0, 100);
+
+        Assert.IsNotNull(result.Error);
+        // Reading carries the same text, so a client that renders only the human-facing field still
+        // learns what went wrong.
+        Assert.AreEqual(result.Error, result.Reading);
+        Assert.AreEqual(0, result.Samples.Length);
+        Assert.AreEqual("Unknown", result.Kind);
+        // The spec is echoed back, so the caller can see what the server thought it was given.
+        StringAssert.Contains(result.Transition, "swoosh");
+    }
+
+    /// <summary>
+    /// Nothing in a simulation may depend on wall-clock time, on scheduling or on a previous run:
+    /// the same question asked twice has to give the same answer, or an agent tuning a transition is
+    /// chasing noise.
+    /// </summary>
+    [TestMethod]
+    public async Task Simulate_IsDeterministic_AcrossRunsAndUnderConcurrency()
+    {
+        var first = await BmotionMotionLab.SimulateAsync("spring(stiffness: 260, damping: 12)", 0, 100);
+        var second = await BmotionMotionLab.SimulateAsync("spring(stiffness: 260, damping: 12)", 0, 100);
+
+        Assert.AreEqual(first.SettleSeconds, second.SettleSeconds);
+        Assert.AreEqual(first.OvershootPercent, second.OvershootPercent);
+        Assert.AreEqual(first.TargetCrossings, second.TargetCrossings);
+        Assert.AreEqual(first.Sparkline, second.Sparkline);
+
+        // Every run builds its own engine and interop, so eight at once must not see each other.
+        var concurrent = await Task.WhenAll(Enumerable.Range(0, 8)
+            .Select(_ => BmotionMotionLab.SimulateAsync("spring(stiffness: 260, damping: 12)", 0, 100)));
+
+        foreach (var result in concurrent)
+        {
+            Assert.AreEqual(first.SettleSeconds, result.SettleSeconds);
+            Assert.AreEqual(first.Sparkline, result.Sparkline);
+        }
+    }
+
+    [TestMethod]
+    public async Task SampleEase_ReturnsACurveThatStartsAtZeroAndEndsAtOne()
+    {
+        foreach (var ease in Enum.GetValues<BmEase>())
+        {
+            var curve = await BmotionMotionLab.SampleEaseAsync(ease);
+
+            Assert.AreEqual(11, curve.Length, $"BmEase.{ease} sampled {curve.Length} points.");
+            Assert.AreEqual(0, curve[0], 0.02, $"BmEase.{ease} does not start at 0.");
+            Assert.AreEqual(1, curve[^1], 0.02, $"BmEase.{ease} does not end at 1.");
+        }
+    }
+
+    [TestMethod]
+    public async Task SampleEase_Linear_IsTheIdentity()
+    {
+        var curve = await BmotionMotionLab.SampleEaseAsync(BmEase.Linear);
+
+        for (int i = 0; i < curve.Length; i++)
+        {
+            Assert.AreEqual(i / 10.0, curve[i], 0.02, $"Linear at t={i / 10.0} sampled {curve[i]}.");
+        }
+    }
+
+    [TestMethod]
+    public async Task SampleEase_HonoursTheRequestedNumberOfPoints()
+    {
+        Assert.AreEqual(5, (await BmotionMotionLab.SampleEaseAsync(BmEase.Out, 5)).Length);
+        Assert.AreEqual(21, (await BmotionMotionLab.SampleEaseAsync(BmEase.Out, 21)).Length);
+    }
+
+    [TestMethod]
+    public async Task AnalyzePlayback_TransformsAndOpacity_GoToTheCompositor()
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync(["x", "opacity"], "tween(0.4, InOut)");
+
+        Assert.IsNull(result.Error);
+        Assert.IsTrue(result.WorksOnBlazorServer, result.Reason);
+        StringAssert.Contains(result.Path, "Compositor");
+        Assert.IsNull(result.HowToOffload, "There is nothing to fix about an animation that already offloads.");
+
+        // The timing handed to the browser is read back off the interop, so a wrong duration here
+        // would mean the tool is reporting an animation other than the one it ran.
+        Assert.AreEqual(400, result.CompositorDurationMs!.Value, 1);
+        Assert.IsNotNull(result.CompositorEasing);
+    }
+
+    [TestMethod]
+    [DataRow("width")]
+    [DataRow("height")]
+    [DataRow("backgroundColor")]
+    [DataRow("top")]
+    public async Task AnalyzePlayback_APropertyTheCompositorCannotOwn_StaysOnTheFrameLoopAndSaysWhy(string property)
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync([property], "tween(0.4)");
+
+        Assert.IsFalse(result.WorksOnBlazorServer, $"'{property}' was reported as compositor-eligible.");
+        StringAssert.Contains(result.Path, "frame loop");
+        StringAssert.Contains(result.Reason, property);
+
+        Assert.IsNotNull(result.HowToOffload);
+        Assert.AreNotEqual(0, result.HowToOffload.Length, "A frame-loop verdict with no remedy leaves the caller stuck.");
+    }
+
+    [TestMethod]
+    public async Task AnalyzePlayback_OneIneligiblePropertyInASetTakesTheWholeAnimationOffTheCompositor()
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync(["x", "opacity", "height"], "tween(0.4)");
+
+        Assert.IsFalse(result.WorksOnBlazorServer);
+        StringAssert.Contains(result.Reason, "height");
+        // The properties that were fine are not blamed for it.
+        Assert.IsFalse(result.Reason.Contains("opacity -", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task AnalyzePlayback_Inertia_NamesTheTransitionAsTheBlocker()
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync(["x"], "inertia(velocity: 500)");
+
+        Assert.IsFalse(result.WorksOnBlazorServer);
+        StringAssert.Contains(result.Reason, "inertia");
+        Assert.IsTrue(result.HowToOffload!.Any(remedy => remedy.Contains("spring", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>
+    /// A spring with an initial velocity drops off the compositor silently - it is the case an agent
+    /// is least likely to predict, and the one the tool most needs to catch.
+    /// </summary>
+    [TestMethod]
+    public async Task AnalyzePlayback_ASpringWithInitialVelocity_LosesTheCompositor()
+    {
+        var still = await BmotionMotionLab.AnalyzePlaybackAsync(["x"], "spring(stiffness: 260, damping: 20)");
+        var flung = await BmotionMotionLab.AnalyzePlaybackAsync(["x"], "spring(stiffness: 260, damping: 20, velocity: 400)");
+
+        Assert.IsTrue(still.WorksOnBlazorServer, still.Reason);
+        Assert.IsFalse(flung.WorksOnBlazorServer, "An initial velocity has to be reported as costing the compositor path.");
+        StringAssert.Contains(flung.Reason, "velocity");
+    }
+
+    [TestMethod]
+    public async Task AnalyzePlayback_AnUnknownPropertyName_IsReportedRatherThanIgnored()
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync(["x", "wobbliness"], "tween(0.3)");
+
+        StringAssert.Contains(result.Reason, "wobbliness");
+        StringAssert.Contains(result.Reason, "no such argument");
+    }
+
+    [TestMethod]
+    public async Task AnalyzePlayback_AnUnreadableTransition_IsNotAVerdictAboutBlazorServer()
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync(["x"], "swoosh(0.4)");
+
+        Assert.IsNotNull(result.Error);
+        Assert.AreEqual("Not analysed", result.Path);
+        Assert.IsFalse(result.WorksOnBlazorServer);
+        Assert.AreEqual(result.Error, result.Reason);
+    }
+
+    [TestMethod]
+    public async Task AnalyzePlayback_NoPropertiesAtAll_DoesNotThrow()
+    {
+        var result = await BmotionMotionLab.AnalyzePlaybackAsync([], "tween(0.3)");
+
+        Assert.AreEqual(0, result.Properties.Length);
+        Assert.IsNotNull(result.Reason);
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/MotionLabTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/MotionLabTests.cs
@@ -218,6 +218,24 @@ public class MotionLabTests
         Assert.AreEqual(21, (await BmotionMotionLab.SampleEaseAsync(BmEase.Out, 21)).Length);
     }
 
+    /// <summary>
+    /// A curve needs two points to be read at all, and the sampling fraction divides by points - 1.
+    /// A caller asking for fewer gets the smallest readable curve rather than an empty array or a
+    /// division by zero.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(-3)]
+    public async Task SampleEase_FewerThanTwoPoints_StillSamplesTheEnds(int points)
+    {
+        var curve = await BmotionMotionLab.SampleEaseAsync(BmEase.Linear, points);
+
+        Assert.AreEqual(2, curve.Length);
+        Assert.AreEqual(0, curve[0], 0.02);
+        Assert.AreEqual(1, curve[1], 0.02);
+    }
+
     [TestMethod]
     public async Task AnalyzePlayback_TransformsAndOpacity_GoToTheCompositor()
     {

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/PropertyCatalogTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/PropertyCatalogTests.cs
@@ -1,0 +1,270 @@
+using System.Reflection;
+
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The animatable-property catalog: the list is reflected off <see cref="BmProps"/> and the
+/// expensive claim on each entry - whether the browser compositor can own it, and therefore whether
+/// it animates or jumps on Blazor Server - is measured by running the engine.
+/// <para>
+/// Two things can go wrong and neither shows up as an exception. A property added to the library
+/// can arrive with no description, so the tool answers about it in placeholders. And the measured
+/// verdict can disagree with <see cref="BmotionPropertyCatalog.IsCompositorProperty"/>, which is
+/// what the same tool uses to *explain* the verdict - leaving the server measuring one thing and
+/// saying another. Both are asserted here.
+/// </para>
+/// </summary>
+[TestClass]
+public class PropertyCatalogTests
+{
+    private static readonly string[] KnownCategories =
+        ["Transform", "Visual", "Layout", "Typography", "Motion path", "SVG", "Custom"];
+
+    [TestMethod]
+    public async Task Get_CoversEveryWritableBmPropsArgument()
+    {
+        var catalog = await BmotionPropertyCatalog.GetAsync();
+
+        var expected = typeof(BmProps)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanWrite && property.Name != nameof(BmProps.Transition))
+            .Select(property => char.ToLowerInvariant(property.Name[0]) + property.Name[1..])
+            .ToArray();
+
+        CollectionAssert.AreEquivalent(expected, catalog.Select(entry => entry.Name).ToArray(),
+                                       "The catalog and Bm.To(...) have drifted apart.");
+    }
+
+    /// <summary>
+    /// A property with no entry in the description table falls back to placeholders ("Other", the
+    /// name as its own CSS, "name: ..."), which is a silent, low-quality answer rather than a
+    /// failure. Adding a property to BmProps without describing it should be caught here.
+    /// </summary>
+    [TestMethod]
+    public async Task Get_EveryProperty_IsDescribed_NotFilledInWithPlaceholders()
+    {
+        var catalog = await BmotionPropertyCatalog.GetAsync();
+
+        var undescribed = catalog.Where(entry => entry.Category == "Other").Select(entry => entry.Name).ToArray();
+
+        Assert.AreEqual(0, undescribed.Length,
+                        $"Not described in BmotionPropertyCatalog: {string.Join(", ", undescribed)}.");
+
+        foreach (var entry in catalog)
+        {
+            CollectionAssert.Contains(KnownCategories, entry.Category, $"'{entry.Name}' has category '{entry.Category}'.");
+            Assert.AreNotEqual(string.Empty, entry.Css.Trim(), $"'{entry.Name}' names no CSS.");
+            StringAssert.Contains(entry.Example, entry.Name, $"'{entry.Name}' has example '{entry.Example}'.");
+            Assert.AreNotEqual(string.Empty, entry.ValueType.Trim());
+        }
+    }
+
+    /// <summary>
+    /// The measured verdict and the rule the tools quote when explaining it have to agree. If they
+    /// ever diverge, AnalyzeBmotionAnimation reports one playback path and gives the reasons for
+    /// the other.
+    /// </summary>
+    [TestMethod]
+    public async Task Get_TheMeasuredVerdict_AgreesWithTheRuleTheToolsExplainItWith()
+    {
+        var catalog = await BmotionPropertyCatalog.GetAsync();
+
+        var disagreements = catalog
+            .Where(entry => entry.CompositorEligible != BmotionPropertyCatalog.IsCompositorProperty(entry.Name))
+            .Select(entry => $"{entry.Name}: engine says {entry.CompositorEligible}, " +
+                             $"IsCompositorProperty says {BmotionPropertyCatalog.IsCompositorProperty(entry.Name)}")
+            .ToArray();
+
+        Assert.AreEqual(0, disagreements.Length, string.Join("; ", disagreements));
+    }
+
+    [TestMethod]
+    [DataRow("x")]
+    [DataRow("y")]
+    [DataRow("scale")]
+    [DataRow("rotate")]
+    [DataRow("opacity")]
+    public async Task Get_TheCheapProperties_AreMeasuredAsCompositorEligible(string name)
+    {
+        var entry = (await BmotionPropertyCatalog.GetAsync()).Single(property => property.Name == name);
+
+        Assert.IsTrue(entry.CompositorEligible, $"'{name}' is documented as compositor-cheap but did not offload.");
+        Assert.AreEqual("Animates", entry.OnBlazorServer);
+    }
+
+    [TestMethod]
+    [DataRow("width")]
+    [DataRow("height")]
+    [DataRow("backgroundColor")]
+    [DataRow("top")]
+    [DataRow("filter")]
+    [DataRow("boxShadow")]
+    public async Task Get_TheExpensiveProperties_AreMeasuredAsNeedingTheFrameLoop(string name)
+    {
+        var entry = (await BmotionPropertyCatalog.GetAsync()).Single(property => property.Name == name);
+
+        Assert.IsFalse(entry.CompositorEligible, $"'{name}' was reported as compositor-eligible.");
+        Assert.AreEqual("Jumps to the target", entry.OnBlazorServer);
+    }
+
+    [TestMethod]
+    public async Task Get_OnBlazorServer_NeverContradictsTheVerdict()
+    {
+        foreach (var entry in await BmotionPropertyCatalog.GetAsync())
+        {
+            Assert.AreEqual(entry.CompositorEligible ? "Animates" : "Jumps to the target", entry.OnBlazorServer,
+                            $"'{entry.Name}' says one thing in two fields.");
+        }
+    }
+
+    [TestMethod]
+    public async Task Get_IsOrderedByCategory_SoTheCheapPropertiesComeFirst()
+    {
+        var catalog = await BmotionPropertyCatalog.GetAsync();
+
+        Assert.AreEqual("Transform", catalog[0].Category);
+
+        // Every Transform entry precedes every non-Transform one, which is the ordering an agent
+        // scanning the list depends on.
+        var lastTransform = Array.FindLastIndex(catalog, entry => entry.Category == "Transform");
+        var firstOther = Array.FindIndex(catalog, entry => entry.Category != "Transform");
+
+        Assert.IsTrue(lastTransform < firstOther, "The categories are interleaved.");
+    }
+
+    /// <summary>The probe runs once per process; it must not be paid for on every call.</summary>
+    [TestMethod]
+    public async Task Get_IsCachedRatherThanReProbedPerCall()
+    {
+        Assert.AreSame(await BmotionPropertyCatalog.GetAsync(), await BmotionPropertyCatalog.GetAsync());
+    }
+
+    [TestMethod]
+    public void BuildTarget_SetsTheNamedProperties_AndReportsTheRest()
+    {
+        var props = BmotionPropertyCatalog.BuildTarget(["x", "opacity", "wobbliness"], out var unknown);
+
+        Assert.IsNotNull(props.X);
+        Assert.IsNotNull(props.Opacity);
+        CollectionAssert.AreEqual(new[] { "wobbliness" }, unknown);
+    }
+
+    [TestMethod]
+    public void BuildTarget_ToleratesTheWayAnAgentQuotesAndSpacesNames()
+    {
+        BmotionPropertyCatalog.BuildTarget([" x ", "\"opacity\"", "BACKGROUNDCOLOR"], out var unknown);
+
+        Assert.AreEqual(0, unknown.Length, $"Rejected: {string.Join(", ", unknown)}.");
+    }
+
+    /// <summary>
+    /// The dictionary-valued escape hatches have no single representative value, so they cannot be
+    /// probed - and are reported as unknown rather than silently becoming a no-op target.
+    /// </summary>
+    [TestMethod]
+    public void BuildTarget_TheDictionaryValuedArguments_AreReportedAsUnprobeable()
+    {
+        BmotionPropertyCatalog.BuildTarget(["css", "cssVars"], out var unknown);
+
+        CollectionAssert.AreEquivalent(new[] { "css", "cssVars" }, unknown);
+    }
+
+    [TestMethod]
+    public void BuildTarget_NoNames_IsAnEmptyTargetRatherThanAThrow()
+    {
+        BmotionPropertyCatalog.BuildTarget([], out var unknown);
+
+        Assert.AreEqual(0, unknown.Length);
+    }
+
+    [TestMethod]
+    public void ExplainPlayback_WhenOffloaded_ExplainsAndOffersNothingToFix()
+    {
+        var (reason, remedies) = BmotionPropertyCatalog.ExplainPlayback(["x", "opacity"], new BmTween(), offloaded: true);
+
+        StringAssert.Contains(reason, "Blazor Server");
+        Assert.AreEqual(0, remedies.Length);
+    }
+
+    [TestMethod]
+    [DataRow("width", "scale")]
+    [DataRow("height", "scale")]
+    [DataRow("top", "x/y")]
+    [DataRow("left", "x/y")]
+    [DataRow("backgroundColor", "opacity")]
+    public void ExplainPlayback_NamesTheCompositorFriendlyReplacement(string property, string replacement)
+    {
+        var (_, remedies) = BmotionPropertyCatalog.ExplainPlayback([property], new BmTween(), offloaded: false);
+
+        Assert.IsTrue(remedies.Any(remedy => remedy.Contains(replacement, StringComparison.OrdinalIgnoreCase)),
+                      $"'{property}' was not pointed at {replacement}. Remedies: {string.Join(" | ", remedies)}");
+    }
+
+    [TestMethod]
+    public void ExplainPlayback_ATweenWithNoDuration_IsNamedAsTheBlocker()
+    {
+        var (reason, remedies) = BmotionPropertyCatalog.ExplainPlayback(["x"], new BmTween { Duration = 0 }, offloaded: false);
+
+        StringAssert.Contains(reason, "no duration");
+        Assert.IsTrue(remedies.Any(remedy => remedy.Contains("duration", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public void ExplainPlayback_AReverseRepeat_IsNamed_WithTheMirrorEquivalent()
+    {
+        var transition = new BmTween { Repeat = BmRepeat.Reverse() };
+
+        var (reason, remedies) = BmotionPropertyCatalog.ExplainPlayback(["x"], transition, offloaded: false);
+
+        StringAssert.Contains(reason, "Reverse");
+        Assert.IsTrue(remedies.Any(remedy => remedy.Contains("Mirror", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void ExplainPlayback_ARepeatDelay_IsNamedAsTheBlocker()
+    {
+        var transition = new BmTween { Repeat = BmRepeat.Loop(3, delay: 0.5) };
+
+        var (reason, _) = BmotionPropertyCatalog.ExplainPlayback(["x"], transition, offloaded: false);
+
+        StringAssert.Contains(reason, "delay between iterations");
+    }
+
+    [TestMethod]
+    public void ExplainPlayback_AnOnUpdateCallback_IsNamedAsTheBlocker()
+    {
+        var transition = new BmTween { OnUpdate = _ => { } };
+
+        var (reason, remedies) = BmotionPropertyCatalog.ExplainPlayback(["x"], transition, offloaded: false);
+
+        StringAssert.Contains(reason, "OnUpdate");
+        Assert.AreNotEqual(0, remedies.Length);
+    }
+
+    /// <summary>
+    /// A verdict the tool cannot explain is the most misleading answer it can give, so it always
+    /// falls back to the general rule rather than to an empty list.
+    /// </summary>
+    [TestMethod]
+    public void ExplainPlayback_WithNoKnownBlocker_StillSaysWhatToDo()
+    {
+        var (reason, remedies) = BmotionPropertyCatalog.ExplainPlayback(["x"], new BmTween { Duration = 0.3 }, offloaded: false);
+
+        StringAssert.Contains(reason, "worth reporting");
+        Assert.AreNotEqual(0, remedies.Length);
+    }
+
+    [TestMethod]
+    [DataRow("x", true)]
+    [DataRow("X", true)]
+    [DataRow("scaleX", true)]
+    [DataRow("perspective", true)]
+    [DataRow("opacity", true)]
+    [DataRow("width", false)]
+    [DataRow("originX", false)]
+    [DataRow("backgroundColor", false)]
+    public void IsCompositorProperty_IsCaseInsensitiveAndCoversTheTransformComponents(string name, bool expected)
+    {
+        Assert.AreEqual(expected, BmotionPropertyCatalog.IsCompositorProperty(name));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/RecipeCatalogTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/RecipeCatalogTests.cs
@@ -1,0 +1,201 @@
+using System.Text.RegularExpressions;
+using Bit.Bmotion.Demo.Client.Shared;
+
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The recipes: the fastest route from a request to correct code, and therefore the code an agent
+/// is most likely to paste unread.
+/// <para>
+/// That makes one test here worth more than the rest put together - every recipe is run through
+/// the server's own code review. A recipe that trips the review teaches the mistake the review
+/// exists to catch, and does it with the server's full authority.
+/// </para>
+/// </summary>
+[TestClass]
+public class RecipeCatalogTests
+{
+    [TestMethod]
+    public void All_EveryRecipe_IsCompleteAndIdentifiable()
+    {
+        Assert.IsTrue(BmotionRecipeCatalog.All.Length >= 10, $"Only {BmotionRecipeCatalog.All.Length} recipes.");
+
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            Assert.IsTrue(Regex.IsMatch(recipe.Id, "^[a-z0-9]+(-[a-z0-9]+)*$"),
+                          $"'{recipe.Id}' is not a kebab-case id an agent can be told to type.");
+            Assert.AreNotEqual(string.Empty, recipe.Title.Trim());
+            Assert.AreNotEqual(string.Empty, recipe.Intent.Trim());
+            Assert.AreNotEqual(string.Empty, recipe.Keywords.Trim());
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(recipe.Code), $"'{recipe.Id}' has no code.");
+            // The caveat is the half of a recipe the code cannot show, and the reason a recipe beats
+            // the API reference for this question at all.
+            Assert.IsFalse(string.IsNullOrWhiteSpace(recipe.Notes), $"'{recipe.Id}' carries no caveat.");
+        }
+    }
+
+    [TestMethod]
+    public void All_TheIdsAreUnique()
+    {
+        var ids = BmotionRecipeCatalog.All.Select(recipe => recipe.Id).ToArray();
+
+        CollectionAssert.AreEquivalent(ids.Distinct().ToArray(), ids);
+    }
+
+    /// <summary>
+    /// The recipes are markup an agent will paste. Running them through the server's own review is
+    /// the strongest statement the two halves of this server agree with each other.
+    /// </summary>
+    [TestMethod]
+    public void All_EveryRecipe_SurvivesTheServersOwnCodeReview()
+    {
+        var failures = new List<string>();
+
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            var review = BmotionCodeReview.Review(recipe.Code);
+
+            foreach (var finding in review.Findings.Where(finding => finding.Severity != "Suggestion"))
+            {
+                failures.Add($"{recipe.Id} line {finding.Line}: [{finding.Severity}] {finding.Rule}");
+            }
+        }
+
+        Assert.AreEqual(0, failures.Count,
+                        $"Recipes the server would itself reject:\n{string.Join("\n", failures)}");
+    }
+
+    /// <summary>
+    /// Every transition written into a recipe has to be one the measuring tools can read back - the
+    /// prompts tell an agent to simulate the transition it is about to use, and it will use this one.
+    /// </summary>
+    [TestMethod]
+    public async Task All_TheTransitionsInTheRecipes_AreReadableByTheMeasuringTools()
+    {
+        var calls = BmotionRecipeCatalog.All
+            .SelectMany(recipe => Regex.Matches(recipe.Code ?? string.Empty, @"Bm\.(Spring|Tween|Inertia)\([^)]*\)")
+                                       .Select(match => (recipe.Id, Spec: match.Value)))
+            .ToArray();
+
+        Assert.AreNotEqual(0, calls.Length, "No recipe writes a transition, which cannot be right.");
+
+        foreach (var (id, spec) in calls)
+        {
+            var result = await BmotionMotionLab.SimulateAsync(spec);
+
+            Assert.IsNull(result.Error, $"'{id}' uses '{spec}', which the simulator cannot read: {result.Error}");
+        }
+    }
+
+    /// <summary>
+    /// SeeAlso is handed to an agent as the demo page that shows the recipe running. A route that
+    /// does not exist is a dead end it cannot tell from a working one.
+    /// </summary>
+    [TestMethod]
+    public void All_TheSeeAlsoLinks_PointAtRealDemoPages()
+    {
+        var routes = NavItem.All.Select(page => $"/{page.Href}").ToArray();
+
+        foreach (var recipe in BmotionRecipeCatalog.All.Where(recipe => recipe.SeeAlso is not null))
+        {
+            CollectionAssert.Contains(routes, recipe.SeeAlso,
+                                      $"'{recipe.Id}' points at '{recipe.SeeAlso}', which is not a page of this demo.");
+        }
+    }
+
+    /// <summary>
+    /// The listing is fetched to choose an id from; carrying every recipe's full markup in it would
+    /// spend a client's context before it has chosen anything.
+    /// </summary>
+    [TestMethod]
+    public void Summaries_LeaveOutTheBodyAndKeepTheIdentity()
+    {
+        var summaries = BmotionRecipeCatalog.Summaries;
+
+        Assert.AreEqual(BmotionRecipeCatalog.All.Length, summaries.Length);
+
+        foreach (var summary in summaries)
+        {
+            Assert.IsNull(summary.Code, $"'{summary.Id}' carries its code into the listing.");
+            Assert.IsNull(summary.Notes, $"'{summary.Id}' carries its notes into the listing.");
+            Assert.AreNotEqual(string.Empty, summary.Id);
+            Assert.AreNotEqual(string.Empty, summary.Intent);
+        }
+    }
+
+    [TestMethod]
+    public void Summaries_AreASnapshot_NotTheCatalogItself()
+    {
+        // The listing is projected per call, so a caller mutating what it got cannot reach the
+        // catalog every other caller reads.
+        var first = BmotionRecipeCatalog.Summaries;
+        var second = BmotionRecipeCatalog.Summaries;
+
+        Assert.AreNotSame(first, second);
+        Assert.AreNotSame(first[0], second[0]);
+
+        // And stripping the code for the listing did not strip it from the catalog itself.
+        Assert.IsNotNull(BmotionRecipeCatalog.All[0].Code);
+    }
+
+    [TestMethod]
+    public void Find_MatchesTheIdExactly_First()
+    {
+        foreach (var recipe in BmotionRecipeCatalog.All)
+        {
+            Assert.AreEqual(recipe.Id, BmotionRecipeCatalog.Find(recipe.Id)?.Id);
+            Assert.AreEqual(recipe.Id, BmotionRecipeCatalog.Find(recipe.Id.ToUpperInvariant())?.Id);
+            Assert.AreEqual(recipe.Id, BmotionRecipeCatalog.Find($"  {recipe.Id}  ")?.Id);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("modal", "modal-dialog")]
+    [DataRow("stagger", "staggered-list")]
+    [DataRow("exit", "exit-animation")]
+    public void Find_MatchesLoosely_SoAHalfRememberedNameStillLands(string typed, string expected)
+    {
+        Assert.AreEqual(expected, BmotionRecipeCatalog.Find(typed)?.Id);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    [DataRow("a recipe for disaster")]
+    public void Find_WhatIsNotARecipe_IsNull(string? id)
+    {
+        Assert.IsNull(BmotionRecipeCatalog.Find(id));
+    }
+
+    /// <summary>
+    /// A recipe whose code the agent must not simply lift - one that only works on WebAssembly -
+    /// has to say so in the notes rather than leaving it to be discovered in production.
+    /// </summary>
+    [TestMethod]
+    [DataRow("layout-animation")]
+    [DataRow("drag-with-constraints")]
+    public void All_TheRecipesThatNeedTheFrameLoop_SayWhereTheyStopWorking(string id)
+    {
+        var recipe = BmotionRecipeCatalog.Find(id);
+
+        Assert.IsNotNull(recipe, $"'{id}' is no longer a recipe.");
+        Assert.IsTrue(recipe.Notes!.Contains("Server", StringComparison.OrdinalIgnoreCase) ||
+                      recipe.Notes.Contains("WebAssembly", StringComparison.OrdinalIgnoreCase),
+                      $"'{id}' does not say which render modes it survives: {recipe.Notes}");
+    }
+
+    /// <summary>An exit animation without its presence component is the mistake the catalog exists to prevent.</summary>
+    [TestMethod]
+    public void All_TheExitRecipes_ShowTheirPresenceComponent()
+    {
+        foreach (var recipe in BmotionRecipeCatalog.All.Where(recipe => recipe.Code!.Contains("Exit=", StringComparison.Ordinal)))
+        {
+            Assert.IsTrue(recipe.Code!.Contains("BmotionAnimatePresence", StringComparison.Ordinal) ||
+                          recipe.Code.Contains("BmotionPresenceGroup", StringComparison.Ordinal) ||
+                          recipe.Code.Contains("BmotionPresenceSwitch", StringComparison.Ordinal),
+                          $"'{recipe.Id}' animates an exit with nothing to hold the element in the DOM.");
+        }
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SearchIndexTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SearchIndexTests.cs
@@ -1,0 +1,290 @@
+using System.Text.RegularExpressions;
+
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The unified search - the tool the other tools' descriptions send an agent to first.
+/// <para>
+/// Its contract is not "returns something relevant"; it is that every hit carries the exact
+/// follow-up call that returns the hit in full. A search that names a section, a type or a recipe
+/// the fetching tools cannot resolve leaves an agent in a loop it has no way out of, and that is
+/// the failure this file is mostly about. The relevance tests below are deliberately about
+/// questions phrased as symptoms rather than as names, because those are the ones a keyword index
+/// gets wrong.
+/// </para>
+/// </summary>
+[TestClass]
+public class SearchIndexTests
+{
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    public async Task Search_NothingToSearchFor_IsNoHits(string? query)
+    {
+        Assert.AreEqual(0, (await BmotionSearchIndex.SearchAsync(query!, 12)).Length);
+    }
+
+    /// <summary>
+    /// Every entry in this index is about animating something in Bmotion, so a query saying so
+    /// matches everything and ranks nothing. Those words are dropped, and a query made only of them
+    /// is no query at all.
+    /// </summary>
+    [TestMethod]
+    [DataRow("how does this work")]
+    [DataRow("animation")]
+    [DataRow("the and for with")]
+    [DataRow("a an in of")]
+    public async Task Search_AQueryMadeOnlyOfNoiseWords_ReturnsNothingRatherThanEverything(string query)
+    {
+        Assert.AreEqual(0, (await BmotionSearchIndex.SearchAsync(query, 12)).Length,
+                        $"'{query}' matched something, which means it would match nearly everything.");
+    }
+
+    [TestMethod]
+    [DataRow("stagger a list")]
+    [DataRow("animate something out before it is removed")]
+    [DataRow("drag within bounds")]
+    [DataRow("spring stiffness damping")]
+    [DataRow("scroll reveal")]
+    [DataRow("shared element transition")]
+    [DataRow("reduced motion accessibility")]
+    [DataRow("keyframes")]
+    public async Task Search_TheQuestionsThisServerExistsFor_FindSomething(string query)
+    {
+        var hits = await BmotionSearchIndex.SearchAsync(query, 12);
+
+        Assert.AreNotEqual(0, hits.Length, $"'{query}' found nothing.");
+    }
+
+    /// <summary>
+    /// The property that makes one search enough: an agent can act on any hit without guessing at
+    /// what to call next. A Tool string naming a call that does not resolve is the worst outcome
+    /// this index has, because it looks like an answer.
+    /// </summary>
+    [TestMethod]
+    public async Task Search_EveryHit_CarriesAFollowUpCallThatActuallyResolves()
+    {
+        var queries = new[]
+        {
+            "stagger", "exit", "drag", "spring", "scroll", "layout", "variants", "opacity",
+            "colour", "keyframes", "presence", "easing", "server", "gesture", "split text",
+        };
+
+        var toolNames = new McpController().GetMcpCatalog().Tools.Select(tool => tool.Name).ToHashSet(StringComparer.Ordinal);
+
+        var checkedCalls = 0;
+
+        foreach (var query in queries)
+        {
+            foreach (var hit in await BmotionSearchIndex.SearchAsync(query, 20))
+            {
+                var call = Regex.Match(hit.Tool, @"^(?<tool>\w+)\((?<args>.*)\)$");
+
+                Assert.IsTrue(call.Success, $"'{hit.Title}' offers '{hit.Tool}', which is not a tool call.");
+
+                var tool = call.Groups["tool"].Value;
+
+                CollectionAssert.Contains(toolNames.ToArray(), tool,
+                                          $"'{hit.Title}' points at '{tool}', which this server does not expose.");
+
+                // The single-argument fetches are the ones that can name something that does not
+                // exist; the multi-argument tools take free text and are checked by name only.
+                var value = Regex.Match(call.Groups["args"].Value, @"^\w+:\s*""(?<value>[^""]*)""$").Groups["value"].Value;
+
+                // And the argument it names has to be one the tool answers for.
+                switch (tool)
+                {
+                    case "GetBmotionGuideSection":
+                        Assert.IsNotNull(BmotionSourceCatalog.GetGuideSection(value), $"No guide section '{value}'.");
+                        break;
+
+                    case "GetBmotionSourceFile":
+                        Assert.IsNotNull(BmotionSourceCatalog.GetSourceFile(value), $"No source file '{value}'.");
+                        break;
+
+                    case "GetBmotionRecipe":
+                        Assert.IsNotNull(BmotionRecipeCatalog.Find(value), $"No recipe '{value}'.");
+                        break;
+
+                    case "GetBmotionApiDetails":
+                        Assert.IsNotNull(BmotionApiCatalog.GetTypeDetails(value), $"No public type '{value}'.");
+                        break;
+
+                    case "GetBmotionSetupGuide":
+                        Assert.IsNotNull(BmotionSetupGuide.Get(value), $"No setup guide for '{value}'.");
+                        break;
+                }
+
+                checkedCalls++;
+            }
+        }
+
+        Assert.IsTrue(checkedCalls > 50, $"Only {checkedCalls} hits were checked, which is too few to mean anything.");
+    }
+
+    [TestMethod]
+    public async Task Search_EveryHit_IsLabelledAndCarriesTheTextThatMatched()
+    {
+        foreach (var hit in await BmotionSearchIndex.SearchAsync("spring bounce overshoot", 20))
+        {
+            Assert.AreNotEqual(string.Empty, hit.Kind.Trim());
+            Assert.AreNotEqual(string.Empty, hit.Title.Trim());
+            Assert.AreNotEqual(string.Empty, hit.Tool.Trim());
+
+            // A snippet is a window on the body, not the body: the point is to spend a client's
+            // context on the shortlist rather than on the answer it has not chosen yet.
+            Assert.IsTrue(hit.Snippet.Length <= 250, $"'{hit.Title}' returned a {hit.Snippet.Length}-character snippet.");
+        }
+    }
+
+    /// <summary>
+    /// A name is what someone asking for it means; prose that merely mentions it is not. The match
+    /// is on the member's own name rather than on the whole title, because a member inherited by
+    /// four transition types is the same member however it is qualified.
+    /// </summary>
+    [TestMethod]
+    [DataRow("BmSpring", "BmSpring")]
+    [DataRow("BmotionAnimatePresence", "BmotionAnimatePresence")]
+    [DataRow("staggerChildren", "StaggerChildren")]
+    [DataRow("LayoutId", "LayoutId")]
+    public async Task Search_ANameQuery_PutsTheThingItselfFirst(string query, string expected)
+    {
+        var hits = await BmotionSearchIndex.SearchAsync(query, 5);
+
+        Assert.AreNotEqual(0, hits.Length, $"'{query}' found nothing.");
+        Assert.IsTrue(hits[0].Title.EndsWith(expected, StringComparison.Ordinal),
+                      $"'{query}' ranked '{hits[0].Title}' first. The rest: " +
+                      $"{string.Join(", ", hits.Skip(1).Select(hit => hit.Title))}.");
+    }
+
+    /// <summary>
+    /// The plural in a heading is an accident of writing, not of meaning: nobody phrases a question
+    /// in the number the guide happens to use.
+    /// </summary>
+    [TestMethod]
+    public async Task Search_FindsASectionWhoseHeadingIsThePluralOfTheQuery()
+    {
+        var hits = await BmotionSearchIndex.SearchAsync("variant", 10);
+
+        Assert.IsTrue(hits.Any(hit => hit.Title.Equals("Variants", StringComparison.OrdinalIgnoreCase)),
+                      $"Found: {string.Join(", ", hits.Select(hit => hit.Title))}.");
+    }
+
+    /// <summary>
+    /// A question phrased as a symptom names no section, type or recipe. Without the two entries for
+    /// the engine-running tools it would match whatever else happens to contain the word "server" -
+    /// and this is the single most common thing to go wrong with a Bmotion app.
+    /// </summary>
+    [TestMethod]
+    public async Task Search_ASymptomWithNoNameInIt_StillFindsTheToolThatDiagnosesIt()
+    {
+        var hits = await BmotionSearchIndex.SearchAsync("the animation snaps instantly in production on the server", 12);
+
+        Assert.IsTrue(hits.Any(hit => hit.Tool.StartsWith("AnalyzeBmotionAnimation", StringComparison.Ordinal)),
+                      $"Found: {string.Join(", ", hits.Select(hit => $"{hit.Title} -> {hit.Tool}"))}.");
+    }
+
+    [TestMethod]
+    public async Task Search_AskingHowLongASpringTakes_FindsTheToolThatMeasuresIt()
+    {
+        var hits = await BmotionSearchIndex.SearchAsync("my spring feels too slow to settle", 12);
+
+        Assert.IsTrue(hits.Any(hit => hit.Tool.StartsWith("SimulateBmotionTransition", StringComparison.Ordinal)),
+                      $"Found: {string.Join(", ", hits.Select(hit => $"{hit.Title} -> {hit.Tool}"))}.");
+    }
+
+    [TestMethod]
+    public async Task Search_HonoursTheLimit_AndClampsItToSomethingAClientCanRead()
+    {
+        Assert.AreEqual(1, (await BmotionSearchIndex.SearchAsync("spring", 1)).Length);
+        Assert.AreEqual(5, (await BmotionSearchIndex.SearchAsync("spring", 5)).Length);
+
+        // Below one is still one hit, not none and not an exception.
+        Assert.AreEqual(1, (await BmotionSearchIndex.SearchAsync("spring", 0)).Length);
+        Assert.AreEqual(1, (await BmotionSearchIndex.SearchAsync("spring", -10)).Length);
+
+        Assert.IsTrue((await BmotionSearchIndex.SearchAsync("spring", 5_000)).Length <= 50);
+    }
+
+    [TestMethod]
+    public async Task Search_TheSameQueryTwice_RanksTheSameWay()
+    {
+        var first = await BmotionSearchIndex.SearchAsync("layout shared element", 12);
+        var second = await BmotionSearchIndex.SearchAsync("layout shared element", 12);
+
+        CollectionAssert.AreEqual(first.Select(hit => hit.Title).ToArray(), second.Select(hit => hit.Title).ToArray());
+    }
+
+    /// <summary>
+    /// Every term is counted against every entry, so the work is terms x corpus. A pasted file as a
+    /// query has to be bounded rather than scanned in full.
+    /// </summary>
+    [TestMethod]
+    public async Task Search_APastedFileAsAQuery_IsBoundedRatherThanScannedInFull()
+    {
+        var pasted = string.Join(' ', Enumerable.Range(0, 4_000).Select(i => $"token{i}"));
+
+        var started = System.Diagnostics.Stopwatch.StartNew();
+
+        await BmotionSearchIndex.SearchAsync(pasted, 12);
+
+        Assert.IsTrue(started.Elapsed < TimeSpan.FromSeconds(5), $"It took {started.Elapsed.TotalSeconds:0.0}s.");
+    }
+
+    [TestMethod]
+    public async Task Search_APunctuatedQuery_IsSplitTheSameWayAsAPlainOne()
+    {
+        var plain = await BmotionSearchIndex.SearchAsync("exit animation presence", 8);
+        var punctuated = await BmotionSearchIndex.SearchAsync("exit-animation (presence)?", 8);
+
+        CollectionAssert.AreEqual(plain.Select(hit => hit.Title).ToArray(), punctuated.Select(hit => hit.Title).ToArray());
+    }
+
+    /// <summary>
+    /// The index is built once, lazily, from six catalogs that each run the engine or walk the
+    /// assembly. Several searches arriving at once must not each build their own.
+    /// </summary>
+    [TestMethod]
+    public async Task Search_IsSafeToCallConcurrentlyWhileTheIndexIsStillBeingBuilt()
+    {
+        var results = await Task.WhenAll(Enumerable.Range(0, 12)
+            .Select(_ => BmotionSearchIndex.SearchAsync("spring damping", 6)));
+
+        foreach (var result in results)
+        {
+            CollectionAssert.AreEqual(results[0].Select(hit => hit.Title).ToArray(),
+                                      result.Select(hit => hit.Title).ToArray());
+        }
+    }
+
+    [TestMethod]
+    public async Task Search_CoversEveryCorpusTheDescriptionPromises()
+    {
+        var kinds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var query in new[]
+        {
+            "variants", "spring", "stagger", "opacity", "BackOut", "drag", "springs page",
+            "server render mode", "settle time", "Program.cs",
+        })
+        {
+            foreach (var hit in await BmotionSearchIndex.SearchAsync(query, 30))
+            {
+                kinds.Add(hit.Kind);
+            }
+        }
+
+        foreach (var promised in new[]
+        {
+            "Guide section", "Recipe", "Animatable property", "Easing preset", "Demo page", "Source file", "Setup guide", "Tool",
+        })
+        {
+            CollectionAssert.Contains(kinds.ToArray(), promised, $"Nothing of kind '{promised}' was ever found.");
+        }
+
+        // The API entries are labelled by what they are - "API component", "API parameter", ...
+        Assert.IsTrue(kinds.Any(kind => kind.StartsWith("API ", StringComparison.OrdinalIgnoreCase)),
+                      $"The public API was never reached. Kinds seen: {string.Join(", ", kinds)}.");
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SetupGuideTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SetupGuideTests.cs
@@ -1,0 +1,125 @@
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The per-render-mode setup guide. Getting this wrong is the setup bug that does not fail at
+/// compile time: registering the services in only one of a Blazor Web App's two DI containers
+/// throws during prerendering, in production, on a page that worked locally. So each guide has to
+/// carry the wiring for every container its render mode actually uses, and has to be honest about
+/// which library features that mode cannot run at all.
+/// </summary>
+[TestClass]
+public class SetupGuideTests
+{
+    [TestMethod]
+    public void Get_AnswersForEveryAdvertisedRenderMode()
+    {
+        foreach (var mode in BmotionSetupGuide.RenderModes)
+        {
+            var guide = BmotionSetupGuide.Get(mode);
+
+            Assert.IsNotNull(guide, $"'{mode}' is advertised but has no guide.");
+            Assert.IsTrue(guide.Length > 500, $"The '{mode}' guide is only {guide.Length} characters.");
+        }
+    }
+
+    [TestMethod]
+    public void Get_EveryGuide_CarriesTheStepsThatCannotBeSkipped()
+    {
+        foreach (var mode in BmotionSetupGuide.RenderModes)
+        {
+            var guide = BmotionSetupGuide.Get(mode)!;
+
+            StringAssert.Contains(guide, "dotnet add package Bit.Bmotion", $"The '{mode}' guide does not say how to install it.");
+            StringAssert.Contains(guide, "_Imports.razor", $"The '{mode}' guide omits the @using nobody remembers.");
+            StringAssert.Contains(guide, "<Bmotion", $"The '{mode}' guide shows no animation to prove the wiring works.");
+
+            // Registration is either written out or factored into the shared extension method the
+            // guide points at; what matters is that following this one guide reaches it.
+            Assert.IsTrue(guide.Contains("AddBitBmotionServices", StringComparison.Ordinal) ||
+                          guide.Contains("AddDemoServices", StringComparison.Ordinal),
+                          $"The '{mode}' guide never registers the services.");
+        }
+    }
+
+    /// <summary>
+    /// The whole point of splitting the guide by render mode: each one has to say what it costs.
+    /// A guide that reads identically for Server and WebAssembly would be worse than none, because
+    /// it is exactly the difference that is invisible until production.
+    /// </summary>
+    [TestMethod]
+    public void Get_TheServerGuide_SaysWhatDoesNotWorkThere()
+    {
+        var server = BmotionSetupGuide.Get("server")!;
+
+        StringAssert.Contains(server, "Blazor Server");
+        Assert.IsTrue(server.Contains("drag", StringComparison.OrdinalIgnoreCase),
+                      "The Server guide does not mention that drag is unavailable.");
+        Assert.IsTrue(server.Contains("compositor", StringComparison.OrdinalIgnoreCase) ||
+                      server.Contains("frame loop", StringComparison.OrdinalIgnoreCase),
+                      "The Server guide does not explain which animations survive.");
+    }
+
+    [TestMethod]
+    public void Get_TheGuidesForDifferentModes_AreActuallyDifferent()
+    {
+        var guides = BmotionSetupGuide.RenderModes.ToDictionary(mode => mode, mode => BmotionSetupGuide.Get(mode)!);
+
+        foreach (var (mode, guide) in guides)
+        {
+            foreach (var (other, otherGuide) in guides.Where(entry => entry.Key != mode))
+            {
+                Assert.AreNotEqual(guide, otherGuide, $"The '{mode}' and '{other}' guides are the same text.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A Blazor Web App has two DI containers and the services must be registered in both. The
+    /// wasm and auto guides are the ones where forgetting the second is the classic failure.
+    /// </summary>
+    [TestMethod]
+    [DataRow("wasm")]
+    [DataRow("auto")]
+    public void Get_TheWebAppGuides_RegisterInBothContainers(string mode)
+    {
+        var guide = BmotionSetupGuide.Get(mode)!;
+
+        StringAssert.Contains(guide, "Server/Program.cs", $"The '{mode}' guide does not wire the server container.");
+        StringAssert.Contains(guide, "Client/Program.cs", $"The '{mode}' guide does not wire the client container.");
+
+        Assert.IsTrue(guide.Contains("BOTH", StringComparison.OrdinalIgnoreCase) ||
+                      guide.Contains("both containers", StringComparison.OrdinalIgnoreCase),
+                      $"The '{mode}' guide does not say out loud that both containers are required - " +
+                      "which is the step that fails during prerendering rather than at compile time.");
+    }
+
+    [TestMethod]
+    [DataRow("webassembly", "wasm")]
+    [DataRow("InteractiveWebAssembly", "wasm")]
+    [DataRow("Blazor Server", "server")]
+    [DataRow("interactiveserver", "server")]
+    [DataRow("InteractiveAuto", "auto")]
+    [DataRow("standalone", "standalone-wasm")]
+    [DataRow("  SERVER  ", "server")]
+    public void Get_AcceptsTheNamesARenderModeIsActuallyCalledBy(string alias, string canonical)
+    {
+        Assert.AreEqual(BmotionSetupGuide.Get(canonical), BmotionSetupGuide.Get(alias),
+                        $"'{alias}' did not resolve to the '{canonical}' guide.");
+    }
+
+    /// <summary>
+    /// An unrecognised mode must not quietly return the WebAssembly guide: that is how an agent
+    /// ends up wiring a Server app as if it were WebAssembly, which compiles and then does nothing.
+    /// </summary>
+    [TestMethod]
+    [DataRow("blazor")]
+    [DataRow("maui")]
+    [DataRow("ssr")]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    public void Get_AnUnknownMode_IsNullRatherThanADefaultGuess(string? mode)
+    {
+        Assert.IsNull(BmotionSetupGuide.Get(mode!));
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SourceCatalogTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SourceCatalogTests.cs
@@ -92,7 +92,11 @@ public class SourceCatalogTests
 
         Assert.IsNotNull(canonical, "The guide no longer has a 'Layout & shared elements' section to test with.");
         Assert.AreEqual(canonical, BmotionSourceCatalog.GetGuideSection("layout shared elements"));
-        Assert.AreEqual(canonical, BmotionSourceCatalog.GetGuideSection("Layout and shared elements".Replace("and ", "", StringComparison.Ordinal)));
+
+        // Normalisation drops everything that is not a letter or a digit, so the "&" disappears
+        // rather than becoming "and". Spelling it out is therefore a different heading, and the
+        // lookup says so instead of quietly matching.
+        Assert.IsNull(BmotionSourceCatalog.GetGuideSection("Layout and shared elements"));
     }
 
     [TestMethod]

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SourceCatalogTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/SourceCatalogTests.cs
@@ -1,0 +1,235 @@
+using Bit.Bmotion.Demo.Client.Shared;
+
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The guide and the demo sources the tools hand out.
+/// <para>
+/// Both are embedded resources, which is the point: a published, single-folder deployment has no
+/// repository next to it. That also makes this the one part of the server that can be wrong in
+/// production and right on a developer's machine - a changed glob in the .csproj takes the text
+/// away without breaking a build or throwing anything, and the tools then answer every question
+/// with an empty string. These tests fail when the payload is missing rather than when it is
+/// merely different.
+/// </para>
+/// </summary>
+[TestClass]
+public class SourceCatalogTests
+{
+    [TestMethod]
+    public void Readme_IsEmbeddedInTheAssembly()
+    {
+        Assert.IsTrue(BmotionSourceCatalog.Readme.Length > 5_000,
+                      $"The guide is {BmotionSourceCatalog.Readme.Length} characters - the embedded resource is missing or truncated.");
+
+        StringAssert.Contains(BmotionSourceCatalog.Readme, "Bmotion");
+    }
+
+    [TestMethod]
+    public void GuideSections_AreListedInReadingOrder_WithTheirLevels()
+    {
+        var sections = BmotionSourceCatalog.GuideSections;
+
+        Assert.IsTrue(sections.Length >= 10, $"Only {sections.Length} sections were found in the guide.");
+
+        foreach (var section in sections)
+        {
+            CollectionAssert.Contains(new[] { 2, 3 }, section.Level, $"'{section.Heading}' is at level {section.Level}.");
+            Assert.IsTrue(section.Lines > 0, $"'{section.Heading}' is empty.");
+            Assert.AreNotEqual(string.Empty, section.Heading.Trim());
+
+            // A sub-section names the section it belongs to; a top-level one has nothing above it.
+            if (section.Level == 3) Assert.IsNotNull(section.Parent, $"'{section.Heading}' is orphaned.");
+            else Assert.IsNull(section.Parent, $"'{section.Heading}' is level 2 but claims a parent.");
+        }
+    }
+
+    /// <summary>
+    /// The table of contents is a list of links to the sections below it: as an answer it is
+    /// strictly worse than the section it points at, and it outranks real content in search.
+    /// </summary>
+    [TestMethod]
+    public void GuideSections_LeaveOutTheTableOfContents()
+    {
+        Assert.IsFalse(BmotionSourceCatalog.GuideSections.Any(section =>
+            section.Heading.Contains("Table of Contents", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>
+    /// Every heading the listing tool advertises has to be one the fetching tool answers - the two
+    /// are separate walks of the same text, and a listing that names a section nobody can fetch
+    /// sends an agent round a loop it cannot leave.
+    /// </summary>
+    [TestMethod]
+    public void GetGuideSection_AnswersForEveryHeadingTheListingAdvertises()
+    {
+        foreach (var section in BmotionSourceCatalog.GuideSections)
+        {
+            var text = BmotionSourceCatalog.GetGuideSection(section.Heading);
+
+            Assert.IsNotNull(text, $"The listing offers '{section.Heading}' but nothing fetches it.");
+            StringAssert.StartsWith(text, new string('#', section.Level),
+                                    $"'{section.Heading}' did not come back starting at its own heading.");
+            StringAssert.Contains(text, section.Heading);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("Installation")]
+    [DataRow("installation")]
+    [DataRow("INSTALLATION")]
+    [DataRow("  Installation  ")]
+    public void GetGuideSection_MatchesHeadingsRegardlessOfCaseAndSpacing(string heading)
+    {
+        Assert.IsNotNull(BmotionSourceCatalog.GetGuideSection(heading));
+    }
+
+    /// <summary>An agent rarely reproduces the punctuation of a heading it was told about second-hand.</summary>
+    [TestMethod]
+    public void GetGuideSection_IgnoresPunctuationInTheHeading()
+    {
+        var canonical = BmotionSourceCatalog.GetGuideSection("Layout & shared elements");
+
+        Assert.IsNotNull(canonical, "The guide no longer has a 'Layout & shared elements' section to test with.");
+        Assert.AreEqual(canonical, BmotionSourceCatalog.GetGuideSection("layout shared elements"));
+        Assert.AreEqual(canonical, BmotionSourceCatalog.GetGuideSection("Layout and shared elements".Replace("and ", "", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void GetGuideSection_ASectionEndsWhereTheNextOneOfItsRankBegins()
+    {
+        var components = BmotionSourceCatalog.GetGuideSection("Components")!;
+
+        // A level-2 section carries its own sub-sections...
+        StringAssert.Contains(components, "### Bmotion");
+        // ...and stops before the next level-2 heading.
+        Assert.IsFalse(components.Contains("\n## Transitions", StringComparison.Ordinal),
+                       "The Components section ran on into the one after it.");
+
+        // A level-3 section carries neither its siblings nor the section above it.
+        var presence = BmotionSourceCatalog.GetGuideSection("BmotionAnimatePresence")!;
+
+        StringAssert.StartsWith(presence, "### BmotionAnimatePresence");
+        Assert.IsFalse(presence.Contains("### BmotionPresenceSwitch", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The guide is full of fenced C# and shell samples, and both use '#' at the start of a line.
+    /// Reading one as a heading would cut a section in half at an arbitrary point.
+    /// </summary>
+    [TestMethod]
+    public void GuideSections_AreNotInventedFromCodeFences()
+    {
+        foreach (var section in BmotionSourceCatalog.GuideSections)
+        {
+            Assert.IsFalse(section.Heading.StartsWith("if ", StringComparison.Ordinal) ||
+                           section.Heading.StartsWith("region", StringComparison.Ordinal) ||
+                           section.Heading.StartsWith("!", StringComparison.Ordinal),
+                           $"'{section.Heading}' looks like a line of code read as a heading.");
+        }
+
+        // The Installation section contains a fenced shell block; it has to survive intact.
+        StringAssert.Contains(BmotionSourceCatalog.GetGuideSection("Installation")!, "```");
+    }
+
+    [TestMethod]
+    [DataRow("Nonexistent section")]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    public void GetGuideSection_AnUnknownHeading_IsNullRatherThanTheWholeGuide(string? heading)
+    {
+        Assert.IsNull(BmotionSourceCatalog.GetGuideSection(heading!));
+    }
+
+    [TestMethod]
+    public void SourceFiles_AreEmbedded_AndEveryListedPathResolves()
+    {
+        var files = BmotionSourceCatalog.SourceFiles;
+
+        Assert.IsTrue(files.Length >= 10, $"Only {files.Length} source files are embedded.");
+
+        foreach (var file in files)
+        {
+            Assert.IsNotNull(BmotionSourceCatalog.GetSourceFile(file.Path),
+                             $"'{file.Path}' is listed but cannot be fetched.");
+            Assert.IsTrue(file.Lines > 0, $"'{file.Path}' is empty.");
+            CollectionAssert.Contains(new[] { "Demo page", "Demo", "Host" }, file.Kind, $"'{file.Path}' is a '{file.Kind}'.");
+        }
+    }
+
+    [TestMethod]
+    public void SourceFiles_IncludeTheHostWiring_TheSetupGuideClaimsToShowAsARealFile()
+    {
+        Assert.IsNotNull(BmotionSourceCatalog.GetSourceFile("Demo/Server/Program.cs"));
+
+        Assert.IsTrue(BmotionSourceCatalog.SourceFiles.Any(file => file.Kind == "Host"),
+                      "Nothing in the catalog is classified as host wiring.");
+        Assert.IsTrue(BmotionSourceCatalog.SourceFiles.Any(file => file.Kind == "Demo page"),
+                      "Nothing in the catalog is classified as a demo page.");
+    }
+
+    /// <summary>
+    /// GetBmotionDemoPages hands out a SourcePath per page and tells the agent to pass it to
+    /// GetBmotionSourceFile. Every one of them has to be a path that resolves.
+    /// </summary>
+    [TestMethod]
+    public void SourceFiles_CoverEveryPageTheDemoPageListingPointsAt()
+    {
+        var missing = NavItem.All
+            .Where(page => BmotionSourceCatalog.GetSourceFile(page.SourcePath) is null)
+            .Select(page => $"{page.Title} -> {page.SourcePath}")
+            .ToArray();
+
+        Assert.AreEqual(0, missing.Length, $"Advertised but not embedded: {string.Join("; ", missing)}.");
+    }
+
+    [TestMethod]
+    public void GetSourceFile_AcceptsThePathHoweverItIsSpelled()
+    {
+        var canonical = BmotionSourceCatalog.GetSourceFile("Demo/Server/Program.cs");
+
+        Assert.IsNotNull(canonical);
+        Assert.AreEqual(canonical, BmotionSourceCatalog.GetSourceFile("demo/server/program.cs"));
+        Assert.AreEqual(canonical, BmotionSourceCatalog.GetSourceFile(@"Demo\Server\Program.cs"));
+        Assert.AreEqual(canonical, BmotionSourceCatalog.GetSourceFile("/Demo/Server/Program.cs"));
+    }
+
+    [TestMethod]
+    [DataRow("Demo/Client/Pages/NotAFile.razor")]
+    [DataRow("../../../etc/passwd")]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    public void GetSourceFile_AnUnknownPath_IsNull(string? path)
+    {
+        Assert.IsNull(BmotionSourceCatalog.GetSourceFile(path!));
+    }
+
+    /// <summary>
+    /// A file's description is taken from whatever the file itself already says. It may be absent,
+    /// but it must never be a wall of the file's own source - that is what a listing is not for.
+    /// </summary>
+    [TestMethod]
+    public void SourceFiles_DescriptionsAreOneLine_OrAbsent()
+    {
+        foreach (var file in BmotionSourceCatalog.SourceFiles.Where(file => file.Description is not null))
+        {
+            Assert.IsTrue(file.Description!.Length <= 220, $"'{file.Path}' has a {file.Description.Length}-character description.");
+            Assert.IsFalse(file.Description.Contains('\n'), $"'{file.Path}' has a multi-line description.");
+        }
+    }
+
+    [TestMethod]
+    public void SourceFiles_LineCounts_MatchTheFilesTheyDescribe()
+    {
+        foreach (var file in BmotionSourceCatalog.SourceFiles)
+        {
+            var content = BmotionSourceCatalog.GetSourceFile(file.Path)!;
+            var newlines = content.Count(c => c == '\n');
+            var expected = content.Length == 0 ? 0 : content[^1] == '\n' ? newlines : newlines + 1;
+
+            Assert.AreEqual(expected, file.Lines, $"'{file.Path}' is reported as {file.Lines} lines.");
+        }
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/TransitionSpecTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/TransitionSpecTests.cs
@@ -1,0 +1,279 @@
+using System.Globalization;
+
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The parser that turns a string an agent typed into the transition the engine runs.
+/// <para>
+/// It is the entry point of every measuring tool, so a spelling it silently mis-reads does not
+/// produce an error - it produces a confident measurement of the wrong motion. These tests pin the
+/// family of spellings it promises to accept, and pin the two failure modes that have to stay
+/// visible: an unreadable spec comes back as an error rather than as a default, and an argument
+/// that was not applied comes back as a warning rather than being dropped.
+/// </para>
+/// </summary>
+[TestClass]
+public class TransitionSpecTests
+{
+    [TestMethod]
+    [DataRow("spring(stiffness: 260, damping: 12)")]
+    [DataRow("Bm.Spring(stiffness: 260, damping: 12)")]
+    [DataRow("Motion.Spring(stiffness: 260, damping: 12)")]
+    [DataRow("Spring(stiffness=260, damping=12)")]
+    [DataRow("spring stiffness=260 damping=12")]
+    [DataRow("  SPRING( STIFFNESS : 260 , DAMPING : 12 )  ")]
+    [DataRow("spring(260, 12)")]
+    public void Parse_EverySpellingOfTheSameSpring_ProducesTheSameTransition(string spec)
+    {
+        var result = BmotionTransitionSpec.Parse(spec);
+
+        Assert.IsNull(result.Error, $"'{spec}' was rejected: {result.Error}");
+
+        var spring = result.Transition as BmSpring;
+
+        Assert.IsNotNull(spring, $"'{spec}' did not parse as a spring but as {result.Transition?.GetType().Name}.");
+        Assert.AreEqual(260, spring.Stiffness);
+        Assert.AreEqual(12, spring.Damping);
+    }
+
+    [TestMethod]
+    public void Parse_PositionalArguments_FollowTheBmFactorySignatures()
+    {
+        var spring = (BmSpring)BmotionTransitionSpec.Parse("spring(260, 12, 1.5)").Transition!;
+
+        Assert.AreEqual(260, spring.Stiffness);
+        Assert.AreEqual(12, spring.Damping);
+        Assert.AreEqual(1.5, spring.Mass);
+
+        var tween = (BmTween)BmotionTransitionSpec.Parse("tween(0.4, InOut)").Transition!;
+
+        Assert.AreEqual(0.4, tween.Duration);
+        Assert.AreEqual(BmEase.InOut, tween.Ease);
+
+        var inertia = (BmInertia)BmotionTransitionSpec.Parse("inertia(500, 700, 0.8)").Transition!;
+
+        Assert.AreEqual(500, inertia.Velocity);
+        Assert.AreEqual(700, inertia.TimeConstant);
+        Assert.AreEqual(0.8, inertia.Power);
+    }
+
+    [TestMethod]
+    public void Parse_EmptySpec_IsTheLibrarysOwnDefaultTween()
+    {
+        foreach (var spec in new string?[] { null, "", "   " })
+        {
+            var result = BmotionTransitionSpec.Parse(spec);
+
+            Assert.IsNull(result.Error);
+            Assert.IsInstanceOfType<BmTween>(result.Transition);
+        }
+    }
+
+    [TestMethod]
+    public void Parse_BareNumber_ReadsAsATweenDurationAndSaysSo()
+    {
+        var result = BmotionTransitionSpec.Parse("0.4, BackOut");
+
+        var tween = result.Transition as BmTween;
+
+        Assert.IsNotNull(tween);
+        Assert.AreEqual(0.4, tween.Duration);
+        Assert.AreEqual(BmEase.BackOut, tween.Ease);
+        // The assumption is the kind of thing that produces a confidently wrong answer if unstated.
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("read as a tween", StringComparison.OrdinalIgnoreCase)),
+                      $"No warning named the assumption. Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    [DataRow("bounce(0.4)")]
+    [DataRow("easeOut")]
+    [DataRow("cubic-bezier(0.4, 0, 0.2, 1)")]
+    public void Parse_AnUnknownKind_IsAnErrorThatNamesTheKindsThatExist(string spec)
+    {
+        var result = BmotionTransitionSpec.Parse(spec);
+
+        Assert.IsNull(result.Transition, $"'{spec}' should not have produced a transition.");
+        Assert.IsNotNull(result.Error);
+
+        foreach (var kind in BmotionTransitionSpec.Kinds)
+        {
+            StringAssert.Contains(result.Error, kind, $"The error does not name '{kind}': {result.Error}");
+        }
+    }
+
+    [TestMethod]
+    public void Parse_AMisspelledArgument_Warns_RatherThanSilentlyBecomingADefault()
+    {
+        var result = BmotionTransitionSpec.Parse("spring(stifness: 260, damping: 12)");
+
+        Assert.IsNotNull(result.Transition);
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("stifness", StringComparison.Ordinal)),
+                      $"The misspelling was dropped silently. Warnings: {string.Join(" | ", result.Warnings)}");
+
+        // The rest of the spec still applied: a typo costs one argument, not the whole call.
+        Assert.AreEqual(12, ((BmSpring)result.Transition).Damping);
+    }
+
+    [TestMethod]
+    public void Parse_ANonNumericValue_Warns_AndLeavesTheArgumentUnset()
+    {
+        var result = BmotionTransitionSpec.Parse("spring(stiffness: lots, damping: 12)");
+
+        var spring = (BmSpring)result.Transition!;
+
+        Assert.AreNotEqual(0, result.Warnings.Length);
+        Assert.AreEqual(12, spring.Damping);
+    }
+
+    [TestMethod]
+    public void Parse_BounceWithStiffness_WarnsThatOneOfThemIsUnused()
+    {
+        var result = BmotionTransitionSpec.Parse("spring(bounce: 0.4, duration: 0.6, stiffness: 260, damping: 12)");
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("Bounce wins", StringComparison.OrdinalIgnoreCase)),
+                      $"Nothing said the physics arguments are ignored. Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    public void Parse_BounceWithoutDuration_WarnsThatTheDurationDefaultApplies()
+    {
+        var result = BmotionTransitionSpec.Parse("spring(bounce: 0.4)");
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("duration", StringComparison.OrdinalIgnoreCase)),
+                      $"Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    public void Parse_SecondsWrittenWithAUnit_IsStillANumber()
+    {
+        var tween = (BmTween)BmotionTransitionSpec.Parse("tween(duration: 0.4s)").Transition!;
+
+        Assert.AreEqual(0.4, tween.Duration);
+    }
+
+    [TestMethod]
+    public void Parse_ABezier_KeepsItsOwnCommasTogether()
+    {
+        var tween = (BmTween)BmotionTransitionSpec.Parse("tween(duration: 0.5, bezier: [0.42, 0, 0.58, 1])").Transition!;
+
+        Assert.AreEqual(0.5, tween.Duration);
+        CollectionAssert.AreEqual(new[] { 0.42, 0, 0.58, 1.0 }, tween.Bezier);
+    }
+
+    [TestMethod]
+    public void Parse_ABezierWithTooFewNumbers_IsRefusedRatherThanTruncated()
+    {
+        var result = BmotionTransitionSpec.Parse("tween(duration: 0.5, bezier: [0.42, 0])");
+
+        Assert.IsNull(((BmTween)result.Transition!).Bezier);
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("four numbers", StringComparison.OrdinalIgnoreCase)),
+                      $"Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    public void Parse_APositionalArgumentPastTheSignature_IsReportedRatherThanDropped()
+    {
+        var result = BmotionTransitionSpec.Parse("tween(0.4, InOut, 99)");
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("99", StringComparison.Ordinal)),
+                      $"Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    [DataRow("InOut", BmEase.InOut)]
+    [DataRow("inout", BmEase.InOut)]
+    [DataRow("BmEase.BackOut", BmEase.BackOut)]
+    [DataRow("ease.BackOut", BmEase.BackOut)]
+    [DataRow("easeBackOut", BmEase.BackOut)]
+    [DataRow("Linear", BmEase.Linear)]
+    public void TryEase_AcceptsEverySpellingAnAgentIsLikelyToWrite(string text, BmEase expected)
+    {
+        Assert.IsTrue(BmotionTransitionSpec.TryEase(text, out var ease), $"'{text}' was not recognised.");
+        Assert.AreEqual(expected, ease);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("swoosh")]
+    public void TryEase_RejectsWhatIsNotAnEasing(string text)
+    {
+        Assert.IsFalse(BmotionTransitionSpec.TryEase(text, out _));
+    }
+
+    [TestMethod]
+    public void Parse_AnUnknownEasing_KeepsTheDefaultAndPointsAtTheToolThatLists()
+    {
+        var result = BmotionTransitionSpec.Parse("tween(0.4, swoosh)");
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("GetBmotionEasings", StringComparison.Ordinal)),
+                      $"Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    public void Parse_TheCanonicalCall_IsTheCodeToWrite_AndParsesBackToTheSameTransition()
+    {
+        foreach (var spec in new[]
+        {
+            "spring(stiffness: 260, damping: 12, mass: 1.2)",
+            "spring(bounce: 0.4, duration: 0.6)",
+            "tween(0.35, BackOut)",
+            "inertia(velocity: 500, power: 0.8)",
+        })
+        {
+            var first = BmotionTransitionSpec.Parse(spec);
+
+            StringAssert.StartsWith(first.Canonical, "Bm.", $"'{spec}' produced '{first.Canonical}', which is not a C# call.");
+
+            // Round-tripping is the property that makes the canonical form safe to paste into code:
+            // what it says was understood has to mean the same thing when read back.
+            var second = BmotionTransitionSpec.Parse(first.Canonical);
+
+            Assert.AreEqual(first.Canonical, second.Canonical,
+                            $"'{spec}' did not round-trip: '{first.Canonical}' -> '{second.Canonical}'.");
+        }
+    }
+
+    /// <summary>
+    /// The server runs with InvariantGlobalization, but a spec is parsed on whatever thread culture
+    /// the host hands it. A comma-decimal culture must not read "0.4" as 4.
+    /// </summary>
+    [TestMethod]
+    public void Parse_ANumber_IsReadTheSameWayUnderACommaDecimalCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var tween = (BmTween)BmotionTransitionSpec.Parse("tween(duration: 0.4)").Transition!;
+
+            Assert.AreEqual(0.4, tween.Duration);
+
+            // And the canonical call it writes back has to be C#, not localized.
+            StringAssert.Contains(BmotionTransitionSpec.Parse("spring(mass: 1.5)").Canonical, "1.5");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [TestMethod]
+    public void Parse_IsTotal_NoInputThrows()
+    {
+        foreach (var spec in new[]
+        {
+            "spring(", ")", "((((", "spring(:::)", "spring(,,,)", "tween(bezier: [)",
+            "spring(stiffness:)", "=", ":", "spring(stiffness: 1e400)", new string('x', 5_000),
+        })
+        {
+            var result = BmotionTransitionSpec.Parse(spec);
+
+            // Either it read something or it explained why not - never both empty, never an exception.
+            Assert.IsTrue(result.Transition is not null || result.Error is not null,
+                          $"'{spec[..Math.Min(40, spec.Length)]}' produced neither a transition nor an error.");
+        }
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/TransitionSpecTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/TransitionSpecTests.cs
@@ -151,6 +151,52 @@ public class TransitionSpecTests
         Assert.AreEqual(0.4, tween.Duration);
     }
 
+    /// <summary>
+    /// Bm.Tween takes the duration first, so "tween(BackOut)" - the way an easing-only tween is
+    /// written - lands in the duration slot. Reading it as a bad duration would throw away the one
+    /// thing the spec says.
+    /// </summary>
+    [TestMethod]
+    [DataRow("tween(BackOut)", BmEase.BackOut)]
+    [DataRow("tween(Linear)", BmEase.Linear)]
+    [DataRow("tween(BmEase.InOut)", BmEase.InOut)]
+    public void Parse_AnEasingInThePositionalDurationSlot_IsReadAsTheEasing(string spec, BmEase expected)
+    {
+        var result = BmotionTransitionSpec.Parse(spec);
+
+        Assert.AreEqual(expected, ((BmTween)result.Transition!).Ease);
+        Assert.IsFalse(result.Warnings.Any(warning => warning.Contains("is not a number", StringComparison.Ordinal)),
+                       $"The easing was reported as a bad duration. Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    /// <summary>A first argument that is neither a number nor an easing is still a bad duration.</summary>
+    [TestMethod]
+    public void Parse_ANonsenseFirstArgument_IsStillReportedAsABadDuration()
+    {
+        var result = BmotionTransitionSpec.Parse("tween(swoosh)");
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("is not a number", StringComparison.Ordinal)),
+                      $"Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    /// <summary>
+    /// Milliseconds are how the CSS and Web Animations worlds write a duration, so an agent copying
+    /// one across writes it that way. Trimming the trailing "s" off it would leave "300m"; dropping
+    /// the unit without converting would leave a five-minute tween.
+    /// </summary>
+    [TestMethod]
+    [DataRow("tween(duration: 300ms)", 0.3)]
+    [DataRow("tween(duration: 300MS)", 0.3)]
+    [DataRow("tween(400ms)", 0.4)]
+    public void Parse_ADurationInMilliseconds_IsConvertedToSeconds(string spec, double expected)
+    {
+        var result = BmotionTransitionSpec.Parse(spec);
+
+        Assert.AreEqual(expected, ((BmTween)result.Transition!).Duration, 1e-9);
+        Assert.IsFalse(result.Warnings.Any(warning => warning.Contains("is not a number", StringComparison.Ordinal)),
+                       $"Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
     [TestMethod]
     public void Parse_ABezier_KeepsItsOwnCommasTogether()
     {

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/TransitionSpecTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/TransitionSpecTests.cs
@@ -260,6 +260,40 @@ public class TransitionSpecTests
         }
     }
 
+    /// <summary>
+    /// Whether an argument exists and whether its value reads as a number are two questions. Answered
+    /// as one, a good name with a bad value comes back as a name the kind does not have - which sends
+    /// the caller off renaming the argument that was already right.
+    /// </summary>
+    [TestMethod]
+    [DataRow("spring(stiffness: fast)", "spring")]
+    [DataRow("tween(duration: quick)", "tween")]
+    [DataRow("inertia(velocity: fast)", "inertia")]
+    public void Parse_AKnownArgumentWithAnUnreadableValue_IsOnlyReportedAsABadValue(string spec, string kind)
+    {
+        var result = BmotionTransitionSpec.Parse(spec);
+
+        Assert.IsNull(result.Error);
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains("is not a number", StringComparison.Ordinal)),
+                      $"Nothing said the value could not be read. Warnings: {string.Join(" | ", result.Warnings)}");
+
+        Assert.IsFalse(result.Warnings.Any(warning => warning.Contains($"is not an argument of a {kind}", StringComparison.Ordinal)),
+                       $"A correct argument name was reported as unknown. Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    [DataRow("spring(stifness: 260)", "spring")]
+    [DataRow("tween(durration: 0.4)", "tween")]
+    [DataRow("inertia(velcity: 500)", "inertia")]
+    public void Parse_AMisspelledArgument_StillNamesTheOnesThatExist(string spec, string kind)
+    {
+        var result = BmotionTransitionSpec.Parse(spec);
+
+        Assert.IsTrue(result.Warnings.Any(warning => warning.Contains($"is not an argument of a {kind}", StringComparison.Ordinal)),
+                      $"A misspelled argument passed unremarked. Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
     [TestMethod]
     public void Parse_IsTotal_NoInputThrows()
     {

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/XmlDocsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/XmlDocsTests.cs
@@ -1,0 +1,99 @@
+namespace Bit.Bmotion.Tests.Mcp.Services;
+
+/// <summary>
+/// The XML documentation reader. It is the only source of prose in the API reference, and it is
+/// deliberately forgiving - a missing or malformed file degrades to no documentation rather than
+/// taking the tools down. These tests hold it to both halves of that: it finds the documentation
+/// when it is there, and it flattens the markup into something an agent can read as a sentence.
+/// </summary>
+[TestClass]
+public class XmlDocsTests
+{
+    [TestMethod]
+    public void GetSummary_FindsTheDocumentationOfAKnownType()
+    {
+        var summary = BmotionXmlDocs.GetSummary($"T:{typeof(BmSpring).FullName}");
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(summary), "BmSpring has no summary, so the XML file was not loaded.");
+    }
+
+    [TestMethod]
+    public void GetSummary_FindsTheDocumentationOfAMember()
+    {
+        var summary = BmotionXmlDocs.GetSummary($"P:{typeof(BmSpring).FullName}.{nameof(BmSpring.Stiffness)}");
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(summary));
+    }
+
+    [TestMethod]
+    [DataRow("T:Bit.Bmotion.NoSuchType")]
+    [DataRow("P:Bit.Bmotion.BmSpring.NoSuchMember")]
+    [DataRow("")]
+    [DataRow("nonsense")]
+    public void GetSummary_AnUnknownId_IsNullRatherThanAThrow(string id)
+    {
+        Assert.IsNull(BmotionXmlDocs.GetSummary(id));
+        Assert.IsNull(BmotionXmlDocs.GetRemarks(id));
+    }
+
+    /// <summary>
+    /// A cref is a fully qualified id in the file and a name in the sentence: "BmSpring", not
+    /// "T:Bit.Bmotion.BmSpring".
+    /// </summary>
+    [TestMethod]
+    public void GetSummary_CrefReferences_ReadAsNames()
+    {
+        var texts = BmotionApiCatalog.Types
+            .Select(type => BmotionApiCatalog.GetTypeDetails(type.Name)!)
+            .SelectMany(details => details.Members.Select(member => member.Summary).Append(details.Summary))
+            .Where(text => text is not null)
+            .ToArray();
+
+        Assert.AreNotEqual(0, texts.Length);
+
+        foreach (var text in texts)
+        {
+            foreach (var prefix in new[] { "T:Bit.Bmotion", "P:Bit.Bmotion", "M:Bit.Bmotion", "F:Bit.Bmotion" })
+            {
+                Assert.IsFalse(text!.Contains(prefix, StringComparison.Ordinal),
+                               $"A documentation id leaked into prose: {text}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// While the prose is unwrapped, a code sample is parked under a U+0001 placeholder so its own
+    /// line breaks survive the whitespace passes. The placeholder itself must always be put back.
+    /// </summary>
+    [TestMethod]
+    public void GetSummary_TheCodeSamplePlaceholder_IsNeverLeftInTheText()
+    {
+        var texts = BmotionApiCatalog.Types
+            .Select(type => BmotionApiCatalog.GetTypeDetails(type.Name)!)
+            .SelectMany(details => details.Members.SelectMany(member => new[] { member.Summary, member.Remarks })
+                                                  .Concat([details.Summary, details.Remarks]))
+            .Where(text => text is not null)
+            .ToArray();
+
+        Assert.AreNotEqual(0, texts.Length, "Nothing in the library is documented, so the XML file was not loaded.");
+
+        foreach (var text in texts)
+        {
+            Assert.IsFalse(text!.Contains((char)1), $"A code-sample placeholder was left in the text: {text}");
+        }
+    }
+
+    [TestMethod]
+    public void GetSummary_TheProseIsUnwrapped_NotLeftAtTheSourcesLineWidth()
+    {
+        var summary = BmotionXmlDocs.GetSummary($"T:{typeof(BmSpring).FullName}")!;
+
+        // Source comments wrap at around a hundred columns; a summary that still has single newlines
+        // in the middle of sentences was not unwrapped.
+        var brokenSentences = summary.Split('\n')
+            .Where((line, index) => index > 0 && line.Length > 0 && char.IsLower(line[0]))
+            .ToArray();
+
+        Assert.AreEqual(0, brokenSentences.Length, $"The summary is still wrapped:\n{summary}");
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/XmlDocsTests.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/Services/XmlDocsTests.cs
@@ -83,6 +83,22 @@ public class XmlDocsTests
         }
     }
 
+    /// <summary>
+    /// A &lt;para&gt; is the only marker of a paragraph in a doc comment, and the pass that unwraps the
+    /// source's line breaks turns a single newline back into a space. This pins the outcome: the break
+    /// the author wrote is still a break by the time an agent reads it.
+    /// </summary>
+    [TestMethod]
+    public void GetSummary_AParagraphAfterProse_KeepsTheBreak()
+    {
+        // Bmotion.Inherit is documented as prose followed by a <para>, and has no <code> sample that
+        // would produce a blank line of its own.
+        var summary = BmotionXmlDocs.GetSummary($"P:{typeof(Bit.Bmotion.Bmotion).FullName}.{nameof(Bit.Bmotion.Bmotion.Inherit)}");
+
+        Assert.IsNotNull(summary);
+        StringAssert.Contains(summary, "\n\n", $"The paragraph break was flattened away:\n{summary}");
+    }
+
     [TestMethod]
     public void GetSummary_TheProseIsUnwrapped_NotLeftAtTheSourcesLineWidth()
     {

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/TestInfra/BmotionMcpServerFixture.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/TestInfra/BmotionMcpServerFixture.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using ModelContextProtocol.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Bmotion.Tests.Mcp.TestInfra;
+
+/// <summary>
+/// The demo's own <c>Program.cs</c>, hosted in memory, with a real MCP client connected to it over
+/// the HTTP transport.
+/// <para>
+/// Everything above this point in the test suite calls the tool methods as C#. That leaves the part
+/// an agent actually depends on untested: the attributes have to be discovered, the DTOs have to
+/// become output schemas, the transport has to be mapped, and every argument has to survive a
+/// round trip through JSON. None of that is exercised by a method call, and all of it is decided by
+/// the wiring in Program.cs.
+/// </para>
+/// </summary>
+internal sealed class BmotionMcpServerFixture : IAsyncDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
+
+    private BmotionMcpServerFixture(WebApplicationFactory<Program> factory, HttpClient httpClient, McpClient client)
+    {
+        _factory = factory;
+        _httpClient = httpClient;
+        Client = client;
+    }
+
+    /// <summary>An MCP client talking to the server the way a coding agent does.</summary>
+    public McpClient Client { get; }
+
+    public static async Task<BmotionMcpServerFixture> StartAsync()
+    {
+        var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder => builder.ConfigureServices(services =>
+            {
+                // The host's own logging would otherwise write a request line per JSON-RPC message.
+                services.AddLogging(logging => logging.ClearProviders());
+            }));
+
+        var httpClient = factory.CreateClient();
+
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri(httpClient.BaseAddress!, "/mcp"),
+                // The server maps the streamable HTTP transport; saying so skips the client's probe
+                // for the older SSE endpoint, which this server does not have.
+                TransportMode = HttpTransportMode.StreamableHttp,
+            },
+            httpClient,
+            ownsHttpClient: false);
+
+        var client = await McpClient.CreateAsync(transport);
+
+        return new BmotionMcpServerFixture(factory, httpClient, client);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Client.DisposeAsync();
+
+        _httpClient.Dispose();
+
+        await _factory.DisposeAsync();
+    }
+}

--- a/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/TestInfra/BmotionMcpServerFixture.cs
+++ b/src/Bmotion/Tests/Bit.Bmotion.Tests.Mcp/TestInfra/BmotionMcpServerFixture.cs
@@ -31,6 +31,9 @@ internal sealed class BmotionMcpServerFixture : IAsyncDisposable
     /// <summary>An MCP client talking to the server the way a coding agent does.</summary>
     public McpClient Client { get; }
 
+    /// <summary>The same in-memory host over plain HTTP, for the tools that are also GET endpoints.</summary>
+    public HttpClient Http => _httpClient;
+
     public static async Task<BmotionMcpServerFixture> StartAsync()
     {
         var factory = new WebApplicationFactory<Program>()
@@ -53,7 +56,21 @@ internal sealed class BmotionMcpServerFixture : IAsyncDisposable
             httpClient,
             ownsHttpClient: false);
 
-        var client = await McpClient.CreateAsync(transport);
+        McpClient client;
+
+        try
+        {
+            client = await McpClient.CreateAsync(transport);
+        }
+        catch
+        {
+            // Nothing is returned to dispose, so the host and its client would outlive the failure
+            // and hold the in-memory server open for the rest of the run.
+            httpClient.Dispose();
+            await factory.DisposeAsync();
+
+            throw;
+        }
 
         return new BmotionMcpServerFixture(factory, httpClient, client);
     }


### PR DESCRIPTION
closes #12950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server for exploring Bmotion documentation, APIs, recipes, source files, setup guidance, and animation tools.
  * Added a dedicated MCP demo page with transition simulation, replay, code review, catalog browsing, and search.
  * Added easing-curve, playback, compositor-compatibility, and animation-markup analysis.
  * Added render-mode-specific setup guidance and expanded recipe documentation.
  * Added searchable navigation using demo titles and keywords.

* **Documentation**
  * Documented MCP endpoints, tools, prompts, resources, and usage in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->