### PR TITLE
Apply new improvements to Butil trimming (#13056)

### DIFF
--- a/src/Butil/Bit.Butil.Build/ButilConsumerScan.cs
+++ b/src/Butil/Bit.Butil.Build/ButilConsumerScan.cs
@@ -81,11 +81,14 @@ public static class ButilConsumerScan
         {
             if (string.IsNullOrWhiteSpace(path)) continue;
             if (string.Equals(Path.GetFileName(path), ButilAssemblyFileName, StringComparison.OrdinalIgnoreCase)) continue;
-            if (seen.Add(Path.GetFullPath(path)) is false) continue;
 
             PeImage image;
             try
             {
+                // A path malformed enough that it cannot even be resolved is one of the unreadable entries
+                // this method passes over, so the guard covers it too.
+                if (seen.Add(Path.GetFullPath(path)) is false) continue;
+
                 image = PeImage.Load(path);
             }
             catch (Exception exception) when (exception is IOException or BadImageFormatException or UnauthorizedAccessException or NotSupportedException or ArgumentException)

--- a/src/Butil/Bit.Butil.Build/ButilConsumerScan.cs
+++ b/src/Butil/Bit.Butil.Build/ButilConsumerScan.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Bit.Butil.Build;
+
+/// <summary>How an untrimmed publish works out which Bit.Butil types the app it is publishing uses.</summary>
+public enum ButilScanMode
+{
+    /// <summary>Do not scan. The default: without ILLink there is then no signal but an explicit list.</summary>
+    None,
+
+    /// <summary>
+    /// Match Bit.Butil type names against the names in each assembly's <c>#Strings</c> heap. Needs no table
+    /// parsing at all, and over-includes whenever an app has a type of its own by the same name - which,
+    /// with names like <c>Window</c>, <c>Console</c> and <c>Storage</c> in the library, is often.
+    /// </summary>
+    TypeNames,
+
+    /// <summary>
+    /// Match each assembly's <c>TypeRef</c> rows, which name the namespace as well, so only real references
+    /// to <c>Bit.Butil</c> types count. Costs no more at publish than <see cref="TypeNames"/> and is the mode
+    /// to use.
+    /// </summary>
+    TypeReferences,
+}
+
+/// <summary>
+/// Reads a publish's own assemblies to find the Bit.Butil types the app references, and turns those into the
+/// set of JavaScript modules it can reach.
+/// </summary>
+/// <remarks>
+/// This is the untrimmed publish's answer to the question ILLink answers for a trimmed one. It is a coarser
+/// answer - a referenced type counts whether or not the call is ever made, and a type reached purely by
+/// reflection counts for nothing - and it errs towards shipping too much JavaScript rather than too little.
+/// <br/>
+/// Two things are deliberately not filtered by name. Which assemblies to read is decided by whether they
+/// reference Bit.Butil at all, not by whether they look like framework assemblies: an exclusion list of
+/// <c>System.*</c> and <c>Microsoft.*</c> would be fast and would silently skip a consumer's own library
+/// that happened to be named that way, and a skipped assembly is a missing module. And Bit.Butil's own
+/// assembly is excluded outright, since it names every one of its types and would light up every module.
+/// </remarks>
+public static class ButilConsumerScan
+{
+    /// <summary>The Bit.Butil assembly, whose own references say nothing about what a consumer calls.</summary>
+    public const string ButilAssemblyFileName = "Bit.Butil.dll";
+
+    private const int TypeRefTable = 0x01;
+
+    /// <summary>What a scan found, in the terms the build needs to report it.</summary>
+    public sealed class Result
+    {
+        /// <summary>The modules the referenced types need, before the manifest closes them over dependencies.</summary>
+        public SortedSet<string> Modules { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>The Bit.Butil types the scan matched, for the build log.</summary>
+        public SortedSet<string> Types { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>Assemblies that were read and do reference Bit.Butil.</summary>
+        public List<string> Scanned { get; } = [];
+
+        /// <summary>Files that are not managed assemblies at all, and were passed over.</summary>
+        public List<string> Skipped { get; } = [];
+    }
+
+    /// <summary>
+    /// Scans the given files. Anything that is not a managed assembly - a native library, a resource file, a
+    /// path that no longer exists - is passed over rather than failing the publish: the list a consumer's
+    /// build hands in is whatever their references resolved to, and it is not this code's place to insist
+    /// every entry be readable.
+    /// </summary>
+    public static Result Scan(IEnumerable<string> assemblyPaths, ButilTypeModules map, ButilScanMode mode)
+    {
+        var result = new Result();
+        if (mode == ButilScanMode.None) return result;
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in assemblyPaths)
+        {
+            if (string.IsNullOrWhiteSpace(path)) continue;
+            if (string.Equals(Path.GetFileName(path), ButilAssemblyFileName, StringComparison.OrdinalIgnoreCase)) continue;
+            if (seen.Add(Path.GetFullPath(path)) is false) continue;
+
+            PeImage image;
+            try
+            {
+                image = PeImage.Load(path);
+            }
+            catch (Exception exception) when (exception is IOException or BadImageFormatException or UnauthorizedAccessException or NotSupportedException or ArgumentException)
+            {
+                result.Skipped.Add(path);
+                continue;
+            }
+
+            try
+            {
+                if (ScanOne(image, map, mode, result)) result.Scanned.Add(path);
+            }
+            catch (BadImageFormatException)
+            {
+                result.Skipped.Add(path);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>True when the assembly references Bit.Butil, which is also what makes its matches count.</summary>
+    private static bool ScanOne(PeImage image, ButilTypeModules map, ButilScanMode mode, Result result)
+        => mode == ButilScanMode.TypeReferences ? ScanTypeReferences(image, map, result) : ScanTypeNames(image, map, result);
+
+    /// <summary>
+    /// Every <c>TypeRef</c> row whose namespace is the library's. Read through the row's own heap index, so a
+    /// name the heap stores as a suffix of another is read back whole.
+    /// </summary>
+    private static bool ScanTypeReferences(PeImage image, ButilTypeModules map, Result result)
+    {
+        var tables = MetadataTables.Read(image);
+        if (tables.TypeRefCount == 0) return false;
+
+        var matches = new List<TypeName>();
+        var nested = new List<TypeName>();
+        var referencesButil = false;
+
+        for (var row = 1; row <= tables.TypeRefCount; row++)
+        {
+            var name = tables.TypeRef(row);
+
+            if (string.Equals(name.Namespace, ButilTypeModules.Namespace, StringComparison.Ordinal)
+                || name.Namespace.StartsWith(ButilTypeModules.Namespace + ".", StringComparison.Ordinal))
+            {
+                referencesButil = true;
+                matches.Add(name);
+            }
+            // A nested type's reference carries no namespace of its own - it hangs off the reference to the
+            // type enclosing it, which this reader does not follow. Matching those on the name alone is the
+            // over-including side of the trade, and only for an assembly that references the library anyway.
+            else if (name.Namespace.Length == 0) nested.Add(name);
+        }
+
+        if (referencesButil is false) return false;
+
+        foreach (var name in matches)
+        {
+            Record(result, name.FullName, map.ForFullName(name.FullName));
+        }
+
+        foreach (var name in nested)
+        {
+            Record(result, name.Name, map.ForName(name.Name));
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Every name in the <c>#Strings</c> heap, matched against the Bit.Butil type names. The heap may store
+    /// one name as a suffix of another, and a sequential walk only reaches the longer one - so a name that
+    /// <em>ends with</em> a known type name counts too, which over-includes rather than missing a module.
+    /// </summary>
+    private static bool ScanTypeNames(PeImage image, ButilTypeModules map, Result result)
+    {
+        var names = new List<string>();
+        var lastCharacters = new HashSet<char>();
+        foreach (var name in map.TypeNames)
+        {
+            names.Add(name);
+            lastCharacters.Add(name[name.Length - 1]);
+        }
+
+        if (names.Count == 0) return false;
+
+        var referencesButil = false;
+        var matched = new List<string>();
+
+        foreach (var text in ReadStrings(image))
+        {
+            if (text.Length == 0) continue;
+
+            if (referencesButil is false
+                && (string.Equals(text, ButilTypeModules.Namespace, StringComparison.Ordinal)
+                    || text.EndsWith("." + ButilTypeModules.Namespace, StringComparison.Ordinal)
+                    || text.StartsWith(ButilTypeModules.Namespace + ".", StringComparison.Ordinal)))
+            {
+                referencesButil = true;
+            }
+
+            // The cheap reject first: a name can only match if the heap entry ends in a character some type
+            // name ends in, which throws out almost every method and parameter name before any comparison.
+            if (lastCharacters.Contains(text[text.Length - 1]) is false) continue;
+
+            foreach (var name in names)
+            {
+                if (name.Length <= text.Length && text.EndsWith(name, StringComparison.Ordinal)) matched.Add(name);
+            }
+        }
+
+        if (referencesButil is false) return false;
+
+        foreach (var name in matched)
+        {
+            Record(result, name, map.ForName(name));
+        }
+
+        return true;
+    }
+
+    private static void Record(Result result, string type, IReadOnlyCollection<string> modules)
+    {
+        if (modules.Count == 0) return;
+
+        result.Types.Add(type);
+        foreach (var module in modules) result.Modules.Add(module);
+    }
+
+    /// <summary>
+    /// The <c>#Strings</c> heap walked end to end: null-terminated UTF-8, one entry after another. Entries
+    /// the heap only reaches as a suffix of a longer one are not returned - see the caller for how that is
+    /// accounted for.
+    /// </summary>
+    public static IEnumerable<string> ReadStrings(PeImage image)
+    {
+        var heap = image.Strings;
+        var strings = new List<string>();
+        if (heap.IsEmpty) return strings;
+
+        // Index 0 of the heap is the empty string; the first real entry starts at 1. Walked in bytes, not in
+        // characters: a name outside the ASCII range takes more than one byte per character, and stepping by
+        // the decoded length would land in the middle of the next entry.
+        var start = heap.Offset + 1;
+        var end = heap.Offset + heap.Size;
+
+        for (var position = start; position < end;)
+        {
+            var terminator = position;
+            while (terminator < end && image.Image[terminator] != 0) terminator++;
+
+            if (terminator > position) strings.Add(Encoding.UTF8.GetString(image.Image, position, terminator - position));
+
+            position = terminator + 1;
+        }
+
+        return strings;
+    }
+}

--- a/src/Butil/Bit.Butil.Build/ButilScriptBundler.cs
+++ b/src/Butil/Bit.Butil.Build/ButilScriptBundler.cs
@@ -147,6 +147,66 @@ public static class ButilScriptBundler
     }
 
     /// <summary>
+    /// Turns the names a consumer wrote in their csproj into modules. Each one is either a module name as
+    /// the manifest spells it (<c>clipboard</c>) or the name of a Bit.Butil class (<c>Clipboard</c>,
+    /// or <c>Bit.Butil.Clipboard</c>) - a consumer thinks in the classes they inject, and a class is the
+    /// safer thing to name anyway, since one class can need more than one module.
+    /// </summary>
+    /// <remarks>
+    /// A name that is neither is an error rather than a shrug. MSBuild accepts a misspelled item silently,
+    /// and the cost of ignoring one here is a module missing from a bundle - which surfaces in a browser,
+    /// after publishing, as an API that does nothing.
+    /// </remarks>
+    /// <param name="names">What the consumer wrote.</param>
+    /// <param name="manifest">The module manifest, which is what makes a name a module name.</param>
+    /// <param name="types">The type map, when one could be built; without it only module names resolve.</param>
+    /// <param name="unresolved">The names that matched nothing, in the order they were given.</param>
+    public static SortedSet<string> ResolveNames(IEnumerable<string> names, ButilScriptManifest manifest, ButilTypeModules? types, out IReadOnlyList<string> unresolved)
+    {
+        var modules = new SortedSet<string>(StringComparer.Ordinal);
+        var missing = new List<string>();
+
+        foreach (var raw in names)
+        {
+            var name = (raw ?? string.Empty).Trim();
+            if (name.Length == 0) continue;
+
+            if (manifest.Dependencies.ContainsKey(name))
+            {
+                modules.Add(name);
+                continue;
+            }
+
+            var fromType = types is null ? [] : types.ForFullName(name);
+            if (fromType.Count == 0 && types is not null) fromType = types.ForName(name);
+
+            if (fromType.Count == 0)
+            {
+                // A last, case-insensitive pass, so that a consumer who wrote the module in the casing of the
+                // class (or the class in the casing of the module) is understood rather than corrected.
+                var module = manifest.Order.FirstOrDefault(candidate => string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase));
+                if (module is not null)
+                {
+                    modules.Add(module);
+                    continue;
+                }
+
+                var type = types?.FullTypeNames.FirstOrDefault(candidate =>
+                    string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(candidate.Substring(candidate.LastIndexOf('.') + 1), name, StringComparison.OrdinalIgnoreCase));
+
+                fromType = type is null ? [] : types!.ForFullName(type);
+            }
+
+            if (fromType.Count == 0) missing.Add(name);
+            else foreach (var module in fromType) modules.Add(module);
+        }
+
+        unresolved = missing;
+        return modules;
+    }
+
+    /// <summary>
     /// Concatenates the chunks of the given modules, in the given order, into a bundle. Chunk files are
     /// <c>&lt;chunksDirectory&gt;/&lt;module&gt;.js</c>.
     /// </summary>

--- a/src/Butil/Bit.Butil.Build/ButilTypeModules.cs
+++ b/src/Butil/Bit.Butil.Build/ButilTypeModules.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bit.Butil.Build;
+
+/// <summary>
+/// Which JavaScript module each <c>Bit.Butil</c> type needs, worked out from the library's own assembly.
+/// </summary>
+/// <remarks>
+/// The publish-time trimming has one signal when ILLink runs - the interop identifiers left in the trimmed
+/// <c>Bit.Butil.dll</c>'s string heap - and needs a different one when it does not, because an untrimmed
+/// <c>Bit.Butil.dll</c> carries every identifier the library has. That other signal is the consumer's own
+/// assemblies: an app that injects <c>Clipboard</c> names the type, and this map says which module answering
+/// that type takes.
+/// <br/>
+/// It cannot be a list of "the type whose name matches the module": <c>LocalStorage</c> carries no
+/// identifiers at all - they live on the <c>ButilStorage</c> base class it inherits - and <c>Window</c>
+/// reaches the <c>events</c> module only through an internal interop class it calls. So the map is a
+/// closure rather than a lookup: a type needs the modules its own method bodies name, plus those of every
+/// type inside Bit.Butil it can reach through a base type, a call, or a field.
+/// <br/>
+/// Over-inclusion is the safe direction and the direction this errs in. A type that merely mentions another
+/// takes on its modules whether or not the path is ever walked at runtime, which costs a consumer some
+/// JavaScript it does not need; the opposite - a module left out of a bundle the app does call into - is
+/// <c>BitButil.x is undefined</c> in a browser, long after publishing.
+/// </remarks>
+public sealed class ButilTypeModules
+{
+    /// <summary>The namespace every public Bit.Butil type sits in, and the prefix its nested ones start with.</summary>
+    public const string Namespace = "Bit.Butil";
+
+    private const int TypeDefTable = 0x02;
+    private const int FieldTable = 0x04;
+    private const int MethodDefTable = 0x06;
+    private const int MemberRefTable = 0x0A;
+    private const int MethodSpecTable = 0x2B;
+    private const int UserStringTable = 0x70;
+
+    private readonly Dictionary<string, SortedSet<string>> _byFullName = new(StringComparer.Ordinal);
+
+    private readonly Dictionary<string, SortedSet<string>> _byName = new(StringComparer.Ordinal);
+
+    private ButilTypeModules()
+    {
+    }
+
+    /// <summary>Every Bit.Butil type name (unqualified) that needs at least one module.</summary>
+    public IEnumerable<string> TypeNames => _byName.Keys;
+
+    /// <summary>Every full type name that needs at least one module, sorted.</summary>
+    public IEnumerable<string> FullTypeNames => _byFullName.Keys.OrderBy(name => name, StringComparer.Ordinal);
+
+    /// <summary>True when the map came out empty, which means the assembly read was not Bit.Butil.</summary>
+    public bool IsEmpty => _byFullName.Count == 0;
+
+    /// <summary>The modules a type needs, by its full name. Empty for a type that calls no JavaScript.</summary>
+    public IReadOnlyCollection<string> ForFullName(string fullName)
+        => _byFullName.TryGetValue(fullName, out var modules) ? modules : (IReadOnlyCollection<string>)Array.Empty<string>();
+
+    /// <summary>
+    /// The modules a type needs, by its unqualified name. Two Bit.Butil types can share one - a nested type
+    /// and a top-level one - and the answer is then the union, which is the safe way round.
+    /// </summary>
+    public IReadOnlyCollection<string> ForName(string name)
+        => _byName.TryGetValue(name, out var modules) ? modules : (IReadOnlyCollection<string>)Array.Empty<string>();
+
+    /// <summary>
+    /// Reads <c>Bit.Butil.dll</c> and works out the map. The assembly must be the untrimmed one the package
+    /// ships: a trimmed copy has already had the identifiers of everything the app does not call removed,
+    /// which is a different question with a different answer.
+    /// </summary>
+    /// <exception cref="System.BadImageFormatException">The file is not a managed assembly, or is malformed.</exception>
+    /// <exception cref="System.IO.IOException">The file could not be read.</exception>
+    public static ButilTypeModules Build(string butilAssemblyPath) => Build(PeImage.Load(butilAssemblyPath));
+
+    public static ButilTypeModules Build(PeImage image)
+    {
+        var tables = MetadataTables.Read(image);
+        var typeCount = tables.TypeDefCount;
+
+        var map = new ButilTypeModules();
+        if (typeCount == 0) return map;
+
+        // Which type owns each method and each field, so a call or a field access can be turned into an edge
+        // between two types.
+        var methodOwner = new int[tables.MethodDefCount + 1];
+        var fieldOwner = new int[tables.RowCount(FieldTable) + 1];
+        for (var type = 1; type <= typeCount; type++)
+        {
+            var (firstMethod, endMethod) = tables.MethodRange(type);
+            for (var method = firstMethod; method < endMethod; method++) methodOwner[method] = type;
+
+            var (firstField, endField) = tables.FieldRange(type);
+            for (var field = firstField; field < endField; field++) fieldOwner[field] = type;
+        }
+
+        var modules = new SortedSet<string>[typeCount + 1];
+        var users = new List<int>[typeCount + 1];
+        for (var type = 1; type <= typeCount; type++)
+        {
+            modules[type] = new SortedSet<string>(StringComparer.Ordinal);
+            users[type] = [];
+        }
+
+        // A type reaches whatever the types nested inside it reach. This is not a nicety about nested public
+        // types: the body of an async method, an iterator or a lambda is compiled into a type nested inside
+        // the one it was written in, so the interop calls of - for one - Window.SubscribeEvent live in a
+        // nested state machine and in nothing the method itself names.
+        for (var row = 1; row <= tables.NestedClassCount; row++)
+        {
+            var (nested, enclosing) = tables.NestedClass(row);
+            if (nested >= 1 && nested <= typeCount && enclosing >= 1 && enclosing <= typeCount && nested != enclosing) users[nested].Add(enclosing);
+        }
+
+        // Modules flow from a type to the types that can reach it, so the edges are recorded the other way
+        // round from how they are found: "t uses u" is stored as "u is used by t".
+        var used = new HashSet<int>();
+
+        void AddMemberRef(int row)
+        {
+            if (row < 1 || row > tables.MemberRefCount) return;
+
+            var parent = tables.MemberRefParent(row);
+            if (parent.Table == TypeDefTable && parent.IsNil is false) used.Add(parent.Row);
+        }
+
+        for (var type = 1; type <= typeCount; type++)
+        {
+            used.Clear();
+
+            var definition = tables.TypeDef(type);
+            if (definition.Extends.Table == TypeDefTable && definition.Extends.IsNil is false) used.Add(definition.Extends.Row);
+
+            var (firstMethod, endMethod) = tables.MethodRange(type);
+            for (var method = firstMethod; method < endMethod; method++)
+            {
+                var owner = type;
+                MethodBody.ReadTokens(image, tables.MethodRva(method), (table, row) =>
+                {
+                    switch (table)
+                    {
+                        case UserStringTable:
+                            if (ButilScriptBundler.TryGetModule(UserStringHeap.ReadAt(image, row), out var module)) modules[owner].Add(module);
+                            break;
+
+                        case TypeDefTable:
+                            if (row >= 1 && row <= typeCount) used.Add(row);
+                            break;
+
+                        case MethodDefTable:
+                            if (row >= 1 && row < methodOwner.Length) used.Add(methodOwner[row]);
+                            break;
+
+                        case FieldTable:
+                            if (row >= 1 && row < fieldOwner.Length) used.Add(fieldOwner[row]);
+                            break;
+
+                        case MemberRefTable:
+                            AddMemberRef(row);
+                            break;
+
+                        // A call to a generic method names a MethodSpec, not the method - so without this
+                        // step every generic call inside the library is a reference nothing can follow.
+                        case MethodSpecTable:
+                            if (row >= 1 && row <= tables.MethodSpecCount)
+                            {
+                                var method = tables.MethodSpecMethod(row);
+                                if (method.Table == MethodDefTable && method.Row >= 1 && method.Row < methodOwner.Length) used.Add(methodOwner[method.Row]);
+                                else if (method.Table == MemberRefTable) AddMemberRef(method.Row);
+                            }
+                            break;
+                    }
+                });
+            }
+
+            foreach (var target in used)
+            {
+                if (target >= 1 && target <= typeCount && target != type) users[target].Add(type);
+            }
+        }
+
+        // Closure by worklist rather than by recursion: the reference graph inside Bit.Butil holds cycles
+        // (a service and the interop class it calls name each other), and a worklist reaches the same fixed
+        // point without having to break them.
+        var pending = new Queue<int>(Enumerable.Range(1, typeCount));
+        var queued = new bool[typeCount + 1];
+        for (var type = 1; type <= typeCount; type++) queued[type] = true;
+
+        while (pending.Count > 0)
+        {
+            var type = pending.Dequeue();
+            queued[type] = false;
+
+            foreach (var user in users[type])
+            {
+                var before = modules[user].Count;
+                modules[user].UnionWith(modules[type]);
+                if (modules[user].Count == before || queued[user]) continue;
+
+                queued[user] = true;
+                pending.Enqueue(user);
+            }
+        }
+
+        for (var type = 1; type <= typeCount; type++)
+        {
+            if (modules[type].Count == 0) continue;
+
+            var name = tables.TypeDef(type).Name;
+
+            // Types outside the library's own namespace are not types a consumer can name. A nested type
+            // carries no namespace of its own (the metadata puts it on the enclosing type), so an empty one
+            // is kept rather than skipped - and the compiler-generated classes that share that shape are
+            // dropped by their names, which no consumer can write and every assembly has some of.
+            if (name.Namespace.Length != 0
+                && string.Equals(name.Namespace, Namespace, StringComparison.Ordinal) is false
+                && name.Namespace.StartsWith(Namespace + ".", StringComparison.Ordinal) is false) continue;
+
+            if (name.Name.IndexOf('<') >= 0 || name.Name.IndexOf('>') >= 0) continue;
+
+            Add(map._byFullName, name.FullName, modules[type]);
+            Add(map._byName, name.Name, modules[type]);
+        }
+
+        return map;
+    }
+
+    private static void Add(Dictionary<string, SortedSet<string>> into, string key, SortedSet<string> values)
+    {
+        if (into.TryGetValue(key, out var existing)) existing.UnionWith(values);
+        else into[key] = new SortedSet<string>(values, StringComparer.Ordinal);
+    }
+}

--- a/src/Butil/Bit.Butil.Build/MetadataTables.cs
+++ b/src/Butil/Bit.Butil.Build/MetadataTables.cs
@@ -1,0 +1,386 @@
+﻿using System;
+
+namespace Bit.Butil.Build;
+
+/// <summary>
+/// The metadata table stream (<c>#~</c>) of a managed assembly, read far enough to answer the two questions
+/// the script trimming asks of an assembly that ILLink never touched: which <c>Bit.Butil</c> types some
+/// consumer assembly names (its <c>TypeRef</c> rows), and which method bodies belong to which type inside
+/// Bit.Butil itself (its <c>TypeDef</c> and <c>MethodDef</c> rows).
+/// </summary>
+/// <remarks>
+/// Deliberately partial. Reaching a table means knowing the row size of every table before it, so a reader
+/// that wanted <c>AssemblyRef</c> (0x23) would have to carry the column layout of all thirty-odd tables in
+/// between - a lot of code whose only use here would be to say which assembly a <c>TypeRef</c> resolves
+/// against. Matching a <c>TypeRef</c> on its namespace and name instead costs nothing and needs only the
+/// tables up to <c>MemberRef</c> (0x0A), which is where this stops. See ECMA-335 II.22 and II.24.2.6.
+/// <br/>
+/// One consequence of stopping there: a <c>MemberRef</c> whose parent is a <c>TypeSpec</c> - a call on a
+/// generic instantiation - cannot be resolved back to the type it instantiates, because that means reading
+/// a signature blob out of a table thirty rows further on. Such a call is only ever a second path to a type
+/// the same method already names some other way, and the module map it feeds is checked against what ILLink
+/// itself concludes (see the repository's trimming harness), so the gap is a measured one rather than an
+/// assumed one.
+/// </remarks>
+public sealed class MetadataTables
+{
+    private const int ModuleTable = 0x00;
+    private const int TypeRefTable = 0x01;
+    private const int TypeDefTable = 0x02;
+    private const int FieldPtrTable = 0x03;
+    private const int FieldTable = 0x04;
+    private const int MethodPtrTable = 0x05;
+    private const int MethodDefTable = 0x06;
+    private const int ParamPtrTable = 0x07;
+    private const int ParamTable = 0x08;
+    private const int InterfaceImplTable = 0x09;
+    private const int MemberRefTable = 0x0A;
+    private const int ConstantTable = 0x0B;
+    private const int CustomAttributeTable = 0x0C;
+    private const int FieldMarshalTable = 0x0D;
+    private const int DeclSecurityTable = 0x0E;
+    private const int ClassLayoutTable = 0x0F;
+    private const int FieldLayoutTable = 0x10;
+    private const int StandAloneSigTable = 0x11;
+    private const int EventMapTable = 0x12;
+    private const int EventPtrTable = 0x13;
+    private const int EventTable = 0x14;
+    private const int PropertyMapTable = 0x15;
+    private const int PropertyPtrTable = 0x16;
+    private const int PropertyTable = 0x17;
+    private const int MethodSemanticsTable = 0x18;
+    private const int MethodImplTable = 0x19;
+    private const int ModuleRefTable = 0x1A;
+    private const int TypeSpecTable = 0x1B;
+    private const int ImplMapTable = 0x1C;
+    private const int FieldRvaTable = 0x1D;
+    private const int EncLogTable = 0x1E;
+    private const int EncMapTable = 0x1F;
+    private const int AssemblyTable = 0x20;
+    private const int AssemblyProcessorTable = 0x21;
+    private const int AssemblyOsTable = 0x22;
+    private const int AssemblyRefTable = 0x23;
+    private const int AssemblyRefProcessorTable = 0x24;
+    private const int AssemblyRefOsTable = 0x25;
+    private const int FileTable = 0x26;
+    private const int ExportedTypeTable = 0x27;
+    private const int ManifestResourceTable = 0x28;
+    private const int NestedClassTable = 0x29;
+    private const int GenericParamTable = 0x2A;
+    private const int MethodSpecTable = 0x2B;
+    private const int GenericParamConstraintTable = 0x2C;
+
+    /// <summary>The last table this reader can lay out; nothing defines one past it.</summary>
+    private const int LastTable = GenericParamConstraintTable;
+
+    private readonly PeImage _image;
+
+    private readonly int[] _rows = new int[64];
+
+    private readonly int[] _rowSize = new int[64];
+
+    private readonly int[] _tableOffset = new int[64];
+
+    private readonly int _stringIndexSize;
+
+    private readonly int _guidIndexSize;
+
+    private readonly int _blobIndexSize;
+
+    private MetadataTables(PeImage image)
+    {
+        _image = image;
+
+        var stream = image.Tables;
+        if (stream.IsEmpty) throw image.Invalid("no metadata table stream");
+
+        // Header: reserved (4), major/minor version (1 each), heap sizes (1), reserved (1), the 64-bit
+        // present-table mask, the 64-bit sorted mask, then one row count per present table.
+        var heapSizes = image.ReadByte(stream.Offset + 6);
+        _stringIndexSize = (heapSizes & 0x01) != 0 ? 4 : 2;
+        _guidIndexSize = (heapSizes & 0x02) != 0 ? 4 : 2;
+        _blobIndexSize = (heapSizes & 0x04) != 0 ? 4 : 2;
+
+        var valid = image.ReadUInt32(stream.Offset + 8) | ((ulong)image.ReadUInt32(stream.Offset + 12) << 32);
+
+        var position = stream.Offset + 24;
+        for (var table = 0; table < 64; table++)
+        {
+            if ((valid & (1UL << table)) == 0) continue;
+
+            _rows[table] = image.ReadInt32(position);
+            position += 4;
+        }
+
+        // An "extra data" word only the edit-and-continue stream shape carries, between the row counts and
+        // the rows themselves. Skipping it keeps every row offset below right for those assemblies too.
+        if ((heapSizes & 0x40) != 0) position += 4;
+
+        // Row sizes, and from them the offset of each table: the tables follow one another in index order, so
+        // a table's offset is where every earlier table's rows end. Every table therefore has to be sized,
+        // including the ones nothing here reads - a single wrong width and every table after it is read at
+        // the wrong offset, which is why the whole of ECMA-335 II.22 is written out rather than the four
+        // tables this actually looks at.
+        _rowSize[ModuleTable] = 2 + _stringIndexSize + (3 * _guidIndexSize);
+        _rowSize[TypeRefTable] = CodedIndexSize(2, ModuleTable, ModuleRefTable, AssemblyRefTable, TypeRefTable) + (2 * _stringIndexSize);
+        _rowSize[TypeDefTable] = 4 + (2 * _stringIndexSize) + CodedIndexSize(2, TypeDefTable, TypeRefTable, TypeSpecTable) + TableIndexSize(FieldTable) + TableIndexSize(MethodDefTable);
+        _rowSize[FieldPtrTable] = TableIndexSize(FieldTable);
+        _rowSize[FieldTable] = 2 + _stringIndexSize + _blobIndexSize;
+        _rowSize[MethodPtrTable] = TableIndexSize(MethodDefTable);
+        _rowSize[MethodDefTable] = 4 + 2 + 2 + _stringIndexSize + _blobIndexSize + TableIndexSize(ParamTable);
+        _rowSize[ParamPtrTable] = TableIndexSize(ParamTable);
+        _rowSize[ParamTable] = 2 + 2 + _stringIndexSize;
+        _rowSize[InterfaceImplTable] = TableIndexSize(TypeDefTable) + CodedIndexSize(2, TypeDefTable, TypeRefTable, TypeSpecTable);
+        _rowSize[MemberRefTable] = MemberRefParentSize + _stringIndexSize + _blobIndexSize;
+        _rowSize[ConstantTable] = 2 + CodedIndexSize(2, FieldTable, ParamTable, PropertyTable) + _blobIndexSize;
+        _rowSize[CustomAttributeTable] = HasCustomAttributeSize + CodedIndexSize(3, MethodDefTable, MemberRefTable) + _blobIndexSize;
+        _rowSize[FieldMarshalTable] = CodedIndexSize(1, FieldTable, ParamTable) + _blobIndexSize;
+        _rowSize[DeclSecurityTable] = 2 + CodedIndexSize(2, TypeDefTable, MethodDefTable, AssemblyTable) + _blobIndexSize;
+        _rowSize[ClassLayoutTable] = 2 + 4 + TableIndexSize(TypeDefTable);
+        _rowSize[FieldLayoutTable] = 4 + TableIndexSize(FieldTable);
+        _rowSize[StandAloneSigTable] = _blobIndexSize;
+        _rowSize[EventMapTable] = TableIndexSize(TypeDefTable) + TableIndexSize(EventTable);
+        _rowSize[EventPtrTable] = TableIndexSize(EventTable);
+        _rowSize[EventTable] = 2 + _stringIndexSize + CodedIndexSize(2, TypeDefTable, TypeRefTable, TypeSpecTable);
+        _rowSize[PropertyMapTable] = TableIndexSize(TypeDefTable) + TableIndexSize(PropertyTable);
+        _rowSize[PropertyPtrTable] = TableIndexSize(PropertyTable);
+        _rowSize[PropertyTable] = 2 + _stringIndexSize + _blobIndexSize;
+        _rowSize[MethodSemanticsTable] = 2 + TableIndexSize(MethodDefTable) + CodedIndexSize(1, EventTable, PropertyTable);
+        _rowSize[MethodImplTable] = TableIndexSize(TypeDefTable) + (2 * MethodDefOrRefSize);
+        _rowSize[ModuleRefTable] = _stringIndexSize;
+        _rowSize[TypeSpecTable] = _blobIndexSize;
+        _rowSize[ImplMapTable] = 2 + CodedIndexSize(1, FieldTable, MethodDefTable) + _stringIndexSize + TableIndexSize(ModuleRefTable);
+        _rowSize[FieldRvaTable] = 4 + TableIndexSize(FieldTable);
+        _rowSize[EncLogTable] = 4 + 4;
+        _rowSize[EncMapTable] = 4;
+        _rowSize[AssemblyTable] = 4 + (4 * 2) + 4 + _blobIndexSize + (2 * _stringIndexSize);
+        _rowSize[AssemblyProcessorTable] = 4;
+        _rowSize[AssemblyOsTable] = 4 + 4 + 4;
+        _rowSize[AssemblyRefTable] = (4 * 2) + 4 + _blobIndexSize + (2 * _stringIndexSize) + _blobIndexSize;
+        _rowSize[AssemblyRefProcessorTable] = 4 + TableIndexSize(AssemblyRefTable);
+        _rowSize[AssemblyRefOsTable] = 4 + 4 + 4 + TableIndexSize(AssemblyRefTable);
+        _rowSize[FileTable] = 4 + _stringIndexSize + _blobIndexSize;
+        _rowSize[ExportedTypeTable] = 4 + 4 + (2 * _stringIndexSize) + ImplementationSize;
+        _rowSize[ManifestResourceTable] = 4 + 4 + _stringIndexSize + ImplementationSize;
+        _rowSize[NestedClassTable] = 2 * TableIndexSize(TypeDefTable);
+        _rowSize[GenericParamTable] = 2 + 2 + CodedIndexSize(1, TypeDefTable, MethodDefTable) + _stringIndexSize;
+        _rowSize[MethodSpecTable] = MethodDefOrRefSize + _blobIndexSize;
+        _rowSize[GenericParamConstraintTable] = TableIndexSize(GenericParamTable) + CodedIndexSize(2, TypeDefTable, TypeRefTable, TypeSpecTable);
+
+        for (var table = ModuleTable; table <= LastTable; table++)
+        {
+            _tableOffset[table] = position;
+            position += _rows[table] * _rowSize[table];
+        }
+
+        // A table past the ones laid out above means an assembly this reader cannot walk. Saying so beats
+        // reading the tables it does know at offsets that are quietly wrong.
+        for (var table = LastTable + 1; table < 64; table++)
+        {
+            if (_rows[table] != 0) throw image.Invalid($"a metadata table (0x{table:X2}) this reader does not know the shape of");
+        }
+
+        if (position > stream.Offset + stream.Size) throw image.Invalid("metadata tables that run past the end of their stream");
+    }
+
+    /// <summary>Reads an image's table stream. Never null; an assembly always has one.</summary>
+    public static MetadataTables Read(PeImage image) => new(image);
+
+    // The coded indexes used by more than one table's layout, named once so the widths cannot drift apart.
+    private int MemberRefParentSize => CodedIndexSize(3, TypeDefTable, TypeRefTable, ModuleRefTable, MethodDefTable, TypeSpecTable);
+
+    private int MethodDefOrRefSize => CodedIndexSize(1, MethodDefTable, MemberRefTable);
+
+    private int ImplementationSize => CodedIndexSize(2, FileTable, AssemblyRefTable, ExportedTypeTable);
+
+    private int HasCustomAttributeSize => CodedIndexSize(5,
+        MethodDefTable, FieldTable, TypeRefTable, TypeDefTable, ParamTable, InterfaceImplTable, MemberRefTable,
+        ModuleTable, DeclSecurityTable, PropertyTable, EventTable, StandAloneSigTable, ModuleRefTable,
+        TypeSpecTable, AssemblyTable, AssemblyRefTable, FileTable, ExportedTypeTable, ManifestResourceTable,
+        GenericParamTable, GenericParamConstraintTable, MethodSpecTable);
+
+    /// <summary>How many rows a table has. Tables the assembly does not carry have none.</summary>
+    public int RowCount(int table) => _rows[table];
+
+    public int TypeRefCount => _rows[TypeRefTable];
+
+    public int TypeDefCount => _rows[TypeDefTable];
+
+    public int MethodDefCount => _rows[MethodDefTable];
+
+    /// <summary>
+    /// One <c>TypeRef</c> row: a type this assembly names but does not define. The resolution scope is
+    /// skipped over rather than resolved - see the remarks on the class.
+    /// </summary>
+    public TypeName TypeRef(int row)
+    {
+        var position = RowStart(TypeRefTable, row) + CodedIndexSize(2, ModuleTable, ModuleRefTable, AssemblyRefTable, TypeRefTable);
+
+        return new TypeName(ReadString(position + _stringIndexSize), ReadString(position));
+    }
+
+    public int MemberRefCount => _rows[MemberRefTable];
+
+    /// <summary>One <c>TypeDef</c> row: a type this assembly defines, and where its members start.</summary>
+    public TypeDefinition TypeDef(int row)
+    {
+        var position = RowStart(TypeDefTable, row);
+        var name = ReadString(position + 4);
+        var space = ReadString(position + 4 + _stringIndexSize);
+
+        var extendsPosition = position + 4 + (2 * _stringIndexSize);
+        var extends = ReadCodedIndex(extendsPosition, 2, TypeDefTable, TypeRefTable, TypeSpecTable);
+
+        var fieldListPosition = extendsPosition + CodedIndexSize(2, TypeDefTable, TypeRefTable, TypeSpecTable);
+        var methodListPosition = fieldListPosition + TableIndexSize(FieldTable);
+
+        return new TypeDefinition(row, new TypeName(space, name), extends,
+            ReadTableIndex(fieldListPosition, FieldTable), ReadTableIndex(methodListPosition, MethodDefTable));
+    }
+
+    /// <summary>
+    /// The row range of a type's methods: from its own <c>MethodList</c> up to the next type's, one-based and
+    /// end-exclusive, which is how ECMA-335 encodes a member list.
+    /// </summary>
+    public (int First, int End) MethodRange(int typeRow) => MemberRange(typeRow, MethodDefTable);
+
+    /// <summary>The row range of a type's fields, on the same one-based, end-exclusive scheme.</summary>
+    public (int First, int End) FieldRange(int typeRow) => MemberRange(typeRow, FieldTable);
+
+    private (int First, int End) MemberRange(int typeRow, int memberTable)
+    {
+        var definition = TypeDef(typeRow);
+        var first = memberTable == FieldTable ? definition.FieldListStart : definition.MethodListStart;
+        var end = _rows[memberTable] + 1;
+
+        if (typeRow < _rows[TypeDefTable])
+        {
+            var next = TypeDef(typeRow + 1);
+            end = memberTable == FieldTable ? next.FieldListStart : next.MethodListStart;
+        }
+
+        if (first < 1) first = 1;
+        if (end > _rows[memberTable] + 1) end = _rows[memberTable] + 1;
+
+        return (first, Math.Max(first, end));
+    }
+
+    /// <summary>The RVA of a method's IL body. Zero for an abstract, extern or runtime-implemented method.</summary>
+    public uint MethodRva(int row) => _image.ReadUInt32(RowStart(MethodDefTable, row));
+
+    /// <summary>
+    /// The type a <c>MemberRef</c> is declared on, when that is a type this assembly defines. Nil for the
+    /// usual case of a member on another assembly's type, and for the generic instantiations this reader
+    /// deliberately does not resolve (see the remarks on the class).
+    /// </summary>
+    public MetadataToken MemberRefParent(int row)
+        => ReadCodedIndex(RowStart(MemberRefTable, row), 3, TypeDefTable, TypeRefTable, ModuleRefTable, MethodDefTable, TypeSpecTable);
+
+    public int MethodSpecCount => _rows[MethodSpecTable];
+
+    /// <summary>
+    /// The method a <c>MethodSpec</c> instantiates. A call to a generic method goes through one of these
+    /// rather than naming the method directly, so without this a generic call is a reference the walk cannot
+    /// see - and inside this library those are the calls that reach the internal interop classes.
+    /// </summary>
+    public MetadataToken MethodSpecMethod(int row)
+        => ReadCodedIndex(RowStart(MethodSpecTable, row), 1, MethodDefTable, MemberRefTable);
+
+    public int NestedClassCount => _rows[NestedClassTable];
+
+    /// <summary>
+    /// One <c>NestedClass</c> row as (nested, enclosing) <c>TypeDef</c> rows. The compiler puts an async
+    /// method's state machine, an iterator's, and a lambda's closure in a type nested inside the one whose
+    /// source they came from - and those bodies are where the calls really live, so a walk that stops at the
+    /// enclosing type sees a method that does nothing.
+    /// </summary>
+    public (int Nested, int Enclosing) NestedClass(int row)
+    {
+        var position = RowStart(NestedClassTable, row);
+
+        return (ReadTableIndex(position, TypeDefTable), ReadTableIndex(position + TableIndexSize(TypeDefTable), TypeDefTable));
+    }
+
+    private int RowStart(int table, int row)
+    {
+        if (row < 1 || row > _rows[table]) throw _image.Invalid($"a row index outside metadata table 0x{table:X2}");
+
+        return _tableOffset[table] + ((row - 1) * _rowSize[table]);
+    }
+
+    private string ReadString(int position)
+        => _image.ReadHeapString(_stringIndexSize == 2 ? _image.ReadUInt16(position) : _image.ReadInt32(position));
+
+    private int TableIndexSize(int table) => _rows[table] < 65536 ? 2 : 4;
+
+    private int ReadTableIndex(int position, int table)
+        => TableIndexSize(table) == 2 ? _image.ReadUInt16(position) : _image.ReadInt32(position);
+
+    /// <summary>
+    /// A coded index is a row number with the table it points into packed into its low bits, so its width is
+    /// decided by the largest of the tables it can reach (ECMA-335 II.24.2.6).
+    /// </summary>
+    private int CodedIndexSize(int tagBits, params int[] tables)
+    {
+        var largest = 0;
+        foreach (var table in tables) largest = Math.Max(largest, _rows[table]);
+
+        return largest < 1 << (16 - tagBits) ? 2 : 4;
+    }
+
+    private MetadataToken ReadCodedIndex(int position, int tagBits, params int[] tables)
+    {
+        var raw = CodedIndexSize(tagBits, tables) == 2 ? _image.ReadUInt16(position) : (uint)_image.ReadInt32(position);
+        var tag = (int)(raw & ((1u << tagBits) - 1));
+
+        return tag >= tables.Length
+            ? default
+            : new MetadataToken(tables[tag], (int)(raw >> tagBits));
+    }
+}
+
+/// <summary>A type's namespace and name, as the metadata spells them.</summary>
+public readonly struct TypeName(string @namespace, string name) : IEquatable<TypeName>
+{
+    public string Namespace { get; } = @namespace ?? string.Empty;
+
+    public string Name { get; } = name ?? string.Empty;
+
+    public string FullName => Namespace.Length == 0 ? Name : Namespace + "." + Name;
+
+    public bool Equals(TypeName other)
+        => string.Equals(Namespace, other.Namespace, StringComparison.Ordinal) && string.Equals(Name, other.Name, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is TypeName other && Equals(other);
+
+    public override int GetHashCode() => (Namespace.GetHashCode() * 397) ^ Name.GetHashCode();
+
+    public override string ToString() => FullName;
+}
+
+/// <summary>A metadata table and a one-based row in it. Row 0 means "nothing".</summary>
+public readonly struct MetadataToken(int table, int row)
+{
+    public int Table { get; } = table;
+
+    public int Row { get; } = row;
+
+    public bool IsNil => Row == 0;
+}
+
+/// <summary>One <c>TypeDef</c> row, in the terms the module map needs.</summary>
+public readonly struct TypeDefinition(int row, TypeName name, MetadataToken extends, int fieldListStart, int methodListStart)
+{
+    public int Row { get; } = row;
+
+    public TypeName Name { get; } = name;
+
+    /// <summary>The base type. Nil for <c>System.Object</c> and for interfaces.</summary>
+    public MetadataToken Extends { get; } = extends;
+
+    /// <summary>The one-based <c>Field</c> row this type's fields start at.</summary>
+    public int FieldListStart { get; } = fieldListStart;
+
+    /// <summary>The one-based <c>MethodDef</c> row this type's methods start at.</summary>
+    public int MethodListStart { get; } = methodListStart;
+}

--- a/src/Butil/Bit.Butil.Build/MethodBody.cs
+++ b/src/Butil/Bit.Butil.Build/MethodBody.cs
@@ -56,7 +56,7 @@ public static class MethodBody
             0x70, 0x71, 0x72, 0x73, 0x74, 0x75,                                     // cpobj, ldobj, ldstr, newobj, castclass, isinst
             0x79,                                                                   // unbox
             0x7B, 0x7C, 0x7D, 0x7E, 0x7F, 0x80, 0x81,                               // ldfld .. stobj
-            0x8D, 0x8F,                                                             // newarr, ldelema
+            0x8C, 0x8D, 0x8F,                                                       // box, newarr, ldelema
             0xA3, 0xA4, 0xA5,                                                       // ldelem, stelem, unbox.any
             0xC2, 0xC6,                                                             // refanyval, mkrefany
             0xD0,                                                                   // ldtoken

--- a/src/Butil/Bit.Butil.Build/MethodBody.cs
+++ b/src/Butil/Bit.Butil.Build/MethodBody.cs
@@ -1,0 +1,168 @@
+﻿using System;
+
+namespace Bit.Butil.Build;
+
+/// <summary>
+/// Walks a method's IL and hands back the metadata tokens its instructions carry - the string literals it
+/// loads and the types, fields and methods it names.
+/// </summary>
+/// <remarks>
+/// A real instruction walk rather than a scan for byte patterns, because the byte that means <c>ldstr</c>
+/// also occurs inside other instructions' operands: a pattern match would invent calls into modules the
+/// method never mentions, and every one of those is JavaScript a consumer ships for nothing. Walking means
+/// knowing how long each instruction is, which is the table below (ECMA-335 III, Partition VI Appendix C).
+/// </remarks>
+public static class MethodBody
+{
+    /// <summary>Operand length in bytes; <see cref="Switch"/> for the one instruction of variable length.</summary>
+    private const int Switch = -1;
+
+    private static readonly int[] OneByteOperand = new int[256];
+
+    private static readonly bool[] OneByteToken = new bool[256];
+
+    private static readonly int[] TwoByteOperand = new int[32];
+
+    private static readonly bool[] TwoByteToken = new bool[32];
+
+    static MethodBody()
+    {
+        // Everything not named below has no operand at all, which is the array's default.
+        foreach (var opcode in new[]
+        {
+            0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13,                                     // ldarg.s .. stloc.s
+            0x1F,                                                                   // ldc.i4.s
+            0x2B, 0x2C, 0x2D,                                                       // br.s, brfalse.s, brtrue.s
+            0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,             // beq.s .. blt.un.s
+            0xDE,                                                                   // leave.s
+        }) OneByteOperand[opcode] = 1;
+
+        foreach (var opcode in new[]
+        {
+            0x20, 0x22,                                                             // ldc.i4, ldc.r4
+            0x38, 0x39, 0x3A,                                                       // br, brfalse, brtrue
+            0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44,             // beq .. blt.un
+            0xDD,                                                                   // leave
+        }) OneByteOperand[opcode] = 4;
+
+        OneByteOperand[0x21] = 8; // ldc.i8
+        OneByteOperand[0x23] = 8; // ldc.r8
+        OneByteOperand[0x45] = Switch;
+
+        foreach (var opcode in new[]
+        {
+            0x27, 0x28, 0x29,                                                       // jmp, call, calli
+            0x6F,                                                                   // callvirt
+            0x70, 0x71, 0x72, 0x73, 0x74, 0x75,                                     // cpobj, ldobj, ldstr, newobj, castclass, isinst
+            0x79,                                                                   // unbox
+            0x7B, 0x7C, 0x7D, 0x7E, 0x7F, 0x80, 0x81,                               // ldfld .. stobj
+            0x8D, 0x8F,                                                             // newarr, ldelema
+            0xA3, 0xA4, 0xA5,                                                       // ldelem, stelem, unbox.any
+            0xC2, 0xC6,                                                             // refanyval, mkrefany
+            0xD0,                                                                   // ldtoken
+        })
+        {
+            OneByteOperand[opcode] = 4;
+            OneByteToken[opcode] = true;
+        }
+
+        foreach (var opcode in new[] { 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E }) TwoByteOperand[opcode] = 2; // ldarg .. stloc
+        foreach (var opcode in new[] { 0x12, 0x19 }) TwoByteOperand[opcode] = 1;                          // unaligned., no.
+
+        foreach (var opcode in new[] { 0x06, 0x07, 0x15, 0x16, 0x1C })                                    // ldftn, ldvirtftn, initobj, constrained., sizeof
+        {
+            TwoByteOperand[opcode] = 4;
+            TwoByteToken[opcode] = true;
+        }
+    }
+
+    /// <summary>
+    /// Calls back once per metadata token the body carries. A <c>ldstr</c> comes through with table
+    /// <c>0x70</c>, whose "row" is a byte offset into the <c>#US</c> heap rather than a row number - that is
+    /// how string tokens are encoded, and the caller reads it back through
+    /// <see cref="UserStringHeap.ReadAt(PeImage, int)"/>.
+    /// </summary>
+    /// <param name="image">The assembly the body lives in.</param>
+    /// <param name="rva">The method's RVA, from <see cref="MetadataTables.MethodRva"/>. Zero means no body.</param>
+    /// <param name="onToken">Receives the token's table byte and its row (or heap offset).</param>
+    public static void ReadTokens(PeImage image, uint rva, Action<int, int> onToken)
+    {
+        if (rva == 0) return;
+
+        var body = image.ResolveRva(rva);
+        var header = image.ReadByte(body);
+
+        int code;
+        int size;
+        switch (header & 0x03)
+        {
+            case 0x02: // tiny: the length lives in the top six bits of the one header byte
+                code = body + 1;
+                size = header >> 2;
+                break;
+
+            case 0x03: // fat: a header whose own length is in the top four bits of its first word
+                var flags = image.ReadUInt16(body);
+                var headerSize = (flags >> 12) * 4;
+                if (headerSize < 12) throw image.Invalid("a fat method header shorter than the format allows");
+                code = body + headerSize;
+                size = image.ReadInt32(body + 4);
+                break;
+
+            default:
+                throw image.Invalid("a method body with neither a tiny nor a fat header");
+        }
+
+        if (size < 0 || size > image.Image.Length - code) throw image.Invalid("a method body that runs past the end of the file");
+
+        var end = code + size;
+        var position = code;
+
+        while (position < end)
+        {
+            var opcode = image.ReadByte(position);
+            position++;
+
+            int operand;
+            bool carriesToken;
+
+            if (opcode == 0xFE)
+            {
+                var second = image.ReadByte(position);
+                position++;
+
+                // Anything past the two-byte opcodes the table covers is not a real instruction; stopping is
+                // safer than guessing a length and walking the rest of the body out of step.
+                if (second >= TwoByteOperand.Length) return;
+
+                operand = TwoByteOperand[second];
+                carriesToken = TwoByteToken[second];
+            }
+            else
+            {
+                operand = OneByteOperand[opcode];
+                carriesToken = OneByteToken[opcode];
+            }
+
+            if (operand == Switch)
+            {
+                var cases = image.ReadInt32(position);
+                position += 4;
+                if (cases < 0 || cases > (end - position) / 4) return;
+
+                position += cases * 4;
+                continue;
+            }
+
+            if (position + operand > end) return;
+
+            if (carriesToken)
+            {
+                var token = image.ReadUInt32(position);
+                onToken((int)(token >> 24), (int)(token & 0x00FFFFFF));
+            }
+
+            position += operand;
+        }
+    }
+}

--- a/src/Butil/Bit.Butil.Build/PeImage.cs
+++ b/src/Butil/Bit.Butil.Build/PeImage.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Bit.Butil.Build;
+
+/// <summary>
+/// A managed assembly opened for reading: the PE headers walked as far as the metadata root, and the
+/// metadata streams (<c>#US</c>, <c>#Strings</c>, <c>#~</c>) located within it.
+/// </summary>
+/// <remarks>
+/// Hand-rolled, rather than through <c>System.Reflection.Metadata</c>, because this code runs inside MSBuild:
+/// a task assembly that carries a metadata-reader dependency has to agree with the copy MSBuild already
+/// loaded, and the two MSBuild flavours (the dotnet CLI's, and Visual Studio's .NET Framework msbuild.exe with
+/// its own binding redirects) ship different versions of it. Depending on nothing keeps the task loadable
+/// everywhere. What is parsed here is a fixed, decades-old on-disk layout - PE headers, the CLI header, the
+/// metadata root, the stream headers - specified in ECMA-335 II.24-25, so there is no moving target.
+/// <br/>
+/// Every read is bounds-checked against the file and every malformed input comes out as a
+/// <see cref="BadImageFormatException"/> naming the file, because the callers are build tasks: a consumer's
+/// publish has to be told which file it could not read, not handed an <c>IndexOutOfRangeException</c>.
+/// </remarks>
+public sealed class PeImage
+{
+    private PeImage(string path, byte[] image)
+    {
+        Path = path;
+        Image = image;
+    }
+
+    /// <summary>The file the image was read from, used in every error message.</summary>
+    public string Path { get; }
+
+    /// <summary>The whole file.</summary>
+    public byte[] Image { get; }
+
+    /// <summary>The <c>#US</c> heap: every string literal the method bodies can still reach.</summary>
+    public MetadataHeap UserStrings { get; private set; }
+
+    /// <summary>The <c>#Strings</c> heap: every name in the metadata - types, members, namespaces.</summary>
+    public MetadataHeap Strings { get; private set; }
+
+    /// <summary>The <c>#~</c> stream: the metadata tables.</summary>
+    public MetadataHeap Tables { get; private set; }
+
+    private int _sectionHeaders;
+
+    private int _sections;
+
+    /// <summary>
+    /// Reads a managed assembly from disk and locates its metadata streams. A stream the assembly does not
+    /// have (an assembly whose method bodies hold no string literal has no <c>#US</c>) comes back empty.
+    /// </summary>
+    /// <exception cref="BadImageFormatException">The file is not a managed PE image, or is malformed.</exception>
+    /// <exception cref="IOException">The file could not be read.</exception>
+    public static PeImage Load(string path)
+    {
+        var image = new PeImage(path, File.ReadAllBytes(path));
+        image.FindStreams();
+        return image;
+    }
+
+    /// <summary>Walks PE header -&gt; CLI header -&gt; metadata root -&gt; the stream headers.</summary>
+    private void FindStreams()
+    {
+        // MS-DOS header: the PE signature's file offset lives at 0x3C.
+        if (Image.Length < 0x40 || Image[0] != 'M' || Image[1] != 'Z') throw Invalid("not a PE image");
+
+        var peHeader = ReadInt32(0x3C);
+        if (ReadUInt32(peHeader) != 0x00004550) throw Invalid("not a PE image"); // "PE\0\0"
+
+        // COFF header: 20 bytes, of which the section count and the size of the optional header matter here.
+        var coffHeader = peHeader + 4;
+        _sections = ReadUInt16(coffHeader + 2);
+        int optionalHeaderSize = ReadUInt16(coffHeader + 16);
+        var optionalHeader = coffHeader + 20;
+
+        // The data directories sit at a magic-dependent offset inside the optional header; the CLI header is
+        // directory 14 (ECMA-335 II.25.2.3.3).
+        var magic = ReadUInt16(optionalHeader);
+        var directories = optionalHeader + magic switch
+        {
+            0x10B => 96,  // PE32
+            0x20B => 112, // PE32+
+            _ => throw Invalid("unknown PE optional header format")
+        };
+
+        _sectionHeaders = optionalHeader + optionalHeaderSize;
+        var cliHeaderRva = ReadUInt32(directories + (14 * 8));
+        if (cliHeaderRva == 0) throw Invalid("not a managed assembly (no CLI header)");
+
+        // CLI header: the metadata root's RVA is at offset 8 (after Cb and the two runtime version numbers).
+        var cliHeader = ResolveRva(cliHeaderRva);
+        var metadata = ResolveRva(ReadUInt32(cliHeader + 8));
+
+        if (ReadUInt32(metadata) != 0x424A5342) throw Invalid("the metadata root is not a 'BSJB' signature"); // "BSJB"
+
+        // Metadata root: signature, two version numbers, reserved, then the length-prefixed version string
+        // padded to a 4-byte boundary, then flags and the stream count.
+        var versionLength = ReadInt32(metadata + 12);
+        if (versionLength < 0) throw Invalid("a negative metadata version length");
+
+        // Step by step, so that a hostile length cannot overflow the padding or the offsets built on it back
+        // into range: bound the raw length against what is left of the file first, then its padded form.
+        if (versionLength > Image.Length - metadata - 16) throw Invalid("a metadata version string that runs past the end of the file");
+        var versionSize = Align4(versionLength);
+        if (versionSize > Image.Length - metadata - 16) throw Invalid("a metadata version string that runs past the end of the file");
+
+        var streamCount = ReadUInt16(metadata + 16 + versionSize + 2);
+        var streamHeader = metadata + 16 + versionSize + 4;
+
+        for (var i = 0; i < streamCount; i++)
+        {
+            var offset = ReadInt32(streamHeader);
+            var size = ReadInt32(streamHeader + 4);
+            var name = ReadStreamName(streamHeader + 8, out var nameLength);
+
+            switch (name)
+            {
+                case "#US": UserStrings = Bound(metadata, offset, size, "#US heap"); break;
+                case "#Strings": Strings = Bound(metadata, offset, size, "#Strings heap"); break;
+                case "#~": case "#-": Tables = Bound(metadata, offset, size, "metadata table stream"); break;
+            }
+
+            streamHeader += 8 + nameLength;
+        }
+    }
+
+    /// <summary>A stream's extent as a file offset, checked against the file it claims to sit in.</summary>
+    private MetadataHeap Bound(int metadata, int offset, int size, string name)
+    {
+        // Step by step, so that a hostile offset or size cannot overflow the sum back into range.
+        if (offset < 0 || offset > Image.Length - metadata) throw Invalid($"the {name} runs past the end of the file");
+        if (size < 0 || size > Image.Length - metadata - offset) throw Invalid($"the {name} runs past the end of the file");
+
+        return new MetadataHeap(metadata + offset, size);
+    }
+
+    /// <summary>A stream header's name: null-terminated ASCII, padded to a 4-byte boundary.</summary>
+    private string ReadStreamName(int position, out int paddedLength)
+    {
+        var length = 0;
+        while (position + length < Image.Length && Image[position + length] != 0) length++;
+        if (position + length >= Image.Length) throw Invalid("an unterminated metadata stream name");
+
+        paddedLength = Align4(length + 1);
+        return Encoding.ASCII.GetString(Image, position, length);
+    }
+
+    /// <summary>The file offset a relative virtual address points at, through the section table.</summary>
+    public int ResolveRva(uint rva)
+    {
+        for (var i = 0; i < _sections; i++)
+        {
+            // Section header: name (8 bytes), virtual size, virtual address, raw size, raw pointer.
+            var header = _sectionHeaders + (i * 40);
+            var virtualSize = ReadUInt32(header + 8);
+            var virtualAddress = ReadUInt32(header + 12);
+            var rawSize = ReadUInt32(header + 16);
+            var rawPointer = ReadUInt32(header + 20);
+
+            // A section's mapped size can exceed what is stored on disk (zero-filled tail), and can also be
+            // rounded up to the file alignment - take the larger of the two so neither case misses.
+            if (rva < virtualAddress || rva >= virtualAddress + Math.Max(virtualSize, rawSize)) continue;
+
+            var offset = rawPointer + (rva - virtualAddress);
+            if (offset >= (uint)Image.Length) throw Invalid("a section points past the end of the file");
+
+            return (int)offset;
+        }
+
+        throw Invalid($"the RVA 0x{rva:X} is not inside any section");
+    }
+
+    /// <summary>
+    /// The UTF-8 string starting at an offset into the <c>#Strings</c> heap, up to its null terminator.
+    /// Index 0 is the empty string.
+    /// </summary>
+    public string ReadHeapString(int index)
+    {
+        if (index < 0 || index >= Strings.Size) throw Invalid("a name index outside the #Strings heap");
+
+        var start = Strings.Offset + index;
+        var end = start;
+        var limit = Strings.Offset + Strings.Size;
+        while (end < limit && Image[end] != 0) end++;
+
+        return Encoding.UTF8.GetString(Image, start, end - start);
+    }
+
+    public static int Align4(int value) => (value + 3) & ~3;
+
+    public byte ReadByte(int position)
+    {
+        if (position < 0 || position >= Image.Length) throw Invalid("a header points past the end of the file");
+
+        return Image[position];
+    }
+
+    public ushort ReadUInt16(int position)
+        => (ushort)(ReadByte(position) | (ReadByte(position + 1) << 8));
+
+    public uint ReadUInt32(int position)
+        => (uint)(ReadByte(position)
+            | (ReadByte(position + 1) << 8)
+            | (ReadByte(position + 2) << 16)
+            | (ReadByte(position + 3) << 24));
+
+    public int ReadInt32(int position)
+    {
+        var value = ReadUInt32(position);
+        if (value > int.MaxValue) throw Invalid("an out-of-range offset");
+
+        return (int)value;
+    }
+
+    public BadImageFormatException Invalid(string reason)
+        => new($"'{Path}' could not be read as a managed assembly: {reason}.");
+}
+
+/// <summary>The file offset and size of one metadata stream. A stream the image does not have is empty.</summary>
+public readonly struct MetadataHeap(int offset, int size)
+{
+    public int Offset { get; } = offset;
+
+    public int Size { get; } = size;
+
+    public bool IsEmpty => Size == 0;
+}

--- a/src/Butil/Bit.Butil.Build/TrimButilScripts.cs
+++ b/src/Butil/Bit.Butil.Build/TrimButilScripts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -7,23 +8,43 @@ using Microsoft.Build.Utilities;
 namespace Bit.Butil.Build;
 
 /// <summary>
-/// Works out which JavaScript modules a trimmed <c>Bit.Butil.dll</c> still calls, and assembles a
+/// Works out which JavaScript modules a consumer's app can still call, and assembles a
 /// <c>bit-butil.js</c> holding only those. Runs in a consumer's publish; wired up by
 /// <c>buildTransitive/Bit.Butil.targets</c>, which also uses <see cref="IncludedModules"/> to decide which
 /// per-module files an app publishing that shape of the scripts still needs.
 /// </summary>
 /// <remarks>
-/// The task is deliberately forgiving: when there is no trimmed assembly to read (the publish is not
-/// trimmed, or trimming did not touch Bit.Butil) it sets <see cref="Skipped"/> and writes nothing, and the
-/// consumer keeps the full set the package ships. Only a genuinely broken input - a manifest that does not
-/// parse, a chunk that is missing - fails the build, because a silently wrong bundle would surface as
+/// Three signals feed the answer, and the targets decide which are in play:
+/// <list type="bullet">
+/// <item><see cref="TrimmedAssembly"/> - the interop identifiers ILLink left in a trimmed
+/// <c>Bit.Butil.dll</c>. The most precise of the three, and the only one on offer when the publish is
+/// trimmed.</item>
+/// <item><see cref="ScanMode"/> over <see cref="ScanAssemblies"/> - the Bit.Butil types the app's own
+/// assemblies reference, for a publish ILLink never touched.</item>
+/// <item><see cref="ExplicitModules"/> - what the consumer wrote in their csproj, always added to whatever
+/// the other two found.</item>
+/// </list>
+/// The task is deliberately forgiving: when the signal it was told to use is not there (a trimmed publish
+/// whose ILLink never reached Bit.Butil, a scan that found no assembly referencing the library) it sets
+/// <see cref="Skipped"/> and writes nothing, and the consumer keeps the full set the package ships. Only a
+/// genuinely broken input - a manifest that does not parse, a chunk that is missing, a module name that
+/// names nothing - fails the build, because a silently wrong bundle would surface as
 /// "BitButil.x is undefined" in a browser long after publishing.
 /// </remarks>
 public sealed class TrimButilScripts : Task
 {
-    /// <summary>The trimmed <c>Bit.Butil.dll</c>, normally <c>$(IntermediateLinkDir)Bit.Butil.dll</c>.</summary>
-    [Required]
+    /// <summary>
+    /// The trimmed <c>Bit.Butil.dll</c>, normally <c>$(IntermediateLinkDir)Bit.Butil.dll</c>. Empty when the
+    /// publish is not trimmed, which is what puts the scan below in play instead.
+    /// </summary>
     public string TrimmedAssembly { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The untrimmed <c>Bit.Butil.dll</c> the app references. Read to work out which module each Bit.Butil
+    /// class needs, which is what a scan - and a consumer naming classes rather than modules - resolves
+    /// against. Not needed when ILLink supplies the answer and the csproj names modules by their own names.
+    /// </summary>
+    public string ButilAssembly { get; set; } = string.Empty;
 
     /// <summary>The folder holding one <c>&lt;module&gt;.js</c> chunk per module (shipped in the package).</summary>
     [Required]
@@ -32,6 +53,21 @@ public sealed class TrimButilScripts : Task
     /// <summary>The <c>manifest.txt</c> emitted next to the chunks by Bit.Butil's build.</summary>
     [Required]
     public string ManifestPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How to read the consumer's own assemblies: <c>None</c> (the default), <c>TypeNames</c> or
+    /// <c>TypeReferences</c>. See <see cref="ButilScanMode"/>.
+    /// </summary>
+    public string ScanMode { get; set; } = nameof(ButilScanMode.None);
+
+    /// <summary>The assemblies to scan. Anything that is not a managed assembly is passed over.</summary>
+    public ITaskItem[] ScanAssemblies { get; set; } = [];
+
+    /// <summary>
+    /// Modules or Bit.Butil class names the consumer named in their csproj. Added to whatever the other
+    /// signals found, never instead of them.
+    /// </summary>
+    public ITaskItem[] ExplicitModules { get; set; } = [];
 
     /// <summary>
     /// Where to write the trimmed bundle. Optional: left empty, no bundle is written and the task only
@@ -43,27 +79,110 @@ public sealed class TrimButilScripts : Task
     [Output]
     public ITaskItem[] IncludedModules { get; set; } = [];
 
-    /// <summary>The modules the trimmed assembly calls directly (before closing over dependencies).</summary>
+    /// <summary>The modules the app calls directly (before closing over dependencies).</summary>
     [Output]
     public ITaskItem[] ReferencedModules { get; set; } = [];
 
-    /// <summary>True when no bundle was written because there was no trimmed assembly to read.</summary>
+    /// <summary>True when no bundle was written because there was no signal to work from.</summary>
     [Output]
     public bool Skipped { get; set; }
 
     public override bool Execute()
     {
-        if (File.Exists(TrimmedAssembly) is false)
-        {
-            Log.LogMessage(MessageImportance.Normal, $"Bit.Butil: no trimmed assembly at '{TrimmedAssembly}', keeping the full bit-butil.js.");
-            Skipped = true;
-            return true;
-        }
+        if (TryParseScanMode(out var mode) is false) return false;
 
         try
         {
             var manifest = ButilScriptBundler.ReadManifest(ManifestPath);
-            var referenced = ButilScriptBundler.ReadReferencedModules(TrimmedAssembly);
+            var referenced = new SortedSet<string>(StringComparer.Ordinal);
+            var explicitNames = ExplicitModules.Select(item => item.ItemSpec).Where(name => string.IsNullOrWhiteSpace(name) is false).ToArray();
+
+            // The type map is what turns a class name into modules. Built once, and only when something
+            // actually asks for it: a trimmed publish whose csproj names modules by their own names needs no
+            // map at all, and reading Bit.Butil.dll for nothing would be a cost on every such publish.
+            ButilTypeModules? types = null;
+            var typesRead = false;
+
+            ButilTypeModules? Types()
+            {
+                if (typesRead) return types;
+
+                typesRead = true;
+                if (string.IsNullOrEmpty(ButilAssembly) || File.Exists(ButilAssembly) is false)
+                {
+                    Log.LogMessage(MessageImportance.Normal, $"Bit.Butil: no untrimmed assembly at '{ButilAssembly}' to read the class-to-module map from.");
+                    return null;
+                }
+
+                types = ButilTypeModules.Build(ButilAssembly);
+                return types.IsEmpty ? null : types;
+            }
+
+            // Signal one: what ILLink left behind. In play whenever the targets passed a path at all, and a
+            // path that is not there means the publish was set up to be trimmed but Bit.Butil was not - the
+            // full bundle is then the only safe answer, whatever else the csproj said.
+            if (string.IsNullOrEmpty(TrimmedAssembly) is false)
+            {
+                if (File.Exists(TrimmedAssembly) is false)
+                {
+                    Log.LogMessage(MessageImportance.Normal, $"Bit.Butil: no trimmed assembly at '{TrimmedAssembly}', keeping the full bit-butil.js.");
+                    Skipped = true;
+                    return true;
+                }
+
+                referenced.UnionWith(ButilScriptBundler.ReadReferencedModules(TrimmedAssembly));
+            }
+            // Signal two: which Bit.Butil types the app's own assemblies name. Only ever reached for an
+            // untrimmed publish - the targets do not set ScanMode when ILLink is in play, because the
+            // identifiers ILLink leaves are the better answer to the same question.
+            else if (mode != ButilScanMode.None)
+            {
+                var map = Types();
+                if (map is null)
+                {
+                    Log.LogError($"Bit.Butil: <BitButilScriptScan>{ScanMode}</BitButilScriptScan> needs to read the untrimmed Bit.Butil.dll to know which module each class uses, and '{ButilAssembly}' could not be read. Set <BitButilScriptScan>None</BitButilScriptScan> to publish the full bundle instead.");
+                    return false;
+                }
+
+                var scan = ButilConsumerScan.Scan(ScanAssemblies.Select(item => item.ItemSpec), map, mode);
+                if (scan.Scanned.Count == 0)
+                {
+                    // Every app that can call into Bit.Butil references it, so finding nothing means the list
+                    // of assemblies was not the app's. Trimming on that would drop every module.
+                    Log.LogWarning(null, "BUTIL002", null, null, 0, 0, 0, 0,
+                        $"Bit.Butil: none of the {ScanAssemblies.Length} assemblies scanned references Bit.Butil, so there is nothing to work out which JavaScript this app uses from; keeping the full bit-butil.js. Set <BitButilScriptScanAssemblies> to the app's own assemblies, or <BitButilScriptScan>None</BitButilScriptScan> to silence this.");
+                    Skipped = true;
+                    return true;
+                }
+
+                referenced.UnionWith(scan.Modules);
+                Log.LogMessage(MessageImportance.Normal,
+                    $"Bit.Butil: scanned {scan.Scanned.Count} assembly(s) referencing Bit.Butil and found {scan.Types.Count} Bit.Butil type(s): {string.Join(", ", scan.Types)}.");
+            }
+
+            // Signal three: the csproj, always added on top. It is how an app keeps a module it reaches in a
+            // way none of the above can see - through reflection, or from JavaScript of its own.
+            if (explicitNames.Length > 0)
+            {
+                var chosen = ButilScriptBundler.ResolveNames(explicitNames, manifest, Types(), out var unresolved);
+                if (unresolved.Count > 0)
+                {
+                    Log.LogError($"Bit.Butil: <BitButilScriptModule> names {string.Join(", ", unresolved.Select(name => $"'{name}'"))}, which is neither a JavaScript module nor a Bit.Butil class. The modules are: {string.Join(", ", manifest.Order)}.");
+                    return false;
+                }
+
+                referenced.UnionWith(chosen);
+            }
+
+            // Nothing to go on: no ILLink, no scan, no csproj. Publishing the full set is the only answer
+            // that cannot be wrong.
+            if (string.IsNullOrEmpty(TrimmedAssembly) && mode == ButilScanMode.None && explicitNames.Length == 0)
+            {
+                Log.LogMessage(MessageImportance.Normal, "Bit.Butil: nothing says which JavaScript this app uses, keeping the full bit-butil.js.");
+                Skipped = true;
+                return true;
+            }
+
             var included = ButilScriptBundler.Resolve(manifest, referenced, out var unknown);
 
             foreach (var module in unknown)
@@ -73,7 +192,7 @@ public sealed class TrimButilScripts : Task
                 // Carries a code so a consumer can silence it the usual way ($(NoWarn), or a warning-as-error
                 // policy) without having to turn the whole trimming off.
                 Log.LogWarning(null, "BUTIL001", null, null, 0, 0, 0, 0,
-                    $"Bit.Butil: the trimmed app calls 'BitButil.{module}.*' but no such JavaScript module exists in this version of Bit.Butil.");
+                    $"Bit.Butil: the app calls 'BitButil.{module}.*' but no such JavaScript module exists in this version of Bit.Butil.");
             }
 
             if (string.IsNullOrEmpty(OutputPath) is false) ButilScriptBundler.WriteBundle(ChunksDirectory, included, OutputPath);
@@ -82,7 +201,7 @@ public sealed class TrimButilScripts : Task
             IncludedModules = included.Select(module => (ITaskItem)new TaskItem(module)).ToArray();
 
             var what = string.IsNullOrEmpty(OutputPath)
-                ? $"the trimmed app can reach {included.Count} of {manifest.Order.Count} modules"
+                ? $"the app can reach {included.Count} of {manifest.Order.Count} modules"
                 : $"bit-butil.js trimmed to {included.Count} of {manifest.Order.Count} modules ({new FileInfo(OutputPath).Length:N0} bytes)";
 
             Log.LogMessage(MessageImportance.High, $"Bit.Butil: {what}: {string.Join(", ", included)}");
@@ -93,5 +212,20 @@ public sealed class TrimButilScripts : Task
             Log.LogError($"Bit.Butil: could not assemble the trimmed bit-butil.js - {exception.Message} Set <BitButilTrimScripts>false</BitButilTrimScripts> to publish the full bundle instead.");
             return false;
         }
+    }
+
+    /// <summary>
+    /// The scan mode as the csproj spelled it. An unknown one is an error rather than a silent <c>None</c>:
+    /// a consumer who misspelled the mode asked for trimming and would otherwise get none, with nothing said.
+    /// </summary>
+    private bool TryParseScanMode(out ButilScanMode mode)
+    {
+        mode = ButilScanMode.None;
+        if (string.IsNullOrWhiteSpace(ScanMode)) return true;
+
+        if (Enum.TryParse(ScanMode.Trim(), ignoreCase: true, out mode) && Enum.IsDefined(typeof(ButilScanMode), mode)) return true;
+
+        Log.LogError($"Bit.Butil: '{ScanMode}' is not a value of <BitButilScriptScan>; it is one of {string.Join(", ", Enum.GetNames(typeof(ButilScanMode)))}.");
+        return false;
     }
 }

--- a/src/Butil/Bit.Butil.Build/UserStringHeap.cs
+++ b/src/Butil/Bit.Butil.Build/UserStringHeap.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Bit.Butil.Build;
 
@@ -10,156 +7,95 @@ namespace Bit.Butil.Build;
 /// still reach - straight from the file.
 /// </summary>
 /// <remarks>
-/// Hand-rolled, rather than through <c>System.Reflection.Metadata</c>, because this code runs inside MSBuild:
-/// a task assembly that carries a metadata-reader dependency has to agree with the copy MSBuild already
-/// loaded, and the two MSBuild flavours (the dotnet CLI's, and Visual Studio's .NET Framework msbuild.exe with
-/// its own binding redirects) ship different versions of it. Depending on nothing keeps the task loadable
-/// everywhere. What is parsed here is a fixed, decades-old on-disk layout - PE headers, the CLI header, the
-/// metadata root, the <c>#US</c> stream - specified in ECMA-335 II.24-25, so there is no moving target.
+/// The PE and metadata walking this rests on lives in <see cref="PeImage"/>; see there for why it is
+/// hand-rolled rather than done through <c>System.Reflection.Metadata</c>.
 /// </remarks>
 public static class UserStringHeap
 {
     /// <summary>
     /// Every string in the assembly's user-string heap, in heap order. Empty when the assembly has none.
     /// </summary>
-    /// <exception cref="BadImageFormatException">The file is not a managed PE image, or is malformed.</exception>
-    public static IEnumerable<string> Read(string assemblyPath)
+    /// <exception cref="System.BadImageFormatException">The file is not a managed PE image, or is malformed.</exception>
+    public static IEnumerable<string> Read(string assemblyPath) => Read(PeImage.Load(assemblyPath));
+
+    /// <summary>
+    /// Every string in an already-loaded image's user-string heap, in heap order - the same computation as
+    /// <see cref="Read(string)"/> for a caller that has other reasons to hold the image open.
+    /// </summary>
+    public static IEnumerable<string> Read(PeImage image)
     {
-        var image = File.ReadAllBytes(assemblyPath);
-        var heap = FindUserStringHeap(image, assemblyPath);
+        var heap = image.UserStrings;
 
         // Index 0 of the heap is the single padding byte that stands for "no string"; the first real string
         // starts at 1. The heap is padded to a 4-byte boundary with zero bytes, which decode as empty strings.
         var strings = new List<string>();
+        if (heap.IsEmpty) return strings;
+
         var position = heap.Offset + 1;
         var end = heap.Offset + heap.Size;
 
         while (position < end)
         {
-            var length = ReadCompressedUInt32(image, ref position, assemblyPath);
+            var length = ReadCompressedUInt32(image, ref position);
             if (length == 0) continue;
 
-            if (length > end - position) throw Invalid(assemblyPath, "a string in the #US heap runs past the end of the heap");
+            if (length > end - position) throw image.Invalid("a string in the #US heap runs past the end of the heap");
 
-            // The blob is UTF-16LE plus one trailing flag byte that says whether any character needs more
-            // than the ANSI range - not part of the string. Decoded character by character rather than
-            // through Encoding.Unicode, which would replace an unpaired surrogate with U+FFFD: the heap
-            // holds whatever the compiler put there, and this has to read it back unchanged.
-            var characters = new char[(length - 1) / 2];
-            for (var i = 0; i < characters.Length; i++)
-            {
-                characters[i] = (char)(image[position + (i * 2)] | (image[position + (i * 2) + 1] << 8));
-            }
-
-            strings.Add(new string(characters));
+            strings.Add(Decode(image, position, (int)length));
             position += (int)length;
         }
 
         return strings;
     }
 
-    private readonly struct Heap(int offset, int size)
+    /// <summary>
+    /// The string a <c>ldstr</c> token names: its operand is a byte offset into the <c>#US</c> heap rather
+    /// than a row number, so the same length-prefixed blob is read from there directly.
+    /// </summary>
+    public static string ReadAt(PeImage image, int offset)
     {
-        public int Offset { get; } = offset;
+        var heap = image.UserStrings;
+        if (heap.IsEmpty || offset <= 0 || offset >= heap.Size) throw image.Invalid("a string token outside the #US heap");
 
-        public int Size { get; } = size;
+        var position = heap.Offset + offset;
+        var length = ReadCompressedUInt32(image, ref position);
+        if (length == 0) return string.Empty;
+        if (length > heap.Offset + heap.Size - position) throw image.Invalid("a string in the #US heap runs past the end of the heap");
+
+        return Decode(image, position, (int)length);
     }
 
-    /// <summary>Walks PE header -&gt; CLI header -&gt; metadata root -&gt; the <c>#US</c> stream.</summary>
-    private static Heap FindUserStringHeap(byte[] image, string path)
+    /// <summary>
+    /// The blob is UTF-16LE plus one trailing flag byte that says whether any character needs more than the
+    /// ANSI range - not part of the string. Decoded character by character rather than through
+    /// <c>Encoding.Unicode</c>, which would replace an unpaired surrogate with U+FFFD: the heap holds
+    /// whatever the compiler put there, and this has to read it back unchanged.
+    /// </summary>
+    private static string Decode(PeImage image, int position, int length)
     {
-        // MS-DOS header: the PE signature's file offset lives at 0x3C.
-        if (image.Length < 0x40 || image[0] != 'M' || image[1] != 'Z') throw Invalid(path, "not a PE image");
-
-        var peHeader = ReadInt32(image, 0x3C, path);
-        if (ReadUInt32(image, peHeader, path) != 0x00004550) throw Invalid(path, "not a PE image"); // "PE\0\0"
-
-        // COFF header: 20 bytes, of which the section count and the size of the optional header matter here.
-        var coffHeader = peHeader + 4;
-        int sections = ReadUInt16(image, coffHeader + 2, path);
-        int optionalHeaderSize = ReadUInt16(image, coffHeader + 16, path);
-        var optionalHeader = coffHeader + 20;
-
-        // The data directories sit at a magic-dependent offset inside the optional header; the CLI header is
-        // directory 14 (ECMA-335 II.25.2.3.3).
-        var magic = ReadUInt16(image, optionalHeader, path);
-        var directories = optionalHeader + magic switch
+        var characters = new char[(length - 1) / 2];
+        for (var i = 0; i < characters.Length; i++)
         {
-            0x10B => 96,  // PE32
-            0x20B => 112, // PE32+
-            _ => throw Invalid(path, "unknown PE optional header format")
-        };
-
-        var sectionHeaders = optionalHeader + optionalHeaderSize;
-        var cliHeaderRva = ReadUInt32(image, directories + (14 * 8), path);
-        if (cliHeaderRva == 0) throw Invalid(path, "not a managed assembly (no CLI header)");
-
-        // CLI header: the metadata root's RVA is at offset 8 (after Cb and the two runtime version numbers).
-        var cliHeader = ResolveRva(image, sectionHeaders, sections, cliHeaderRva, path);
-        var metadata = ResolveRva(image, sectionHeaders, sections, ReadUInt32(image, cliHeader + 8, path), path);
-
-        if (ReadUInt32(image, metadata, path) != 0x424A5342) throw Invalid(path, "the metadata root is not a 'BSJB' signature"); // "BSJB"
-
-        // Metadata root: signature, two version numbers, reserved, then the length-prefixed version string
-        // padded to a 4-byte boundary, then flags and the stream count.
-        var versionLength = ReadInt32(image, metadata + 12, path);
-        if (versionLength < 0) throw Invalid(path, "a negative metadata version length");
-
-        // Step by step, so that a hostile length cannot overflow the padding or the offsets built on it back
-        // into range: bound the raw length against what is left of the file first, then its padded form.
-        if (versionLength > image.Length - metadata - 16) throw Invalid(path, "a metadata version string that runs past the end of the file");
-        var versionSize = Align4(versionLength);
-        if (versionSize > image.Length - metadata - 16) throw Invalid(path, "a metadata version string that runs past the end of the file");
-
-        var streamCount = ReadUInt16(image, metadata + 16 + versionSize + 2, path);
-        var streamHeader = metadata + 16 + versionSize + 4;
-
-        for (var i = 0; i < streamCount; i++)
-        {
-            var offset = ReadInt32(image, streamHeader, path);
-            var size = ReadInt32(image, streamHeader + 4, path);
-            var name = ReadStreamName(image, streamHeader + 8, path, out var nameLength);
-
-            if (name == "#US")
-            {
-                // Step by step, so that a hostile offset or size cannot overflow the sum back into range.
-                if (offset < 0 || offset > image.Length - metadata) throw Invalid(path, "the #US heap runs past the end of the file");
-                if (size < 0 || size > image.Length - metadata - offset) throw Invalid(path, "the #US heap runs past the end of the file");
-                return new Heap(metadata + offset, size);
-            }
-
-            streamHeader += 8 + nameLength;
+            characters[i] = (char)(image.Image[position + (i * 2)] | (image.Image[position + (i * 2) + 1] << 8));
         }
 
-        // An assembly whose method bodies hold no string literal at all simply has no #US stream.
-        return new Heap(0, 0);
-    }
-
-    /// <summary>A stream header's name: null-terminated ASCII, padded to a 4-byte boundary.</summary>
-    private static string ReadStreamName(byte[] image, int position, string path, out int paddedLength)
-    {
-        var length = 0;
-        while (position + length < image.Length && image[position + length] != 0) length++;
-        if (position + length >= image.Length) throw Invalid(path, "an unterminated metadata stream name");
-
-        paddedLength = Align4(length + 1);
-        return Encoding.ASCII.GetString(image, position, length);
+        return new string(characters);
     }
 
     /// <summary>
     /// The compressed unsigned integer of ECMA-335 II.23.2: one, two or four bytes, told apart by the top
     /// bits of the first one.
     /// </summary>
-    private static uint ReadCompressedUInt32(byte[] image, ref int position, string path)
+    private static uint ReadCompressedUInt32(PeImage image, ref int position)
     {
-        var first = ReadByte(image, position, path);
+        var first = image.ReadByte(position);
         position++;
 
         if ((first & 0x80) == 0) return first;
 
         if ((first & 0xC0) == 0x80)
         {
-            var value = (uint)(((first & 0x3F) << 8) | ReadByte(image, position, path));
+            var value = (uint)(((first & 0x3F) << 8) | image.ReadByte(position));
             position += 1;
             return value;
         }
@@ -167,67 +103,13 @@ public static class UserStringHeap
         if ((first & 0xE0) == 0xC0)
         {
             var value = (uint)(((first & 0x1F) << 24)
-                | (ReadByte(image, position, path) << 16)
-                | (ReadByte(image, position + 1, path) << 8)
-                | ReadByte(image, position + 2, path));
+                | (image.ReadByte(position) << 16)
+                | (image.ReadByte(position + 1) << 8)
+                | image.ReadByte(position + 2));
             position += 3;
             return value;
         }
 
-        throw Invalid(path, "a malformed compressed integer in the #US heap");
+        throw image.Invalid("a malformed compressed integer in the #US heap");
     }
-
-    /// <summary>The file offset a relative virtual address points at, through the section table.</summary>
-    private static int ResolveRva(byte[] image, int sectionHeaders, int sections, uint rva, string path)
-    {
-        for (var i = 0; i < sections; i++)
-        {
-            // Section header: name (8 bytes), virtual size, virtual address, raw size, raw pointer.
-            var header = sectionHeaders + (i * 40);
-            var virtualSize = ReadUInt32(image, header + 8, path);
-            var virtualAddress = ReadUInt32(image, header + 12, path);
-            var rawSize = ReadUInt32(image, header + 16, path);
-            var rawPointer = ReadUInt32(image, header + 20, path);
-
-            // A section's mapped size can exceed what is stored on disk (zero-filled tail), and can also be
-            // rounded up to the file alignment - take the larger of the two so neither case misses.
-            if (rva < virtualAddress || rva >= virtualAddress + Math.Max(virtualSize, rawSize)) continue;
-
-            var offset = rawPointer + (rva - virtualAddress);
-            if (offset >= (uint)image.Length) throw Invalid(path, "a section points past the end of the file");
-
-            return (int)offset;
-        }
-
-        throw Invalid(path, $"the RVA 0x{rva:X} is not inside any section");
-    }
-
-    private static int Align4(int value) => (value + 3) & ~3;
-
-    private static byte ReadByte(byte[] image, int position, string path)
-    {
-        if (position < 0 || position >= image.Length) throw Invalid(path, "a header points past the end of the file");
-
-        return image[position];
-    }
-
-    private static ushort ReadUInt16(byte[] image, int position, string path)
-        => (ushort)(ReadByte(image, position, path) | (ReadByte(image, position + 1, path) << 8));
-
-    private static uint ReadUInt32(byte[] image, int position, string path)
-        => (uint)(ReadByte(image, position, path)
-            | (ReadByte(image, position + 1, path) << 8)
-            | (ReadByte(image, position + 2, path) << 16)
-            | (ReadByte(image, position + 3, path) << 24));
-
-    private static int ReadInt32(byte[] image, int position, string path)
-    {
-        var value = ReadUInt32(image, position, path);
-        if (value > int.MaxValue) throw Invalid(path, "an out-of-range offset");
-
-        return (int)value;
-    }
-
-    private static BadImageFormatException Invalid(string path, string reason)
-        => new($"'{path}' could not be read as a managed assembly: {reason}.");
 }

--- a/src/Butil/Bit.Butil.Demo/Client/Docs/DocsSearchIndex.cs
+++ b/src/Butil/Bit.Butil.Demo/Client/Docs/DocsSearchIndex.cs
@@ -1,0 +1,45 @@
+﻿namespace Bit.Butil.Demo.Client.Docs;
+
+/// <summary>
+/// One searchable piece of the site: a whole page, one of its sections, or one row of its API
+/// reference table.
+/// <para>
+/// The fields are held apart rather than concatenated into a single haystack so a hit on a name can
+/// outrank a hit buried in prose - see Shared/SearchBox.razor, which scores them.
+/// </para>
+/// </summary>
+/// <param name="Title">What the hit is called: the page's title, the section's heading, the member's name.</param>
+/// <param name="Page">
+/// The title of the page this entry lives on, or null when the entry IS the page. It is what the
+/// result list shows beside a section so the reader knows where it would take them.
+/// </param>
+/// <param name="Url">The href, including the fragment that scrolls to the section.</param>
+/// <param name="Group">The nav group the page belongs to.</param>
+/// <param name="Keywords">
+/// Names that are not in the title but that someone would search by: the type the page documents,
+/// the member badge on a section, the signature of an API row, the words of the slug.
+/// </param>
+/// <param name="Summary">The one sentence shown under the title in the result list.</param>
+/// <param name="Body">
+/// The rest of the entry's text - code samples, the labels and prose of the live demo, the callouts.
+/// It is matched but never shown in full: a hit in it is quoted as a window around the match.
+/// </param>
+public record DocsSearchEntry(
+    string Title,
+    string? Page,
+    string Url,
+    string Group,
+    string Keywords,
+    string Summary,
+    string Body);
+
+/// <summary>
+/// The corpus behind the site's search box, served by the host at <c>/api/docs/search-index</c> and
+/// fetched once by the browser.
+/// <para>
+/// It is built on the server (Server/Services/DocsContentIndex.cs) from the embedded source of the
+/// pages themselves, so it cannot go stale against them: a section added to a page is a section
+/// that becomes searchable, with no list to remember to update.
+/// </para>
+/// </summary>
+public record DocsSearchIndex(DocsSearchEntry[] Entries);

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/GettingStartedPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/GettingStartedPage.razor
@@ -71,12 +71,12 @@ var secure = await window.IsSecureContext();
              Api="BitButilTrimScripts"
              Description="The bundle behind step 2 covers every API on this site, and a published app can shed the parts it never calls - the JavaScript half of the trimming the C# side already gets. In a Blazor WebAssembly project there is nothing to add: a trimmed publish rebuilds bit-butil.js from only the modules the trimmed Bit.Butil.dll still calls, so an app injecting Clipboard, LocalStorage and Window ships around 8 KB of JavaScript instead of 110 KB. Publishing without trimming - a WebAssembly app with PublishTrimmed off, Blazor Server, a server host that prerenders - leaves no trimmed assembly to read, and BitButilScriptScan answers the same question from the app's own assemblies instead: injecting Clipboard is a reference to Bit.Butil.Clipboard, and the package works out which module that class needs. Whatever either concludes, BitButilScriptModule adds modules or Bit.Butil class names on top, for an API reached by reflection or from your own JavaScript. All of it is publish-only: a build, and dotnet run and dotnet watch on top of it, keeps the full bundle."
              Code=@("""
-<!-- Nothing to add: it is the default in a WebAssembly project. To opt out: -->
+<!-- Nothing to add: it is the default in a WebAssembly project. To opt out entirely: -->
 <PropertyGroup>
   <BitButilTrimScripts>false</BitButilTrimScripts>
 </PropertyGroup>
 
-<!-- Publishing WITHOUT trimming? Read the app's own assemblies instead. -->
+<!-- Or publishing WITHOUT trimming? Read the app's own assemblies instead. -->
 <PropertyGroup>
   <BitButilTrimScripts>true</BitButilTrimScripts>
   <BitButilScriptScan>TypeReferences</BitButilScriptScan>

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/GettingStartedPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/GettingStartedPage.razor
@@ -69,12 +69,23 @@ var secure = await window.IsSecureContext();
 
 <DemoSection Title="Optional: tree-shake the JavaScript"
              Api="BitButilTrimScripts"
-             Description="The bundle behind step 2 covers every API on this site, and a published app can shed the parts it never calls - the JavaScript half of the trimming the C# side already gets. There is nothing to add for it: in a Blazor WebAssembly project a trimmed publish rebuilds bit-butil.js from only the modules the trimmed Bit.Butil.dll still calls, so an app injecting Clipboard, LocalStorage and Window ships around 8 KB of JavaScript instead of 110 KB. It is on by default only there, because that is the one shape where the assembly being trimmed is the assembly calling the served JavaScript. A server that hosts a WebAssembly client keeps its own full copy of the bundle and wants lazy scripts below instead."
+             Description="The bundle behind step 2 covers every API on this site, and a published app can shed the parts it never calls - the JavaScript half of the trimming the C# side already gets. In a Blazor WebAssembly project there is nothing to add: a trimmed publish rebuilds bit-butil.js from only the modules the trimmed Bit.Butil.dll still calls, so an app injecting Clipboard, LocalStorage and Window ships around 8 KB of JavaScript instead of 110 KB. Publishing without trimming - a WebAssembly app with PublishTrimmed off, Blazor Server, a server host that prerenders - leaves no trimmed assembly to read, and BitButilScriptScan answers the same question from the app's own assemblies instead: injecting Clipboard is a reference to Bit.Butil.Clipboard, and the package works out which module that class needs. Whatever either concludes, BitButilScriptModule adds modules or Bit.Butil class names on top, for an API reached by reflection or from your own JavaScript. All of it is publish-only: a build, and dotnet run and dotnet watch on top of it, keeps the full bundle."
              Code=@("""
 <!-- Nothing to add: it is the default in a WebAssembly project. To opt out: -->
 <PropertyGroup>
   <BitButilTrimScripts>false</BitButilTrimScripts>
 </PropertyGroup>
+
+<!-- Publishing WITHOUT trimming? Read the app's own assemblies instead. -->
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
+</PropertyGroup>
+
+<!-- Always kept, whatever the above concluded: -->
+<ItemGroup>
+  <BitButilScriptModule Include="Clipboard;geolocation" />
+</ItemGroup>
 """)
              Language="xml" />
 

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/TroubleshootingPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/TroubleshootingPage.razor
@@ -115,8 +115,14 @@ if (await crypto.IsSupported() is false) { /* SubtleCrypto is https-only */ }
 """) />
 
     <DemoSection Title="One API stops working after publish, the rest are fine"
-                 Description="A published WebAssembly app rebuilds bit-butil.js from the modules its trimmed assembly still calls, so the JavaScript for an API the trimmer decided was unreachable is genuinely not in the bundle - and the symptom is the missing-bridge error above, for that one API. It is almost always correct: the API really is only reached from code that was trimmed away, or only through reflection, which the trimmer cannot follow. Inject the service somewhere the trimmer can see, or set BitButilTrimScripts to false to publish the whole bundle and confirm that is the cause."
+                 Description="A published app rebuilds bit-butil.js from the modules it can still reach, so the JavaScript for an API that neither the trimmer nor BitButilScriptScan could see is genuinely not in the bundle - and the symptom is the missing-bridge error above, for that one API. It is almost always correct: the API really is only reached from code that was trimmed away, or only through reflection, which neither can follow. Name the module - or the Bit.Butil class behind it - in BitButilScriptModule, which is added to whatever they concluded; or set BitButilTrimScripts to false to publish the whole bundle and confirm that is the cause first."
                  Code=@("""
+<!-- Keep this one whatever the publish concluded -->
+<ItemGroup>
+  <BitButilScriptModule Include="Clipboard" />
+</ItemGroup>
+
+<!-- Or rule trimming out as the cause entirely -->
 <PropertyGroup>
   <BitButilTrimScripts>false</BitButilTrimScripts>
 </PropertyGroup>

--- a/src/Butil/Bit.Butil.Demo/Client/Shared/SearchBox.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Shared/SearchBox.razor
@@ -56,7 +56,7 @@
                     id="@($"header-search-option-{index}")"
                     aria-selected="@(index == _activeIndex ? "true" : "false")"
                     class="@(index == _activeIndex ? "active" : null)"
-                    @key="hit.Url"
+                    @key="@($"{index}:{hit.Url}")"
                     @onmousedown="() => Go(hit.Url)" @onmousedown:preventDefault>
                     <span class="header-search-result-text">
                         <span class="header-search-result-title">@hit.Title</span>

--- a/src/Butil/Bit.Butil.Demo/Client/Shared/SearchBox.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Shared/SearchBox.razor
@@ -1,11 +1,21 @@
 ﻿@implements IAsyncDisposable
 @inject NavigationManager navManager
+@using System.Net.Http.Json
+@using Microsoft.Extensions.DependencyInjection
+@inject IServiceProvider services
 @inject Bit.Butil.Keyboard keyboard
 @inject Bit.Butil.UserAgent userAgent
 
-@* Client-side docs search over DocsNav - no index build and no server call: the taxonomy's titles,
-   summaries, slugs, group names and documented type names are the corpus. It lives in the header
-   rather than in the nav panel so it also works on the home page, where there is no panel.
+@* Client-side docs search. The corpus is the content of the pages themselves - every section, every
+   code sample, every row of every API table - built by the host from the pages' own source
+   (Server/Services/DocsContentIndex.cs) and fetched once, the first time someone reaches for the
+   field. Searching it here rather than asking the server per keystroke is what keeps the list
+   following the typing, and it means a hit can point at the section it matched rather than at the
+   top of a page the reader then has to scan.
+
+   Until that fetch lands - and if it never does - the taxonomy in DocsNav is the corpus, which is
+   the titles and one-line summaries this box searched before. Every result it can give is a result
+   the content index also gives, so the box is never empty-handed and never wrong, only coarser.
 
    The input is a WAI-ARIA combobox: ArrowUp/ArrowDown move the highlighted option, Enter opens it,
    Escape closes the list. Options navigate on mousedown so the click wins the race against the
@@ -31,6 +41,7 @@
            aria-controls="header-search-listbox"
            aria-activedescendant="@(_results is { Length: > 0 } ? $"header-search-option-{_activeIndex}" : null)"
            value="@_query"
+           @onfocus="LoadContent"
            @oninput="OnInput"
            @onkeydown="OnKeyDown"
            @onblur="() => _results = null" />
@@ -45,13 +56,28 @@
                     id="@($"header-search-option-{index}")"
                     aria-selected="@(index == _activeIndex ? "true" : "false")"
                     class="@(index == _activeIndex ? "active" : null)"
-                    @key="hit.Link.Url"
-                    @onmousedown="() => Go(hit.Link)" @onmousedown:preventDefault>
+                    @key="hit.Url"
+                    @onmousedown="() => Go(hit.Url)" @onmousedown:preventDefault>
                     <span class="header-search-result-text">
-                        <span class="header-search-result-title">@hit.Link.Title</span>
-                        <span class="header-search-result-summary">@hit.Link.Summary</span>
+                        <span class="header-search-result-title">@hit.Title</span>
+                        <span class="header-search-result-summary">
+                            @* The matched words are marked in place: a hit whose reason is a
+                               sentence halfway down a page has to show that sentence, or the reader
+                               is asked to take the ranking on trust. *@
+                            @foreach (var segment in hit.Snippet)
+                            {
+                                if (segment.Match)
+                                {
+                                    <mark>@segment.Text</mark>
+                                }
+                                else
+                                {
+                                    @segment.Text
+                                }
+                            }
+                        </span>
                     </span>
-                    <span class="header-search-result-group">@hit.Group</span>
+                    <span class="header-search-result-group">@hit.Context</span>
                 </li>
             }
         </ul>
@@ -65,20 +91,58 @@
 </div>
 
 @code {
+    /// <summary>How many hits the list shows, and how many of them one page is allowed to own.</summary>
+    private const int MaxResults = 10;
+    private const int MaxPerPage = 3;
+
+    /// <summary>Roughly a line of the flyout - what a snippet is cut down to before it is shown.</summary>
+    private const int SnippetLength = 140;
+
     /// <summary>
-    /// One searchable page. The fields are held apart rather than concatenated into a single
-    /// haystack so a hit in the title can outrank a hit in a summary.
+    /// One entry of the corpus with its text lowered once, when the corpus arrives, so a keystroke
+    /// scans it with ordinal comparisons instead of folding every character it walks past.
     /// </summary>
-    private sealed record Entry(DocLink Link, string Group, string Types, string Slug);
+    private sealed class Entry
+    {
+        public required DocsSearchEntry Source { get; init; }
 
-    private sealed record Hit(DocLink Link, string Group);
+        /// <summary>
+        /// The title split into words, camel-case humps included, so "WriteText" is found by "write
+        /// text" - and so a term counts as a title word only when it IS one of them, rather than
+        /// merely appearing inside one ("cache" inside "CacheStorage").
+        /// </summary>
+        public required string[] TitleWords { get; init; }
 
-    // The taxonomy is static, so the corpus is built once for the lifetime of the app.
-    private static readonly Entry[] _entries =
+        public required string Title { get; init; }
+        public required string Keywords { get; init; }
+        public required string Summary { get; init; }
+        public required string Body { get; init; }
+    }
+
+    private sealed record Segment(string Text, bool Match);
+
+    private sealed record Hit(string Title, string Url, string? Context, Segment[] Snippet);
+
+    /// <summary>
+    /// The taxonomy as a corpus: what the box searches until the content index arrives, and what it
+    /// keeps searching if the request for it fails.
+    /// </summary>
+    private static readonly Entry[] _navEntries =
     [
-        .. DocsNav.Groups.SelectMany(group => group.Links.Select(link =>
-            new Entry(link, group.Title, string.Join(' ', link.TypeNames()), link.Url.Replace('-', ' ')))),
+        .. DocsNav.Groups.SelectMany(group => group.Links.Select(link => Index(new DocsSearchEntry(
+            Title: link.Title,
+            Page: null,
+            Url: $"/{link.Url}",
+            Group: group.Title,
+            Keywords: $"{link.Url.Replace('-', ' ')} {string.Join(' ', link.TypeNames())}",
+            Summary: link.Summary,
+            Body: "")))),
     ];
+
+    // The corpus is the same for every instance of this component and for the whole life of the
+    // app, so it is fetched once into a static rather than per header, per navigation.
+    private static Entry[]? _contentEntries;
+    private static Task? _loading;
 
     private string _query = "";
     private Hit[]? _results;
@@ -89,58 +153,331 @@
     private ButilSubscription? _metaK;
     private readonly List<ButilSubscription> _listboxKeys = [];
 
+    /// <summary>
+    /// Fetches the content index, once, the first time someone puts the caret in the field.
+    /// <para>
+    /// On focus rather than on load: it is the largest thing this site downloads, and the visitor
+    /// who came to read one page should not pay for the search of a visitor who came to search. By
+    /// the time a query is two characters long it has usually landed; while it has not, the nav
+    /// corpus answers and the query is re-run when it does.
+    /// </para>
+    /// </summary>
+    private async Task LoadContent()
+    {
+        if (_contentEntries is not null) return;
+
+        // Nothing to fetch from while the page is being prerendered: the host's container has no
+        // HttpClient in it, and nobody is typing into a page that has not reached a browser yet.
+        if (services.GetService<HttpClient>() is not { } http) return;
+
+        // A failed fetch clears the task rather than caching it, so the next focus tries again -
+        // this is one request, and the alternative is a session that never gets the content index
+        // because of one bad moment on the network.
+        _loading ??= Load(http);
+
+        try
+        {
+            await _loading;
+        }
+        catch
+        {
+            _loading = null;
+            return;
+        }
+
+        if (_query.Trim().Length < 2) return;
+
+        _results = Find(_query.Trim());
+        _activeIndex = 0;
+
+        StateHasChanged();
+    }
+
+    private static async Task Load(HttpClient http)
+    {
+        var index = await http.GetFromJsonAsync<DocsSearchIndex>("api/docs/search-index");
+
+        if (index?.Entries is { Length: > 0 } entries) _contentEntries = [.. entries.Select(Index)];
+    }
+
+    private static Entry Index(DocsSearchEntry entry) => new()
+    {
+        Source = entry,
+        TitleWords = [.. SplitWords(entry.Title)],
+        Title = entry.Title.ToLowerInvariant(),
+        Keywords = entry.Keywords.ToLowerInvariant(),
+        Summary = entry.Summary.ToLowerInvariant(),
+        Body = entry.Body.ToLowerInvariant(),
+    };
+
     private void OnInput(ChangeEventArgs e)
     {
         _query = e.Value?.ToString() ?? "";
         _results = _query.Trim().Length < 2 ? null : Find(_query.Trim());
         _activeIndex = 0;
+
+        // Typing into a field that was focused programmatically, or pasted into, may be the first
+        // this component hears of it.
+        _ = LoadContent();
     }
 
     private static Hit[] Find(string query)
     {
-        var terms = query.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var terms = Terms(query);
+        if (terms.Length == 0) return [];
 
-        return [.. _entries
-            .Select(entry => (Entry: entry, Score: Score(entry, terms)))
+        // Every word first, because that is what someone typing two of them means. A question -
+        // "how do I copy an image to the clipboard" - is words a page cannot all contain, and
+        // answering it with nothing when three of its words point straight at a section is the
+        // failure this box is most often accused of; so if nothing matches all of them, the same
+        // ranking runs again over the entries that match some, where matching more wins.
+        var hits = Rank(terms, requireEveryTerm: true);
+
+        return hits.Length > 0 ? hits : Rank(terms, requireEveryTerm: false);
+    }
+
+    private static Hit[] Rank(string[] terms, bool requireEveryTerm)
+    {
+        var ranked = (_contentEntries ?? _navEntries)
+            .Select(entry => (Entry: entry, Score: Score(entry, terms, requireEveryTerm)))
             .Where(hit => hit.Score > 0)
             .OrderByDescending(hit => hit.Score)
-            .ThenBy(hit => hit.Entry.Link.Title, StringComparer.OrdinalIgnoreCase)
-            .Take(8)
-            .Select(hit => new Hit(hit.Entry.Link, hit.Entry.Group))];
+            .ThenBy(hit => hit.Entry.Source.Title, StringComparer.OrdinalIgnoreCase);
+
+        var hits = new List<Hit>(MaxResults);
+        var perPage = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var (entry, _) in ranked)
+        {
+            // A page whose every section says "cookie" would otherwise fill the list with itself and
+            // hide the nine other pages that mention it once.
+            var page = entry.Source.Url.Split('#')[0];
+            var taken = perPage.GetValueOrDefault(page);
+            if (taken >= MaxPerPage) continue;
+
+            perPage[page] = taken + 1;
+            hits.Add(new Hit(
+                entry.Source.Title,
+                entry.Source.Url,
+                entry.Source.Page ?? entry.Source.Group,
+                Snippet(entry, terms)));
+
+            if (hits.Count == MaxResults) break;
+        }
+
+        return [.. hits];
     }
 
     /// <summary>
-    /// The sum of every term's best field, or zero as soon as one term matches nothing: two words
-    /// narrow the result set rather than widening it.
+    /// The words of a query. Anything shorter than two characters is dropped: a single letter is in
+    /// every entry of the corpus, so it ranks nothing and only costs the other terms their meaning.
     /// </summary>
-    private static int Score(Entry entry, string[] terms)
+    private static string[] Terms(string query)
+    {
+        var terms = query
+            .Split([' ', '\t', '.', ',', '(', ')', '/', ':', '?'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(term => term.Length > 1)
+            .Select(term => term.ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        // The words a question is phrased with are in every page on the site, so they rank nothing
+        // and cost the words that do. They are dropped only when something is left after them:
+        // "how to" is a poor query, but it is the query that was typed.
+        var meaningful = terms.Where(term => _stopWords.Contains(term) is false).ToArray();
+
+        return meaningful.Length > 0 ? meaningful : terms;
+    }
+
+    /// <summary>
+    /// Words that carry no signal here: the ones a question is built from, and the three this whole
+    /// site is about - every page is about the browser, in Blazor, through Butil.
+    /// <para>
+    /// The two-letter words are listed one by one rather than dropped as a class, which is what the
+    /// MCP server's index does with them. This corpus is full of two-letter names someone would
+    /// search by - <c>db</c>, <c>ui</c>, <c>id</c>, <c>ip</c> - and a rule that lost those to be rid
+    /// of "am" would be trading a query that works for a sentence that reads well.
+    /// </para>
+    /// </summary>
+    private static readonly HashSet<string> _stopWords = new(StringComparer.Ordinal)
+    {
+        "how", "the", "and", "for", "with", "from", "that", "this", "what", "when", "where", "which",
+        "does", "did", "are", "was", "you", "your", "can", "its", "but", "any", "get", "use", "using",
+        "have", "has", "want", "need", "into", "way", "make", "butil", "blazor", "browser",
+        "am", "is", "it", "do", "in", "on", "of", "to", "my", "me", "be", "by", "at", "or", "if",
+        "so", "we", "as", "an",
+    };
+
+    /// <summary>
+    /// The sum of every term's best field, multiplied by how many of them were found - matching
+    /// more of the query is the strongest signal a hit is the right one.
+    /// </summary>
+    private static int Score(Entry entry, string[] terms, bool requireEveryTerm)
     {
         var total = 0;
+        var body = 0;
+        var matched = 0;
 
         foreach (var term in terms)
         {
             var score = Score(entry, term);
-            if (score == 0) return 0;
 
-            total += score;
+            if (score == 0)
+            {
+                if (requireEveryTerm) return 0;
+                continue;
+            }
+
+            matched++;
+            if (score == 1) body++; else total += score;
         }
 
-        return total;
+        if (matched == 0) return 0;
+
+        // A body is the whole of a section - its sample, its controls, its prose - and long text
+        // mentions everything. Capping what it can contribute is what lets it be indexed at all: it
+        // can rank a hit and break a tie between two, but it can never outweigh the entry whose name
+        // was asked for.
+        total += Math.Min(body, 3);
+
+        // A page outranks its own sections at equal evidence: someone typing "clipboard" wants the
+        // Clipboard page, not the first of its four sections.
+        return (total + (entry.Source.Page is null ? 3 : 0)) * matched;
     }
 
     // The name someone reaches for is rarely the name the platform chose - "copy" is on Clipboard,
-    // "keep the screen on" is WakeLock - so the summary and the group name are searched too. They
-    // score lowest: a page whose title is the word wins over a page that merely mentions it.
+    // "keep the screen on" is WakeLock - so the summary and the body are searched too. They score
+    // lowest: an entry whose title is the word wins over one that merely mentions it.
     private static int Score(Entry entry, string term) => true switch
     {
-        _ when entry.Link.Title.StartsWith(term, StringComparison.OrdinalIgnoreCase) => 6,
-        _ when entry.Link.Title.Contains(term, StringComparison.OrdinalIgnoreCase) => 4,
-        _ when entry.Types.Contains(term, StringComparison.OrdinalIgnoreCase) => 3,
-        _ when entry.Slug.Contains(term, StringComparison.OrdinalIgnoreCase) => 2,
-        _ when entry.Link.Summary.Contains(term, StringComparison.OrdinalIgnoreCase) => 1,
-        _ when entry.Group.Contains(term, StringComparison.OrdinalIgnoreCase) => 1,
+        _ when entry.TitleWords.Any(word => Equivalent(word, term)) => 12,
+        _ when entry.Title.Contains(term, StringComparison.Ordinal) => 6,
+        _ when entry.Keywords.Contains(term, StringComparison.Ordinal) => 4,
+        _ when entry.Summary.Contains(term, StringComparison.Ordinal) => 2,
+        _ when entry.Body.Contains(term, StringComparison.Ordinal) => 1,
         _ => 0,
     };
+
+    /// <summary>
+    /// The same word, plural aside - "cookie" has to find "Cookies", and nobody phrases a question
+    /// in the number the API happens to use. Both sides are already lowered, so this is ordinal.
+    /// </summary>
+    private static bool Equivalent(string word, string term)
+    {
+        return string.Equals(word, term, StringComparison.Ordinal)
+            || (word.Length == term.Length + 1 && word[^1] == 's' && string.Equals(word[..^1], term, StringComparison.Ordinal))
+            || (term.Length == word.Length + 1 && term[^1] == 's' && string.Equals(term[..^1], word, StringComparison.Ordinal));
+    }
+
+    /// <summary>Splits a name into words, breaking camel-case humps as well as punctuation.</summary>
+    private static IEnumerable<string> SplitWords(string text)
+    {
+        var word = new System.Text.StringBuilder();
+
+        foreach (var c in text)
+        {
+            if (char.IsLetterOrDigit(c) is false)
+            {
+                if (word.Length > 0) { yield return word.ToString().ToLowerInvariant(); word.Clear(); }
+                continue;
+            }
+
+            // A capital after a lowercase letter starts a new word ("WriteText" -> write text),
+            // while a run of capitals stays together ("URL", "NFC").
+            if (char.IsUpper(c) && word.Length > 0 && char.IsLower(word[^1]))
+            {
+                yield return word.ToString().ToLowerInvariant();
+                word.Clear();
+            }
+
+            word.Append(c);
+        }
+
+        if (word.Length > 0) yield return word.ToString().ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// What the result shows under its title: the entry's own summary when that is where the match
+    /// is, and otherwise a window of the body around the match - the sentence the query actually
+    /// hit, which is the only thing that explains why the row is in the list at all.
+    /// </summary>
+    private static Segment[] Snippet(Entry entry, string[] terms)
+    {
+        var summary = entry.Source.Summary;
+        var inSummary = terms.Any(term => entry.Summary.Contains(term, StringComparison.Ordinal));
+
+        if (inSummary || entry.Body.Length == 0)
+        {
+            return Highlight(Trim(summary, First(entry.Summary, terms)), terms);
+        }
+
+        return Highlight(Trim(entry.Source.Body, First(entry.Body, terms)), terms);
+    }
+
+    /// <summary>Where the earliest of the terms occurs in an already-lowered field, or 0.</summary>
+    private static int First(string lowered, string[] terms)
+    {
+        var first = -1;
+
+        foreach (var term in terms)
+        {
+            var index = lowered.IndexOf(term, StringComparison.Ordinal);
+            if (index >= 0 && (first < 0 || index < first)) first = index;
+        }
+
+        return Math.Max(first, 0);
+    }
+
+    /// <summary>A window of text around one position, cut at the words on both sides of it.</summary>
+    private static string Trim(string text, int around)
+    {
+        if (text.Length <= SnippetLength) return text;
+
+        var start = Math.Max(0, around - SnippetLength / 3);
+        if (start > 0)
+        {
+            var space = text.IndexOf(' ', start);
+            start = space < 0 || space > around ? start : space + 1;
+        }
+
+        var length = Math.Min(SnippetLength, text.Length - start);
+        var window = text.Substring(start, length).Trim();
+
+        return $"{(start > 0 ? "…" : null)}{window}{(start + length < text.Length ? "…" : null)}";
+    }
+
+    /// <summary>Splits a line into the pieces the query matched and the pieces around them.</summary>
+    private static Segment[] Highlight(string text, string[] terms)
+    {
+        var segments = new List<Segment>();
+        var index = 0;
+
+        while (index < text.Length)
+        {
+            var at = -1;
+            var length = 0;
+
+            foreach (var term in terms)
+            {
+                var found = text.IndexOf(term, index, StringComparison.OrdinalIgnoreCase);
+                if (found < 0 || (at >= 0 && found >= at)) continue;
+
+                at = found;
+                length = term.Length;
+            }
+
+            if (at < 0) break;
+
+            if (at > index) segments.Add(new Segment(text[index..at], false));
+
+            segments.Add(new Segment(text.Substring(at, length), true));
+            index = at + length;
+        }
+
+        if (index < text.Length) segments.Add(new Segment(text[index..], false));
+
+        return [.. segments];
+    }
 
     private void OnKeyDown(KeyboardEventArgs e)
     {
@@ -164,14 +501,14 @@
     {
         if (_results is not { Length: > 0 } results) return;
 
-        Go(results[Math.Clamp(_activeIndex, 0, results.Length - 1)].Link);
+        Go(results[Math.Clamp(_activeIndex, 0, results.Length - 1)].Url);
         StateHasChanged();
     });
 
-    private void Go(DocLink link)
+    private void Go(string url)
     {
         Reset();
-        navManager.NavigateTo(link.Url);
+        navManager.NavigateTo(url);
     }
 
     private void Reset()

--- a/src/Butil/Bit.Butil.Demo/Client/Shared/SearchBox.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Shared/SearchBox.razor
@@ -275,7 +275,7 @@
     private static string[] Terms(string query)
     {
         var terms = query
-            .Split([' ', '\t', '.', ',', '(', ')', '/', ':', '?'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split([' ', '\t', '.', ',', '(', ')', '/', ':', '?', '-', '_'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Where(term => term.Length > 1)
             .Select(term => term.ToLowerInvariant())
             .Distinct(StringComparer.Ordinal)

--- a/src/Butil/Bit.Butil.Demo/Server/Controllers/DocsController.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Controllers/DocsController.cs
@@ -35,13 +35,21 @@ public class DocsController : ControllerBase
         Response.Headers.ETag = payload.ETag;
         Response.Headers[HeaderNames.Vary] = HeaderNames.AcceptEncoding;
 
-        if (Request.Headers.IfNoneMatch.Any(tag => string.Equals(tag, payload.ETag, StringComparison.Ordinal)))
+        // Both headers are lists with a syntax of their own - If-None-Match is comma-separated and its tags
+        // may be weak, Accept-Encoding carries q values - so they are read parsed rather than as raw strings.
+        var headers = Request.GetTypedHeaders();
+        var etag = EntityTagHeaderValue.Parse(payload.ETag);
+
+        if (headers.IfNoneMatch.Any(tag => tag.Equals(EntityTagHeaderValue.Any) ||
+                                           tag.Compare(etag, useStrongComparison: false)))
         {
             return StatusCode(StatusCodes.Status304NotModified);
         }
 
-        var acceptsGzip = Request.Headers.AcceptEncoding
-            .Any(encoding => encoding?.Contains("gzip", StringComparison.OrdinalIgnoreCase) is true);
+        // q=0 is a client saying it does not want gzip, which reads as "gzip" to a substring match.
+        var acceptsGzip = headers.AcceptEncoding
+            .Any(encoding => string.Equals(encoding.Value.Value, "gzip", StringComparison.OrdinalIgnoreCase) &&
+                             encoding.Quality != 0);
 
         if (acceptsGzip is false) return File(payload.Json, MediaTypeNames.Application.Json);
 

--- a/src/Butil/Bit.Butil.Demo/Server/Controllers/DocsController.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Controllers/DocsController.cs
@@ -1,0 +1,52 @@
+﻿using System.Net.Mime;
+using Bit.Butil.Demo.Server.Services;
+using Microsoft.Net.Http.Headers;
+
+namespace Bit.Butil.Demo.Server.Controllers;
+
+/// <summary>
+/// What the site's own pages ask the host for. Today that is one thing: the corpus its search box
+/// searches - see <see cref="DocsContentIndex"/> and <c>Client/Shared/SearchBox.razor</c>.
+/// <para>
+/// The index is served rather than searched here on purpose. A search that runs on the server is a
+/// request per keystroke, each of them racing the last, and a result list that stutters behind the
+/// typing on a slow connection; the whole corpus is one download that the browser then searches at
+/// memory speed, and that a returning visitor revalidates in a single 304.
+/// </para>
+/// </summary>
+[ApiController]
+[Route("api/docs")]
+public class DocsController : ControllerBase
+{
+    /// <summary>
+    /// The search corpus, gzipped for the browsers that say they can take it - it is prose, so the
+    /// compressed copy is a fraction of the size, and this is the one payload on the site big enough
+    /// for that to matter.
+    /// </summary>
+    [HttpGet("search-index")]
+    public IActionResult SearchIndex()
+    {
+        var payload = DocsContentIndex.Wire;
+
+        // The corpus changes when the app is deployed and never in between, so the ETag is the whole
+        // caching story: no-cache asks the browser to revalidate rather than to re-download, and the
+        // answer to a revalidation is 304 with no body at all.
+        Response.Headers.CacheControl = "no-cache";
+        Response.Headers.ETag = payload.ETag;
+        Response.Headers[HeaderNames.Vary] = HeaderNames.AcceptEncoding;
+
+        if (Request.Headers.IfNoneMatch.Any(tag => string.Equals(tag, payload.ETag, StringComparison.Ordinal)))
+        {
+            return StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        var acceptsGzip = Request.Headers.AcceptEncoding
+            .Any(encoding => encoding?.Contains("gzip", StringComparison.OrdinalIgnoreCase) is true);
+
+        if (acceptsGzip is false) return File(payload.Json, MediaTypeNames.Application.Json);
+
+        Response.Headers.ContentEncoding = "gzip";
+
+        return File(payload.Gzip, MediaTypeNames.Application.Json);
+    }
+}

--- a/src/Butil/Bit.Butil.Demo/Server/Program.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Program.cs
@@ -217,6 +217,13 @@ _ = Task.Run(ButilSearchIndex.Warm).ContinueWith(
     task => app.Logger.LogError(task.Exception, "Building the Bit.Butil search index failed at startup. SearchButil will rebuild it on the next call."),
     TaskContinuationOptions.OnlyOnFaulted);
 
+// The site's own search corpus (Services/DocsContentIndex.cs), on the same terms: it parses every
+// page on the site, so the first visitor to open the search box should not be the one who pays for
+// that. Also lazy, so a failure here costs the search box its content index and nothing else.
+_ = Task.Run(DocsContentIndex.Warm).ContinueWith(
+    task => app.Logger.LogError(task.Exception, "Building the docs search index failed at startup. The site's search box will rebuild it on the next request."),
+    TaskContinuationOptions.OnlyOnFaulted);
+
 app.Run();
 
 // The absolute origin this request arrived on. Behind a reverse proxy the forwarded-headers

--- a/src/Butil/Bit.Butil.Demo/Server/Services/ButilSetupGuide.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Services/ButilSetupGuide.cs
@@ -275,13 +275,13 @@ public static partial class ButilSetupGuide
         1. `dotnet add package Bit.Butil`.
         2. Add `<script src="_content/Bit.Butil/bit-butil.js"></script>` to the host page, BEFORE the Blazor script.
            The app boots as soon as the Blazor script runs, so `window.BitButil` has to exist by then. It is a static
-           web asset of the package - there is nothing to copy into your own wwwroot. Two optional csproj switches
+           web asset of the package - there is nothing to copy into your own wwwroot. Four optional csproj switches
            tree-shake that JavaScript, so a published app ships only the modules it can still reach.
            `<BitButilTrimScripts>` rebuilds `bit-butil.js` from just those modules, and publishes only those under
            `modules/` too - publish only, never a build. It is on by default in a standalone WebAssembly project,
            where the trimmed `Bit.Butil.dll` says what the app can still call; `false` opts out, and
            `<BitButilIncludeScriptModules>true</BitButilIncludeScriptModules>` publishes every module regardless.
-           Publishing WITHOUT trimming there is no trimmed assembly to read, so
+           Publishing WITHOUT trimming, there is no trimmed assembly to read, so
            `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` answers the same question from the app's own
            assemblies - the Bit.Butil classes they reference - and works in every hosting model; it is ignored when
            the publish IS trimmed. `<BitButilScriptModule Include="Clipboard;geolocation" />` (an ItemGroup) adds

--- a/src/Butil/Bit.Butil.Demo/Server/Services/ButilSetupGuide.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Services/ButilSetupGuide.cs
@@ -43,7 +43,10 @@ public static partial class ButilSetupGuide
 
                 This is also the one hosting model where the JavaScript tree-shaking of step 2 needs nothing said:
                 a WebAssembly publish trims `Bit.Butil.dll`, and it is the same assembly that calls the JavaScript
-                being served, so `bit-butil.js` is rebuilt from just the modules the app can still reach.
+                being served, so `bit-butil.js` is rebuilt from just the modules the app can still reach. Publish
+                this app with `<PublishTrimmed>false</PublishTrimmed>` and that signal is gone - add
+                `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` to keep the tree-shaking, which then reads
+                the Bit.Butil classes the app's own assemblies reference instead.
 
                 Two things in the sample below are this repository's rather than yours, and both should be
                 dropped when you copy it: its `.csproj` imports Bit.Butil's consumer-side targets by hand and
@@ -80,9 +83,22 @@ public static partial class ButilSetupGuide
 
                 The same "both containers" rule governs the JavaScript tree-shaking of step 2:
                 `<BitButilLazyScripts>true</BitButilLazyScripts>` belongs in both `.csproj` files, because both of
-                them run components that call Butil. Publish-time bundle trimming is off in this shape and should
-                stay off - the host serves the JavaScript out of its own, untrimmed reference to the package, which
-                says nothing about what the WebAssembly client calls.
+                them run components that call Butil.
+
+                Bundle trimming in this shape wants `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` in the
+                HOST `.csproj` - the host is the project that serves `bit-butil.js`, and the scan reads its own
+                assemblies and the client's alike, because the client is one of its references. What it must not do
+                is trim from `PublishTrimmed`: the host's trimmed assembly set is about the host's own code and says
+                nothing about what the WebAssembly client calls, which is why the trimmed signal is off in this
+                shape and should stay off.
+
+                ```xml
+                <!-- in the HOST .csproj -->
+                <PropertyGroup>
+                  <BitButilTrimScripts>true</BitButilTrimScripts>
+                  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
+                </PropertyGroup>
+                ```
 
                 The files below are this documentation site itself, which is exactly that shape. Its full host
                 `Program.cs` is `GetButilSourceFile(path: "Demo/Server/Program.cs")` - it carries endpoints of its
@@ -178,6 +194,17 @@ public static partial class ButilSetupGuide
             The host page is `Components/App.razor` in a Blazor Web App, or `Pages/_Host.cshtml` in a classic
             (pre-.NET 8) Blazor Server app. If the app prerenders - the default - the same rule as everywhere else
             applies: touch the browser from `OnAfterRenderAsync`, not from `OnInitializedAsync`.
+
+            Nothing here is ever trimmed, so the JavaScript tree-shaking of step 2 has to be told what to work from:
+            `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` reads the Bit.Butil classes this project's own
+            assemblies reference. Lazy scripts are the alternative, and cost one request per API instead of a bundle.
+
+            ```xml
+            <PropertyGroup>
+              <BitButilTrimScripts>true</BitButilTrimScripts>
+              <BitButilScriptScan>TypeReferences</BitButilScriptScan>
+            </PropertyGroup>
+            ```
             """).AppendLine();
         builder.AppendLine(Checklist).AppendLine();
         builder.AppendLine("""
@@ -249,12 +276,17 @@ public static partial class ButilSetupGuide
         2. Add `<script src="_content/Bit.Butil/bit-butil.js"></script>` to the host page, BEFORE the Blazor script.
            The app boots as soon as the Blazor script runs, so `window.BitButil` has to exist by then. It is a static
            web asset of the package - there is nothing to copy into your own wwwroot. Two optional csproj switches
-           tree-shake that JavaScript, so a published app ships only the modules it can still reach: by default a
-           trimmed publish (standalone WebAssembly) rebuilds `bit-butil.js` from only the modules the trimmed
-           `Bit.Butil.dll` still calls, and publishes only those modules under `modules/` too - publish only,
-           never a build (`<BitButilTrimScripts>false</BitButilTrimScripts>` opts out,
-           `<BitButilIncludeScriptModules>true</BitButilIncludeScriptModules>` publishes every module);
-           `<BitButilLazyScripts>true</BitButilLazyScripts>` drops the script tag altogether and has each API
+           tree-shake that JavaScript, so a published app ships only the modules it can still reach.
+           `<BitButilTrimScripts>` rebuilds `bit-butil.js` from just those modules, and publishes only those under
+           `modules/` too - publish only, never a build. It is on by default in a standalone WebAssembly project,
+           where the trimmed `Bit.Butil.dll` says what the app can still call; `false` opts out, and
+           `<BitButilIncludeScriptModules>true</BitButilIncludeScriptModules>` publishes every module regardless.
+           Publishing WITHOUT trimming there is no trimmed assembly to read, so
+           `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` answers the same question from the app's own
+           assemblies - the Bit.Butil classes they reference - and works in every hosting model; it is ignored when
+           the publish IS trimmed. `<BitButilScriptModule Include="Clipboard;geolocation" />` (an ItemGroup) adds
+           modules or Bit.Butil class names on top of whatever either concluded, for an API reached by reflection.
+           `<BitButilLazyScripts>true</BitButilLazyScripts>` instead drops the script tag altogether and has each API
            `import()` its own module on first use, in every hosting model - set it in every project that uses Butil.
         3. Call `AddBitButilServices()` in EVERY DI container that renders your components. A Blazor Web App with an
            interactive WebAssembly client has two of them (the host prerenders, the browser hydrates), and a missing

--- a/src/Butil/Bit.Butil.Demo/Server/Services/DocsContentIndex.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Services/DocsContentIndex.cs
@@ -1,0 +1,426 @@
+﻿using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using Bit.Butil.Demo.Client.Docs;
+
+namespace Bit.Butil.Demo.Server.Services;
+
+/// <summary>
+/// The corpus behind the site's own search box: every documentation page broken into the pieces a
+/// reader actually looks for - the page, each of its sections, and each row of its API reference.
+/// <para>
+/// The site used to search nothing but the nav taxonomy - sixty-eight titles and sixty-eight
+/// one-line summaries - which finds a page only for someone who already knows what it is called.
+/// The words a reader types are in the pages: "unsanitized" is a sentence on the Clipboard page,
+/// keeping the screen awake is a section on WakeLock, <c>ReadText</c> is a row of a table. This
+/// indexes that text, and anchors each hit at the section it came from rather than at the top of
+/// the page.
+/// </para>
+/// <para>
+/// The text is read out of the pages' own embedded source (see <see cref="ButilSourceCatalog"/>),
+/// the way <see cref="ButilSearchIndex"/> reads it for the MCP tools, so nothing here is a second
+/// copy of the documentation that could drift from what the page renders. It is built once, served
+/// to the browser as one JSON document, and searched in the browser: a docs corpus this size
+/// compresses to less than a photograph, and searching it locally is what keeps the result list
+/// following the keystrokes.
+/// </para>
+/// </summary>
+public static partial class DocsContentIndex
+{
+    /// <summary>The anchor <c>Shared/ApiTable.razor</c> gives its section.</summary>
+    private const string ApiTableAnchor = "api-section";
+
+    // PublicationOnly for the same reason ButilSearchIndex uses it: a failed build is retried by the
+    // next caller rather than cached and rethrown for the lifetime of the process.
+    private static readonly Lazy<Payload> _payload = new(BuildPayload, LazyThreadSafetyMode.PublicationOnly);
+
+    /// <summary>
+    /// Web defaults, named here rather than left to the controller: the client deserializes with
+    /// <c>HttpClient.GetFromJsonAsync</c>, whose defaults are these, and a mismatch between the two
+    /// ends is a corpus that arrives with every field null.
+    /// </summary>
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// The index as it goes over the wire, built once: the JSON, the same JSON gzipped for the
+    /// browsers that ask for it - this is prose, so it compresses to a fraction of itself - and the
+    /// ETag that lets a returning visitor revalidate instead of downloading it again.
+    /// </summary>
+    /// <param name="ETag">Quoted, ready to be written into the header.</param>
+    public sealed record Payload(byte[] Json, byte[] Gzip, string ETag);
+
+    /// <inheritdoc cref="Payload"/>
+    public static Payload Wire => _payload.Value;
+
+    /// <summary>The entries as objects, for anything that wants them instead of the bytes.</summary>
+    public static DocsSearchEntry[] Entries => Build();
+
+    /// <summary>
+    /// Builds the index ahead of the first visitor who opens the search box, since it parses every
+    /// page on the site. Startup has the time to spare; the person typing does not.
+    /// </summary>
+    public static void Warm() => _ = _payload.Value;
+
+    private static Payload BuildPayload()
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(new DocsSearchIndex(Build()), _jsonOptions);
+
+        using var buffer = new MemoryStream();
+        using (var gzip = new GZipStream(buffer, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            gzip.Write(json);
+        }
+
+        return new Payload(json, buffer.ToArray(), $"\"{Convert.ToHexString(SHA256.HashData(json))[..16]}\"");
+    }
+
+    private static DocsSearchEntry[] Build()
+    {
+        var entries = new List<DocsSearchEntry>(1024);
+
+        foreach (var group in DocsNav.Groups)
+        {
+            foreach (var link in group.Links)
+            {
+                var source = ButilSourceCatalog.GetSourceFile($"Demo/Client/Pages/{link.PageType.Name}.razor") ?? string.Empty;
+                var markup = Markup(source);
+
+                AddPage(entries, group, link, markup);
+                AddSections(entries, group, link, markup);
+                AddApiMembers(entries, group, link, markup);
+            }
+        }
+
+        return [.. entries];
+    }
+
+    /// <summary>
+    /// The page itself. Its body is what belongs to no section - the lead, the callouts, whatever
+    /// prose the page writes around them - rather than the whole page: a page entry that contained
+    /// everything its sections contain would match every query one of them matches, and then push
+    /// the section that actually answers it out of the list.
+    /// </summary>
+    private static void AddPage(List<DocsSearchEntry> entries, DocGroup group, DocLink link, string markup)
+    {
+        var header = Elements(markup, "PageHeader").FirstOrDefault();
+        var lead = Attribute(header.Attributes, "Lead");
+        var inject = Attribute(header.Attributes, "InjectAs");
+
+        // Only the titles: a callout's body is a text node, so it is already in what Outside keeps.
+        var callouts = Elements(markup, "Callout").Select(callout => Attribute(callout.Attributes, "Title"));
+
+        entries.Add(new DocsSearchEntry(
+            Title: link.Title,
+            Page: null,
+            Url: $"/{link.Url}",
+            Group: group.Title,
+            Keywords: Join(link.Url.Replace('-', ' '), string.Join(' ', link.TypeNames()), inject, link.Support.Label()),
+            // The lead is the page's own sentence about itself and is written to be read; the
+            // taxonomy's summary stands in for the few pages that have no header.
+            Summary: string.IsNullOrWhiteSpace(lead) ? link.Summary : lead,
+            Body: Join(link.Summary, string.Join('\n', callouts), Text(Outside(markup)))));
+    }
+
+    /// <summary>
+    /// One entry per <c>DemoSection</c>, anchored at the id the section gives itself, so a hit opens
+    /// the page scrolled to the paragraph it matched rather than at the top of it.
+    /// </summary>
+    private static void AddSections(List<DocsSearchEntry> entries, DocGroup group, DocLink link, string markup)
+    {
+        foreach (var section in Elements(markup, "DemoSection"))
+        {
+            var title = Attribute(section.Attributes, "Title");
+            if (string.IsNullOrWhiteSpace(title)) continue;
+
+            entries.Add(new DocsSearchEntry(
+                Title: title,
+                Page: link.Title,
+                Url: $"/{link.Url}#{Slug(title)}",
+                Group: group.Title,
+                Keywords: Join(Attribute(section.Attributes, "Api"), string.Join(' ', link.TypeNames())),
+                Summary: Attribute(section.Attributes, "Description") ?? string.Empty,
+                // The code sample and the live demo's own labels: someone who remembers a call they
+                // saw on this site remembers how it was written, not which heading it was under.
+                Body: Join(Attribute(section.Attributes, "Code"), Text(section.Inner))));
+        }
+    }
+
+    /// <summary>
+    /// One entry per row of the page's API reference table - the exact names and signatures, which
+    /// is what someone types when they know what they want and only need to be shown where it is.
+    /// </summary>
+    private static void AddApiMembers(List<DocsSearchEntry> entries, DocGroup group, DocLink link, string markup)
+    {
+        foreach (var member in Elements(markup, "ApiMember"))
+        {
+            var name = Attribute(member.Attributes, "Name");
+            if (string.IsNullOrWhiteSpace(name)) continue;
+
+            entries.Add(new DocsSearchEntry(
+                Title: name,
+                Page: link.Title,
+                Url: $"/{link.Url}#{ApiTableAnchor}",
+                Group: group.Title,
+                Keywords: Join(Attribute(member.Attributes, "Signature"), string.Join(' ', link.TypeNames())),
+                Summary: Attribute(member.Attributes, "Description") ?? string.Empty,
+                Body: string.Empty));
+        }
+    }
+
+    private static string Join(params string?[] parts)
+        => string.Join(' ', parts.Where(part => string.IsNullOrWhiteSpace(part) is false)).Trim();
+
+    /// <summary>The anchor a section gives itself - kept in step with <c>Shared/DemoSection.razor</c>.</summary>
+    private static string Slug(string title) => string.Join('-',
+        string.Concat(title.ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '-'))
+              .Split('-', StringSplitOptions.RemoveEmptyEntries));
+
+    /// <summary>
+    /// The markup half of a page: everything before its <c>@code</c> block, with the Razor comments
+    /// dropped.
+    /// <para>
+    /// The code-behind is the demo's plumbing - field names, event handlers, the JSON it logs to its
+    /// console - and none of it is what a reader is searching for; the comments are notes to whoever
+    /// maintains the page. Indexing either only makes every page match more queries, which is the
+    /// same as making the search worse. The MCP server indexes the full source for agents, which is
+    /// a different reader with a different question - see <see cref="ButilSearchIndex"/>.
+    /// </para>
+    /// </summary>
+    private static string Markup(string source)
+    {
+        var withoutComments = RazorCommentRegex().Replace(source, " ");
+        var code = IndexOfCodeBlock(withoutComments);
+
+        return code < 0 ? withoutComments : withoutComments[..code];
+    }
+
+    /// <summary>
+    /// Where a page's own <c>@code</c> block starts - skipping the raw string literals on the way,
+    /// because half the samples on this site are components and a component sample has a
+    /// <c>@code</c> block of its own, at the start of a line, inside a quoted attribute. Stopping at
+    /// the first one that looks right would cut a page off at its first code sample and hide
+    /// everything below it, which is most of the page.
+    /// </summary>
+    private static int IndexOfCodeBlock(string source)
+    {
+        const string code = "@code";
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            if (source[i] == '"' && i + 2 < source.Length && source[i + 1] == '"' && source[i + 2] == '"')
+            {
+                var terminator = source.IndexOf("\"\"\"", i + 3, StringComparison.Ordinal);
+                if (terminator < 0) return -1;
+
+                i = terminator + 2;
+                continue;
+            }
+
+            if (source[i] != '@' || source.AsSpan(i).StartsWith(code, StringComparison.Ordinal) is false) continue;
+
+            // The real one opens a block at the start of a line; "@code" mentioned mid-sentence in
+            // a paragraph about Razor is prose.
+            var lineStart = i == 0 ? 0 : source.LastIndexOf('\n', i - 1) + 1;
+            if (source.AsSpan(lineStart, i - lineStart).IsWhiteSpace() is false) continue;
+
+            var brace = i + code.Length;
+            while (brace < source.Length && char.IsWhiteSpace(source[brace])) brace++;
+
+            if (brace < source.Length && source[brace] == '{') return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// A page's markup with its sections and its API table cut out, so the page entry keeps the
+    /// prose that is only on the page - a paragraph between two sections, the note under the header -
+    /// without swallowing the text that already has an entry of its own.
+    /// </summary>
+    private static string Outside(string markup)
+    {
+        var kept = new StringBuilder(markup.Length);
+        var cut = 0;
+
+        foreach (var element in Elements(markup, "DemoSection").Concat(Elements(markup, "ApiTable")).OrderBy(e => e.Start))
+        {
+            // The two lists are each in reading order but their concatenation is not sorted by the
+            // time the spans overlap - they never nest, so an element that starts before the cut has
+            // already been removed.
+            if (element.Start < cut) continue;
+
+            kept.Append(markup[cut..element.Start]);
+            cut = element.End;
+        }
+
+        return kept.Append(markup[cut..]).ToString();
+    }
+
+    /// <param name="Attributes">The text of the opening tag, from the end of the tag name to its end.</param>
+    /// <param name="Inner">What the element wraps, or empty when it is self-closing.</param>
+    /// <param name="Start">Where the element begins in the markup it was found in.</param>
+    /// <param name="End">Where it ends, exclusive.</param>
+    private readonly record struct Element(string Attributes, string Inner, int Start, int End);
+
+    /// <summary>
+    /// Every occurrence of one component in a page's markup.
+    /// <para>
+    /// A regex cannot do this: an attribute of these components is as likely to be a raw string
+    /// holding a whole code sample - quotes, angle brackets and all - as it is to be a word, and
+    /// that sample would end the tag early for any pattern that looks for the next <c>&gt;</c>.
+    /// Scanning is what can tell a delimiter from the same character inside a string.
+    /// </para>
+    /// </summary>
+    private static List<Element> Elements(string markup, string name)
+    {
+        var elements = new List<Element>();
+        var open = $"<{name}";
+        var close = $"</{name}>";
+
+        var index = markup.IndexOf(open, StringComparison.Ordinal);
+
+        while (index >= 0)
+        {
+            // "<Callout" must not match "<CalloutHeading": the tag name ends where the name ends.
+            var after = index + open.Length;
+            if (after < markup.Length && (char.IsLetterOrDigit(markup[after]) || markup[after] == '_'))
+            {
+                index = markup.IndexOf(open, after, StringComparison.Ordinal);
+                continue;
+            }
+
+            var end = EndOfOpenTag(markup, after, out var selfClosing);
+            if (end < 0) break;
+
+            var attributes = markup[after..end];
+            var inner = string.Empty;
+            var next = end + 1;
+
+            if (selfClosing is false)
+            {
+                var closing = markup.IndexOf(close, next, StringComparison.Ordinal);
+                if (closing >= 0)
+                {
+                    inner = markup[next..closing];
+                    next = closing + close.Length;
+                }
+            }
+
+            elements.Add(new Element(attributes, inner, index, next));
+
+            index = markup.IndexOf(open, next, StringComparison.Ordinal);
+        }
+
+        return elements;
+    }
+
+    /// <summary>
+    /// The index of the <c>&gt;</c> that closes an opening tag, skipping over anything quoted.
+    /// Returns -1 when the tag is never closed, which would mean the page did not compile.
+    /// </summary>
+    private static int EndOfOpenTag(string markup, int start, out bool selfClosing)
+    {
+        selfClosing = false;
+
+        for (var i = start; i < markup.Length; i++)
+        {
+            var c = markup[i];
+
+            // A C# raw string literal: three quotes to three quotes, and everything between them -
+            // single quotes and '>' included - is text.
+            if (c == '"' && i + 2 < markup.Length && markup[i + 1] == '"' && markup[i + 2] == '"')
+            {
+                var terminator = markup.IndexOf("\"\"\"", i + 3, StringComparison.Ordinal);
+                if (terminator < 0) return -1;
+
+                i = terminator + 2;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                var terminator = markup.IndexOf('"', i + 1);
+                if (terminator < 0) return -1;
+
+                i = terminator;
+                continue;
+            }
+
+            if (c != '>') continue;
+
+            selfClosing = markup[start..i].TrimEnd().EndsWith('/');
+
+            return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// The value of one attribute of an opening tag. Both spellings of a Razor attribute are
+    /// accepted - the plain <c>Title="..."</c> and the expression <c>Code=@("...")</c>, whose string
+    /// is as often a raw one holding a multi-line sample.
+    /// </summary>
+    private static string? Attribute(string? attributes, string name)
+    {
+        if (string.IsNullOrEmpty(attributes)) return null;
+
+        var match = AttributeRegex(name).Match(attributes);
+        if (match.Success is false) return null;
+
+        var value = match.Groups["raw"].Success ? match.Groups["raw"].Value
+                  : match.Groups["expression"].Success ? match.Groups["expression"].Value
+                  : match.Groups["plain"].Value;
+
+        return WebUtility.HtmlDecode(value).Trim();
+    }
+
+    /// <summary>
+    /// One attribute by name. Built per call rather than declared with <c>[GeneratedRegex]</c>
+    /// because the name is the pattern; the cache the Regex class keeps is what stops that from
+    /// costing a compile each time.
+    /// </summary>
+    private static Regex AttributeRegex(string name) => new(
+        // Four quotes delimit it: the pattern itself contains the three that delimit a raw string,
+        // because a raw string is one of the three ways a page writes an attribute value.
+        $$""""\b{{Regex.Escape(name)}}\s*=\s*(?:@\(\s*"""(?<raw>[\s\S]*?)"""\s*\)|@\(\s*"(?<expression>[^"]*)"\s*\)|"(?<plain>[^"]*)")"""",
+        RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The words inside a fragment of markup: its text nodes and nothing else.
+    /// <para>
+    /// The tags around them are the page's plumbing - element names, CSS classes, event bindings -
+    /// and a corpus that contains them matches "div" and "button" on every page. What is left is
+    /// what a visitor can actually see: the labels of the demo's controls, its headings, its prose.
+    /// </para>
+    /// </summary>
+    private static string Text(string markup)
+    {
+        if (string.IsNullOrWhiteSpace(markup)) return string.Empty;
+
+        var text = new StringBuilder(markup.Length);
+        var depth = 0;
+
+        foreach (var c in markup)
+        {
+            if (c == '<') { depth++; continue; }
+            if (c == '>') { if (depth > 0) depth--; text.Append(' '); continue; }
+
+            if (depth == 0) text.Append(c);
+        }
+
+        // Razor expressions - @_writeText, @onclick - are identifiers, not words anyone searches for.
+        var words = WebUtility.HtmlDecode(text.ToString())
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(word => word.StartsWith('@') is false);
+
+        return string.Join(' ', words);
+    }
+
+    /// <summary>A Razor comment: <c>@* ... *@</c>, across as many lines as it likes.</summary>
+    [GeneratedRegex(@"@\*[\s\S]*?\*@")]
+    private static partial Regex RazorCommentRegex();
+}

--- a/src/Butil/Bit.Butil.Demo/Server/wwwroot/css/app.css
+++ b/src/Butil/Bit.Butil.Demo/Server/wwwroot/css/app.css
@@ -1011,6 +1011,16 @@ svg {
     color: var(--colorNeutralForeground3);
 }
 
+/* The words the query matched, inside that one line. Fluent has no highlight token, and a filled
+   swatch behind two words in a list of ten rows is noise; weight and the brand hue say the same
+   thing without repainting the row. The default <mark> background has to go with it - it is a
+   yellow the dark theme has no answer for. */
+.header-search-result-summary mark {
+    background-color: transparent;
+    color: var(--colorBrandForeground1);
+    font-weight: var(--fontWeightSemibold);
+}
+
 .header-search-result-group {
     flex: none;
     font-size: var(--fontSizeBase100);

--- a/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
+++ b/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
@@ -19,12 +19,11 @@
                                  false   (default) Bundle mode: the app references bit-butil.js itself and
                                          the per-module files are dropped from its static web assets.
 
-      BitButilTrimScripts        true    In bundle mode, when the app is published trimmed, rebuild
-                                         bit-butil.js from only the modules the trimmed Bit.Butil.dll
-                                         still calls - the JavaScript equivalent of the IL trimming the
+      BitButilTrimScripts        true    In bundle mode, rebuild bit-butil.js from only the modules this app
+                                         can still call - the JavaScript equivalent of the IL trimming the
                                          library already supports. Wherever the per-module files are
-                                         published too, the same signal narrows them: only the modules that
-                                         assembly can still import are published, the rest of modules/ is
+                                         published too, the same signal narrows them: only the modules the
+                                         app can still import are published, the rest of modules/ is
                                          dropped, and nothing can 404 over it - the identifier that would
                                          have imported a dropped module left with the module.
                                          Publish only: a build - and everything development runs on top of
@@ -33,7 +32,46 @@
                                          Default: true in a Blazor WebAssembly project (the one case where
                                          the assembly that is trimmed is the assembly that calls the served
                                          JavaScript), false elsewhere.
-                                 false   Publish the full bundle even when trimming.
+                                 false   Publish the full bundle, whatever the signals below say.
+
+                                         The switch decides *whether* to trim; the three below are *what it
+                                         knows*, and with none of them in play it does nothing at all.
+
+      PublishTrimmed             true    (not a Bit.Butil property) The most precise signal there is: the
+                                         interop identifiers ILLink left in the trimmed Bit.Butil.dll are
+                                         exactly what the surviving code can call. In play whenever the
+                                         publish is trimmed, and it then supersedes BitButilScriptScan -
+                                         the same question, better answered.
+
+      BitButilScriptScan         None    (default) Do not read the app's own assemblies.
+                       TypeReferences    Read them, and take every Bit.Butil type they reference - an
+                                         @inject Clipboard is a reference to Bit.Butil.Clipboard - through
+                                         to the modules that type needs. The signal for an app published
+                                         WITHOUT trimming, and the mode to use of the two: on this
+                                         repository's own trimming harness it produces the same module set
+                                         ILLink does, exactly.
+                            TypeNames    The same idea without reading the metadata tables: match the
+                                         library's type names against the names in each assembly's string
+                                         heap. Cheaper to reason about, and coarser - an app with a class
+                                         of its own called Window, Console or Storage pulls in that
+                                         module too. It over-includes, never misses.
+                                         Ignored outright when PublishTrimmed is true.
+
+      BitButilScriptModule               An item, not a property: modules or Bit.Butil class names this app
+                                         needs whatever the above concluded.
+                                           <ItemGroup>
+                                             <BitButilScriptModule Include="Clipboard;geolocation" />
+                                           </ItemGroup>
+                                         Always ADDED to what the other signals found, never instead of
+                                         them, and it is the way to keep a module reached from somewhere
+                                         none of them can see - by reflection, or from an app's own
+                                         JavaScript. A name that is neither a module nor a Bit.Butil class
+                                         fails the build rather than being ignored.
+
+      BitButilScriptScanAssembly         An item: which assemblies BitButilScriptScan reads. Defaults to
+                                         this project's own assembly and its copy-local references, which
+                                         is the app; set it only if that is not where the code calling
+                                         Bit.Butil lives.
 
       BitButilIncludeScriptBundle / BitButilIncludeScriptModules
                                          Fine-grained overrides of which shape ends up in the app's static
@@ -42,14 +80,17 @@
                                          BitButilIncludeScriptModules=true, written out in the csproj, is
                                          also what publishes every module file through a trimmed publish:
                                          asking for them by name outranks the trimming, which otherwise
-                                         keeps only the ones the assembly's own interop calls can reach.
+                                         keeps only the ones the app can reach.
 
-    Trimming the bundle relies on Bit.Butil.dll being trimmed in *this* project's publish, so it is on by
-    default only for a standalone Blazor WebAssembly app (or PWA). A server host that references a
-    WebAssembly client keeps its own, full copy of the bundle - and must not trim it from its own trimmed
-    assembly set, which does not reflect what the client calls - so use lazy scripts there. Any other
-    project that runs ILLink over Bit.Butil.dll and serves the JavaScript to that same code can opt in with
-    BitButilTrimScripts=true.
+    Which signal suits which app. A standalone Blazor WebAssembly app (or PWA) publishes trimmed by default
+    and is the one case where the assembly ILLink trims is the assembly that calls the served JavaScript, so
+    BitButilTrimScripts defaults to true there and needs nothing else. An app published untrimmed - a
+    WebAssembly app with PublishTrimmed off, a Blazor Server app, a server host that prerenders - has no
+    ILLink to ask, and BitButilScriptScan=TypeReferences is what replaces it. A server host that references
+    a WebAssembly client is the case to think about: scanning covers the host and the client alike, because
+    the client's assembly is one of the host's references, but ILLink's answer for such a host is about the
+    host's own code only - which is why trimming there wants the scan (or lazy scripts) rather than
+    PublishTrimmed.
     -->
 
     <!-- The package carries the same targets file under buildTransitive\ and build\, and tooling that
@@ -68,6 +109,10 @@
         <BitButilLazyScripts Condition="'$(BitButilLazyScripts)' == ''">false</BitButilLazyScripts>
         <BitButilTrimScripts Condition="'$(BitButilTrimScripts)' == '' and ('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true')">true</BitButilTrimScripts>
         <BitButilTrimScripts Condition="'$(BitButilTrimScripts)' == ''">false</BitButilTrimScripts>
+        <!-- Off by default everywhere. Reading a publish's assemblies is a cost and a judgement about what
+             the app calls, and neither belongs in a default: an app gets the scan because its csproj asked
+             for it, having decided which of the two modes it wants. -->
+        <BitButilScriptScan Condition="'$(BitButilScriptScan)' == ''">None</BitButilScriptScan>
         <BitButilIncludeScriptBundle Condition="'$(BitButilIncludeScriptBundle)' == '' and '$(BitButilLazyScripts)' == 'true'">false</BitButilIncludeScriptBundle>
         <BitButilIncludeScriptBundle Condition="'$(BitButilIncludeScriptBundle)' == ''">true</BitButilIncludeScriptBundle>
         <!-- Whether the consumer asked for the per-module files by name, as opposed to getting them from
@@ -88,7 +133,13 @@
              keep whatever it already holds, and so do the WebAssembly SDK's additions. This is the same
              stage at which the WebAssembly SDK swaps in its trimmed assemblies, after ILLink has run and
              before compressed variants, service-worker manifests and fingerprinted endpoints are computed. -->
-        <ResolvePublishStaticWebAssetsDependsOn>$(ResolvePublishStaticWebAssetsDependsOn);BitButilTrimScriptBundle;BitButilTrimScriptModules</ResolvePublishStaticWebAssetsDependsOn>
+        <!-- _BitButilResolveScriptTrimming is named here as well as in the DependsOnTargets of the target
+             that needs it, and first in the list on purpose: MSBuild evaluates a target's own Condition
+             before it builds that target's DependsOnTargets, so a gate the dependency sets would be read
+             while it is still unset. Listed here, it has run by the time either target is reached. -->
+        <!-- BitButilSelectPublishScriptAssets first of the four: it drops the shape of the JavaScript this app
+             does not use, and the two trimming targets after it only ever narrow what is left. -->
+        <ResolvePublishStaticWebAssetsDependsOn>$(ResolvePublishStaticWebAssetsDependsOn);_BitButilResolveScriptTrimming;BitButilSelectPublishScriptAssets;BitButilTrimScriptBundle;BitButilTrimScriptModules</ResolvePublishStaticWebAssetsDependsOn>
 
         <!-- Same appending trick, for the stage that gathers the assets themselves (see
              BitButilSelectScriptAssets). The SDK collects them from three places in a fixed order - the
@@ -143,15 +194,18 @@
 
     <!--
     Drops the shape of the JavaScript the app does not use from its static web assets, so a bundle-mode app
-    does not publish 65 module files it never requests and a lazy-mode app does not publish a bundle it
-    never loads. Runs once the SDK has gathered the assets from every source (see the DependsOn properties
-    above) and long before the build manifest publish later resumes from is written, so the removed items
-    reach neither the build output nor the publish output.
+    does not carry 65 module files it never requests and a lazy-mode app does not carry a bundle it never
+    loads. Runs once the SDK has gathered the assets from every source (see the DependsOn properties above)
+    and long before the build manifest is written, so the removed items reach neither the build output nor
+    that manifest.
 
     Gathering assets from every source is what makes this work for a ProjectReference to Bit.Butil - the
     layout the repository's own samples and tests use - as well as for the PackageReference a consumer has:
     a referenced project contributes its assets after the package ones, so a step that ran any earlier
-    would find nothing to drop and silently publish the whole set.
+    would find nothing to drop and silently keep the whole set.
+
+    This is the build half only. A publish rebuilds the asset list from scratch and has to be told again -
+    see BitButilSelectPublishScriptAssets below for why, and why it cannot be this same target.
     -->
     <Target Name="BitButilSelectScriptAssets"
             Condition="'$(BitButilIncludeScriptBundle)' != 'true' or '$(BitButilIncludeScriptModules)' != 'true'">
@@ -189,12 +243,62 @@
         </ItemGroup>
     </Target>
 
+    <!--
+    The same selection again, on the publish asset list, because a publish does not inherit the build's.
+    ResolveCorePublishStaticWebAssets empties @(StaticWebAsset), reloads it from the build manifest - which is
+    correct, and is where the removals above did land - and then asks every referenced project for its own
+    *publish* assets and merges those back in wholesale. Bit.Butil, asked that question, answers with the whole
+    of its wwwroot: it has no idea which shape the consuming app chose. So a bundle-mode app that references
+    Bit.Butil as a project ends up publishing all 65 module files, and a lazy-scripts app publishes the bundle
+    it never loads, even though neither is in its build output or its build manifest.
+
+    Written out twice rather than shared: a target runs at most once per project build, so one target hooked
+    into both stages would run at the first and be skipped at the second - which is the very thing that leaves
+    the publish output wrong. The two bodies are identical, and are meant to stay that way.
+    -->
+    <Target Name="BitButilSelectPublishScriptAssets"
+            Condition="'$(BitButilIncludeScriptBundle)' != 'true' or '$(BitButilIncludeScriptModules)' != 'true'">
+        <ItemGroup>
+            <_BitButilAsset Include="@(StaticWebAsset)" Condition="'%(StaticWebAsset.SourceId)' == 'Bit.Butil'" />
+            <_BitButilAsset>
+                <_Path>$([MSBuild]::NormalizePath('%(FullPath)'))</_Path>
+                <_MatchPath>$([MSBuild]::NormalizePath('%(FullPath)'))</_MatchPath>
+            </_BitButilAsset>
+            <!-- A derived asset - a pre-compressed .gz/.br variant the package ships - is classified by the
+                 asset it was derived from, so that it leaves together with it instead of staying behind with
+                 a RelatedAsset pointing at a file that is no longer part of the app. -->
+            <_BitButilAsset Condition="'%(_BitButilAsset.RelatedAsset)' != ''">
+                <_MatchPath>$([MSBuild]::NormalizePath('%(_BitButilAsset.RelatedAsset)'))</_MatchPath>
+            </_BitButilAsset>
+            <_BitButilAsset>
+                <_IsBundle>$([System.String]::Copy('%(_MatchPath)').EndsWith('bit-butil.js', System.StringComparison.OrdinalIgnoreCase))</_IsBundle>
+                <_IsModule>$([System.String]::Copy('%(_MatchPath)').Replace('\', '/').Contains('/modules/'))</_IsModule>
+            </_BitButilAsset>
+
+            <_BitButilRemovedAsset Include="@(_BitButilAsset)" Condition="'$(BitButilIncludeScriptBundle)' != 'true' and '%(_BitButilAsset._IsBundle)' == 'True'" />
+            <_BitButilRemovedAsset Include="@(_BitButilAsset)" Condition="'$(BitButilIncludeScriptModules)' != 'true' and '%(_BitButilAsset._IsModule)' == 'True'" />
+
+            <!-- Endpoints (.NET 9 SDK and later) are keyed by the asset file they serve. -->
+            <_BitButilRemovedEndpointKey Include="@(_BitButilRemovedAsset)">
+                <AssetFile>%(_BitButilRemovedAsset._Path)</AssetFile>
+            </_BitButilRemovedEndpointKey>
+
+            <StaticWebAsset Remove="@(_BitButilRemovedAsset)" />
+            <StaticWebAssetEndpoint Remove="@(_BitButilRemovedEndpointKey)" MatchOnMetadata="AssetFile" MatchOnMetadataOptions="PathLike" />
+
+            <_BitButilAsset Remove="@(_BitButilAsset)" />
+            <_BitButilRemovedAsset Remove="@(_BitButilRemovedAsset)" />
+            <_BitButilRemovedEndpointKey Remove="@(_BitButilRemovedEndpointKey)" />
+        </ItemGroup>
+    </Target>
+
 
     <!--
-    Publish-time bundle trimming. After ILLink has produced the trimmed Bit.Butil.dll, replace the package's
-    bit-butil.js static web asset with one assembled from just the modules that assembly still calls. The
-    replacement is a fresh asset defined through the SDK's own tasks, so its fingerprint, integrity, endpoints
-    and (afterwards) compressed variants are all computed from the new content.
+    Publish-time bundle trimming. Replace the package's bit-butil.js static web asset with one assembled from
+    just the modules this app can still call - read from the trimmed Bit.Butil.dll where ILLink produced one,
+    and from the app's own assemblies where it did not. The replacement is a fresh asset defined through the
+    SDK's own tasks, so its fingerprint, integrity, endpoints and (afterwards) compressed variants are all
+    computed from the new content.
 
     Three targets rather than one because the .NET 8 SDK has neither endpoints nor content fingerprinting, and
     MSBuild rejects an unknown task (or task parameter) even under a false condition: the pieces that need the
@@ -204,41 +308,101 @@
       _BitButilAssembleTrimmedBundle   runs the bundler and prepares the candidate asset + the stale set
       _BitButilDefineTrimmedBundle     defines the asset (plain form here, fingerprinted form in the 9+ file)
       BitButilTrimScriptBundle         swaps the assets and endpoints in the static web asset lists
-      BitButilTrimScriptModules        drops the per-module files the trimmed app can no longer import
+      BitButilTrimScriptModules        drops the per-module files the app can no longer import
     -->
     <PropertyGroup>
-        <!-- Publish only, on three counts: every target these gate hangs off ResolvePublishStaticWebAssets,
-             which no build reaches; PublishTrimmed only ever produces the trimmed assembly that is read here
-             during a publish; and a design-time build is excluded outright. A build, and so dotnet run and
-             dotnet watch, keeps the JavaScript exactly as the package ships it - what a developer debugs is
-             always the full, untrimmed set. -->
-        <_BitButilPublishTrimming>false</_BitButilPublishTrimming>
-        <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(PublishTrimmed)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
-
-        <!-- The bundle half: rebuild bit-butil.js from the surviving modules. Needs a bundle to rebuild. -->
-        <_BitButilTrimEnabled>false</_BitButilTrimEnabled>
-        <_BitButilTrimEnabled Condition="'$(_BitButilPublishTrimming)' == 'true' and '$(BitButilIncludeScriptBundle)' == 'true'">true</_BitButilTrimEnabled>
-
-        <!-- The per-module half: publish only the module files the trimmed assembly can still import. The
-             same signal, applied to the other shape of the same JavaScript - a module no surviving code
-             names is a file nothing can ever request. Skipped when the csproj asked for the modules by
-             name, which is how an app that loads them from somewhere this cannot see keeps the full set. -->
-        <_BitButilTrimModulesEnabled>false</_BitButilTrimModulesEnabled>
-        <_BitButilTrimModulesEnabled Condition="'$(_BitButilPublishTrimming)' == 'true' and '$(BitButilIncludeScriptModules)' == 'true' and '$(_BitButilScriptModulesRequested)' != 'true'">true</_BitButilTrimModulesEnabled>
-
-        <_BitButilTrimAnyEnabled>false</_BitButilTrimAnyEnabled>
-        <_BitButilTrimAnyEnabled Condition="'$(_BitButilTrimEnabled)' == 'true' or '$(_BitButilTrimModulesEnabled)' == 'true'">true</_BitButilTrimAnyEnabled>
-
+        <!-- Evaluation time, because the Import at the foot of this file conditions on it. Everything else
+             the trimming is gated on is decided in _BitButilResolveScriptTrimming instead: it has to read
+             @(BitButilScriptModule), and MSBuild evaluates every property in every import before it reaches
+             any item, so a property that read that item here would always find it empty. -->
         <_BitButilSdkHasEndpoints>false</_BitButilSdkHasEndpoints>
         <_BitButilSdkHasEndpoints Condition="'$(NETCoreSdkVersion)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">true</_BitButilSdkHasEndpoints>
     </PropertyGroup>
 
-    <Target Name="_BitButilAssembleTrimmedBundle" Condition="'$(_BitButilTrimAnyEnabled)' == 'true'">
+    <!--
+    Which signal the trimming runs on, and whether it runs at all. A target rather than a plain property
+    group because it reads @(BitButilScriptModule), and MSBuild evaluates every property of every import
+    before it reaches any item - a property group here would read that item while it is still empty.
+
+    Reached two ways, and it needs both. Naming it in DependsOnTargets of the target that uses its output is
+    what makes it run for a direct invocation; naming it FIRST in ResolvePublishStaticWebAssetsDependsOn is
+    what makes it run early enough, because MSBuild evaluates a target's own Condition before building that
+    target's DependsOnTargets - so a gate set only by the dependency is still unset when the gate is read.
+    -->
+    <Target Name="_BitButilResolveScriptTrimming">
 
         <PropertyGroup>
-            <_BitButilTrimmedAssembly>$(IntermediateLinkDir)Bit.Butil.dll</_BitButilTrimmedAssembly>
+            <!-- ILLink's answer supersedes the scan rather than joining it: both answer "what can this app
+                 call", and the identifiers left in a trimmed assembly answer it from what survived rather
+                 than from what was referenced. Running both would only ever widen the precise answer with
+                 the approximate one. -->
+            <_BitButilScanMode>None</_BitButilScanMode>
+            <_BitButilScanMode Condition="'$(PublishTrimmed)' != 'true'">$(BitButilScriptScan)</_BitButilScanMode>
+
+            <!-- Nothing to go on is not a reason to trim to nothing: with no ILLink, no scan and no module
+                 named in the csproj, the whole feature stands down and the full bundle is published. -->
+            <_BitButilHasSignal>false</_BitButilHasSignal>
+            <_BitButilHasSignal Condition="'$(PublishTrimmed)' == 'true' or ('$(_BitButilScanMode)' != '' and '$(_BitButilScanMode)' != 'None') or '@(BitButilScriptModule)' != ''">true</_BitButilHasSignal>
+
+            <!-- Publish only, on three counts: every target these gate hangs off ResolvePublishStaticWebAssets,
+                 which no build reaches; the assemblies read here are a publish's; and a design-time build is
+                 excluded outright. A build, and so dotnet run and dotnet watch, keeps the JavaScript exactly
+                 as the package ships it - what a developer debugs is always the full, untrimmed set. -->
+            <_BitButilPublishTrimming>false</_BitButilPublishTrimming>
+            <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
+
+            <!-- The bundle half: rebuild bit-butil.js from the modules the app can reach. Needs a bundle to
+                 rebuild. -->
+            <_BitButilTrimEnabled>false</_BitButilTrimEnabled>
+            <_BitButilTrimEnabled Condition="'$(_BitButilPublishTrimming)' == 'true' and '$(BitButilIncludeScriptBundle)' == 'true'">true</_BitButilTrimEnabled>
+
+            <!-- The per-module half: publish only the module files the app can still import. The same signal,
+                 applied to the other shape of the same JavaScript - a module no reachable code names is a
+                 file nothing can ever request. Skipped when the csproj asked for the modules by name, which
+                 is how an app that loads them from somewhere this cannot see keeps the full set. -->
+            <_BitButilTrimModulesEnabled>false</_BitButilTrimModulesEnabled>
+            <_BitButilTrimModulesEnabled Condition="'$(_BitButilPublishTrimming)' == 'true' and '$(BitButilIncludeScriptModules)' == 'true' and '$(_BitButilScriptModulesRequested)' != 'true'">true</_BitButilTrimModulesEnabled>
+
+            <_BitButilTrimAnyEnabled>false</_BitButilTrimAnyEnabled>
+            <_BitButilTrimAnyEnabled Condition="'$(_BitButilTrimEnabled)' == 'true' or '$(_BitButilTrimModulesEnabled)' == 'true'">true</_BitButilTrimAnyEnabled>
+        </PropertyGroup>
+
+        <Message Importance="normal" Condition="'$(PublishTrimmed)' == 'true' and '$(BitButilScriptScan)' != '' and '$(BitButilScriptScan)' != 'None'"
+                 Text="Bit.Butil: this publish is trimmed, so &lt;BitButilScriptScan&gt;$(BitButilScriptScan)&lt;/BitButilScriptScan&gt; is not used - the trimmed assembly answers the same question more precisely." />
+
+        <!-- The app's own assemblies: this project's output and everything copied next to it. Overridable in
+             the csproj for the app whose Bit.Butil calls live somewhere this cannot see. Only gathered when
+             a scan is actually going to read them. -->
+        <ItemGroup Condition="'$(_BitButilScanMode)' != '' and '$(_BitButilScanMode)' != 'None' and '@(BitButilScriptScanAssembly)' == ''">
+            <BitButilScriptScanAssembly Include="@(IntermediateAssembly->'%(FullPath)')" />
+            <BitButilScriptScanAssembly Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
+        </ItemGroup>
+
+    </Target>
+
+    <Target Name="_BitButilAssembleTrimmedBundle" DependsOnTargets="_BitButilResolveScriptTrimming" Condition="'$(_BitButilTrimAnyEnabled)' == 'true'">
+
+        <PropertyGroup>
+            <!-- Only set when ILLink is in play: the task reads "a path was given but the file is not there"
+                 as "this publish was set up to be trimmed and Bit.Butil was not", and keeps the full bundle.
+                 Left empty, the scan and the csproj are what it goes on instead. -->
+            <_BitButilTrimmedAssembly Condition="'$(PublishTrimmed)' == 'true'">$(IntermediateLinkDir)Bit.Butil.dll</_BitButilTrimmedAssembly>
             <_BitButilTrimmedBundleDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'bit-butil'))</_BitButilTrimmedBundleDir>
             <_BitButilTrimmedBundle>$(_BitButilTrimmedBundleDir)bit-butil.js</_BitButilTrimmedBundle>
+        </PropertyGroup>
+
+        <!-- The untrimmed Bit.Butil.dll, which is what says which module each Bit.Butil class needs. Needed
+             by a scan, and by a csproj that names classes rather than modules; the task says so itself if it
+             turns out to be needed and missing. -->
+        <ItemGroup>
+            <_BitButilReferencedAssembly Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)%(Extension)' == 'Bit.Butil.dll'" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <_BitButilUntrimmedAssembly>@(_BitButilReferencedAssembly->'%(FullPath)')</_BitButilUntrimmedAssembly>
+            <!-- More than one, and there is no telling which is the Bit.Butil this app compiled against.
+                 Empty is the honest answer: the task then says what it could not read, and why it needed to. -->
+            <_BitButilUntrimmedAssembly Condition="'$(_BitButilUntrimmedAssembly)' != '' and $(_BitButilUntrimmedAssembly.Contains(';'))"></_BitButilUntrimmedAssembly>
         </PropertyGroup>
 
         <ItemGroup Condition="'$(_BitButilTrimEnabled)' == 'true'">
@@ -255,19 +419,27 @@
                Text="Bit.Butil: expected a single primary bit-butil.js static web asset but found @(_BitButilBundleAsset->Count()): @(_BitButilBundleAsset->'%(FullPath)', ', '). Set &lt;BitButilTrimScripts&gt;false&lt;/BitButilTrimScripts&gt; to publish the full bundle instead." />
 
         <!-- No OutputPath when there is no bundle to rebuild: the task then only works out which modules the
-             trimmed assembly can still reach, which is all the per-module half below needs. -->
+             app can still reach, which is all the per-module half below needs. -->
         <PropertyGroup>
             <_BitButilTrimmedBundleOutput Condition="'@(_BitButilBundleAsset)' != ''">$(_BitButilTrimmedBundle)</_BitButilTrimmedBundleOutput>
         </PropertyGroup>
 
         <TrimButilScripts Condition="'@(_BitButilBundleAsset)' != '' or '$(_BitButilTrimModulesEnabled)' == 'true'"
                           TrimmedAssembly="$(_BitButilTrimmedAssembly)"
+                          ButilAssembly="$(_BitButilUntrimmedAssembly)"
+                          ScanMode="$(_BitButilScanMode)"
+                          ScanAssemblies="@(BitButilScriptScanAssembly)"
+                          ExplicitModules="@(BitButilScriptModule)"
                           ChunksDirectory="$(BitButilChunksDirectory)"
                           ManifestPath="$(BitButilScriptManifest)"
                           OutputPath="$(_BitButilTrimmedBundleOutput)">
             <Output TaskParameter="Skipped" PropertyName="_BitButilTrimSkipped" />
             <Output TaskParameter="IncludedModules" ItemName="BitButilIncludedScriptModule" />
         </TrimButilScripts>
+
+        <ItemGroup>
+            <_BitButilReferencedAssembly Remove="@(_BitButilReferencedAssembly)" />
+        </ItemGroup>
 
         <ItemGroup Condition="'@(_BitButilBundleAsset)' != '' and '$(_BitButilTrimSkipped)' != 'true'">
             <!-- The old bundle, plus anything derived from it (a build-time compressed variant points back
@@ -358,7 +530,7 @@
             Condition="'$(_BitButilTrimModulesEnabled)' == 'true'">
 
         <!-- The reachable set as a delimited string, so a module name can be looked up in it from an item
-             condition. Empty when the bundler found no trimmed assembly to read (_BitButilTrimSkipped), and
+             condition. Empty when the bundler had nothing to work from (_BitButilTrimSkipped), and
              the target then leaves every module in place rather than dropping the lot. -->
         <PropertyGroup>
             <_BitButilKeptModules>;@(BitButilIncludedScriptModule);</_BitButilKeptModules>
@@ -397,7 +569,7 @@
         </ItemGroup>
 
         <Message Importance="normal" Condition="'@(_BitButilRemovedModule)' != ''"
-                 Text="Bit.Butil: dropped @(_BitButilRemovedModule->Count()) per-module script file(s) the trimmed app can no longer import. Set &lt;BitButilIncludeScriptModules&gt;true&lt;/BitButilIncludeScriptModules&gt; to publish every module instead." />
+                 Text="Bit.Butil: dropped @(_BitButilRemovedModule->Count()) per-module script file(s) this app can no longer import. Set &lt;BitButilIncludeScriptModules&gt;true&lt;/BitButilIncludeScriptModules&gt; to publish every module instead." />
 
         <ItemGroup>
             <_BitButilModuleCandidate Remove="@(_BitButilModuleCandidate)" />

--- a/src/Butil/README.md
+++ b/src/Butil/README.md
@@ -288,6 +288,43 @@ it - keeps the full bundle and every module, so what you debug is never the trim
 </PropertyGroup>
 ```
 
+**Publishing without trimming?** `BitButilTrimScripts` decides *whether* to trim the JavaScript; what it
+trims against is a separate question, and a publish with `PublishTrimmed` off has no trimmed assembly to
+read. `BitButilScriptScan` answers it from the app's own assemblies instead: an `@inject Clipboard` is a
+reference to `Bit.Butil.Clipboard`, and the package's build logic reads `Bit.Butil.dll` to know which
+JavaScript module answering that class takes - through base classes and internal interop helpers, so
+`LocalStorage` correctly pulls in `storage` and `Window` pulls in `events` as well as `window`. On this
+repository's own trimming harness it reaches exactly the module set ILLink does. It works in every hosting
+model - a WebAssembly app with `PublishTrimmed` off, Blazor Server, a server host that prerenders - and it
+costs the publish one pass over the app's assemblies, tens of milliseconds; a build is untouched either way.
+
+```xml
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
+</PropertyGroup>
+```
+
+`TypeNames` is the other mode: it matches the library's type names against the names in each assembly, with
+no metadata tables read at all. It is coarser - an app with a class of its own called `Window`, `Console` or
+`Storage` pulls in that module too - and it over-includes rather than missing anything, so prefer
+`TypeReferences` unless you have a reason not to. Either is ignored when `PublishTrimmed` is `true`: the
+trimmed assembly answers the same question more precisely.
+
+**Keeping a module none of that can see.** `BitButilScriptModule` names modules, or the Bit.Butil classes
+behind them, that must survive whatever the scan or the trimmer concluded - for an API reached by reflection,
+or from your own JavaScript. It is always *added* to what they found, never used instead of it, and a name
+that is neither a module nor a Bit.Butil class fails the build rather than being quietly ignored:
+
+```xml
+<ItemGroup>
+  <BitButilScriptModule Include="Clipboard;geolocation" />
+</ItemGroup>
+```
+
+With none of the three in play - no `PublishTrimmed`, no `BitButilScriptScan`, no `BitButilScriptModule` -
+there is nothing to trim against, and the full bundle is published.
+
 **Lazy scripts.** No script tag at all: the first call into an API `import()`s that API's module
 (`_content/Bit.Butil/modules/clipboard.js` for `Clipboard`), so only the JavaScript for the APIs the
 app actually calls is ever downloaded - in every hosting model, trimmed or not. Each module file is

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/Program.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/Program.cs
@@ -168,6 +168,16 @@ internal static class Program
         Console.WriteLine($"  {bundlingPassed} checks passed, {bundlingFailed} failed");
         Console.WriteLine();
 
+        // The other two signals a publish can trim on, which stand in for ILLink when it never runs: the
+        // class-to-module map, and the scan of a consumer's own assemblies that uses it. Checked against the
+        // very set trimming produces for the very same code, so the three cannot drift apart.
+        Console.WriteLine("--- script scanning ---");
+        var (scanningPassed, scanningFailed) = ScriptScanning.Run(string.IsNullOrEmpty(assembly.Location) ? null : assembly.Location, trimmed, failures);
+        Console.WriteLine(trimmed
+            ? "  not checked in a trimmed run - the map is a question about the untrimmed library"
+            : $"  {scanningPassed} checks passed, {scanningFailed} failed");
+        Console.WriteLine();
+
         Console.WriteLine("--- lazy scripts ---");
         var (lazyPassed, lazyFailed) = await LazyScripts.Run(failures);
         Console.WriteLine($"  {lazyPassed} checks passed, {lazyFailed} failed");

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/Program.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/Program.cs
@@ -178,6 +178,17 @@ internal static class Program
             : $"  {scanningPassed} checks passed, {scanningFailed} failed");
         Console.WriteLine();
 
+        // And the same feature as MSBuild actually runs it: a real consumer app published with each
+        // combination of the switches, and the JavaScript that came out read back off disk. The only checks
+        // here that go through a publish rather than through a method call.
+        Console.WriteLine("--- script publishing ---");
+        var publishingStarted = DateTime.UtcNow;
+        var (publishingPassed, publishingFailed) = ScriptPublishing.Run(trimmed, failures);
+        Console.WriteLine(trimmed
+            ? "  not checked in a trimmed run - this process publishes the fixture itself, to the same answers either way"
+            : $"  {publishingPassed} checks passed, {publishingFailed} failed ({(DateTime.UtcNow - publishingStarted).TotalSeconds:N0}s)");
+        Console.WriteLine();
+
         Console.WriteLine("--- lazy scripts ---");
         var (lazyPassed, lazyFailed) = await LazyScripts.Run(failures);
         Console.WriteLine($"  {lazyPassed} checks passed, {lazyFailed} failed");

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
@@ -1,11 +1,14 @@
 ﻿# Bit.Butil.Tests.Manual
 
-A hand-run harness that answers three questions about a trimmed consumer of `Bit.Butil`:
+A hand-run harness that answers four questions about a consumer of `Bit.Butil`:
 
-1. Does it only pay for the Butil classes it actually uses?
+1. Does a trimmed consumer only pay for the Butil classes it actually uses?
 2. Do the pieces the library reaches **by name at runtime** survive that trimming?
 3. Does the JavaScript follow suit - is the bundle a trimmed publish would ship exactly the modules the
    trimmed assembly still calls, and does the lazy per-module loader behave?
+4. And for a consumer published **without** trimming, where there is no trimmed assembly to read: do the
+   signals that stand in for it - a scan of the app's own assemblies, and a module list in its csproj -
+   reach the same answer, and does a real `dotnet publish` carry that answer into its output?
 
 It is a console app rather than a test project on purpose. Trimming is a *publish* step, so the thing
 under test is the produced output, and the same executable is both the report and the check - it exits
@@ -123,6 +126,64 @@ and this repository never does, plus the artifacts the whole feature rests on:
 Node runs the last of those; it is already a build dependency of Bit.Butil (it compiles the TypeScript), so
 a checkout that can produce the artifacts under test can always run them.
 
+**Script scanning** ([`ScriptScanning.cs`](ScriptScanning.cs)). Everything above rests on ILLink having
+run. A consumer publishing untrimmed has no trimmed assembly, and an *untrimmed* `Bit.Butil.dll` names every
+module the library has - so the signal has to come from somewhere else: the Bit.Butil types the app's own
+assemblies reference (`BitButilScriptScan`), and the modules its csproj names outright
+(`BitButilScriptModule`). These check that the somewhere else arrives at the same place. Untrimmed runs only,
+since the map is a question about the library as shipped rather than about what one app's trimming left.
+
+- **the class-to-module map**, built from `Bit.Butil.dll` by walking each type's IL for interop literals and
+  closing over the types it can reach. Every module the library calls has to be reachable from some class -
+  one that is not is a module no scan could ever include - and the map, asked about the five classes
+  `ConsumerComponent` injects, has to answer **exactly `MustSurviveModules`**: the same set ILLink
+  independently arrives at for the same code. That equality is the point of the file. It is also a real test
+  of the closure rather than a restatement of it: `LocalStorage` carries no interop literals of its own (they
+  are on the `ButilStorage` base class) and `Window` reaches `events` only through an internal interop class
+  called from inside a compiler-generated async state machine, so anything less than the full reference
+  closure gets both wrong;
+- **the scan** over this harness's own assembly, which has to find that same set through `TypeReferences`;
+  `TypeNames` has to find no less (it matches bare names, so it over-includes on purpose - never the other
+  way); an assembly that does not reference Bit.Butil has to count for nothing rather than for "this app
+  calls no JavaScript", which acted on would trim every module away; and Bit.Butil's own assembly has to be
+  left out, since it names all of its types and would light up every module;
+- **the csproj list** (`ResolveNames`): a module name, a class name, a full type name, a class whose module
+  is named nothing like it (`LocalStorage` → `storage`), a class needing two modules (`Window`), the wrong
+  case, duplicates and whitespace - and a name that is neither *reported* rather than ignored, since MSBuild
+  accepts a misspelled item without a word;
+- **unreadable inputs**: the map refuses a text file, a truncated assembly and a missing one with the typed
+  exceptions the MSBuild task catches, while the scan passes over all three instead of failing the publish -
+  the list it is handed is whatever a consumer's references resolved to, native libraries and stale paths
+  included;
+- **running the result**: the bundle a scan-trimmed publish would serve, with a csproj-named module mixed in,
+  assembled and evaluated under Node the same way the bundling checks evaluate the ILLink-derived one. A
+  module set that is right on paper still ships broken JavaScript if the chunks behind it do not stand alone.
+
+**Script publishing** ([`ScriptPublishing.cs`](ScriptPublishing.cs),
+[`../Bit.Butil.Tests.PublishFixture`](../Bit.Butil.Tests.PublishFixture)). Everything above checks the
+*computation* by calling into `Bit.Butil.Build`. That is one step of the feature; the rest is MSBuild, and
+none of it is reachable from a method call - whether the trimming runs at all, which of the three signals it
+is allowed to use, that a csproj list is *added* to what the others found rather than replacing it, that
+assets removed from the build list are also removed from the publish list, and that a name meaning nothing
+fails the build. So these publish a real consumer app - a two-class web app next door, published in seconds
+rather than the minutes a WebAssembly one takes - and read the JavaScript back out of its publish output.
+Nine `dotnet publish` runs, about fifteen seconds in total, untrimmed runs only:
+
+- with **no signal at all** the full bundle is published - the case that has to keep working for every
+  consumer who never asked for any of this;
+- a **scan** trims the bundle to the modules the fixture's two classes need; `TypeNames` finds at least those;
+- a **csproj module list** trims it on its own, with no scan and no ILLink;
+- a csproj list **plus** a scan produces the union of the two, which is the whole meaning of "additive";
+- **lazy scripts** publish one file per reachable module and no bundle at all;
+- `BitButilTrimScripts=false` publishes the full bundle even when given a scan and a list to work from;
+- a **misspelled module name**, and a **scan mode that is not one of the three**, each fail the publish with
+  the error naming what was wrong.
+
+Every bundle assertion reads the published file and asks which chunk guards are in it - the same thing the
+browser would find - rather than comparing byte counts. Each scenario also asserts the per-module files:
+exactly the reachable ones under lazy scripts, and *none at all* in bundle mode, which is the half of the
+selection that only a publish exercises.
+
 **Lazy scripts** ([`LazyScripts.cs`](LazyScripts.cs)). Against a recording `IJSRuntime`, with
 `BitButil.UseLazyScripts()` on: the first call into an API must `import()` that API's module - and only
 that one - before invoking it; later calls, and other services on the same runtime, must not import again;
@@ -179,8 +240,14 @@ read only partly would report `PASS` having verified less of it than the output 
 | JavaScript modules called | 63 of 65 | 6 of 65 (clipboard, cookie, events, geolocation, storage, window) |
 | `bit-butil.js` a publish would ship | 112,422 bytes, all 65 modules | 9,134 bytes, 8 modules (3,046 gzip / 2,695 brotli) - 8.1% |
 | lazy scripts would download | 147,730 bytes over 63 files | 11,940 bytes over 6 files |
-| script-bundling checks | 76 / 76 | 76 / 76 |
+| script-bundling checks | 82 / 82 | 82 / 82 |
+| script-scanning checks | 37 / 37 | not run |
+| script-publishing checks | 26 / 26 (9 publishes, ~15s) | not run |
 | lazy-loader checks | 16 / 16 | 16 / 16 |
+
+The two new rows are untrimmed-only by design: the class-to-module map is a question about the library as
+shipped, and the publish fixture is published by this process, so a trimmed run would publish the same app
+to the same answers at twice the cost.
 
 The trimmed run keeps `DomEventsInterop` with all 11 `[JSInvokable]` methods and
 `GeolocationCoordinates` with all 7 properties - neither is named anywhere in this project's code.
@@ -240,5 +307,27 @@ assembly comes out at 30,720 bytes and 36 types.
   what a consumer would see as `BitButil.x is undefined`), and *packed into the folder the consumer-side
   targets read them from* (Bit.Butil.csproj and buildTransitive/Bit.Butil.targets disagree about where the
   chunks, the manifest or the task live, which breaks every consumer's publish and no build in this repo).
+- **`script scanning: the classes ConsumerComponent injects map to exactly the modules ILLink leaves ...`** -
+  the class-to-module map and the trimmer have stopped agreeing about the same five classes. A module the map
+  *misses* is the serious direction: an untrimmed consumer would publish a bundle without JavaScript their app
+  calls. Usually the reference closure stopped following something - a base class, an internal interop helper,
+  a generic call, or the compiler-generated type an `async` method's body actually lives in.
+- **`script scanning: TypeNames never finds less than TypeReferences`** - the coarse mode has become the less
+  safe one, which is the one thing it may never be. It matches bare names and is allowed to over-include;
+  finding *less* means a name is not being matched at all.
+- **`script scanning: an assembly that does not reference Bit.Butil counts for nothing`** - the filter that
+  decides which assemblies a scan reads has started letting framework assemblies through, or (the harmful
+  way round) Bit.Butil's own assembly, which names every one of its types and would defeat the whole scan.
+- **`script publishing: ...`** - the MSBuild half. The message names the claim; the ones worth knowing on
+  sight are *is added to what the scan found, not used instead of it* (the csproj list has stopped being
+  additive - a consumer naming one module would lose everything else), *publishes no per-module files* (the
+  publish asset list is no longer being narrowed, so a bundle-mode app ships all 65 module files - that is
+  `BitButilSelectPublishScriptAssets` not running, or running too late), *with no signal at all the full
+  bundle is published* (the feature has started trimming against nothing, which would strip JavaScript from
+  every consumer who never opted in), and *fails the publish* (a name that means nothing is being accepted in
+  silence, which surfaces in a browser rather than in a build).
+- **`script publishing: ... was not checked`** - a publish of the fixture failed for a reason the scenario
+  did not ask for. The message carries the first error line; usually the fixture cannot find Bit.Butil's
+  chunks or the MSBuild task, both of which it points at the source tree.
 - **`lazy scripts: ...`** - the lazy loader imported the wrong module, imported twice, did not retry a
   failed import, or imported with lazy scripts off. See `LazyScripts.cs` for the exact expectation.

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptBundling.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptBundling.cs
@@ -708,7 +708,7 @@ internal static class ScriptBundling
     /// <summary>A target's body, comments and layout removed, so two of them can be compared for what they do.</summary>
     private static string TargetBody(string targets, string name)
     {
-        var match = Regex.Match(targets, $"<Target Name=\"{Regex.Escape(name)}\"(?<body>.*?)</Target>", RegexOptions.Singleline);
+        var match = Regex.Match(targets, $"<Target Name=\"{Regex.Escape(name)}\"[^>]*>(?<body>.*?)</Target>", RegexOptions.Singleline);
         if (match.Success is false) return string.Empty;
 
         var body = Regex.Replace(match.Groups["body"].Value, "<!--.*?-->", " ", RegexOptions.Singleline);

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptBundling.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptBundling.cs
@@ -27,7 +27,7 @@ namespace ButilTests.Manual;
 internal static class ScriptBundling
 {
     /// <summary>The script that evaluates an assembled bundle, copied next to the executable by the csproj.</summary>
-    private const string VerifierFileName = "verify-bundle.mjs";
+    internal const string VerifierFileName = "verify-bundle.mjs";
 
     /// <summary>
     /// An interop identifier naming a module Bit.Butil does not ship, present in this assembly for the
@@ -527,10 +527,10 @@ internal static class ScriptBundling
     }
 
     /// <summary>The <c>BitButil.&lt;key&gt;</c> namespaces a set of modules registers between them.</summary>
-    private static string Keys(IEnumerable<string> modules)
+    internal static string Keys(IEnumerable<string> modules)
         => string.Join(",", modules.Select(module => module == "butil" ? "version" : module));
 
-    private static void RunVerifier(Checks checks, string verifier, string expectedKeys, params string[] scripts)
+    internal static void RunVerifier(Checks checks, string verifier, string expectedKeys, params string[] scripts)
     {
         var what = string.Join(" + ", scripts.Select(Path.GetFileName));
         var process = new Process

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptBundling.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptBundling.cs
@@ -620,6 +620,9 @@ internal static class ScriptBundling
         }
 
         var targets = File.ReadAllText(targetsPath);
+
+        CheckScriptAssetSelection(checks, targets);
+
         var packed = XDocument.Load(projectPath).Descendants()
             .Where(element => element.Name.LocalName is "TfmSpecificPackageFile" or "None")
             .Select(element => (Include: element.Attribute("Include")?.Value ?? string.Empty, PackagePath: element.Attribute("PackagePath")?.Value))
@@ -653,6 +656,68 @@ internal static class ScriptBundling
             "the targets are packed under both buildTransitive/ (what NuGet imports today) and build/ (older tooling)",
             $"packed to [{string.Join(", ", packedTargets.Select(entry => entry.PackagePath))}]");
     }
+
+    /// <summary>
+    /// The one piece of the consumer-side targets that exists twice: dropping the shape of the JavaScript an
+    /// app does not use, once for the build asset list and once for the publish one.
+    /// </summary>
+    /// <remarks>
+    /// The duplication is forced - a target runs at most once per project build, so a single target hooked
+    /// into both stages runs at the first and is skipped at the second - and it is the kind that rots: a fix
+    /// made to one body and not the other leaves a publish shipping 65 module files an app never requests,
+    /// or a bundle a lazy-scripts app never loads, and neither shows up in a build. So the two bodies are
+    /// compared here, and each is checked to be hooked into the stage it exists for.
+    /// </remarks>
+    private static void CheckScriptAssetSelection(Checks checks, string targets)
+    {
+        const string build = "BitButilSelectScriptAssets";
+        const string publish = "BitButilSelectPublishScriptAssets";
+
+        var buildBody = TargetBody(targets, build);
+        var publishBody = TargetBody(targets, publish);
+
+        if (checks.That(buildBody.Length > 0 && publishBody.Length > 0,
+                "the JavaScript shape an app does not use is dropped at both the build and the publish stage",
+                $"{(buildBody.Length == 0 ? build : publish)} is not a target in the consumer-side targets file") is false)
+        {
+            return;
+        }
+
+        checks.That(string.Equals(buildBody, publishBody, StringComparison.Ordinal),
+            "the build-stage and publish-stage selections still do the same thing",
+            $"{build} and {publish} have drifted apart - the publish output no longer matches the build's idea of which scripts the app uses");
+
+        // Hooked into the right stage, and in the publish list ahead of the trimming, which only narrows what
+        // the selection leaves behind.
+        var publishHook = HookList(targets, "ResolvePublishStaticWebAssetsDependsOn");
+        var buildHook = HookList(targets, "ResolveCoreStaticWebAssetsDependsOn");
+
+        checks.That(buildHook.Contains(build, StringComparison.Ordinal), $"{build} runs at the build stage", $"it is not in ResolveCoreStaticWebAssetsDependsOn: '{buildHook}'");
+        checks.That(publishHook.Contains(publish, StringComparison.Ordinal), $"{publish} runs at the publish stage", $"it is not in ResolvePublishStaticWebAssetsDependsOn: '{publishHook}'");
+        checks.That(publishHook.Contains(build, StringComparison.Ordinal) is false,
+            $"{build} is not also hooked into the publish stage",
+            "a target runs once per build, so hooking the same one into both stages leaves the second with nothing to do");
+
+        var selection = publishHook.IndexOf(publish, StringComparison.Ordinal);
+        var trimming = publishHook.IndexOf("BitButilTrimScript", StringComparison.Ordinal);
+        checks.That(selection >= 0 && trimming > selection,
+            "the publish-stage selection runs before the trimming it feeds",
+            $"the publish hook list orders them '{publishHook}'");
+    }
+
+    /// <summary>A target's body, comments and layout removed, so two of them can be compared for what they do.</summary>
+    private static string TargetBody(string targets, string name)
+    {
+        var match = Regex.Match(targets, $"<Target Name=\"{Regex.Escape(name)}\"(?<body>.*?)</Target>", RegexOptions.Singleline);
+        if (match.Success is false) return string.Empty;
+
+        var body = Regex.Replace(match.Groups["body"].Value, "<!--.*?-->", " ", RegexOptions.Singleline);
+        return Regex.Replace(body, @"\s+", " ").Trim();
+    }
+
+    /// <summary>The value this targets file appends to one of the SDK's DependsOn properties.</summary>
+    private static string HookList(string targets, string property)
+        => Regex.Match(targets, $"<{property}>(?<value>[^<]*)</{property}>").Groups["value"].Value;
 
     /// <summary>The folders one pack item's PackagePath names - it may name several, separated by semicolons.</summary>
     private static string[] PackageFolders(string? packagePath)
@@ -695,7 +760,7 @@ internal static class ScriptBundling
     /// Counts what held and records what did not, in the harness's own terms - every failure ends up in the
     /// list the report prints and the exit code is read from.
     /// </summary>
-    private sealed class Checks(List<string> failures)
+    internal sealed class Checks(List<string> failures, string subject = "script bundling")
     {
         public int Passed { get; private set; }
 
@@ -710,7 +775,7 @@ internal static class ScriptBundling
             }
 
             Failed++;
-            failures.Add($"script bundling: {what}{(detail is null ? string.Empty : $" - {detail}")}.");
+            failures.Add($"{subject}: {what}{(detail is null ? string.Empty : $" - {detail}")}.");
             return false;
         }
 

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
@@ -1,0 +1,300 @@
+﻿using System.Diagnostics;
+using Bit.Butil.Build;
+
+namespace ButilTests.Manual;
+
+/// <summary>
+/// The publish itself: a real consumer app published with each combination of the switches, and the
+/// JavaScript that came out of it read back off disk.
+/// </summary>
+/// <remarks>
+/// Everything else in this harness checks the computation - which modules a set of inputs works out to - by
+/// calling into Bit.Butil.Build directly. That is one step of the feature. The rest is MSBuild: whether the
+/// trimming runs at all, which of the three signals it is allowed to use, that a csproj module list is added
+/// to what the others found rather than replacing it, that the assets removed from the build list are also
+/// removed from the publish list, and that a name that means nothing fails the build instead of being
+/// ignored. None of that is reachable from a method call, and all of it is what a consumer actually gets.
+/// <br/>
+/// So these publish <c>Bit.Butil.Tests.PublishFixture</c> - a two-class web app next door - and assert on the
+/// bundle and the module files in its publish output. One <c>dotnet publish</c> each, which is why the list
+/// of scenarios is short and every one of them is a distinct claim rather than a variation.
+/// <br/>
+/// Untrimmed runs only. The fixture is published by this process, so the trimmed copy of this harness would
+/// publish the very same app to the very same answers - twice the cost for nothing.
+/// </remarks>
+internal static class ScriptPublishing
+{
+    private const string FixtureProject = "Bit.Butil.Tests.PublishFixture.csproj";
+
+    /// <summary>Where the fixture's JavaScript lands, under the publish directory.</summary>
+    private const string ContentPath = "wwwroot/_content/Bit.Butil";
+
+    /// <summary>
+    /// A publish is slow enough that a hung one has to be cut off rather than waited on: a build server that
+    /// stops making progress would otherwise take the whole harness down with it.
+    /// </summary>
+    private static readonly TimeSpan PublishTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>What a scenario asks of a publish, and what its output has to look like afterwards.</summary>
+    /// <param name="Name">Named after the claim, since that is what a failure reports.</param>
+    /// <param name="Properties">The MSBuild properties a consumer would put in their csproj.</param>
+    /// <param name="Bundle">The modules bit-butil.js must hold. Null, with <paramref name="FullBundle"/> off, means there must be no bundle at all.</param>
+    /// <param name="FullBundle">The bundle must hold every module the library ships - the feature standing down.</param>
+    /// <param name="BundleIsMinimum">The bundle must hold at least <paramref name="Bundle"/>; more is allowed.</param>
+    /// <param name="Modules">The per-module files that must be published, or null for "none of them".</param>
+    /// <param name="Error">A fragment of the build error the publish must fail with, when it must fail.</param>
+    private sealed record Scenario(
+        string Name,
+        string[] Properties,
+        string[]? Bundle = null,
+        bool FullBundle = false,
+        bool BundleIsMinimum = false,
+        string[]? Modules = null,
+        string? Error = null);
+
+    /// <summary>
+    /// The modules the fixture's own two classes need, and the two that every bundle carries: <c>butil</c> is
+    /// the prelude every module depends on and <c>utils</c> is pulled in behind these two by the manifest.
+    /// Spelled out rather than computed, so a change in what the fixture calls has to be stated here too.
+    /// </summary>
+    private static readonly string[] Scanned = ["butil", "utils", "clipboard", "geolocation"];
+
+    private static Scenario[] Scenarios =>
+    [
+        // Nothing to trim against. The one that has to keep working: a consumer who never asked for any of
+        // this must publish the whole bundle, not an empty one.
+        new("with no signal at all the full bundle is published",
+            [],
+            FullBundle: true),
+
+        // Option 2/3: the app's own assemblies, for a publish ILLink never touched.
+        new("a scan of the app's own assemblies trims the bundle to what its classes need",
+            ["BitButilScriptScan=TypeReferences"],
+            Bundle: Scanned),
+
+        // The coarser mode. A minimum rather than an exact set: matching bare type names is meant to
+        // over-include - the library has classes called Console, Document and Location - and pinning the
+        // exact list would be asserting which of those names the framework happens to use this month.
+        new("the name-matching scan finds at least what the reference-matching one does",
+            ["BitButilScriptScan=TypeNames"],
+            Bundle: Scanned,
+            BundleIsMinimum: true),
+
+        // Option 1 alone: no ILLink, no scan, just a csproj. The whole point of it being a signal in its own
+        // right rather than an addition to one.
+        new("a csproj module list is a signal on its own",
+            ["FixtureScriptModules=Cookie"],
+            Bundle: ["butil", "cookie"]),
+
+        // Option 1 on top of option 3 - the thing that has to be additive rather than either/or.
+        new("a csproj module list is added to what the scan found, not used instead of it",
+            ["BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie|battery"],
+            Bundle: [.. Scanned, "cookie", "battery"]),
+
+        // The other shape of the same JavaScript: no bundle at all, one file per module the app can reach.
+        new("lazy scripts publish only the module files the scan can reach, and no bundle",
+            ["BitButilLazyScripts=true", "BitButilScriptScan=TypeReferences"],
+            Modules: Scanned),
+
+        // Turning the feature off has to survive being given something to trim against.
+        new("BitButilTrimScripts=false publishes the full bundle whatever else is set",
+            ["BitButilTrimScripts=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
+            FullBundle: true),
+
+        // MSBuild accepts a misspelled item without a word, so the build is the only thing that can say so.
+        new("a module name that names nothing fails the publish",
+            ["FixtureScriptModules=Clippboard"],
+            Error: "'Clippboard'"),
+
+        new("a scan mode that is not one of the three fails the publish",
+            ["BitButilScriptScan=TypeRefs"],
+            Error: "not a value of <BitButilScriptScan>"),
+    ];
+
+    public static (int Passed, int Failed) Run(bool trimmed, List<string> failures)
+    {
+        var checks = new ScriptBundling.Checks(failures, "script publishing");
+        if (trimmed) return (0, 0);
+
+        var butilRoot = ScriptTrimming.LocateButilProject();
+        var fixtureProject = butilRoot is null ? null : Path.Combine(butilRoot, "..", "tests", "Bit.Butil.Tests.PublishFixture", FixtureProject);
+        var manifestPath = butilRoot is null ? null : Path.Combine(butilRoot, "obj", "butil-js", "chunks", "manifest.txt");
+
+        if (fixtureProject is null || File.Exists(fixtureProject) is false || manifestPath is null || File.Exists(manifestPath) is false)
+        {
+            checks.That(false, "no publish was run", $"{FixtureProject} or Bit.Butil's module manifest could not be found from {AppContext.BaseDirectory}");
+            return (checks.Passed, checks.Failed);
+        }
+
+        var manifest = ButilScriptBundler.ReadManifest(manifestPath);
+        var workspace = Path.Combine(AppContext.BaseDirectory, "script-publishing");
+        if (Directory.Exists(workspace)) Directory.Delete(workspace, recursive: true);
+
+        var scenario = 0;
+        foreach (var candidate in Scenarios)
+        {
+            var output = Path.Combine(workspace, $"publish-{++scenario}");
+            if (Publish(checks, fixtureProject, output, candidate, out var log) is false) continue;
+
+            if (candidate.Error is not null)
+            {
+                checks.That(log.Contains(candidate.Error, StringComparison.Ordinal), candidate.Name,
+                    $"the publish did fail, but over something else: {FirstError(log)}");
+                continue;
+            }
+
+            var expectedBundle = candidate.FullBundle ? manifest.Order : candidate.Bundle;
+
+            CheckBundle(checks, candidate, Path.Combine(output, ContentPath, "bit-butil.js"), expectedBundle, manifest);
+            CheckModules(checks, candidate, Path.Combine(output, ContentPath, "modules"), manifest);
+        }
+
+        return (checks.Passed, checks.Failed);
+    }
+
+    /// <summary>
+    /// The bundle holds a module when it holds the chunk that registers it, which is what the browser would
+    /// find too - the file is the chunks concatenated, so its content is the assertion, not its size.
+    /// </summary>
+    private static void CheckBundle(ScriptBundling.Checks checks, Scenario scenario, string bundlePath, IReadOnlyList<string>? expected, ButilScriptManifest manifest)
+    {
+        if (expected is null)
+        {
+            checks.That(File.Exists(bundlePath) is false, scenario.Name,
+                $"bit-butil.js was published anyway ({(File.Exists(bundlePath) ? new FileInfo(bundlePath).Length.ToString("N0") : "0")} bytes) - a lazy-scripts app never loads it");
+            return;
+        }
+
+        if (File.Exists(bundlePath) is false)
+        {
+            checks.That(false, scenario.Name, "no bit-butil.js was published at all");
+            return;
+        }
+
+        var content = File.ReadAllText(bundlePath);
+        var present = manifest.Order.Where(module => content.Contains(Guard(module), StringComparison.Ordinal)).ToArray();
+
+        if (scenario.BundleIsMinimum)
+        {
+            var missing = expected.Except(present, StringComparer.Ordinal).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+            checks.That(missing.Length == 0, scenario.Name,
+                $"the published bundle is missing [{string.Join(", ", missing)}] - those APIs would be dead in the browser");
+            return;
+        }
+
+        Compare(checks, scenario.Name, expected, present,
+            missing => $"the published bundle is missing [{missing}] - those APIs would be dead in the browser",
+            extra => $"the published bundle carries [{extra}], which nothing in the app can reach");
+    }
+
+    private static void CheckModules(ScriptBundling.Checks checks, Scenario scenario, string modulesDirectory, ButilScriptManifest manifest)
+    {
+        var present = Directory.Exists(modulesDirectory)
+            ? Directory.GetFiles(modulesDirectory, "*.js").Select(Path.GetFileNameWithoutExtension).OfType<string>().ToArray()
+            : [];
+
+        if (scenario.Modules is null)
+        {
+            checks.That(present.Length == 0, $"{scenario.Name} (and publishes no per-module files)",
+                $"{present.Length} of them were published anyway: [{string.Join(", ", present.Take(8))}{(present.Length > 8 ? ", ..." : string.Empty)}]");
+            return;
+        }
+
+        Compare(checks, $"{scenario.Name} (module files)", scenario.Modules, present,
+            missing => $"[{missing}] was not published, so the import() for it would 404",
+            extra => $"[{extra}] was published for nothing");
+
+        // A module file the manifest does not know is a name this check would silently pass over.
+        var unknown = present.Where(module => manifest.Dependencies.ContainsKey(module) is false).ToArray();
+        checks.That(unknown.Length == 0, $"{scenario.Name} (every published module file is a real module)", $"[{string.Join(", ", unknown)}] is not in the manifest");
+    }
+
+    /// <summary>
+    /// The guard build.mjs wraps every chunk in, which names the namespace that chunk registers. Matching on
+    /// it rather than on any occurrence of the module's name keeps a module that merely <em>mentions</em>
+    /// another from being read as that other one being present.
+    /// </summary>
+    private static string Guard(string module) => $"window.BitButil.{(module == "butil" ? "version" : module)}";
+
+    private static bool Publish(ScriptBundling.Checks checks, string project, string output, Scenario scenario, out string log)
+    {
+        log = string.Empty;
+
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            }
+        };
+
+        foreach (var argument in new[] { "publish", project, "-c", "Debug", "--nologo", "-v", "quiet", "-tl:off", "-o", output })
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        foreach (var property in scenario.Properties) process.StartInfo.ArgumentList.Add($"-p:{property}");
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception exception)
+        {
+            checks.That(false, $"{scenario.Name} was not checked", $"dotnet could not be started ({exception.Message})");
+            return false;
+        }
+
+        // Read both streams before waiting: a publish writes more than a pipe buffer holds, and waiting first
+        // would deadlock against a process blocked on a full stdout.
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+
+        if (process.WaitForExit((int)PublishTimeout.TotalMilliseconds) is false)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* it is already gone, which is the outcome wanted */ }
+            checks.That(false, $"{scenario.Name} was not checked", $"the publish did not finish within {PublishTimeout.TotalMinutes:N0} minutes");
+            return false;
+        }
+
+        log = standardOutput.Result + standardError.Result;
+        var failed = process.ExitCode != 0;
+
+        if (scenario.Error is not null)
+        {
+            // The scenario is the failure, so a publish that succeeded is the defect: MSBuild took a name
+            // that means nothing and published something anyway.
+            return checks.That(failed, scenario.Name, "the publish succeeded, so the bad input was accepted in silence");
+        }
+
+        return checks.That(failed is false, $"{scenario.Name} was not checked", $"the publish failed: {FirstError(log)}");
+    }
+
+    /// <summary>The first error line of a build log, which is the one that says what went wrong.</summary>
+    private static string FirstError(string log)
+    {
+        var line = log.Split('\n').FirstOrDefault(candidate => candidate.Contains("error", StringComparison.OrdinalIgnoreCase))?.Trim();
+
+        return string.IsNullOrEmpty(line) ? "no error line in the build log" : (line.Length > 300 ? line[..300] + "..." : line);
+    }
+
+    private static void Compare(ScriptBundling.Checks checks, string what, IEnumerable<string> expected, IEnumerable<string> actual,
+        Func<string, string> onMissing, Func<string, string> onExtra)
+    {
+        var missing = expected.Except(actual, StringComparer.Ordinal).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+        var extra = actual.Except(expected, StringComparer.Ordinal).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+
+        if (missing.Length == 0 && extra.Length == 0)
+        {
+            checks.That(true, what);
+            return;
+        }
+
+        var detail = missing.Length > 0 ? onMissing(string.Join(", ", missing)) : onExtra(string.Join(", ", extra));
+        if (missing.Length > 0 && extra.Length > 0) detail += $"; it also {onExtra(string.Join(", ", extra))}";
+
+        checks.That(false, what, detail);
+    }
+}

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptScanning.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptScanning.cs
@@ -1,0 +1,244 @@
+﻿using Bit.Butil.Build;
+
+namespace ButilTests.Manual;
+
+/// <summary>
+/// The signals an <em>untrimmed</em> publish trims its JavaScript on: the map from Bit.Butil class to
+/// JavaScript module, the scan of a consumer's own assemblies that uses it, and the module list a consumer
+/// writes into their csproj.
+/// </summary>
+/// <remarks>
+/// <see cref="ScriptTrimming"/> checks the trimmed publish's signal - the interop identifiers ILLink leaves
+/// behind - against <see cref="ScriptTrimming.MustSurviveModules"/>, the modules
+/// <see cref="ConsumerComponent"/>'s five injected services need. That list is this file's ground truth too,
+/// and that is the whole point: the map and the scan are meant to reach the same answer about the same code
+/// without ILLink having run, so the check that matters is that they do. If they ever diverge, an untrimmed
+/// consumer publishes a bundle missing JavaScript their app calls, and finds out in a browser.
+/// <br/>
+/// Only run untrimmed. Everything here starts from the <em>untrimmed</em> Bit.Butil.dll - the map says which
+/// module each class needs, which is a question about the library as shipped, not about what survived one
+/// app's trimming - and a trimmed self-contained publish has no such assembly to read.
+/// </remarks>
+internal static class ScriptScanning
+{
+    public static (int Passed, int Failed) Run(string? butilAssemblyPath, bool trimmed, List<string> failures)
+    {
+        var checks = new ScriptBundling.Checks(failures, "script scanning");
+
+        if (trimmed)
+        {
+            // Not a failure, and not silence either: the count printed by the report would otherwise look
+            // like the checks passed.
+            return (0, 0);
+        }
+
+        if (string.IsNullOrEmpty(butilAssemblyPath) || File.Exists(butilAssemblyPath) is false)
+        {
+            checks.That(false, "the class-to-module map was not checked", "there is no Bit.Butil assembly file to read (a single-file build)");
+            return (checks.Passed, checks.Failed);
+        }
+
+        var workspace = Path.Combine(AppContext.BaseDirectory, "script-scanning");
+        if (Directory.Exists(workspace)) Directory.Delete(workspace, recursive: true);
+        Directory.CreateDirectory(workspace);
+
+        var map = ButilTypeModules.Build(butilAssemblyPath);
+        if (checks.That(map.IsEmpty is false, "the class-to-module map is read out of Bit.Butil.dll",
+                $"{butilAssemblyPath} produced no mapped types at all") is false)
+        {
+            return (checks.Passed, checks.Failed);
+        }
+
+        CheckMapCoverage(checks, butilAssemblyPath, map);
+        CheckMapAgreesWithTrimming(checks, map);
+        CheckScanFindsTheSameModules(checks, map);
+        CheckExplicitNames(checks, butilAssemblyPath, map);
+        CheckUnreadableInputs(checks, workspace, butilAssemblyPath, map);
+
+        return (checks.Passed, checks.Failed);
+    }
+
+    /// <summary>
+    /// Every module the library calls is behind some class. A module the map cannot attribute is one no
+    /// scan can ever conclude, so a consumer relying on the scan would silently never get it.
+    /// </summary>
+    private static void CheckMapCoverage(ScriptBundling.Checks checks, string butilAssemblyPath, ButilTypeModules map)
+    {
+        var named = ButilScriptBundler.ReadReferencedModules(butilAssemblyPath);
+        var attributed = new SortedSet<string>(map.FullTypeNames.SelectMany(map.ForFullName), StringComparer.Ordinal);
+        var unattributed = named.Except(attributed, StringComparer.Ordinal).ToArray();
+
+        checks.That(unattributed.Length == 0,
+            "every module the library calls is reachable from some Bit.Butil class",
+            $"[{string.Join(", ", unattributed)}] {(unattributed.Length == 1 ? "is named" : "are named")} by an interop identifier but no class leads to {(unattributed.Length == 1 ? "it" : "them")}, so a scan could never include {(unattributed.Length == 1 ? "it" : "them")}");
+    }
+
+    /// <summary>
+    /// The check this file exists for: the map, asked about exactly the classes
+    /// <see cref="ConsumerComponent"/> injects, must answer what ILLink concludes about exactly that code.
+    /// </summary>
+    /// <remarks>
+    /// It is a real test of the closure and not a restatement of it. <c>LocalStorage</c> carries no interop
+    /// identifiers of its own - they are on the <c>ButilStorage</c> base class - and <c>Window</c> reaches
+    /// the <c>events</c> module only through an internal interop class, called from inside a compiler-
+    /// generated async state machine. A map built from anything less than the reference closure gets both
+    /// of those wrong, and the difference shows up here as a missing module.
+    /// </remarks>
+    private static void CheckMapAgreesWithTrimming(ScriptBundling.Checks checks, ButilTypeModules map)
+    {
+        var actual = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var type in ConsumerComponent.InjectedTypes)
+        {
+            var modules = map.ForFullName(type.FullName ?? type.Name);
+            checks.That(modules.Count > 0, $"the map knows which JavaScript {type.Name} needs", "it maps to no module at all");
+            foreach (var module in modules) actual.Add(module);
+        }
+
+        Compare(checks, ScriptTrimming.MustSurviveModules, actual,
+            "the classes ConsumerComponent injects map to exactly the modules ILLink leaves in a trimmed build of them",
+            missing => $"the map does not lead from any injected class to [{missing}], so an untrimmed publish would drop JavaScript the app calls",
+            extra => $"the map leads to [{extra}], which trimming the same code does not keep - the closure is reaching further than the code does");
+    }
+
+    /// <summary>
+    /// The scan, over this harness's own assembly, has to reach the same set: it is the same five classes,
+    /// named the way a consumer's assembly names them.
+    /// </summary>
+    private static void CheckScanFindsTheSameModules(ScriptBundling.Checks checks, ButilTypeModules map)
+    {
+        var self = typeof(ScriptScanning).Assembly.Location;
+        if (checks.That(string.IsNullOrEmpty(self) is false, "the scan was checked against a real assembly", "this harness has no assembly file") is false) return;
+
+        var references = ButilConsumerScan.Scan([self], map, ButilScanMode.TypeReferences);
+        checks.That(references.Scanned.Count == 1, "an assembly that references Bit.Butil is recognised as one to read", $"{references.Scanned.Count} of 1 assemblies were read");
+
+        Compare(checks, ScriptTrimming.MustSurviveModules, references.Modules,
+            "TypeReferences over this assembly finds exactly the modules its Butil classes need",
+            missing => $"the scan missed [{missing}] - an untrimmed publish of this app would ship a bundle without it",
+            extra => $"the scan added [{extra}], which nothing here calls");
+
+        // TypeNames matches on the bare name, so it cannot miss what TypeReferences found and may well find
+        // more - that is the trade the mode exists to make, and the direction of it is what is asserted.
+        var names = ButilConsumerScan.Scan([self], map, ButilScanMode.TypeNames);
+        var missed = references.Modules.Except(names.Modules, StringComparer.Ordinal).ToArray();
+        checks.That(missed.Length == 0,
+            "TypeNames never finds less than TypeReferences",
+            $"it missed [{string.Join(", ", missed)}], so the coarser mode is the less safe one in the wrong direction");
+
+        // Nothing to find is reported as nothing read, not as "this app calls no JavaScript" - which, acted
+        // on, would trim every module away.
+        var framework = typeof(object).Assembly.Location;
+        var unrelated = ButilConsumerScan.Scan([framework], map, ButilScanMode.TypeReferences);
+        checks.That(unrelated.Scanned.Count == 0 && unrelated.Modules.Count == 0,
+            "an assembly that does not reference Bit.Butil counts for nothing",
+            $"{Path.GetFileName(framework)} was read as referencing Bit.Butil and contributed {unrelated.Modules.Count} module(s)");
+
+        // The library's own assembly names every one of its types, so reading it would conclude that every
+        // app uses every module.
+        var itself = ButilConsumerScan.Scan([typeof(Bit.Butil.BitButil).Assembly.Location], map, ButilScanMode.TypeReferences);
+        checks.That(itself.Scanned.Count == 0,
+            "Bit.Butil's own assembly is left out of the scan",
+            $"it was read, and contributed {itself.Modules.Count} module(s) - which would defeat the whole scan");
+    }
+
+    /// <summary>
+    /// <see cref="ButilScriptBundler.ResolveNames"/>: what a consumer may write in
+    /// <c>&lt;BitButilScriptModule&gt;</c>, and what happens to what they may not.
+    /// </summary>
+    private static void CheckExplicitNames(ScriptBundling.Checks checks, string butilAssemblyPath, ButilTypeModules map)
+    {
+        var butilRoot = ScriptTrimming.LocateButilProject();
+        var manifestPath = butilRoot is null ? null : Path.Combine(butilRoot, "obj", "butil-js", "chunks", "manifest.txt");
+        if (manifestPath is null || File.Exists(manifestPath) is false)
+        {
+            checks.That(false, "the csproj module list was not checked", "Bit.Butil's JavaScript build outputs are missing");
+            return;
+        }
+
+        var manifest = ButilScriptBundler.ReadManifest(manifestPath);
+
+        (string[] Names, string[] Expected, string Because)[] cases =
+        [
+            (["clipboard"], ["clipboard"], "a module name is a module"),
+            (["Clipboard"], ["clipboard"], "a Bit.Butil class name resolves to the module behind it"),
+            (["Bit.Butil.Clipboard"], ["clipboard"], "a class can be named in full"),
+            (["LocalStorage"], ["storage"], "a class whose module is named nothing like it still resolves - the map, not the spelling, decides"),
+            (["Window"], ["events", "window"], "a class needing more than one module contributes all of them"),
+            (["CLIPBOARD"], ["clipboard"], "a module named in the wrong case is understood rather than rejected"),
+            (["clipboard", "Clipboard"], ["clipboard"], "the same module reached two ways is one module"),
+            ([" clipboard ", ""], ["clipboard"], "surrounding space is trimmed and an empty entry is ignored"),
+        ];
+
+        foreach (var (names, expected, because) in cases)
+        {
+            var modules = ButilScriptBundler.ResolveNames(names, manifest, map, out var unresolved);
+            checks.That(unresolved.Count == 0 && modules.SequenceEqual(expected, StringComparer.Ordinal),
+                because,
+                $"[{string.Join(", ", names)}] resolved to [{string.Join(", ", modules)}]{(unresolved.Count == 0 ? string.Empty : $" with [{string.Join(", ", unresolved)}] unresolved")}");
+        }
+
+        // The one that must NOT quietly resolve: MSBuild accepts a misspelled item without a word, so the
+        // build has to be the thing that says something.
+        ButilScriptBundler.ResolveNames(["Clippboard", "clipboard"], manifest, map, out var missing);
+        checks.That(missing.Count == 1 && missing[0] == "Clippboard",
+            "a name that is neither a module nor a class is reported rather than ignored",
+            $"unresolved: [{string.Join(", ", missing)}]");
+
+        // Without the map only module names can resolve, which is what a publish that never had reason to
+        // read Bit.Butil.dll gets. A class named like its module (Clipboard/clipboard) still resolves on the
+        // case-insensitive pass; one named unlike it cannot, and is reported rather than dropped.
+        var withoutMap = ButilScriptBundler.ResolveNames(["clipboard", "Clipboard", "LocalStorage"], manifest, null, out var withoutMapMissing);
+        checks.That(withoutMap.SequenceEqual(["clipboard"], StringComparer.Ordinal)
+                && withoutMapMissing.SequenceEqual(["LocalStorage"], StringComparer.Ordinal),
+            "without the class map a class named unlike its module is reported rather than dropped",
+            $"resolved [{string.Join(", ", withoutMap)}], unresolved [{string.Join(", ", withoutMapMissing)}]");
+
+        checks.That(File.Exists(butilAssemblyPath), "the map was built from a file that is really there");
+    }
+
+    /// <summary>
+    /// What the metadata reader does with a file that is not what it was told it is. These run inside a
+    /// consumer's publish over whatever their references resolved to, so "reported" versus "crashed the
+    /// build" is decided here.
+    /// </summary>
+    private static void CheckUnreadableInputs(ScriptBundling.Checks checks, string workspace, string butilAssemblyPath, ButilTypeModules map)
+    {
+        var text = Path.Combine(workspace, "not-an-assembly.dll");
+        File.WriteAllText(text, "A text file that a consumer's build pointed the task at.");
+
+        var truncated = Path.Combine(workspace, "truncated.dll");
+        File.WriteAllBytes(truncated, [.. File.ReadAllBytes(butilAssemblyPath).Take(512)]);
+
+        checks.Throws<BadImageFormatException>(() => ButilTypeModules.Build(text),
+            "a file that is not a PE image is reported as a bad image rather than crashing the build");
+        checks.Throws<BadImageFormatException>(() => ButilTypeModules.Build(truncated),
+            "an assembly cut short is reported as a bad image rather than read past its end");
+        checks.Throws<IOException>(() => ButilTypeModules.Build(Path.Combine(workspace, "not-there.dll")),
+            "an assembly that is not there is reported as an IO failure the publish can explain");
+
+        // The scan, by contrast, must not fail a publish over any of them: the list it is handed is whatever
+        // a consumer's references resolved to, native libraries and stale paths included.
+        var scan = ButilConsumerScan.Scan([text, truncated, Path.Combine(workspace, "not-there.dll"), string.Empty], map, ButilScanMode.TypeReferences);
+        checks.That(scan.Skipped.Count == 3 && scan.Scanned.Count == 0 && scan.Modules.Count == 0,
+            "a scan passes over what it cannot read instead of failing the publish",
+            $"{scan.Skipped.Count} skipped, {scan.Scanned.Count} read, {scan.Modules.Count} module(s)");
+    }
+
+    private static void Compare(ScriptBundling.Checks checks, IEnumerable<string> expected, IEnumerable<string> actual,
+        string what, Func<string, string> onMissing, Func<string, string> onExtra)
+    {
+        var missing = expected.Except(actual, StringComparer.Ordinal).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+        var extra = actual.Except(expected, StringComparer.Ordinal).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+
+        if (missing.Length == 0 && extra.Length == 0)
+        {
+            checks.That(true, what);
+            return;
+        }
+
+        var detail = missing.Length > 0 ? onMissing(string.Join(", ", missing)) : onExtra(string.Join(", ", extra));
+        if (missing.Length > 0 && extra.Length > 0) detail += $"; it also {onExtra(string.Join(", ", extra))}";
+
+        checks.That(false, what, detail);
+    }
+}

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptScanning.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptScanning.cs
@@ -54,6 +54,7 @@ internal static class ScriptScanning
         CheckScanFindsTheSameModules(checks, map);
         CheckExplicitNames(checks, butilAssemblyPath, map);
         CheckUnreadableInputs(checks, workspace, butilAssemblyPath, map);
+        CheckScannedBundleRuns(checks, workspace, map);
 
         return (checks.Passed, checks.Failed);
     }
@@ -222,6 +223,52 @@ internal static class ScriptScanning
         checks.That(scan.Skipped.Count == 3 && scan.Scanned.Count == 0 && scan.Modules.Count == 0,
             "a scan passes over what it cannot read instead of failing the publish",
             $"{scan.Skipped.Count} skipped, {scan.Scanned.Count} read, {scan.Modules.Count} module(s)");
+    }
+
+    /// <summary>
+    /// The end of it: assemble the bundle a scan-trimmed publish of this harness would serve, and run it.
+    /// </summary>
+    /// <remarks>
+    /// Every check above compares one list of module names with another, and a module set that is right on
+    /// paper still ships broken JavaScript if the chunks behind it do not stand alone - a module whose
+    /// dependency the manifest does not record evaluates to a <c>BitButil.x is undefined</c> the moment
+    /// something calls it. <c>verify-bundle.mjs</c> evaluates the assembled file and asks which
+    /// <c>BitButil</c> namespaces it registered, which is the only check here that the browser would agree
+    /// with. <see cref="ScriptBundling"/> does the same for the bundle ILLink's own answer produces; this is
+    /// the same artifact for the publish that never ran ILLink.
+    /// </remarks>
+    private static void CheckScannedBundleRuns(ScriptBundling.Checks checks, string workspace, ButilTypeModules map)
+    {
+        var verifier = Path.Combine(AppContext.BaseDirectory, ScriptBundling.VerifierFileName);
+        var butilRoot = ScriptTrimming.LocateButilProject();
+        var self = typeof(ScriptScanning).Assembly.Location;
+        if (butilRoot is null || string.IsNullOrEmpty(self)) return;   // Already reported above.
+
+        var chunks = Path.Combine(butilRoot, "obj", "butil-js", "chunks");
+        var manifestPath = Path.Combine(chunks, "manifest.txt");
+        if (File.Exists(verifier) is false || File.Exists(manifestPath) is false)
+        {
+            checks.That(false, "the scanned bundle was not run", $"{ScriptBundling.VerifierFileName} or the module manifest is missing");
+            return;
+        }
+
+        var manifest = ButilScriptBundler.ReadManifest(manifestPath);
+
+        // Exactly what the MSBuild task assembles for an untrimmed publish: the scan's modules, plus the ones
+        // named in a csproj, closed over the manifest's dependencies.
+        var scan = ButilConsumerScan.Scan([self], map, ButilScanMode.TypeReferences);
+        var referenced = new SortedSet<string>(scan.Modules, StringComparer.Ordinal);
+        referenced.UnionWith(ButilScriptBundler.ResolveNames(["Battery"], manifest, map, out _));
+
+        var included = ButilScriptBundler.Resolve(manifest, referenced, out var unknown);
+        checks.That(unknown.Count == 0, "everything a scan concludes is a module the library ships", $"[{string.Join(", ", unknown)}] is not");
+        checks.That(included.Contains("battery"),
+            "a module named in the csproj survives into the bundle beside the ones the scan found",
+            $"the bundle holds [{string.Join(", ", included)}]");
+
+        var bundle = Path.Combine(workspace, "scanned-bundle.js");
+        ButilScriptBundler.WriteBundle(chunks, included, bundle);
+        ScriptBundling.RunVerifier(checks, verifier, ScriptBundling.Keys(included), bundle);
     }
 
     private static void Compare(ScriptBundling.Checks checks, IEnumerable<string> expected, IEnumerable<string> actual,

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptTrimming.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptTrimming.cs
@@ -26,7 +26,7 @@ internal static class ScriptTrimming
     /// internal <c>DomEventsInterop</c>). Dependencies (<c>butil</c>, <c>utils</c>) are added by the manifest,
     /// not listed here, so this stays a statement about what the C# side calls.
     /// </summary>
-    private static readonly string[] MustSurviveModules = ["clipboard", "cookie", "events", "geolocation", "storage", "window"];
+    internal static readonly string[] MustSurviveModules = ["clipboard", "cookie", "events", "geolocation", "storage", "window"];
 
     /// <summary>
     /// Modules no C# code calls directly and that are legitimately only ever pulled in as a dependency of

--- a/src/Butil/tests/Bit.Butil.Tests.Mcp/DocsSearchIndexTests.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Mcp/DocsSearchIndexTests.cs
@@ -1,0 +1,232 @@
+﻿using System.Net;
+using System.Text.Json;
+using System.Xml.Linq;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using Bit.Butil.Tests.Mcp.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Butil.Tests.Mcp;
+
+/// <summary>
+/// The corpus the site's own search box downloads and searches: <c>/api/docs/search-index</c>.
+/// <para>
+/// It is served by the same app as the MCP tools and it is built the same way - by parsing the
+/// embedded source of the docs pages - so it fails the same way: silently. A parser that loses its
+/// footing on one attribute does not throw, it returns a shorter index, and the only symptom is a
+/// search box that cannot find what is plainly written on the page. Every assertion here is a
+/// version of that symptom, checked against the deployment rather than against the parser.
+/// </para>
+/// </summary>
+[TestClass]
+public class DocsSearchIndexTests
+{
+    private const string IndexPath = "api/docs/search-index";
+
+    private static HttpClient Http => McpServerFixture.Http;
+
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    private static Index? _index;
+
+    /// <summary>The wire shape, restated here: this suite talks to the app over HTTP, not to its types.</summary>
+    private sealed record Entry(string Title, string? Page, string Url, string Group, string Keywords, string Summary, string Body);
+
+    private sealed record Index(Entry[] Entries);
+
+    /// <summary>
+    /// The index, fetched once for the fixture. The tests inside a fixture run in order, so the
+    /// first of them pays for it and the rest read it.
+    /// </summary>
+    private static async Task<Entry[]> EntriesAsync()
+    {
+        if (_index is not null) return _index.Entries;
+
+        var json = await Http.GetStringAsync(McpServerFixture.Url(IndexPath));
+        _index = JsonSerializer.Deserialize<Index>(json, _json);
+
+        Assert.IsNotNull(_index?.Entries, "The search index did not deserialize into anything.");
+
+        return _index.Entries;
+    }
+
+    /// <summary>Every page of the site, taken from the sitemap it generates from its own nav.</summary>
+    private static async Task<string[]> PagesAsync()
+    {
+        var sitemap = XDocument.Parse(await Http.GetStringAsync(McpServerFixture.Url("sitemap.xml")));
+
+        return
+        [
+            .. sitemap.Descendants()
+                .Where(element => element.Name.LocalName == "loc")
+                .Select(element => new Uri(element.Value).AbsolutePath)
+                .Where(path => path != "/")
+        ];
+    }
+
+    [TestMethod]
+    public async Task Every_page_the_site_publishes_is_in_the_index()
+    {
+        var entries = await EntriesAsync();
+        var pages = await PagesAsync();
+
+        var indexed = entries.Where(entry => entry.Page is null).Select(entry => entry.Url).ToHashSet(StringComparer.Ordinal);
+
+        using (Assert.Scope())
+        {
+            foreach (var page in pages)
+            {
+                Assert.IsTrue(indexed.Contains(page), $"{page} is in the sitemap but has no entry of its own in the search index.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task Every_page_is_indexed_deeper_than_its_own_title()
+    {
+        // The failure this catches: a page that parses down to one entry. The corpus is what a
+        // reader searches, and a page reduced to its title is a page whose content is unfindable -
+        // which is the whole reason the index exists rather than the nav taxonomy alone.
+        var entries = await EntriesAsync();
+        var pages = await PagesAsync();
+
+        var counts = entries
+            .GroupBy(entry => entry.Url.Split('#')[0], StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+
+        using (Assert.Scope())
+        {
+            foreach (var page in pages)
+            {
+                Assert.IsTrue(counts.GetValueOrDefault(page) > 1,
+                    $"{page} contributed {counts.GetValueOrDefault(page)} entries: its sections and its API table were not indexed.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task A_section_is_a_hit_of_its_own_at_its_own_anchor()
+    {
+        var entries = await EntriesAsync();
+
+        var section = entries.FirstOrDefault(entry => entry.Url == "/clipboard#copy-text");
+
+        Assert.IsNotNull(section, "The Clipboard page's 'Copy text' section is not in the index.");
+
+        using (Assert.Scope())
+        {
+            Assert.AreEqual("Copy text", section.Title);
+            Assert.AreEqual("Clipboard", section.Page, "A section has to name the page it would open.");
+            Assert.Contains("WriteText", section.Keywords, "The member the section documents is what someone searches for it by.");
+            // The sample is the section's body, and a sample is what someone remembers of a page.
+            Assert.Contains("WriteText", section.Body);
+        }
+    }
+
+    [TestMethod]
+    public async Task The_reference_table_is_indexed_row_by_row()
+    {
+        var entries = await EntriesAsync();
+
+        var member = entries.FirstOrDefault(entry => entry.Url == "/clipboard#api-section" && entry.Title == "ReadText");
+
+        Assert.IsNotNull(member, "Clipboard.ReadText has no row in the index, so searching its exact name finds only the page.");
+        Assert.Contains("ValueTask<string> ReadText()", member.Keywords, "The signature is part of what a row is searched by.");
+    }
+
+    [TestMethod]
+    public async Task The_prose_of_a_page_is_searchable_and_not_only_its_headings()
+    {
+        var entries = await EntriesAsync();
+
+        // "unsanitized" is written once, in the middle of a section on one page, and appears nowhere
+        // in any title, slug or nav summary. Before the pages themselves were indexed, this word -
+        // and every word like it - found nothing at all.
+        var matches = entries.Where(entry =>
+            entry.Summary.Contains("unsanitized", StringComparison.OrdinalIgnoreCase) ||
+            entry.Body.Contains("unsanitized", StringComparison.OrdinalIgnoreCase));
+
+        Assert.IsNotEmpty(matches, "A word written in a page's prose is not in the index.");
+        Assert.IsTrue(matches.All(entry => entry.Url.StartsWith("/clipboard", StringComparison.Ordinal)),
+            "'unsanitized' is Clipboard's word; matching it elsewhere means text is leaking between entries.");
+    }
+
+    [TestMethod]
+    public async Task The_index_carries_text_rather_than_markup()
+    {
+        var entries = await EntriesAsync();
+
+        // Markup in a body is a corpus that matches "div" and "class" on every page, and a snippet
+        // that quotes a CSS class back at the reader. What is looked for here is only what the
+        // pages' own markup brings with it: the code samples ARE indexed, deliberately, and they
+        // contain angle brackets and Razor directives of their own.
+        string[] leaks = ["class=\"", "<span", "role=\"row\""];
+
+        using (Assert.Scope())
+        {
+            foreach (var leak in leaks)
+            {
+                var entry = entries.FirstOrDefault(entry => entry.Body.Contains(leak, StringComparison.Ordinal)
+                                                         || entry.Summary.Contains(leak, StringComparison.Ordinal));
+
+                Assert.IsNull(entry, $"\"{leak}\" reached the index through {entry?.Url}: it is markup, not documentation.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task Every_entry_can_be_opened()
+    {
+        var entries = await EntriesAsync();
+        var pages = (await PagesAsync()).ToHashSet(StringComparer.Ordinal);
+
+        using (Assert.Scope())
+        {
+            foreach (var entry in entries)
+            {
+                Assert.IsNotEmpty(entry.Title, $"{entry.Url} has an entry with no title.");
+                Assert.IsTrue(pages.Contains(entry.Url.Split('#')[0]), $"{entry.Url} points at a page the site does not publish.");
+                Assert.IsFalse(entry.Url.EndsWith('#'), $"{entry.Url} carries an empty anchor.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task The_index_is_served_compressed()
+    {
+        // It is the largest thing the site downloads and it is prose, which compresses to a fraction
+        // of itself. Serving it uncompressed to a browser that asked for gzip is the difference
+        // between a search box that is ready by the time a query is typed and one that is not.
+        using var request = new HttpRequestMessage(HttpMethod.Get, McpServerFixture.Url(IndexPath));
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+        using var response = await Http.SendAsync(request);
+        var compressed = await response.Content.ReadAsByteArrayAsync();
+
+        Assert.Contains("gzip", response.Content.Headers.ContentEncoding, "The index was served uncompressed to a client that asked for gzip.");
+
+        using var stream = new GZipStream(new MemoryStream(compressed), CompressionMode.Decompress);
+        using var reader = new StreamReader(stream);
+        var json = await reader.ReadToEndAsync();
+
+        Assert.IsGreaterThan(compressed.Length * 2, json.Length, "The compressed index is barely smaller than the JSON, which means it is not the JSON.");
+        Assert.Contains("\"entries\"", json);
+    }
+
+    [TestMethod]
+    public async Task A_returning_visitor_revalidates_instead_of_downloading_it_again()
+    {
+        using var first = await Http.GetAsync(McpServerFixture.Url(IndexPath));
+        var etag = first.Headers.ETag;
+
+        Assert.IsNotNull(etag, "The index has no ETag, so every visit downloads it again.");
+
+        using var again = new HttpRequestMessage(HttpMethod.Get, McpServerFixture.Url(IndexPath));
+        again.Headers.IfNoneMatch.Add(etag);
+
+        using var second = await Http.SendAsync(again);
+
+        Assert.AreEqual(HttpStatusCode.NotModified, second.StatusCode);
+        Assert.IsEmpty(await second.Content.ReadAsByteArrayAsync(), "A 304 answered with a body.");
+    }
+}

--- a/src/Butil/tests/Bit.Butil.Tests.Mcp/ScriptDeliveryTests.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Mcp/ScriptDeliveryTests.cs
@@ -36,6 +36,15 @@ public class ScriptDeliveryTests : McpTestBase
 
     private const string ModulesProperty = "BitButilIncludeScriptModules";
 
+    /// <summary>
+    /// What an app publishing WITHOUT trimming has to be told, and the escape hatch beside it. Both are new
+    /// answers to a question the older properties answer only for a trimmed publish, so an agent that knows
+    /// <see cref="TrimProperty"/> and not these tells an untrimmed app the feature does not apply to it.
+    /// </summary>
+    private const string ScanProperty = "BitButilScriptScan";
+
+    private const string ModuleItem = "BitButilScriptModule";
+
     [TestMethod]
     public async Task Every_setup_guide_names_both_ways_to_tree_shake_the_javascript()
     {
@@ -51,6 +60,12 @@ public class ScriptDeliveryTests : McpTestBase
             {
                 Assert.Contains(LazyProperty, text, $"The '{model}' guide never mentions {LazyProperty}.");
                 Assert.Contains(TrimProperty, text, $"The '{model}' guide never mentions {TrimProperty}.");
+
+                // The switch that decides WHETHER to trim is useless on its own to an app publishing
+                // untrimmed, which most hosting models here are: without this one named beside it, the
+                // agent reads "on by default in WebAssembly" and concludes the feature is not for them.
+                Assert.Contains(ScanProperty, text, $"The '{model}' guide never mentions {ScanProperty}, so an untrimmed publish has nothing to tree-shake against.");
+                Assert.Contains(ModuleItem, text, $"The '{model}' guide never mentions {ModuleItem}, which is the only way to keep a module nothing static can see.");
             }
         }
     }
@@ -113,6 +128,11 @@ public class ScriptDeliveryTests : McpTestBase
             Assert.Contains(TrimProperty, section);
             Assert.Contains(ModulesProperty, section);
             Assert.Contains("_content/Bit.Butil/modules/", section);
+
+            // And what the bundle trimming works FROM, which is a separate question from whether it
+            // runs: an agent that only ever sees TrimProperty has no answer for an untrimmed publish.
+            Assert.Contains(ScanProperty, section);
+            Assert.Contains(ModuleItem, section);
         }
     }
 
@@ -221,6 +241,7 @@ public class ScriptDeliveryTests : McpTestBase
             Assert.Contains(LazyProperty, page);
             Assert.Contains(TrimProperty, page);
             Assert.Contains(ModulesProperty, page);
+            Assert.Contains(ScanProperty, page);
             Assert.Contains("AddBitButilServices", page);
         }
     }
@@ -256,6 +277,8 @@ public class ScriptDeliveryTests : McpTestBase
                 $"The page never names {ModulesProperty}, which is the fix when the module files were not published.");
             Assert.Contains(TrimProperty, page,
                 $"The page never names {TrimProperty}, which is how a trimmed bundle is ruled in or out as the cause.");
+            Assert.Contains(ModuleItem, page,
+                $"The page never names {ModuleItem}, which is the fix once a trimmed bundle IS the cause and the API is reached by reflection.");
         }
     }
 

--- a/src/Butil/tests/Bit.Butil.Tests.PublishFixture/Bit.Butil.Tests.PublishFixture.csproj
+++ b/src/Butil/tests/Bit.Butil.Tests.PublishFixture/Bit.Butil.Tests.PublishFixture.csproj
@@ -1,0 +1,62 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <!--
+    A consumer app that exists to be published, over and over, with different Bit.Butil settings - see
+    ScriptPublishing.cs in Bit.Butil.Tests.Manual, which is the only thing that ever builds it.
+
+    Everything the script trimming does happens inside `dotnet publish`, in MSBuild, over the SDK's static
+    web asset lists. None of that is reachable from a test that calls into Bit.Butil.Build: the task is one
+    step of it, and the gating, the ordering, the asset surgery and the publish output are the rest. So the
+    checks that cover it publish a real app and read what came out, and this is that app.
+
+    Deliberately a plain web app rather than a Blazor WebAssembly one: it publishes in seconds rather than
+    minutes, and it is the shape the scanning exists for - a publish ILLink never touches, where without a
+    scan or an explicit list there is nothing to trim against.
+
+    Not in the solution, and not a test project. It is a fixture: building it on its own proves nothing, and
+    a `dotnet test` that picked it up would find nothing to run.
+    -->
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <!-- Its own name, so the Bit.Butil.Console type below cannot shadow System.Console. -->
+        <RootNamespace>ButilTests.PublishFixture</RootNamespace>
+        <!-- One less thing to differ between runs, and nothing here is ever run. -->
+        <InvariantGlobalization>true</InvariantGlobalization>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Bit.Butil\Bit.Butil.csproj" />
+    </ItemGroup>
+
+    <!--
+    Butil reaches this app as a ProjectReference, so the consumer-side logic a NuGet package would import is
+    imported by hand and pointed at the source tree - the same arrangement Samples.Web uses, and the one that
+    makes this fixture test the targets in this working copy rather than the ones in some published package.
+    -->
+    <PropertyGroup>
+        <BitButilChunksDirectory>$(MSBuildThisFileDirectory)..\..\Bit.Butil\obj\butil-js\chunks\</BitButilChunksDirectory>
+        <BitButilBuildTasksAssembly>$(MSBuildThisFileDirectory)..\..\Bit.Butil.Build\bin\$(Configuration)\netstandard2.0\Bit.Butil.Build.dll</BitButilBuildTasksAssembly>
+        <!-- Not a WebAssembly project, so the trimming is off by default here; every scenario wants it on and
+             differs in what it is given to trim against. -->
+        <BitButilTrimScripts Condition="'$(BitButilTrimScripts)' == ''">true</BitButilTrimScripts>
+    </PropertyGroup>
+
+    <!-- The <BitButilScriptModule> items of a scenario, passed in as a property because that is what a
+         command line can set; a real csproj writes the ItemGroup out directly.
+
+         Pipe-separated, and turned back into a list here, because neither a semicolon nor a comma survives the
+         trip: an MSBuild command line reads both as the separator between one property and the next, and an
+         escaped semicolon (%3B) arrives as a literal one inside a single item rather than as a separator.
+         Unescape is what makes the swapped-in semicolons separators again - the result of a property function
+         is escaped, so without it the Include is one item whose name happens to contain a semicolon. -->
+    <ItemGroup Condition="'$(FixtureScriptModules)' != ''">
+        <BitButilScriptModule Include="$([MSBuild]::Unescape($(FixtureScriptModules.Replace('|', ';'))))" />
+    </ItemGroup>
+
+    <Import Project="..\..\Bit.Butil\buildTransitive\Bit.Butil.targets" />
+
+</Project>

--- a/src/Butil/tests/Bit.Butil.Tests.PublishFixture/Program.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.PublishFixture/Program.cs
@@ -1,0 +1,42 @@
+﻿using Bit.Butil;
+
+namespace ButilTests.PublishFixture;
+
+/// <summary>
+/// The whole app. Two Bit.Butil classes are named and no others, which is what makes the module set a
+/// publish should arrive at small enough to assert on by name.
+/// </summary>
+/// <remarks>
+/// Injected through the non-generic <see cref="IServiceProvider.GetService(Type)"/>, the way Blazor fills an
+/// <c>@inject</c> property: what a scan reads is the type reference, and going through the generic overload
+/// would add an annotation that has nothing to do with what is being measured.
+/// <br/>
+/// The classes are chosen for what they prove rather than for what they do. <see cref="Clipboard"/> and
+/// <see cref="Geolocation"/> each need one module of their own name; the scenarios that add
+/// <c>LocalStorage</c> or <c>Window</c> to this list would be measuring the class-to-module map, which the
+/// checks in ScriptScanning.cs already cover against ILLink's own answer. Here the question is only whether a
+/// publish carries what was worked out into the output.
+/// </remarks>
+public static class Program
+{
+    /// <summary>The modules the two classes below need, before the manifest closes them over dependencies.</summary>
+    public const string ExpectedModules = "clipboard,geolocation";
+
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Services.AddBitButilServices();
+
+        var app = builder.Build();
+
+        app.MapGet("/", (IServiceProvider services) =>
+        {
+            var clipboard = (Clipboard)services.GetRequiredService(typeof(Clipboard));
+            var geolocation = (Geolocation)services.GetRequiredService(typeof(Geolocation));
+
+            return $"{clipboard.GetType().Name} {geolocation.GetType().Name}";
+        });
+
+        app.Run();
+    }
+}


### PR DESCRIPTION
closes #13056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added publish-time JavaScript trimming based on assembly scanning or explicitly selected modules.
  * Added `TypeReferences` and `TypeNames` scanning modes.
  * Added flexible module and type-name resolution, including case-insensitive matching.
  * Expanded documentation search across pages, sections, API entries, and prose.
  * Added compressed search-index delivery with caching support.

* **Documentation**
  * Updated setup, getting-started, troubleshooting, and README guidance.

* **Tests**
  * Added coverage for scanning, publishing, documentation indexing, compression, and cache validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->