### PR TITLE
Add cloudflare tunnels support to bit Boilerplate (#13060)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Directory.Packages.props
@@ -71,6 +71,7 @@
         <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(filesStorage)' == 'AzureBlobStorage' OR '$(filesStorage)' == '') " Include="Aspire.Hosting.Azure.Storage" Version="13.5.3" />
         <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(filesStorage)' == 'S3' OR '$(filesStorage)' == '') " Include="CommunityToolkit.Aspire.Hosting.Minio" Version="13.5.0" />
         <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '')" Include="Aspire.Hosting.Keycloak" Version="13.5.3-preview.1.26425.3" />
+        <PackageVersion Condition=" ('$(aspire)' == 'true' OR '$(aspire)' == '') AND ('$(cloudflare)' == 'true' OR '$(cloudflare)' == '') " Include="Shirubasoft.Aspire.CloudflareTunnels" Version="1.1.3" />
         <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
         <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
         <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.9.0" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Api/appsettings.json
@@ -223,7 +223,8 @@
         "ForwardedHeaders_Comment": "These values apply only if your backend is hosted behind a CDN (such as `Cloudflare`).",
         "ForwardedHostHeaderName": "X-Forwarded-Host",
         "ForwardedHostHeaderName_Comment": "For Cloudflare, use X-Host instead of X-Forwarded-Host.",
-        "KnownNetworks": [],
+        "KnownIPNetworks": [],
+        "KnownIPNetworks_Comment": "CIDR ranges of trusted proxies, e.g. [ \"172.28.0.0/24\" ]. Parsed in code (not JSON-bindable). Loopback (127.0.0.0/8, ::1) is already trusted.",
         "KnownProxies": [],
         "AllowedHosts": [ "" ]
     },

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Boilerplate.Server.AppHost.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Boilerplate.Server.AppHost.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.DevTunnels" />
+        <PackageReference Condition="'$(cloudflare)' == 'true' OR '$(cloudflare)' == ''" Include="Shirubasoft.Aspire.CloudflareTunnels" />
         <PackageReference Include="Aspire.Hosting.Keycloak" />
         <PackageReference Include="Aspire.Hosting.Maui" />
         <PackageReference Condition=" '$(database)' == 'MySql' OR '$(database)' == '' " Include="Aspire.Hosting.MySql" />

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Infrastructure/Extensions/IDistributedApplicationBuilderExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Infrastructure/Extensions/IDistributedApplicationBuilderExtensions.cs
@@ -188,6 +188,35 @@ public static class IDistributedApplicationBuilderExtensions
         }
         //#endif
 
+        //#if (cloudflare == true)
+        /// <summary>
+        /// Exposes the server projects through a Cloudflare Tunnel (cloudflared dials out, so the origin needs no
+        /// public ip). Opt-in: does nothing unless the <c>cloudflare-tunnel-*</c> parameters are set (see appsettings.Development.json).
+        /// </summary>
+        public void AddCloudflareTunnels(
+            IResourceBuilder<ProjectResource> serverWebProject
+            //#if (api == "Standalone")
+            , IResourceBuilder<ProjectResource> serverApiProject
+            //#endif
+            )
+        {
+            var domain = builder.Configuration["Parameters:cloudflare-tunnel-web-domain"];
+            if (string.IsNullOrEmpty(domain))
+                return;
+
+            var tunnel = builder.AddCloudflareTunnel("cloudflare-tunnel");
+
+            serverWebProject.WithCloudflareTunnel(tunnel, hostname: domain);
+
+            //#if (api == "Standalone")
+            // Standalone's API is a separate server, so expose it on its own hostname when one is configured.
+            var apiDomain = builder.Configuration["Parameters:cloudflare-tunnel-api-domain"];
+            if (string.IsNullOrEmpty(apiDomain) is false)
+                serverApiProject.WithCloudflareTunnel(tunnel, hostname: apiDomain);
+            //#endif
+        }
+        //#endif
+
         /// <summary>
         /// Adds the .NET MAUI Blazor Hybrid project and configures it for all supported device targets
         /// (Windows, macOS Catalyst, iOS Device, iOS Simulator, Android Device, Android Emulator).
@@ -239,6 +268,26 @@ public static class IDistributedApplicationBuilderExtensions
                 .WithReference(serverWebProject, tunnel);
 
             return mauiapp;
+        }
+
+        /// <summary>
+        /// Projects' launchSettings bind <c>http://*:port</c> so a direct <c>dotnet run</c> is reachable over the LAN
+        /// (e.g. from Android/iOS devices), but Aspire can't give a container a reachable address for a wildcard host,
+        /// so that endpoint only makes the ingress container fail to start. Drops every wildcard endpoint from the
+        /// model - run mode only, and launchSettings is untouched, so a direct run still binds every interface.
+        /// </summary>
+        public IDistributedApplicationBuilder RemoveWildcardEndpoints()
+        {
+            if (builder.ExecutionContext.IsRunMode is false)
+                return builder;
+
+            foreach (var project in builder.Resources.OfType<ProjectResource>().ToArray())
+            {
+                foreach (var wildcard in project.Annotations.OfType<EndpointAnnotation>().Where(endpoint => endpoint.TargetHost is "*").ToArray())
+                    project.Annotations.Remove(wildcard);
+            }
+
+            return builder;
         }
 
         /// <summary>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/Program.cs
@@ -98,6 +98,18 @@ serverWebProject.WithReference(redisPersistent).WaitFor(redisPersistent);
 //#endif
 //#endif
 
+// Drop the projects' http://*:port (wildcard) endpoints - Aspire can't reach a wildcard host from the ingress container.
+builder.RemoveWildcardEndpoints();
+
+//#if (cloudflare == true)
+// cloudflared connects straight to the projects (no reverse proxy) - possible now that RemoveWildcardEndpoints drops http2.
+builder.AddCloudflareTunnels(serverWebProject
+    //#if (api == "Standalone")
+    , serverApiProject
+    //#endif
+    );
+//#endif
+
 if (builder.ExecutionContext.IsRunMode) // The following project is only added for testing purposes.
 {
     // Blazor WebAssembly Standalone project.
@@ -117,12 +129,12 @@ if (builder.ExecutionContext.IsRunMode) // The following project is only added f
     //#if (api == "Standalone")
     builder.AddDevTunnel("api-dev-tunnel")
         .WithAnonymousAccess()
-        .WithReference(serverApiProject.WithHttpEndpoint(name: "devTunnel", port: 5031).GetEndpoint("devTunnel"));
+        .WithReference(serverApiProject);
     //#endif
 
     var tunnel = builder.AddDevTunnel("web-dev-tunnel")
         .WithAnonymousAccess()
-        .WithReference(serverWebProject.WithHttpEndpoint(name: "devTunnel", port: 5000).GetEndpoint("devTunnel"));
+        .WithReference(serverWebProject);
 
     if (OperatingSystem.IsWindows())
     {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/appsettings.Development.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.AppHost/appsettings.Development.json
@@ -25,6 +25,13 @@
         "redis-cache-password": "P@ssw0rd",
         "redis-persistent-password": "P@ssw0rd",
         //#endif
+        //#if (cloudflare == true)
+        "cloudflare-tunnel-account-id": "",
+        "cloudflare-tunnel-api-token": "",
+        "cloudflare-tunnel-web-domain": "app.my-domain-configured-in-cloudflare.com",
+        "cloudflare-tunnel-api-domain": "app-api.my-domain-configured-in-cloudflare.com",
+        "cloudflare-tunnel__Comment": "Cloudflare Tunnel credentials. Create a custom API token at https://dash.cloudflare.com/profile/api-tokens with the permissions at https://github.com/shirubasoft/aspire-cloudflare-tunnels#required-permissions; account-id is on your domain's Cloudflare overview. The tunnel and its DNS record are created for you.",
+        //#endif
         "Comment": "You might need to delete the docker volumes to apply changes to the passwords"
     }
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Shared/Infrastructure/Extensions/WebApplicationExtensions.cs
@@ -1,4 +1,5 @@
 //+:cnd:noEmit
+using System.Net;
 using Boilerplate.Server.Shared;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Http;
@@ -66,6 +67,13 @@ public static class WebApplicationExtensions
 
             var forwardedHeadersOptions = forwardedHeadersConfig.DynamicBind<ForwardedHeadersOptions>();
             forwardedHeadersOptions.AllowedHosts = [.. (forwardedHeadersOptions.AllowedHosts ?? []).Union(settings.TrustedOrigins.Select(ServerSharedSettings.GetTrustedOriginHost))];
+
+            // IPAddress/IPNetwork don't bind from config, so DynamicBind drops KnownProxies/KnownIPNetworks values;
+            // parse them here. Loopback (::1, 127.0.0.0/8) is trusted by default, so a localhost proxy needs none.
+            foreach (var proxy in forwardedHeadersConfig.GetSection("KnownProxies").Get<string[]>() ?? [])
+                forwardedHeadersOptions.KnownProxies.Add(IPAddress.Parse(proxy));
+            foreach (var network in forwardedHeadersConfig.GetSection("KnownIPNetworks").Get<string[]>() ?? [])
+                forwardedHeadersOptions.KnownIPNetworks.Add(IPNetwork.Parse(network));
 
             if (app.Environment.IsDevelopment() || forwardedHeadersOptions.AllowedHosts.Any())
             {

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/Program.Middlewares.cs
@@ -62,7 +62,7 @@ public static partial class Program
                     {
                         context.Response.GetTypedHeaders().CacheControl = new()
                         {
-                            NoStore = true
+                            NoCache = true
                         };
                     }
                     else

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Server/Boilerplate.Server.Web/appsettings.json
@@ -159,7 +159,8 @@
         "ForwardedHeaders_Comment": "These values apply only if your backend is hosted behind a CDN (such as `Cloudflare`).",
         "ForwardedHostHeaderName": "X-Forwarded-Host",
         "ForwardedHostHeaderName_Comment": "For Cloudflare, use X-Host instead of X-Forwarded-Host.",
-        "KnownNetworks": [],
+        "KnownIPNetworks": [],
+        "KnownIPNetworks_Comment": "CIDR ranges of trusted proxies, e.g. [ \"172.28.0.0/24\" ]. Parsed in code (not JSON-bindable). Loopback (127.0.0.0/8, ::1) is already trusted.",
         "KnownProxies": [],
         "AllowedHosts": [ "" ]
     },
@@ -174,7 +175,7 @@
     },
     "AllowedHosts": "*",
     "WebAppRender": {
-        "BlazorMode": "BlazorServer",
+        "BlazorMode": "BlazorWebAssembly",
         "BlazorMode_Comment": "BlazorServer, BlazorWebAssembly and BlazorAuto.",
         "PrerenderEnabled": false,
         "PrerenderEnabled_Comment": "for apps with Prerender enabled, follow the instructions in the Client.Web/wwwroot/service-worker.published.js file"


### PR DESCRIPTION
closes #13060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Cloudflare Tunnel support for web and standalone API applications.
  * Added configuration fields for tunnel credentials and domains.
  * Added support for trusted proxy IP addresses and CIDR ranges.

* **Improvements**
  * Updated the default web rendering mode to Blazor WebAssembly.
  * Improved local development endpoint handling.

* **Bug Fixes**
  * Corrected development response caching behavior.
  * Updated forwarded-header configuration to recognize trusted IP networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->