### PR TITLE
Disable wasm thread in BlazorUI demo project (#12993)

### DIFF
--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Components/App.razor
@@ -14,13 +14,7 @@
 #else
     var blazorWebScript = "_framework/bit.blazor.web.es2019.js";
 #endif
-    // The ChartLegacy demo can't run its samples in WebAssembly: Blazor's lazy assembly loading isn't
-    // compatible with the multi-threaded WASM runtime this app is built with, so BitChartLegacyDemo renders
-    // a note explaining that instead of the samples. Prerendering that page would paint the samples on the
-    // server and then swap them for the note as soon as WASM boots, so prerendering is turned off for it.
-    // Builds without the WASM client render in Blazor Server mode, where the samples work, so they keep it.
-    var chartLegacyOnWasm = includeWasm && HttpContext.Request.Path.StartsWithSegments("/components/legacy/chart");
-    var noPrerender = HttpContext.Request.Query["no-prerender"].Count > 0 || chartLegacyOnWasm;
+    var noPrerender = HttpContext.Request.Query["no-prerender"].Count > 0;
     // Without the WASM client in the build, WebAssembly render modes can't boot, so fall back to Blazor Server
     // even where AppRenderMode.Current would pick WebAssembly (e.g. Release with IncludeWasm=false).
     var renderMode = noPrerender

--- a/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Startup/Middlewares.cs
+++ b/src/BlazorUI/Demo/Bit.BlazorUI.Demo.Server/Startup/Middlewares.cs
@@ -16,20 +16,6 @@ public class Middlewares
     {
         app.UseForwardedHeaders();
 
-        // Cross-origin isolation, required for the multi-threaded WebAssembly runtime
-        // (WasmEnableThreads in Bit.BlazorUI.Demo.Client.Web) to use SharedArrayBuffer.
-        // Without these headers on the top-level document, crossOriginIsolated stays
-        // false and the runtime silently falls back to a single thread. COEP
-        // 'credentialless' is used instead of 'require-corp' so cross-origin
-        // subresources (fonts, images) keep loading without their own CORP/CORS headers;
-        // it enables isolation on Chromium and Firefox (Safari needs 'require-corp').
-        app.Use(async (context, next) =>
-        {
-            context.Response.Headers["Cross-Origin-Opener-Policy"] = "same-origin";
-            context.Response.Headers["Cross-Origin-Embedder-Policy"] = "credentialless";
-            await next.Invoke(context);
-        });
-
         if (env.IsDevelopment())
         {
 #if INCLUDE_WASM

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/BitChartLegacyDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/BitChartLegacyDemo.razor
@@ -1,94 +1,57 @@
-@page "/components/legacy/chart"
+﻿@page "/components/legacy/chart"
 
 <PageOutlet Url="components/legacy/chart"
             Title="ChartLegacy"
             Description="Simple and flexible charting component for data visualization, which supports eight chart types: bar, line, area, pie, bubble, radar, polar, and scatter." />
 
-<DemoPage Name="ChartLegacy"
-          Description="Simple and flexible charting component for data visualization, which supports eight chart types: bar, line, area, pie, bubble, radar, polar, and scatter."
-          Parameters="componentParameters"
-          SubClasses="componentSubClasses"
-          GitHubLegacyUrl="Chart/BitChartLegacy.razor"
-          GitHubDemoUrl="Legacy/Chart/BitChartLegacyDemo.razor">
-    <NotesTemplate>
-        <BitText>
-            To use this component, you need to install the
-            <BitLink Href="https://www.nuget.org/packages/Bit.BlazorUI.Legacy" Target="_blank">
-                <BitTag Reversed
-                        Text="Bit.BlazorUI.Legacy"
-                        Color="BitColor.SecondaryBackground"
-                        IconName="@BitIconName.NavigateExternalInline" />
-            </BitLink>
-            nuget package, as described in the <BitLink Href="/getting-started#legacy-components">Legacy components</BitLink> section of the Getting started page.
-        </BitText>
-    </NotesTemplate>
-    <Examples>
-        @if (isWasm)
-        {
-            <BitMessage Multiline Color="BitColor.Warning">
-                <BitText Element="p">
-                    <strong>The samples of this page are not rendered in the WebAssembly version of this demo app.</strong>
+<div>
+    @if (isLoadingAssemblies)
+    {
+        <LoadingComponent />
+    }
+    else
+    {
+        <DemoPage Name="ChartLegacy"
+                  Description="Simple and flexible charting component for data visualization, which supports eight chart types: bar, line, area, pie, bubble, radar, polar, and scatter."
+                  Parameters="componentParameters"
+                  SubClasses="componentSubClasses"
+                  GitHubLegacyUrl="Chart/BitChartLegacy.razor"
+                  GitHubDemoUrl="Legacy/Chart/BitChartLegacyDemo.razor">
+            <NotesTemplate>
+                <BitText>
+                    To use this component, you need to install the
+                    <BitLink Href="https://www.nuget.org/packages/Bit.BlazorUI.Legacy" Target="_blank">
+                        <BitTag Reversed
+                                Text="Bit.BlazorUI.Legacy"
+                                Color="BitColor.SecondaryBackground"
+                                IconName="@BitIconName.NavigateExternalInline" />
+                    </BitLink>
+                    nuget package, as described in the <BitLink Href="/getting-started#legacy-components">Legacy components</BitLink> section of the Getting started page.
                 </BitText>
-                <br />
-                <BitText Element="p">
-                    BitChartLegacy serializes its configuration with
-                    <BitTag Color="BitColor.SecondaryBackground">Newtonsoft.Json</BitTag>, so the samples need the
-                    <BitTag Color="BitColor.SecondaryBackground">Newtonsoft.Json</BitTag>,
-                    <BitTag Color="BitColor.SecondaryBackground">System.Private.Xml</BitTag> and
-                    <BitTag Color="BitColor.SecondaryBackground">System.Data.Common</BitTag> assemblies. To keep the
-                    startup download of this app small, those assemblies are not part of the initial payload: they are
-                    declared as <BitTag Color="BitColor.SecondaryBackground">BlazorWebAssemblyLazyLoad</BitTag> in the
-                    project file and used to be fetched on demand with
-                    <BitTag Color="BitColor.SecondaryBackground">LazyAssemblyLoader</BitTag> when this page was opened.
-                </BitText>
-                <br />
-                <BitText Element="p">
-                    Blazor's lazy assembly loading feature is not compatible with the multi-threaded WebAssembly
-                    runtime, and this demo app is built with
-                    <BitTag Color="BitColor.SecondaryBackground">WasmEnableThreads</BitTag> enabled, which other
-                    components of the app rely on. The lazy load therefore fails with an exception that takes the whole
-                    app down, so this page now shows this note instead of running the samples.
-                </BitText>
-                <br />
-                <BitText Element="p">
-                    This is a limitation of the configuration of this demo app and not of the component itself:
-                    BitChartLegacy works in Blazor Server, in Blazor Hybrid (MAUI, WPF, WinForms) and in any Blazor
-                    WebAssembly app that either doesn't enable WASM threads or ships those assemblies in the initial
-                    download instead of lazy loading them.
-                </BitText>
-                <br />
-                <BitText Element="p">
-                    You can still read the full source code of every sample
-                    <BitLink Href="https://github.com/bitfoundation/bitplatform/tree/develop/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart"
-                             Target="_blank">on GitHub</BitLink>. For new apps we recommend the native
-                    <BitLink Href="/components/chart">BitChart</BitLink> component instead: it renders with SVG, needs
-                    no JavaScript charting engine and no lazy loaded assemblies, so it also runs here.
-                </BitText>
-            </BitMessage>
-        }
-        else
-        {
-            <_BitChartLegacyBarDemo />
+            </NotesTemplate>
+            <Examples>
+                <_BitChartLegacyBarDemo />
 
-            <_BitChartLegacyHorizontalBarDemo />
+                <_BitChartLegacyHorizontalBarDemo />
 
-            <_BitChartLegacyStackedBarDemo />
+                <_BitChartLegacyStackedBarDemo />
 
-            <_BitChartLegacyLineDemo />
+                <_BitChartLegacyLineDemo />
 
-            <_BitChartLegacyPieDemo />
+                <_BitChartLegacyPieDemo />
 
-            <_BitChartLegacyDoughnutDemo />
+                <_BitChartLegacyDoughnutDemo />
 
-            <_BitChartLegacyPolarAreaDemo />
+                <_BitChartLegacyPolarAreaDemo />
 
-            <_BitChartLegacyTimeDemo />
+                <_BitChartLegacyTimeDemo />
 
-            <_BitChartLegacyScatterDemo />
+                <_BitChartLegacyScatterDemo />
 
-            <_BitChartLegacyBubbleDemo />
+                <_BitChartLegacyBubbleDemo />
 
-            <_BitChartLegacyRadarDemo />
-        }
-    </Examples>
-</DemoPage>
+                <_BitChartLegacyRadarDemo />
+            </Examples>
+        </DemoPage>
+    }
+</div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/BitChartLegacyDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/BitChartLegacyDemo.razor.cs
@@ -1,4 +1,4 @@
-﻿// using Microsoft.AspNetCore.Components.WebAssembly.Services;
+﻿using Microsoft.AspNetCore.Components.WebAssembly.Services;
 
 namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Legacy.Chart;
 
@@ -73,32 +73,26 @@ public partial class BitChartLegacyDemo
 
     // BitChartLegacy serializes its config with Newtonsoft.Json, so the samples need assemblies that this
     // demo app keeps out of its initial WebAssembly payload through the BlazorWebAssemblyLazyLoad item group.
-    // Blazor's lazy assembly loading is not compatible with the multi-threaded WebAssembly runtime the app is
-    // built with (WasmEnableThreads), and the failing load brought the whole app down, so in WebAssembly the
-    // samples are replaced by a note explaining the limitation. Every other host (Blazor Server, MAUI,
-    // Windows) has those assemblies from the start and renders the samples as usual.
-    private readonly bool isWasm = OperatingSystem.IsBrowser();
+    // They are fetched on demand here, before the samples render. Every other host (Blazor Server, MAUI,
+    // Windows) already has them and the load is skipped.
+    [AutoInject] LazyAssemblyLoader lazyAssemblyLoader = default!;
 
+    private bool isLoadingAssemblies = true;
 
+    protected async override Task OnInitializedAsync()
+    {
+        try
+        {
+            if (OperatingSystem.IsBrowser())
+            {
+                await lazyAssemblyLoader.LoadAssembliesAsync(["Newtonsoft.Json.wasm", "System.Private.Xml.wasm", "System.Data.Common.wasm"]);
+            }
+        }
+        finally
+        {
+            isLoadingAssemblies = false;
+        }
 
-    // [AutoInject] LazyAssemblyLoader lazyAssemblyLoader = default!;
-
-    // private bool isLoadingAssemblies = true;
-
-    // protected async override Task OnInitializedAsync()
-    // {
-    //     try
-    //     {
-    //         if (OperatingSystem.IsBrowser())
-    //         {
-    //             await lazyAssemblyLoader.LoadAssembliesAsync(["Newtonsoft.Json.wasm", "System.Private.Xml.wasm", "System.Data.Common.wasm"]);
-    //         }
-    //     }
-    //     finally
-    //     {
-    //         isLoadingAssemblies = false;
-    //     }
-
-    //     await base.OnInitializedAsync();
-    // }
+        await base.OnInitializedAsync();
+    }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyBubbleDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyBubbleDemo.razor
@@ -1,4 +1,4 @@
-<DemoExample Title="Bubble" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example7">
+<DemoExample Title="Bubble" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example10">
     <div class="example-desc">
         A bubble chart is used to display three dimensions of data at the same time.
         The location of the bubble is determined by the first two dimensions and the corresponding horizontal and vertical axes. The third dimension is represented by the size of the individual bubbles.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyPolarAreaDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyPolarAreaDemo.razor
@@ -1,4 +1,4 @@
-<DemoExample Title="PolarArea Chart" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example1">
+<DemoExample Title="PolarArea Chart" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example7">
     <div class="example-desc">
         Polar area charts are similar to pie charts, but each segment has the same angle - the radius of the segment differs depending on the value.
         This type of chart is often useful when we want to show a comparison data similar to a pie chart, but also show a scale of values for context.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyRadarDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyRadarDemo.razor
@@ -1,4 +1,4 @@
-<DemoExample Title="Radar Chart" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example1">
+<DemoExample Title="Radar Chart" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example11">
     <div class="example-desc">
         A radar chart is a way of showing multiple data points and the variation between them.
         They are often useful for comparing the points of two or more different data sets.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyScatterDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyScatterDemo.razor
@@ -1,4 +1,4 @@
-<DemoExample Title="Scatter" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example7">
+<DemoExample Title="Scatter" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example9">
     <div class="example-desc">
         Scatter charts are based on basic line charts with the x-axis changed to a linear axis.
         To use a scatter chart, data must be passed as objects containing X and Y properties. The example below creates a scatter chart with 4 points.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyTimeDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Legacy/Chart/_BitChartLegacyTimeDemo.razor
@@ -1,4 +1,4 @@
-<DemoExample Title="Time Cartesian Axis" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example7">
+<DemoExample Title="Time Cartesian Axis" RazorCode="@razorCode" CsharpCode="@csharpCode" Id="example8">
     <div class="example-desc">
         The time scale is used to display times and dates.
         When building its ticks, it will automatically calculate the most comfortable unit base on the size of the scale.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Web/Bit.BlazorUI.Demo.Client.Web.csproj
@@ -16,11 +16,6 @@
         <StaticWebAssetsFingerprintContent>false</StaticWebAssetsFingerprintContent>
         <StaticWebAssetFingerprintingEnabled>false</StaticWebAssetFingerprintingEnabled>
         <WasmEnableSIMD>true</WasmEnableSIMD>
-        <!-- Multi-threaded WebAssembly runtime: lets BitPdfViewer's BackgroundRendering
-             offload parsing/rendering to a worker thread. Requires the hosting server to
-             send the COOP/COEP cross-origin-isolation headers (see the demo server's
-             Middlewares.cs) so the runtime can use SharedArrayBuffer. -->
-        <WasmEnableThreads>true</WasmEnableThreads>
     </PropertyGroup>
 
     <ItemGroup>
@@ -48,11 +43,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- These assemblies are only needed by the legacy Chart's Newtonsoft.Json serialization, so
-             keeping them out of the initial WASM download reduces the app's startup payload. Note that
-             nothing loads them back at runtime here: Blazor's lazy assembly loading isn't compatible
-             with the multi-threaded runtime enabled by WasmEnableThreads above, so BitChartLegacyDemo
-             shows a note about that limitation instead of its samples in WebAssembly. -->
+        <!-- Lazily loaded on demand by the legacy Chart demo (see BitChartLegacyDemo). These
+             assemblies are only needed by the legacy Chart's Newtonsoft.Json serialization, so
+             keeping them out of the initial WASM download reduces the app's startup payload. -->
         <BlazorWebAssemblyLazyLoad Include="Newtonsoft.Json.wasm" />
         <BlazorWebAssemblyLazyLoad Include="System.Private.Xml.wasm" />
         <BlazorWebAssemblyLazyLoad Include="System.Data.Common.wasm" />


### PR DESCRIPTION
closes #12993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legacy chart demonstrations now load required components on demand.
  * Added a loading state while chart components are being loaded.
  * All chart examples are available after loading completes.

* **Bug Fixes**
  * Removed outdated WebAssembly limitations and warnings from the legacy chart demo.
  * Prerendering is now controlled solely by the `no-prerender` query parameter.
  * Removed unnecessary cross-origin isolation response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->