### PR TITLE
Add e2e tests to bit Boilerplate (#13064)

### DIFF
--- a/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/.template.config/template.json
@@ -609,6 +609,9 @@
                         "**/*.nuspec",
                         "src/Server/**/Data/Migrations/**",
                         "src/**/App_Data/**",
+                        // E2E tests against the deployed demo apps (adminpanel/todo/sales.bitplatform.dev and friends),
+                        // which only exist for this repository - a generated project has no such deployments.
+                        "src/Internal/**",
                         // Needs ProductController (Admin module) and ProductViewController + the product page (Sales
                         // module) at once, and "module" is a single choice, so it can only ever run against the
                         // template's own source tree.
@@ -736,6 +739,7 @@
                         "src/Tests/Features/Identity/EmailUniquenessIndexTests.cs",
                         "src/Tests/Features/Identity/TestAccountUtils.cs",
                         "src/Tests/Features/Identity/AccountErasureTests.cs",
+                        "src/Tests/Features/Identity/UnconfirmedUsersRetentionTests.cs",
                         "src/Tests/Features/Attachments/AttachmentMetadataStrippingTests.cs",
                         "src/Tests/Features/Identity/RoleAdministrationGuardTests.cs",
                         "src/Tests/Features/Identity/ConfirmPageTwoFactorTests.cs",

--- a/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.Web.slnf
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.Web.slnf
@@ -4,6 +4,9 @@
     "projects": [
       "src\\Client\\Boilerplate.Client.Core\\Boilerplate.Client.Core.csproj",
       "src\\Client\\Boilerplate.Client.Web\\Boilerplate.Client.Web.csproj",
+//#if (IsInsideProjectTemplate == true)
+      "src\\Internal\\Boilerplate.Tests.E2E\\Boilerplate.Tests.E2E.csproj",
+//#endif
 //#if (aspire == true)
       "src\\Server\\Boilerplate.Server.AppHost\\Boilerplate.Server.AppHost.csproj",
 //#endif

--- a/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.slnx
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/Boilerplate.slnx
@@ -108,4 +108,11 @@
       <Build Solution="DebugBlazorServer|*" Project="false" />
     </Project>
   </Folder>
+<!--#if (IsInsideProjectTemplate == true)-->
+  <Folder Name="/Internal/">
+    <Project Path="src/Internal/Boilerplate.Tests.E2E/Boilerplate.Tests.E2E.csproj">
+      <Build Solution="DebugBlazorServer|*" Project="false" />
+    </Project>
+  </Folder>
+<!--#endif-->
 </Solution>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Boilerplate.Client.Maui.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Client/Boilerplate.Client.Maui/Boilerplate.Client.Maui.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
         <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
@@ -63,14 +63,9 @@
     <PropertyGroup Condition="$(TargetFramework.Contains('-android')) and '$(Environment)' != 'Development'">
         <AndroidLinkTool>r8</AndroidLinkTool>
         <AndroidUseAapt2>True</AndroidUseAapt2>
-        <RunAOTCompilation>True</RunAOTCompilation>
-        <AndroidStripILAfterAOT>true</AndroidStripILAfterAOT>
-        <AndroidEnableProfiledAot>true</AndroidEnableProfiledAot>
-        <MauiUseDefaultAotProfile Condition="Exists('custom.aprof')">false</MauiUseDefaultAotProfile>
         <RuntimeIdentifiers Condition="'$(AndroidPackageFormat)' == 'apk'">android-arm64</RuntimeIdentifiers>
 
-        <EnableLLVM>false</EnableLLVM>
-        <!-- https://github.com/dotnet/runtime/issues/95406#issuecomment-1983736335 -->
+        <UseMonoRuntime>false</UseMonoRuntime>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios')) and '$(Environment)' == 'Development'">
@@ -191,13 +186,6 @@
 
     <Target Name="BuildCssFiles">
         <Exec Command="../Boilerplate.Client.Core/node_modules/.bin/sass Components:Components --style compressed --silence-deprecation=import --update --color" StandardOutputImportance="high" StandardErrorImportance="high" LogStandardErrorAsError="true" />
-    </Target>
-
-    <!-- https://github.com/dotnet/runtime/issues/104599  -->
-    <Target Name="_FixAndroidAotInputs" DependsOnTargets="_AndroidAotInputs" BeforeTargets="_AndroidAotCompilation">
-        <ItemGroup Condition="$(EnableLLVM)">
-            <_AndroidAotInputs Remove="$(IntermediateLinkDir)**\System.Net.Sockets.dll" />
-        </ItemGroup>
     </Target>
 
 </Project>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/.runsettings
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/.runsettings
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- +:cnd:noEmit -->
 <RunSettings>
 
     <RunConfiguration>
@@ -9,15 +8,24 @@
             <!-- https://playwright.dev/docs/debug -->
             <!--<HEADED>1</HEADED>-->
             <!--<PWDEBUG>1</PWDEBUG>-->
+
+            <!-- Every test in this suite runs on chromium by default and re-targets as a whole through BROWSER -
+                 uncomment (or set the environment variable per run: `BROWSER=firefox dotnet test`) to cover Gecko and
+                 WebKit/Safari. -->
             <!--<BROWSER>firefox</BROWSER>-->
+            <!--<BROWSER>webkit</BROWSER>-->
 
             <!--<PLAYWRIGHT_SERVER_ENDPOINT>ws://192.168.178.24:4444/</PLAYWRIGHT_SERVER_ENDPOINT>-->
             <!-- Runs the selected BROWSER on another computer (e.g. webkit on the mac on the local network), after
                  starting the following command on it: -->
             <COMMAND_TO_RUN_IN_REMOTE_MACHINE>npx playwright@1.62.0 install; npx playwright@1.62.0 run-server --port 4444 --host 0.0.0.0</COMMAND_TO_RUN_IN_REMOTE_MACHINE>
 
-            <!-- You can override the configuration from appsettings.json for tests here. -->
-            <DOTNET_SYSTEM_GLOBALIZATION_INVARIANT>false</DOTNET_SYSTEM_GLOBALIZATION_INVARIANT>
+            <!-- The deployed demo apps are PWAs whose assets are largely downloaded by their bswup service worker
+                 rather than by the page itself, and Playwright only surfaces service worker requests through the
+                 browser context's Request/RequestFinished events when this flag is set before the driver starts.
+                 https://playwright.dev/docs/service-workers-experimental -->
+            <PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS>1</PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS>
+
         </EnvironmentVariables>
     </RunConfiguration>
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Boilerplate.Tests.E2E.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Boilerplate.Tests.E2E.csproj
@@ -8,7 +8,7 @@
         <Nullable>enable</Nullable>
         <UserSecretsId>154C08DF-B089-4D8F-91F3-A95D2A4A27D2</UserSecretsId>
         <RunSettingsFilePath>$(MSBuildProjectDirectory)\.runsettings</RunSettingsFilePath>
-        <TestingPlatformCommandLineArguments>--settings ./.runsettings --report-trx --report-trx-filename TestResults.trx --results-directory ./TestResults</TestingPlatformCommandLineArguments>
+        <TestingPlatformCommandLineArguments>--settings $(MSBuildProjectDirectory)/.runsettings --report-trx --report-trx-filename TestResults.trx --results-directory ./TestResults</TestingPlatformCommandLineArguments>
         <EnableMSTestRunner>true</EnableMSTestRunner>
     </PropertyGroup>
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Boilerplate.Tests.E2E.csproj
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Boilerplate.Tests.E2E.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!-- End-to-end Playwright tests running against the already deployed demo apps (web, Android and Windows).
+         This project lives only inside the bitplatform repository; template.json excludes src/Internal/** from the packed template. -->
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <UserSecretsId>154C08DF-B089-4D8F-91F3-A95D2A4A27D2</UserSecretsId>
+        <RunSettingsFilePath>$(MSBuildProjectDirectory)\.runsettings</RunSettingsFilePath>
+        <TestingPlatformCommandLineArguments>--settings ./.runsettings --report-trx --report-trx-filename TestResults.trx --results-directory ./TestResults</TestingPlatformCommandLineArguments>
+        <EnableMSTestRunner>true</EnableMSTestRunner>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Playwright.MSTest.v4" />
+        <PackageReference Include="MSTest" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Tests\Boilerplate.Tests.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="System.Net" />
+        <Using Include="System.Text.RegularExpressions" />
+        <Using Include="Boilerplate.Tests.Infrastructure" />
+        <Using Include="Boilerplate.Tests.E2E.Infrastructure" />
+        <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+        <Using Include="Microsoft.Playwright" />
+        <Using Include="Microsoft.Playwright.MSTest" />
+    </ItemGroup>
+
+</Project>

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Android/AndroidSmokeTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Android/AndroidSmokeTests.cs
@@ -1,0 +1,13 @@
+using Boilerplate.Tests.E2E.Features.Core;
+
+namespace Boilerplate.Tests.E2E.Features.Android;
+
+/// <summary>
+/// Not parallelized: both apps run on the single connected device/emulator, and launching one backgrounds the other.
+/// See <see cref="HybridAppConnector"/> for what a test machine must have connected and installed.
+/// </summary>
+[TestClass, TestCategory(TestCategories.Android), DoNotParallelize, Retry(2)]
+public partial class AndroidSmokeTests : SmokeTestsBase
+{
+    protected override IAppOpener AppOpener => new AndroidAppOpener();
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Core/SmokeTestsBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Core/SmokeTestsBase.cs
@@ -1,0 +1,53 @@
+namespace Boilerplate.Tests.E2E.Features.Core;
+
+/// <summary>
+/// Opens each app and proves it not only rendered but is actually interactive. Written once here; the Web, Windows and
+/// Android shells decide where the app runs, and the web shell additionally re-targets chromium/firefox/webkit through
+/// BROWSER.
+/// </summary>
+public abstract class SmokeTestsBase : AppsTestBase
+{
+    /// <summary>
+    /// Waits for the app shell every app renders through Client.Core's AppShell.razor, then opens the header's account
+    /// menu (AppMenu.razor's BitDropMenu) and expects its callout. Prerendered html can show the shell - and even the
+    /// menu's trigger - with no .NET app running behind it, but only a booted app handles the click.
+    /// </summary>
+    [TestMethod]
+    [DataRow(App.AdminPanel, DisplayName = nameof(App.AdminPanel))]
+    [DataRow(App.AdminPanelWasmStandalone, DisplayName = nameof(App.AdminPanelWasmStandalone))]
+    [DataRow(App.Todo, DisplayName = nameof(App.Todo))]
+    [DataRow(App.TodoAot, DisplayName = nameof(App.TodoAot))]
+    [DataRow(App.TodoSmall, DisplayName = nameof(App.TodoSmall))]
+    [DataRow(App.TodoOffline, DisplayName = nameof(App.TodoOffline))]
+    [DataRow(App.Sales, DisplayName = nameof(App.Sales))]
+    public async Task App_Should_BecomeInteractive(App app)
+    {
+        var page = await OpenApp(app);
+
+        // Generous because a first visit includes the WebAssembly boot / bswup precache on a cold cache.
+        await Expect(page.Locator("main .main-container").First)
+            .ToBeVisibleAsync(new() { Timeout = (float)TimeSpan.FromMinutes(2).TotalMilliseconds });
+
+        var menuTrigger = page.Locator("header .bit-drm").First;
+        var menuCallout = page.Locator(".app-menu-callout .app-menu-card").First;
+
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(2);
+
+        // A click landing in the gap between prerendered html and the app taking over is simply swallowed, so the
+        // click is retried against a deadline rather than trusted once (the same reasoning as
+        // PlaywrightLocatorExtensions' FillEnsuringStable).
+        while (true)
+        {
+            await menuTrigger.ClickAsync();
+
+            try
+            {
+                await Expect(menuCallout).ToBeVisibleAsync(new() { Timeout = 2_000 });
+                return;
+            }
+            catch (PlaywrightException) when (DateTimeOffset.UtcNow < deadline)
+            {
+            }
+        }
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Web/WebAppDownloadSizeTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Web/WebAppDownloadSizeTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Concurrent;
+
+namespace Boilerplate.Tests.E2E.Features.Web;
+
+[TestClass, TestCategory(TestCategories.Web), Retry(2)]
+public partial class WebAppDownloadSizeTests : AppPageTest
+{
+    /// <summary>
+    /// Growing past the expected size by more than this fails the test - the regression this test exists to catch.
+    /// </summary>
+    private const double growthTolerance = 0.10;
+
+    /// <summary>
+    /// Shrinking below the expected size by more than this also fails: either the measurement broke (a deployment is
+    /// down, the service worker no longer precaches) or the app genuinely got smaller and the expected size in the
+    /// DataRow should be re-baselined to the measured value the failure message prints.
+    /// </summary>
+    private const double shrinkTolerance = 0.30;
+
+    /// <summary>
+    /// The download is considered complete once the context has started and finished no request for this long.
+    /// Long enough to bridge the gaps in a bswup install (page load -> service worker precache -> app start),
+    /// short enough that recurring telemetry beacons cannot keep the wait alive forever on their own.
+    /// </summary>
+    private static readonly TimeSpan networkQuietPeriod = TimeSpan.FromSeconds(10);
+
+    private static readonly TimeSpan measurementDeadline = TimeSpan.FromMinutes(4);
+
+    /// <summary>
+    /// First visit with a cold cache: everything the app makes the browser download - the page's own requests plus the
+    /// bswup service worker's precache - summed as compressed-over-the-wire bytes. The expected sizes are simply
+    /// earlier measurements of this same method, so re-baseline them from the failure message whenever a deliberate
+    /// change moves an app's size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(DeployedApps.AdminPanel, 5.3, DisplayName = nameof(DeployedApps.AdminPanel))]
+    [DataRow(DeployedApps.AdminPanelWasmStandalone, 4.9, DisplayName = nameof(DeployedApps.AdminPanelWasmStandalone))]
+    [DataRow(DeployedApps.Todo, 5.0, DisplayName = nameof(DeployedApps.Todo))]
+    [DataRow(DeployedApps.TodoAot, 8.0, DisplayName = nameof(DeployedApps.TodoAot))]
+    [DataRow(DeployedApps.TodoSmall, 3.5, DisplayName = nameof(DeployedApps.TodoSmall))]
+    [DataRow(DeployedApps.TodoOffline, 7.3, DisplayName = nameof(DeployedApps.TodoOffline))]
+    [DataRow(DeployedApps.Sales, 5.4, DisplayName = nameof(DeployedApps.Sales))]
+    public async Task FirstVisitDownloadSize_Should_NotRegress(string url, double expectedMegabytes)
+    {
+        // Qualified because the inherited BrowserType property (an IBrowserType) shadows the type of the same name.
+        if (BrowserName is not Microsoft.Playwright.BrowserType.Chromium)
+            Assert.Inconclusive("Only chromium honors PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS, so on other engines the service worker's downloads go uncounted and the totals here would be meaningless. The payload is engine-independent anyway; a BROWSER=firefox/webkit run covers compatibility through the other web tests.");
+
+        var (totalBytes, requestCount) = await MeasureFirstVisitDownloadSize(url);
+
+        var actualMegabytes = totalBytes / 1024d / 1024d;
+
+        TestContext.WriteLine($"{url} downloaded {actualMegabytes:F2}MB over {requestCount} requests (expected ~{expectedMegabytes:F2}MB).");
+
+        Assert.IsLessThanOrEqualTo(expectedMegabytes * (1 + growthTolerance), actualMegabytes,
+            $"{url} now downloads {actualMegabytes:F2}MB, more than {growthTolerance:P0} over the expected {expectedMegabytes:F2}MB - a size regression.");
+
+        Assert.IsGreaterThanOrEqualTo(expectedMegabytes * (1 - shrinkTolerance), actualMegabytes,
+            $"{url} downloaded only {actualMegabytes:F2}MB against the expected {expectedMegabytes:F2}MB - either the measurement broke or the app shrank and this DataRow should be re-baselined.");
+    }
+
+    /// <summary>
+    /// Navigates a fresh, empty-cache context to <paramref name="url"/>, waits until the network has been quiet for
+    /// <see cref="networkQuietPeriod"/>, and sums the encoded (compressed) body + header bytes of every request the
+    /// context made - the service worker's included, thanks to the PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS flag
+    /// .runsettings sets.
+    /// </summary>
+    private async Task<(long totalBytes, int requestCount)> MeasureFirstVisitDownloadSize(string url)
+    {
+        var requests = new ConcurrentQueue<IRequest>();
+        var lastActivityTicks = DateTimeOffset.UtcNow.UtcTicks;
+
+        void Touch() => Interlocked.Exchange(ref lastActivityTicks, DateTimeOffset.UtcNow.UtcTicks);
+
+        Context.Request += (_, request) => { requests.Enqueue(request); Touch(); };
+        Context.RequestFinished += (_, _) => Touch();
+        Context.RequestFailed += (_, _) => Touch();
+
+        await Page.GotoAsync(url);
+
+        var deadline = DateTimeOffset.UtcNow + measurementDeadline;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var lastActivity = new DateTimeOffset(Interlocked.Read(ref lastActivityTicks), TimeSpan.Zero);
+
+            if (DateTimeOffset.UtcNow - lastActivity >= networkQuietPeriod)
+                break;
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500), TestContext.CancellationToken);
+        }
+
+        long totalBytes = 0;
+        var requestCount = 0;
+
+        foreach (var request in requests)
+        {
+            try
+            {
+                var sizes = await request.SizesAsync();
+                totalBytes += Math.Max(0, sizes.ResponseBodySize) + Math.Max(0, sizes.ResponseHeadersSize);
+                requestCount++;
+            }
+            catch (PlaywrightException)
+            {
+                // A request that never finished (cancelled, or still in flight past the deadline) has no sizes; the
+                // bytes it did move are not part of what the app needs, so skipping it is the right call.
+            }
+        }
+
+        return (totalBytes, requestCount);
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Web/WebSmokeTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Web/WebSmokeTests.cs
@@ -1,0 +1,9 @@
+using Boilerplate.Tests.E2E.Features.Core;
+
+namespace Boilerplate.Tests.E2E.Features.Web;
+
+[TestClass, TestCategory(TestCategories.Web), Retry(2)]
+public partial class WebSmokeTests : SmokeTestsBase
+{
+    protected override IAppOpener AppOpener => new WebAppOpener();
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Windows/WindowsSmokeTests.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Features/Windows/WindowsSmokeTests.cs
@@ -1,0 +1,13 @@
+using Boilerplate.Tests.E2E.Features.Core;
+
+namespace Boilerplate.Tests.E2E.Features.Windows;
+
+/// <summary>
+/// Not parallelized: every Client.Windows app answers on the same hard-coded CDP port 9222, so two sessions at once
+/// would attach to whichever app won the port. See <see cref="HybridAppConnector"/> for what a test machine must have installed.
+/// </summary>
+[TestClass, TestCategory(TestCategories.Windows), DoNotParallelize, Retry(2)]
+public partial class WindowsSmokeTests : SmokeTestsBase
+{
+    protected override IAppOpener AppOpener => new WindowsAppOpener();
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/App.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/App.cs
@@ -1,0 +1,17 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// The demo apps as platform-agnostic identities. Which platforms actually carry an app - and how to reach it there -
+/// is the <see cref="IAppOpener"/>s' knowledge; a test written against <see cref="AppsTestBase"/> just names the app
+/// and runs wherever it exists.
+/// </summary>
+public enum App
+{
+    AdminPanel,
+    AdminPanelWasmStandalone,
+    Todo,
+    TodoAot,
+    TodoSmall,
+    TodoOffline,
+    Sales,
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/AppOpeners.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/AppOpeners.cs
@@ -1,0 +1,77 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// How a platform turns an <see cref="App"/> into a live page: the web opener navigates the test's own browser page,
+/// the hybrid ones launch the installed app and attach over CDP. Null means the app has no build on that platform,
+/// which <see cref="AppsTestBase.OpenApp"/> turns into an inconclusive test rather than a failure.
+/// </summary>
+public interface IAppOpener
+{
+    Task<IPage?> TryOpen(AppsTestBase test, App app);
+}
+
+public sealed class WebAppOpener : IAppOpener
+{
+    public async Task<IPage?> TryOpen(AppsTestBase test, App app)
+    {
+        var url = app switch
+        {
+            App.AdminPanel => DeployedApps.AdminPanel,
+            App.AdminPanelWasmStandalone => DeployedApps.AdminPanelWasmStandalone,
+            App.Todo => DeployedApps.Todo,
+            App.TodoAot => DeployedApps.TodoAot,
+            App.TodoSmall => DeployedApps.TodoSmall,
+            App.TodoOffline => DeployedApps.TodoOffline,
+            App.Sales => DeployedApps.Sales,
+            _ => throw new ArgumentOutOfRangeException(nameof(app), app, "Unknown app"),
+        };
+
+        await test.Page.GotoAsync(url);
+
+        return test.Page;
+    }
+}
+
+public sealed class WindowsAppOpener : IAppOpener
+{
+    public async Task<IPage?> TryOpen(AppsTestBase test, App app)
+    {
+        var windowsAppId = app switch
+        {
+            App.Todo => DeployedApps.TodoWindowsAppId,
+            App.AdminPanel => DeployedApps.AdminPanelWindowsAppId,
+            _ => null,
+        };
+
+        if (windowsAppId is null)
+            return null;
+
+        var session = await test.Playwright.LaunchWindowsApp(windowsAppId);
+
+        test.RegisterForCleanup(session);
+
+        return session.Page;
+    }
+}
+
+public sealed class AndroidAppOpener : IAppOpener
+{
+    public async Task<IPage?> TryOpen(AppsTestBase test, App app)
+    {
+        var applicationId = app switch
+        {
+            App.Todo => DeployedApps.TodoAndroidAppId,
+            App.AdminPanel => DeployedApps.AdminPanelAndroidAppId,
+            _ => null,
+        };
+
+        if (applicationId is null)
+            return null;
+
+        var session = await test.Playwright.LaunchAndroidApp(applicationId);
+
+        test.RegisterForCleanup(session);
+
+        return session.Page;
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/AppOpeners.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/AppOpeners.cs
@@ -40,6 +40,7 @@ public sealed class WindowsAppOpener : IAppOpener
         {
             App.Todo => DeployedApps.TodoWindowsAppId,
             App.AdminPanel => DeployedApps.AdminPanelWindowsAppId,
+            App.Sales => DeployedApps.SalesWindowsAppId,
             _ => null,
         };
 

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/AppsTestBase.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/AppsTestBase.cs
@@ -1,0 +1,47 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// Base for tests written once and run against every platform that carries the app: the feature's tests live in an
+/// abstract class under Features/Core, and a shell class per platform inherits it, only picking its
+/// <see cref="AppOpener"/> and the platform's category/parallelism attributes. The tests call <see cref="OpenApp"/>
+/// and drive the returned page without knowing whether it lives in a browser tab or an installed app's WebView.
+/// <para>
+/// The hybrid shells inherit the browser-page plumbing too and simply never touch the tab it opens; that costs
+/// milliseconds and keeps the timeout, remote-server and video-on-retry setup single-sourced in AppPageTest.
+/// </para>
+/// </summary>
+public abstract class AppsTestBase : AppPageTest
+{
+    private readonly List<IAsyncDisposable> cleanups = [];
+
+    protected abstract IAppOpener AppOpener { get; }
+
+    /// <summary>
+    /// What an <see cref="IAppOpener"/> created lives exactly as long as the test: registered here, closed by
+    /// <see cref="AppsCleanup"/> (e.g. the launched hybrid app).
+    /// </summary>
+    public void RegisterForCleanup(IAsyncDisposable disposable) => cleanups.Add(disposable);
+
+    /// <summary>
+    /// A live page of <paramref name="app"/> on this shell's platform; inconclusive when the app has no build there,
+    /// so a coverage gap shows up as skipped rather than hiding as a pass.
+    /// </summary>
+    protected async Task<IPage> OpenApp(App app)
+    {
+        var page = await AppOpener.TryOpen(this, app);
+
+        if (page is null)
+            Assert.Inconclusive($"{app} has no build on this platform.");
+
+        return page!;
+    }
+
+    [TestCleanup]
+    public async ValueTask AppsCleanup()
+    {
+        foreach (var cleanup in cleanups)
+            await cleanup.DisposeAsync();
+
+        cleanups.Clear();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/DeployedApps.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/DeployedApps.cs
@@ -40,9 +40,7 @@ public static class DeployedApps
     /// <summary>Velopack app id of the published AdminPanel Windows app, for <see cref="HybridAppConnector.LaunchWindowsApp"/>.</summary>
     public const string AdminPanelWindowsAppId = "AdminPanel.Client.Windows";
 
-    /// <summary>Installer that puts the Todo Windows app where <see cref="HybridAppConnector.LaunchWindowsApp"/> expects it.</summary>
-    public const string TodoWindowsSetupUrl = "https://windows-todo.bitplatform.dev/TodoSample.Client.Windows-win-Setup.exe";
+    /// <summary>Velopack app id of the published Sales Windows app, for <see cref="HybridAppConnector.LaunchWindowsApp"/>.</summary>
+    public const string SalesWindowsAppId = "SalesModule.Client.Windows";
 
-    /// <summary>Installer that puts the AdminPanel Windows app where <see cref="HybridAppConnector.LaunchWindowsApp"/> expects it.</summary>
-    public const string AdminPanelWindowsSetupUrl = "https://windows-admin.bitplatform.dev/AdminPanel.Client.Windows-win-Setup.exe";
 }

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/DeployedApps.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/DeployedApps.cs
@@ -1,0 +1,48 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// The always-on demo apps that .github/workflows/{admin-sample,todo-sample,sales-module-demo}.cd.yml build from this
+/// very template (dotnet new bit-bp) and deploy. Together they cover Client.Web, Server.Web, Client.Maui and
+/// Client.Windows, so tests in this project run against real production deployments instead of a locally started server.
+/// </summary>
+public static class DeployedApps
+{
+    /// <summary>Admin module, prerendered PWA served by Server.Web with a standalone API (Azure Web App + Cloudflare CDN).</summary>
+    public const string AdminPanel = "https://adminpanel.bitplatform.dev/";
+
+    /// <summary>Admin module, Blazor WebAssembly Standalone (Azure Static Web App).</summary>
+    public const string AdminPanelWasmStandalone = "https://adminpanel.bitplatform.cc/";
+
+    /// <summary>Todo sample, prerendered PWA served by Server.Web with a standalone API (Azure Web App + Cloudflare CDN).</summary>
+    public const string Todo = "https://todo.bitplatform.dev/";
+
+    /// <summary>Todo sample, AOT compiled Blazor WebAssembly Standalone (Azure Static Web App).</summary>
+    public const string TodoAot = "https://todo-aot.bitplatform.cc/";
+
+    /// <summary>Todo sample, Blazor WebAssembly Standalone published for the smallest download footprint (Azure Static Web App).</summary>
+    public const string TodoSmall = "https://todo-small.bitplatform.cc/";
+
+    /// <summary>Todo sample with the offline in-browser SQLite database and sync, full-offline bswup mode (Azure Static Web App).</summary>
+    public const string TodoOffline = "https://todo-offline.bitplatform.cc/";
+
+    /// <summary>Sales module, prerendered PWA served by Server.Web with an integrated API (Azure Web App + Cloudflare CDN).</summary>
+    public const string Sales = "https://sales.bitplatform.dev/";
+
+    /// <summary>Application id of the published Todo Android app, for <see cref="HybridAppConnector.LaunchAndroidApp"/>.</summary>
+    public const string TodoAndroidAppId = "com.bitplatform.Todo.Template";
+
+    /// <summary>Application id of the published AdminPanel Android app, for <see cref="HybridAppConnector.LaunchAndroidApp"/>.</summary>
+    public const string AdminPanelAndroidAppId = "com.bitplatform.AdminPanel.Template";
+
+    /// <summary>Velopack app id of the published Todo Windows app, for <see cref="HybridAppConnector.LaunchWindowsApp"/>.</summary>
+    public const string TodoWindowsAppId = "TodoSample.Client.Windows";
+
+    /// <summary>Velopack app id of the published AdminPanel Windows app, for <see cref="HybridAppConnector.LaunchWindowsApp"/>.</summary>
+    public const string AdminPanelWindowsAppId = "AdminPanel.Client.Windows";
+
+    /// <summary>Installer that puts the Todo Windows app where <see cref="HybridAppConnector.LaunchWindowsApp"/> expects it.</summary>
+    public const string TodoWindowsSetupUrl = "https://windows-todo.bitplatform.dev/TodoSample.Client.Windows-win-Setup.exe";
+
+    /// <summary>Installer that puts the AdminPanel Windows app where <see cref="HybridAppConnector.LaunchWindowsApp"/> expects it.</summary>
+    public const string AdminPanelWindowsSetupUrl = "https://windows-admin.bitplatform.dev/AdminPanel.Client.Windows-win-Setup.exe";
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/HybridAppConnector.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/HybridAppConnector.cs
@@ -1,0 +1,297 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// Launches an installed Blazor Hybrid app and attaches Playwright to its WebView over the Chrome DevTools Protocol,
+/// so the Windows (WebView2) and Android (Android WebView) apps are driven exactly like a web page.
+/// <para>
+/// A machine running these tests is assumed to be prepared like this:
+/// the Windows apps are installed through their Velopack setup (see the setup urls in <see cref="DeployedApps"/>),
+/// which puts them at <c>%LocalAppData%\{appId}\current\{appId}.exe</c>, and exactly one Android device or emulator
+/// is connected through adb with both Android apps installed - or, when adb sees nothing, an AVD with them installed
+/// exists locally, and the first one is booted automatically.
+/// </para>
+/// <para>
+/// Unlike a launched browser, the attached browser already contains the app's context and page: use the session's
+/// <c>Page</c> instead of creating a new one.
+/// </para>
+/// </summary>
+public static class HybridAppConnector
+{
+    /// <summary>
+    /// How long a freshly started app gets to bring up its WebView's CDP endpoint and first page. Generous because a
+    /// cold start includes the Velopack update check on Windows and process + WebView spin-up on Android.
+    /// </summary>
+    private static readonly TimeSpan connectDeadline = TimeSpan.FromMinutes(1);
+
+    extension(IPlaywright playwright)
+    {
+        /// <summary>
+        /// Starts the installed Client.Windows app identified by <paramref name="windowsAppId"/>
+        /// (e.g. <see cref="DeployedApps.TodoWindowsAppId"/>) and attaches to it.
+        /// <para>
+        /// Every Client.Windows app hard-codes <c>--remote-debugging-port=9222</c> (see Client.Windows/Program.cs), so
+        /// only one Windows app can be driven at a time, and a leftover instance of any of them would be the one
+        /// answering on the port - this session would silently drive the wrong window. Hence every Client.Windows
+        /// process still running is stopped first: on a test machine a fresh app per session is worth more than any
+        /// window someone left open.
+        /// </para>
+        /// </summary>
+        public async Task<HybridAppSession> LaunchWindowsApp(string windowsAppId, int port = 9222)
+        {
+            var exePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), windowsAppId, "current", $"{windowsAppId}.exe");
+
+            if (File.Exists(exePath) is false)
+                throw new InvalidOperationException($"'{exePath}' does not exist. Install the app from its setup exe first (see {nameof(DeployedApps)}).");
+
+            StopWindowsApps();
+
+            Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = true });
+
+            var browser = await ConnectWithRetry(playwright, $"http://localhost:{port}");
+
+            return new HybridAppSession(browser, stopApp: () =>
+            {
+                StopWindowsApps();
+                return Task.CompletedTask;
+            });
+        }
+
+        /// <summary>
+        /// (Re)starts the Client.Maui Android app identified by <paramref name="applicationId"/>
+        /// (e.g. <see cref="DeployedApps.TodoAndroidAppId"/>) on the connected device/emulator and attaches to it.
+        /// The WebView's CDP endpoint is an abstract socket on the device, so it is forwarded to
+        /// <paramref name="localPort"/> first - a port other than 9222 by default, so a Windows app session can exist
+        /// alongside an Android one.
+        /// </summary>
+        public async Task<HybridAppSession> LaunchAndroidApp(string applicationId, int localPort = 9223)
+        {
+            await EnsureAndroidDeviceOnline();
+
+            // Force-stopped first so each session drives a freshly started app rather than whatever state a previous
+            // run or a human left behind on the device.
+            await RunAdb($"shell am force-stop {applicationId}");
+            await RunAdb($"shell monkey -p {applicationId} -c android.intent.category.LAUNCHER 1");
+
+            var deadline = DateTimeOffset.UtcNow + connectDeadline;
+            string pid;
+
+            while (true)
+            {
+                pid = (await RunAdb($"shell pidof {applicationId}", allowNonZeroExit: true)).Trim();
+
+                if (string.IsNullOrEmpty(pid) is false)
+                    break;
+
+                if (DateTimeOffset.UtcNow >= deadline)
+                    throw new TimeoutException($"'{applicationId}' did not start on the connected Android device/emulator within {connectDeadline}. Is it installed?");
+
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+            }
+
+            await RunAdb($"forward tcp:{localPort} localabstract:webview_devtools_remote_{pid}");
+
+            var browser = await ConnectWithRetry(playwright, $"http://localhost:{localPort}");
+
+            return new HybridAppSession(browser, stopApp: async () =>
+            {
+                await RunAdb($"forward --remove tcp:{localPort}", allowNonZeroExit: true);
+                await RunAdb($"shell am force-stop {applicationId}");
+            });
+        }
+    }
+
+    private static void StopWindowsApps()
+    {
+        foreach (var process in Process.GetProcesses().Where(p => p.ProcessName.EndsWith(".Client.Windows", StringComparison.Ordinal)))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+    }
+
+    /// <summary>
+    /// The CDP endpoint appears some time after the app process does (and its page later still), so a single connect
+    /// attempt right after launch would routinely lose the race - this keeps trying until <see cref="connectDeadline"/>.
+    /// </summary>
+    private static async Task<IBrowser> ConnectWithRetry(IPlaywright playwright, string cdpUrl)
+    {
+        var deadline = DateTimeOffset.UtcNow + connectDeadline;
+
+        while (true)
+        {
+            try
+            {
+                var browser = await playwright.Chromium.ConnectOverCDPAsync(cdpUrl);
+
+                if (browser.Contexts.SelectMany(c => c.Pages).Any())
+                {
+                    foreach (var context in browser.Contexts)
+                        context.SetDefaultTimeout((float)TimeSpan.FromMinutes(1).TotalMilliseconds);
+
+                    return browser;
+                }
+
+                // Connected before the WebView opened its page; disconnect and try again.
+                await browser.CloseAsync();
+            }
+            catch (PlaywrightException) when (DateTimeOffset.UtcNow < deadline)
+            {
+            }
+
+            if (DateTimeOffset.UtcNow >= deadline)
+                throw new TimeoutException($"No CDP endpoint with a page appeared at {cdpUrl} within {connectDeadline}.");
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+        }
+    }
+
+    /// <summary>
+    /// A connected device is the assumption, but when adb sees none, the first locally available AVD is booted
+    /// instead - and deliberately left running afterwards: booting costs minutes and the next session reuses it.
+    /// </summary>
+    private static async Task EnsureAndroidDeviceOnline()
+    {
+        if (await IsAnyAndroidDeviceOnline())
+            return;
+
+        var emulator = FindEmulatorExecutable();
+
+        var avdName = (await RunProcess(emulator, "-list-avds"))
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            // Newer emulators mix INFO/WARNING lines into -list-avds; actual AVD names never contain spaces.
+            .FirstOrDefault(line => line.Contains(' ') is false)
+            ?? throw new InvalidOperationException($"No Android device/emulator is connected and '{emulator}' lists no AVD to start. Create one (with the apps installed) or connect a device.");
+
+        var process = Process.Start(new ProcessStartInfo(emulator, $"-avd {avdName}")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        })!;
+
+        // Drained but discarded: the emulator logs plenty, and an unread redirected pipe would eventually block it.
+        process.OutputDataReceived += delegate { };
+        process.ErrorDataReceived += delegate { };
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        var deadline = DateTimeOffset.UtcNow + emulatorBootDeadline;
+
+        while (true)
+        {
+            if (await IsAnyAndroidDeviceOnline()
+                && (await RunAdb("shell getprop sys.boot_completed", allowNonZeroExit: true)).Trim() is "1")
+            {
+                return;
+            }
+
+            if (process.HasExited)
+                throw new InvalidOperationException($"The '{avdName}' emulator exited with code {process.ExitCode} before finishing its boot.");
+
+            if (DateTimeOffset.UtcNow >= deadline)
+                throw new TimeoutException($"The '{avdName}' emulator did not finish booting within {emulatorBootDeadline}.");
+
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        }
+    }
+
+    private static async Task<bool> IsAnyAndroidDeviceOnline()
+    {
+        var output = await RunAdb("devices", allowNonZeroExit: true);
+
+        // Skips the "List of devices attached" header; a usable row reads "<serial>\tdevice" ("offline" and
+        // "unauthorized" rows are not usable).
+        return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Skip(1)
+            .Any(line => line.Split(['\t', ' '], StringSplitOptions.RemoveEmptyEntries) is [_, "device", ..]);
+    }
+
+    /// <summary>
+    /// The emulator does not have to be on PATH the way adb is, so this looks in the usual sdk roots - the ANDROID_HOME /
+    /// ANDROID_SDK_ROOT variables, the default install location, and the sdk adb itself runs from (its platform-tools' parent).
+    /// </summary>
+    private static string FindEmulatorExecutable()
+    {
+        string?[] sdkRoots =
+        [
+            Environment.GetEnvironmentVariable("ANDROID_HOME"),
+            Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android", "Sdk"),
+            FindSdkRootFromAdbOnPath(),
+        ];
+
+        var candidates = sdkRoots.OfType<string>()
+            .SelectMany(root => new[] { Path.Combine(root, "emulator", "emulator.exe"), Path.Combine(root, "emulator", "emulator") });
+
+        return candidates.FirstOrDefault(File.Exists)
+            ?? throw new InvalidOperationException("No Android device/emulator is connected and no emulator executable was found next to any known sdk root. Connect a device or install the Android emulator.");
+    }
+
+    private static string? FindSdkRootFromAdbOnPath()
+    {
+        foreach (var directory in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                if (File.Exists(Path.Combine(directory, "adb.exe")) || File.Exists(Path.Combine(directory, "adb")))
+                    return Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory)));
+            }
+            catch (Exception)
+            {
+                // A malformed PATH entry is not this method's problem; the next entry may still hold adb.
+            }
+        }
+
+        return null;
+    }
+
+    private static readonly TimeSpan emulatorBootDeadline = TimeSpan.FromMinutes(5);
+
+    private static async Task<string> RunAdb(string arguments, bool allowNonZeroExit = false)
+    {
+        return await RunProcess("adb", arguments, allowNonZeroExit,
+            startFailureHint: "Is the Android SDK's platform-tools directory on PATH?");
+    }
+
+    private static async Task<string> RunProcess(string fileName, string arguments, bool allowNonZeroExit = false, string? startFailureHint = null)
+    {
+        var process = Process.Start(new ProcessStartInfo(fileName, arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        }) ?? throw new InvalidOperationException($"Could not start {fileName}. {startFailureHint}");
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode is not 0 && allowNonZeroExit is false)
+            throw new InvalidOperationException($"{fileName} {arguments} failed ({process.ExitCode}): {error}");
+
+        return output;
+    }
+}
+
+/// <summary>
+/// A running hybrid app with Playwright attached to its WebView. Disposing disconnects and stops the app, so the next
+/// session starts from a fresh app.
+/// </summary>
+public sealed class HybridAppSession(IBrowser browser, Func<Task> stopApp) : IAsyncDisposable
+{
+    public IBrowser Browser => browser;
+
+    /// <summary>
+    /// The page the app is showing. A hybrid app has exactly one - drive this instead of creating a new page.
+    /// </summary>
+    public IPage Page => browser.Contexts.SelectMany(c => c.Pages).FirstOrDefault()
+        ?? throw new InvalidOperationException("The attached app exposes no page (anymore).");
+
+    public async ValueTask DisposeAsync()
+    {
+        await browser.CloseAsync();
+        await stopApp();
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/TestCategories.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/TestCategories.cs
@@ -1,0 +1,22 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// The platform a test drives, so a run can target one of them, e.g. <c>dotnet test --filter "TestCategory=Web"</c>.
+/// </summary>
+public static class TestCategories
+{
+    /// <summary>
+    /// Tests against the deployed web apps listed in <see cref="DeployedApps"/>.
+    /// </summary>
+    public const string Web = "Web";
+
+    /// <summary>
+    /// Tests driving the installed Android apps' WebView over CDP. See <see cref="HybridAppConnector.LaunchAndroidApp"/>.
+    /// </summary>
+    public const string Android = "Android";
+
+    /// <summary>
+    /// Tests driving the installed Windows apps' WebView2 over CDP. See <see cref="HybridAppConnector.LaunchWindowsApp"/>.
+    /// </summary>
+    public const string Windows = "Windows";
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/TestConfiguration.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/Infrastructure/TestConfiguration.cs
@@ -1,0 +1,21 @@
+namespace Boilerplate.Tests.E2E.Infrastructure;
+
+/// <summary>
+/// Configuration for tests that reach the deployed apps' backing services - the PostgreSQL database and the Azure Blob
+/// Storage account. Locally the values live in this project's user secrets (<c>dotnet user-secrets set
+/// "ConnectionStrings:postgresdb" "..."</c> in this project's directory); on CI, environment variables
+/// (<c>ConnectionStrings__postgresdb</c>) override them.
+/// </summary>
+public static class TestConfiguration
+{
+    public static IConfigurationRoot Current { get; } = new ConfigurationBuilder()
+        .AddUserSecrets(typeof(TestConfiguration).Assembly)
+        .AddEnvironmentVariables()
+        .Build();
+
+    public static string GetRequiredConnectionString(string name)
+    {
+        return Current.GetConnectionString(name)
+            ?? throw new InvalidOperationException($"Connection string '{name}' was found in neither this project's user secrets nor the environment variables.");
+    }
+}

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/MSTestSettings.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/MSTestSettings.cs
@@ -1,0 +1,1 @@
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 2)]

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/RunTests.bat
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/RunTests.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+
+set EXIT_CODE=0
+
+echo ================================ Web tests on chromium ================================
+dotnet test --filter "TestCategory=Web"
+if errorlevel 1 set EXIT_CODE=1
+
+echo ================================ Web tests on firefox =================================
+set BROWSER=firefox
+dotnet test --filter "TestCategory=Web" --no-build
+if errorlevel 1 set EXIT_CODE=1
+set BROWSER=
+
+echo ==================== Web tests on webkit (Safari) on the remote mac ===================
+set BROWSER=webkit
+set PLAYWRIGHT_SERVER_ENDPOINT=ws://192.168.178.24:4444/
+dotnet test --filter "TestCategory=Web" --no-build
+if errorlevel 1 set EXIT_CODE=1
+set BROWSER=
+set PLAYWRIGHT_SERVER_ENDPOINT=
+
+echo ================================== Windows app tests ==================================
+dotnet test --filter "TestCategory=Windows" --no-build
+if errorlevel 1 set EXIT_CODE=1
+
+echo ================================== Android app tests ==================================
+dotnet test --filter "TestCategory=Android" --no-build
+if errorlevel 1 set EXIT_CODE=1
+
+exit /b %EXIT_CODE%

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/RunTests.bat
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Internal/Boilerplate.Tests.E2E/RunTests.bat
@@ -22,12 +22,12 @@ if errorlevel 1 set EXIT_CODE=1
 set BROWSER=
 set PLAYWRIGHT_SERVER_ENDPOINT=
 
-echo ================================== Windows app tests ==================================
-dotnet test --filter "TestCategory=Windows" --no-build
-if errorlevel 1 set EXIT_CODE=1
-
 echo ================================== Android app tests ==================================
 dotnet test --filter "TestCategory=Android" --no-build
+if errorlevel 1 set EXIT_CODE=1
+
+echo ================================== Windows app tests ==================================
+dotnet test --filter "TestCategory=Windows" --no-build
 if errorlevel 1 set EXIT_CODE=1
 
 exit /b %EXIT_CODE%

--- a/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
+++ b/src/Templates/Boilerplate/Bit.Boilerplate/src/Tests/Infrastructure/AppPageTest.cs
@@ -49,6 +49,19 @@ public class AppPageTest : PageTest
     }
 
     /// <summary>
+    /// Runs the selected <c>BROWSER</c> on another computer when <c>PLAYWRIGHT_SERVER_ENDPOINT</c> (see .runsettings)
+    /// points at a Playwright server there - most usefully a mac, where webkit runs against the actual Apple frameworks
+    /// and is as close to Safari as automation gets, but chromium and firefox connect the same way.
+    /// </summary>
+    public override async Task<(string, BrowserTypeConnectOptions?)?> ConnectOptionsAsync()
+    {
+        if (Environment.GetEnvironmentVariable("PLAYWRIGHT_SERVER_ENDPOINT") is { Length: > 0 } playwrightServerEndpoint)
+            return (playwrightServerEndpoint, new());
+
+        return await base.ConnectOptionsAsync();
+    }
+
+    /// <summary>
     /// Runs the headless tests on <c>chromium-headless-shell</c> - the small headless-only build that plain
     /// <c>Headless = true</c> used to mean before Playwright 1.49 made the <c>chromium</c> channel launch the real Chrome
     /// browser in its new headless mode. The shell is what the suite actually needs and is markedly cheaper.


### PR DESCRIPTION
closes #13064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform end-to-end smoke testing for web, Android, and Windows apps.
  * Added checks for app interactivity and web download-size regressions.
  * Added support for running browser tests through a remote Playwright server.
  * Added platform-specific app launching and cleanup support for hybrid applications.

* **Template Improvements**
  * Internal test assets are excluded from packaged templates.
  * Advanced test exclusions are applied when advanced tests are disabled.
  * Android production builds use simplified runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->