### PR TITLE
Fix AutoFocusSearchBox issues in BitDropdown (#13133)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -1829,6 +1829,10 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             {
                 await FocusTrigger();
             }
+
+            // A dropdown that starts out open ends up with the focus its search box would have taken on
+            // any other opening, which is also what AutoFocus means while the list is showing.
+            await FocusOnSearchBox();
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -2656,6 +2660,13 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             if (toggle)
             {
                 await ToggleCallout();
+
+                // The internal open flows follow their own toggle with the focus work that opening the
+                // list means; an open pushed from the outside (a bound IsOpen, a programmatic Assign)
+                // has none, so a search-first dropdown hands the focus to its search box here instead.
+                // Only after the toggle: the callout is hidden until then, and a hidden input cannot
+                // take the focus.
+                await FocusOnSearchBox();
             }
 
             await (isOpen ? OnOpen.InvokeAsync() : OnClose.InvokeAsync());

--- a/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Inputs/Dropdown/BitDropdown.razor.cs
@@ -54,6 +54,7 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
     private bool _openedOnFocus;
     private bool _inputSearchHasFocus;
     private bool _inputComboHasFocus;
+    private bool _pendingSearchBoxFocus;
     private List<TItem> _selectedItems = [];
     private List<TItem> _lastShownItems = [];
     private ICollection<TItem>? _lastItemsReference;
@@ -1800,6 +1801,16 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         {
             await RefreshCalloutScrollOffset();
 
+            // An open pushed in from the outside left its focus work here: its hook runs while the
+            // parameters of the batch are still being applied, so a search box the same batch turns
+            // on only exists as of this render.
+            if (_pendingSearchBoxFocus)
+            {
+                _pendingSearchBoxFocus = false;
+
+                await FocusOnSearchBox();
+            }
+
             return;
         }
 
@@ -2483,6 +2494,12 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
             // next toggle of the callout, so a click that comes long after the focus (and after the
             // callout was dismissed in between) opens the callout itself as it always did.
             _openedOnFocus = IsOpen && wasOpen is false;
+
+            // The rest of what opening the list means for a search-first dropdown. The click this
+            // focus may be the first half of does the same, but only a pointer open has a click after
+            // it: a dropdown reached with the keyboard would otherwise show its search box and leave
+            // the focus behind on the trigger.
+            await FocusOnSearchBox();
         }
 
         await OnFocusIn.InvokeAsync(e);
@@ -2663,10 +2680,17 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
 
                 // The internal open flows follow their own toggle with the focus work that opening the
                 // list means; an open pushed from the outside (a bound IsOpen, a programmatic Assign)
-                // has none, so a search-first dropdown hands the focus to its search box here instead.
-                // Only after the toggle: the callout is hidden until then, and a hidden input cannot
-                // take the focus.
-                await FocusOnSearchBox();
+                // has none, so a search-first dropdown hands the focus to its search box as well. The
+                // render answers it (see OnAfterRenderAsync) rather than this hook: the hook runs while
+                // the parameters of the batch are still being applied, so a search box the same batch
+                // turns on is not on the page yet, and an input that does not exist cannot take the
+                // focus. The callout is shown by the toggle above, from JS, so it is up by then either
+                // way.
+                if (IsDisposed is false)
+                {
+                    _pendingSearchBoxFocus = true;
+                    StateHasChanged();
+                }
             }
 
             await (isOpen ? OnOpen.InvokeAsync() : OnClose.InvokeAsync());
@@ -2685,8 +2709,17 @@ public partial class BitDropdown<TItem, TValue> : BitInputBase<TValue> where TIt
         if (HasSearchBox is false) return;
         if (AutoFocusSearchBox is false) return;
         if (IsOpen is false) return;
+        // Reached from paths that are fired and forgotten (the IsOpen hook) or already detached from
+        // the request that started them (a render, a focus the dropdown moved itself), so a component
+        // that went away in between has to end here rather than throw out of a discarded task.
+        if (IsRendered is false || IsDisposed) return;
 
-        await _searchInputRef.FocusAsync();
+        try
+        {
+            await _searchInputRef.FocusAsync();
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+        catch (InvalidOperationException) { } // an input that is not on the page cannot take the focus
     }
 
     private async Task ClearComboBoxInput()

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Dropdown/BitDropdownTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Dropdown/BitDropdownTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bunit;
@@ -2289,6 +2290,59 @@ public class BitDropdownTests : BunitTestContext
 
         Assert.IsTrue(component.Instance.IsOpen);
         Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Dropdowns.focusItem"].Count);
+    }
+
+    [TestMethod]
+    public void BitDropdownBoundOpenShouldHonorAutoFocusSearchBox()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var isOpen = false;
+        var component = RenderComponent<BitDropdown<BitDropdownItem<string>, string>>(parameters =>
+        {
+            parameters.Add(p => p.Items, GetShortDropdownItems());
+            parameters.Add(p => p.ShowSearchBox, true);
+            parameters.Add(p => p.AutoFocusSearchBox, true);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        // An open pushed through the binding is the third way of opening the callout, next to the
+        // pointer and the keyboard, so it hands the focus to the search box the same way they do.
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Items, GetShortDropdownItems());
+            parameters.Add(p => p.ShowSearchBox, true);
+            parameters.Add(p => p.AutoFocusSearchBox, true);
+            parameters.Bind(p => p.IsOpen, true, v => isOpen = v);
+        });
+
+        Assert.IsTrue(component.Instance.IsOpen);
+
+        var focused = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].ToList();
+
+        Assert.AreEqual(1, focused.Count);
+        Assert.AreEqual(component.Instance.SearchInputElement!.Value.Id, ((ElementReference)focused[0].Arguments[0]!).Id);
+    }
+
+    [TestMethod]
+    public void BitDropdownInitiallyOpenShouldHonorAutoFocusSearchBox()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        // A dropdown that starts out open reaches the hook before there is a callout to show, so the
+        // first render applies the open state - and with it the focus the search box would have taken.
+        var component = RenderComponent<BitDropdown<BitDropdownItem<string>, string>>(parameters =>
+        {
+            parameters.Add(p => p.Items, GetShortDropdownItems());
+            parameters.Add(p => p.ShowSearchBox, true);
+            parameters.Add(p => p.AutoFocusSearchBox, true);
+            parameters.Add(p => p.IsOpen, true);
+        });
+
+        var focused = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].ToList();
+
+        Assert.AreEqual(1, focused.Count);
+        focused[0].Arguments[0].ShouldBeElementReferenceTo(component.Find(".bit-drp-sin"));
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Dropdown/BitDropdownTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Inputs/Dropdown/BitDropdownTests.cs
@@ -2346,6 +2346,61 @@ public class BitDropdownTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitDropdownOpenOnFocusShouldHonorAutoFocusSearchBox()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDropdown<BitDropdownItem<string>, string>>(parameters =>
+        {
+            parameters.Add(p => p.Items, GetShortDropdownItems());
+            parameters.Add(p => p.OpenOnFocus, true);
+            parameters.Add(p => p.ShowSearchBox, true);
+            parameters.Add(p => p.AutoFocusSearchBox, true);
+        });
+
+        // Tabbing in is the fourth way of opening the callout, and the only one with no click behind it
+        // to do the focus work instead: without it the list shows and the focus stays on the trigger.
+        component.Find(".bit-drp-wrp").FocusIn();
+
+        Assert.IsTrue(component.Instance.IsOpen);
+
+        var focused = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].ToList();
+
+        Assert.AreEqual(1, focused.Count);
+        Assert.AreEqual(component.Instance.SearchInputElement!.Value.Id, ((ElementReference)focused[0].Arguments[0]!).Id);
+    }
+
+    [TestMethod]
+    public void BitDropdownBoundOpenShouldHonorASearchBoxTurnedOnInTheSameBatch()
+    {
+        Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var component = RenderComponent<BitDropdown<BitDropdownItem<string>, string>>(parameters =>
+        {
+            parameters.Add(p => p.Items, GetShortDropdownItems());
+            parameters.Add(p => p.AutoFocusSearchBox, true);
+        });
+
+        // The IsOpen hook runs while the rest of the batch is still being applied, so the search box
+        // this very batch turns on is not on the page yet - and an input that does not exist cannot take
+        // the focus. The focus waits for the render that puts it there instead of being dropped.
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Items, GetShortDropdownItems());
+            parameters.Add(p => p.AutoFocusSearchBox, true);
+            parameters.Add(p => p.ShowSearchBox, true);
+            parameters.Add(p => p.IsOpen, true);
+        });
+
+        Assert.IsTrue(component.Instance.IsOpen);
+
+        var focused = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].ToList();
+
+        Assert.AreEqual(1, focused.Count);
+        focused[0].Arguments[0].ShouldBeElementReferenceTo(component.Find(".bit-drp-sin"));
+    }
+
+    [TestMethod]
     public void BitDropdownComboInputShouldBeNamedAfterTheLabel()
     {
         Context.JSInterop.Mode = JSRuntimeMode.Loose;


### PR DESCRIPTION
closes #13133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown search-box autofocus when the dropdown starts open.
  * Search boxes now receive focus when dropdowns open through bound state changes, programmatic updates, or trigger focus.
  * Autofocus now works when the search box and open state are enabled in the same update.
  * Improved focus handling when the dropdown is not yet rendered or has been disposed.

* **Tests**
  * Added coverage for autofocus during initial rendering and all supported dropdown-opening scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->