### PR TITLE
Fix trimming issues of Butil (#13137)

### DIFF
--- a/src/Butil/Bit.Butil.Build/TrimButilScripts.cs
+++ b/src/Butil/Bit.Butil.Build/TrimButilScripts.cs
@@ -140,7 +140,7 @@ public sealed class TrimButilScripts : Task
                 var map = Types();
                 if (map is null)
                 {
-                    Log.LogError($"Bit.Butil: <BitButilScriptScan>{ScanMode}</BitButilScriptScan> needs to read the untrimmed Bit.Butil.dll to know which module each class uses, and '{ButilAssembly}' could not be read. Set <BitButilScriptScan>None</BitButilScriptScan> to publish the full bundle instead.");
+                    Log.LogError($"Bit.Butil: <BitButilScriptScan>{ScanMode}</BitButilScriptScan> needs to read the untrimmed Bit.Butil.dll to know which module each class uses, and '{ButilAssembly}' could not be read. Set <BitButilUntrimmedAssembly> to that assembly, or <BitButilScriptScan>None</BitButilScriptScan> to publish the full bundle instead.");
                     return false;
                 }
 
@@ -150,7 +150,7 @@ public sealed class TrimButilScripts : Task
                     // Every app that can call into Bit.Butil references it, so finding nothing means the list
                     // of assemblies was not the app's. Trimming on that would drop every module.
                     Log.LogWarning(null, "BUTIL002", null, null, 0, 0, 0, 0,
-                        $"Bit.Butil: none of the {ScanAssemblies.Length} assemblies scanned references Bit.Butil, so there is nothing to work out which JavaScript this app uses from; keeping the full bit-butil.js. Set <BitButilScriptScanAssemblies> to the app's own assemblies, or <BitButilScriptScan>None</BitButilScriptScan> to silence this.");
+                        $"Bit.Butil: none of the {ScanAssemblies.Length} assemblies scanned references Bit.Butil, so there is nothing to work out which JavaScript this app uses from; keeping the full bit-butil.js. Add a <BitButilScriptScanAssembly> item for each of the app's own assemblies, or set <BitButilScriptScan>None</BitButilScriptScan> to silence this.");
                     Skipped = true;
                     return true;
                 }

--- a/src/Butil/Bit.Butil.Demo/Client/Docs/DocsNav.cs
+++ b/src/Butil/Bit.Butil.Demo/Client/Docs/DocsNav.cs
@@ -15,6 +15,7 @@ public static class DocsNav
         [
             new("Getting started", "getting-started", "Install the package, add the script, register the services.", typeof(GettingStartedPage), ApiSupport.Guide),
             new("Render modes", "render-modes", "How Butil behaves under WebAssembly, Server, Hybrid and prerendering.", typeof(RenderModesPage), ApiSupport.Guide),
+            new("JavaScript trimming", "javascript-trimming", "Ship only the JavaScript your app calls: the switch, the three signals behind it, and what none of them can see.", typeof(JavaScriptTrimmingPage), ApiSupport.Guide),
             new("Browser support", "browser-support", "Which APIs need a secure context, a permission or a specific engine.", typeof(BrowserSupportPage), ApiSupport.Guide),
             new("Troubleshooting", "troubleshooting", "The errors people hit first, and what each one actually means.", typeof(TroubleshootingPage), ApiSupport.Guide),
             new("MCP server", "mcp-server", "This site as tools an AI agent can call - and a live client to try them in.", typeof(McpServerPage), ApiSupport.Guide),

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/GettingStartedPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/GettingStartedPage.razor
@@ -68,17 +68,15 @@ var secure = await window.IsSecureContext();
 </DemoSection>
 
 <DemoSection Title="Optional: tree-shake the JavaScript"
-             Api="BitButilTrimScripts"
-             Description="The bundle behind step 2 covers every API on this site, and a published app can shed the parts it never calls - the JavaScript half of the trimming the C# side already gets. In a Blazor WebAssembly project there is nothing to add: a trimmed publish rebuilds bit-butil.js from only the modules the trimmed Bit.Butil.dll still calls, so an app injecting Clipboard, LocalStorage and Window ships around 8 KB of JavaScript instead of 110 KB. Publishing without trimming - a WebAssembly app with PublishTrimmed off, Blazor Server, a server host that prerenders - leaves no trimmed assembly to read, and BitButilScriptScan answers the same question from the app's own assemblies instead: injecting Clipboard is a reference to Bit.Butil.Clipboard, and the package works out which module that class needs. Whatever either concludes, BitButilScriptModule adds modules or Bit.Butil class names on top, for an API reached by reflection or from your own JavaScript. All of it is publish-only: a build, and dotnet run and dotnet watch on top of it, keeps the full bundle."
+             Api="BitButilTrimScripts / BitButilScriptScan / BitButilScriptModule"
+             Description="The bundle behind step 2 covers every API on this site, and a published app can shed the parts it never calls. One property turns it on, and in a Blazor WebAssembly project it is already on: a trimmed publish rebuilds bit-butil.js from only the modules the trimmed Bit.Butil.dll still calls, so an app injecting Clipboard, LocalStorage and Window ships around 8 KB of JavaScript instead of 110 KB. Publishing without trimming - a WebAssembly app with PublishTrimmed off, Blazor Server, a server host that prerenders - has no trimmed assembly to read, and BitButilScriptScan answers the same question from the app's own assemblies instead. It defaults to TypeReferences wherever the switch is on, so there too the switch is the whole of what you write; None turns it off again and TypeNames is a coarser name-matching mode. BitButilScriptModule adds modules or Bit.Butil class names on top of whatever either concluded, for an API reached by reflection or from your own JavaScript. It is publish-only, so a build - dotnet run and dotnet watch included - always keeps the full bundle, and it takes effect only in the project that publishes the app's static web assets."
              Code=@("""
-<!-- Nothing to add: it is the default in a WebAssembly project. To opt out entirely: -->
-<PropertyGroup>
-  <BitButilTrimScripts>false</BitButilTrimScripts>
-</PropertyGroup>
-
-<!-- Or publishing WITHOUT trimming? Read the app's own assemblies instead. -->
+<!-- In a Blazor WebAssembly project there is nothing to add. Anywhere else: -->
 <PropertyGroup>
   <BitButilTrimScripts>true</BitButilTrimScripts>
+
+  <!-- Implied by the switch above; write it out to pick a different value.
+       TypeNames is the coarser mode, None publishes the full bundle. -->
   <BitButilScriptScan>TypeReferences</BitButilScriptScan>
 </PropertyGroup>
 
@@ -86,8 +84,21 @@ var secure = await window.IsSecureContext();
 <ItemGroup>
   <BitButilScriptModule Include="Clipboard;geolocation" />
 </ItemGroup>
+
+<!-- ...and to opt out entirely, wherever it is on: -->
+<PropertyGroup>
+  <BitButilTrimScripts>false</BitButilTrimScripts>
+</PropertyGroup>
 """)
              Language="xml" />
+
+<Callout Type="info" Title="The full story is one page away">
+    <a href="javascript-trimming">JavaScript trimming</a> covers the rest of it: the three signals the
+    trimming works from and which one suits which hosting model, why these properties belong in the project
+    you publish rather than in a shared <code>Directory.Build.props</code>, the two overrides for a layout
+    where the defaults look in the wrong place, the build warnings it can produce - and a live check that
+    reads back which modules the app you are looking at actually downloaded.
+</Callout>
 
 <DemoSection Title="Optional: lazy scripts"
              Api="BitButil.UseLazyScripts"
@@ -133,7 +144,9 @@ BitButil.UseNormalInvoke();
 
 <Callout Type="info" Title="Where to next?">
     <a href="render-modes">Render modes</a> covers how Butil behaves under WebAssembly, Server, Hybrid and
-    prerendering - worth ten minutes before you write much. Otherwise, start with the most used APIs:
+    prerendering - worth ten minutes before you write much, and
+    <a href="javascript-trimming">JavaScript trimming</a> is worth another ten before you publish.
+    Otherwise, start with the most used APIs:
     <a href="storage">LocalStorage</a>, <a href="clipboard">Clipboard</a>, <a href="keyboard">Keyboard</a>,
     <a href="crypto">Crypto</a> and <a href="web-authn">WebAuthn</a>.
 </Callout>

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/JavaScriptTrimmingPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/JavaScriptTrimmingPage.razor
@@ -1,4 +1,4 @@
-@page "/javascript-trimming"
+﻿@page "/javascript-trimming"
 @inject Bit.Butil.Fetch fetch
 @inject NavigationManager navManager
 
@@ -164,9 +164,9 @@ for (var at = script.IndexOf(anchor); at >= 0; at = script.IndexOf(anchor, at + 
     obvious home and is the one place they should not go - from there they also reach every Razor class
     library and every MAUI/Blazor Hybrid head in the solution, and a class library asked what "the app"
     calls would answer from its own references, which are not the app's. Butil settles this rather than
-    trusting it: trimming runs only where the SDK set <code>StaticWebAssetProjectMode</code> to
-    <code>Root</code> - the Web SDK and the Blazor WebAssembly SDK do, every class library and hybrid head
-    is left at <code>Default</code> - and anywhere else it stands down, saying so in the build output when
+    trusting it: trimming runs only in a project loaded by the Web SDK or the Blazor WebAssembly SDK -
+    which is every project that publishes an app, and neither a Razor class library nor a hybrid head -
+    and anywhere else it stands down, saying so in the build output when
     what reached that project describes what the app calls rather than being only the switch. So a shared
     props file costs you a message rather than a wrong bundle. <code>BitButilTrimScripts</code> is the
     exception worth sharing: it is only a switch, it already defaults to on exactly where it applies, and

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/JavaScriptTrimmingPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/JavaScriptTrimmingPage.razor
@@ -1,0 +1,354 @@
+@page "/javascript-trimming"
+@inject Bit.Butil.Fetch fetch
+@inject NavigationManager navManager
+
+<PageTitle>JavaScript trimming - Bit.Butil</PageTitle>
+
+<PageHeader Category="Overview"
+            Title="JavaScript trimming"
+            Lead="Butil's bridge script carries 65 JavaScript modules - every browser API on this site - and almost no app calls all of them. A published app can rebuild that bundle from only the modules it can still reach - tree-shaking the JavaScript, the same way the IL trimming the C# side already gets shakes out the wrappers you never inject. This page is the whole feature: the one switch that turns it on, the three signals it works from, where the properties go, and what it cannot see." />
+
+<Callout Type="success" Title="One property, and the rest is defaults">
+    <code>&lt;BitButilTrimScripts&gt;true&lt;/BitButilTrimScripts&gt;</code> is all an app writes, and a
+    Blazor WebAssembly project does not even write that - it is already on there. Everything else on this
+    page is either a default explained, or an exception: a module reached where nothing static can follow, a
+    project layout the defaults look at from the wrong angle. Read the first three sections and skip the rest
+    until a publish surprises you.
+</Callout>
+
+<div class="stack">
+    <DemoSection Title="The switch"
+                 Api="BitButilTrimScripts"
+                 Description="One property decides whether a publish tree-shakes bit-butil.js, rebuilding it from the modules the app can still reach. It defaults to true in a Blazor WebAssembly project - the one hosting model where the assembly ILLink trims is the same assembly that calls the served JavaScript - and to false everywhere else, so a Blazor Server app or a Blazor Web App's server project turns it on itself. Two boundaries hold the whole feature in. It is publish-only: a build, and so dotnet run and dotnet watch on top of it, keeps the full bundle, so what you debug is never the trimmed JavaScript. And it is head-only: it takes effect in the project that publishes the app's static web assets and stands down in every Razor class library and MAUI/Blazor Hybrid head that shares the solution."
+                 Code=@("""
+<!-- A Blazor WebAssembly project: nothing to add, this is already the default -->
+
+<!-- Anywhere else - Blazor Server, a Blazor Web App's server project -->
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+</PropertyGroup>
+
+<!-- ...and to opt out of it where it is on by default -->
+<PropertyGroup>
+  <BitButilTrimScripts>false</BitButilTrimScripts>
+</PropertyGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="What this app actually downloaded"
+                 Api="Fetch"
+                 Description="Every chunk in the bundle opens with a guard naming the module it registers, so the bundle is self-describing: fetch it, count the guards, and you have the exact list the browser sees - which is the check to run against your own published app when you want to know whether the trimming did anything. Run it here and it reports on this documentation site, which has a page for every API in the library and does not turn the trimming on, so it is the full 65 and a baseline rather than a success story. The second button asks the app for one per-module file, which is the other half of the same question: a 200 means this app publishes the per-module files as well as the bundle, and a 404 means it is in plain bundle mode, where the modules/ folder is dropped from its static web assets entirely - a file that cannot be requested is one more thing that cannot 404 in production."
+                 Code=@("""
+var url = navManager.ToAbsoluteUri("_content/Bit.Butil/bit-butil.js");
+var response = await fetch.Send(new FetchRequest { Url = url.ToString(), Cache = "no-store" });
+
+var script = Encoding.UTF8.GetString(response.Body);
+
+// Every chunk opens with `if (window.BitButil && window.BitButil.<key>) return;` - the guard
+// that makes loading it twice a no-op. It survives minification, so it is the one marker that
+// reads the same in a development build and a published bundle.
+const string anchor = "window.BitButil&&window.BitButil.";
+var modules = new List<string>();
+
+for (var at = script.IndexOf(anchor); at >= 0; at = script.IndexOf(anchor, at + 1))
+{
+    var start = at + anchor.Length;
+    var end = start;
+    while (end < script.Length && (char.IsLetterOrDigit(script[end]) || script[end] == '_')) end++;
+
+    // The prelude chunk guards on `version` rather than on a module of its own.
+    var name = script[start..end];
+    modules.Add(name == "version" ? "butil" : name);
+}
+""")>
+        <div class="controls">
+            <button @onclick="InspectBundle" disabled="@_busy">Inspect the bundle</button>
+            <button @onclick="ProbeModuleFile" disabled="@_busy">Ask for one module file</button>
+        </div>
+        <DemoConsole @ref="bundleOutput" Title="bundle inspection output" />
+    </DemoSection>
+
+    <DemoSection Title="Signal 1 - the trimmed assembly"
+                 Api="PublishTrimmed"
+                 Description="Not a Bit.Butil property, and the most precise signal there is. Every interop call in the library goes through a literal string of the form BitButil.&lt;module&gt;.&lt;function&gt;, and ILLink rewrites a trimmed assembly's string heap to hold only the literals that surviving method bodies still reference. So the set of those prefixes left in a trimmed Bit.Butil.dll is exactly the set of JavaScript modules the app can still reach - not an approximation of it. A standalone Blazor WebAssembly app publishes trimmed by default, which is why it needs nothing configured at all. Whenever this signal is in play it supersedes the scan below: the same question, better answered."
+                 Code=@("""
+<!-- The default for a standalone Blazor WebAssembly publish - nothing to write.
+     Turning it off is what hands the question to BitButilScriptScan instead. -->
+<PropertyGroup>
+  <PublishTrimmed>true</PublishTrimmed>
+</PropertyGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="Signal 2 - a scan of the app's own assemblies"
+                 Api="BitButilScriptScan"
+                 Description="An app published without trimming has no trimmed assembly to read, so the question is answered from the app's own assemblies instead: injecting Clipboard is a reference to Bit.Butil.Clipboard, and the package reads the untrimmed Bit.Butil.dll to know which JavaScript module answering that class takes. The closure is followed properly, through base classes and internal interop helpers - LocalStorage carries no interop literals of its own and still correctly pulls in storage, and Window pulls in events as well as window. It defaults to TypeReferences wherever BitButilTrimScripts is on, which is what makes that switch enough on its own, and it costs the publish one pass over the app's assemblies - tens of milliseconds. On this repository's own trimming harness, and on a real WebAssembly app published both ways, it reaches exactly the module set ILLink independently arrives at."
+                 Code=@("""
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+
+  <!-- ...which already implies this. Write it out only to choose a different value: -->
+  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
+</PropertyGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="The three values of BitButilScriptScan"
+                 Api="TypeReferences / TypeNames / None"
+                 Description="TypeReferences is the default and the precise one: it reads each assembly's metadata tables and takes the Bit.Butil types they genuinely reference. TypeNames matches the library's type names against the names in each assembly's string heap instead - cheaper to reason about and deliberately coarser, since an app with a class of its own called Window, Console or Storage pulls in that module too. It over-includes and never misses, so it is the value to reach for if you ever suspect the precise mode of missing something. None turns the scan off: it is how one project publishes the full bundle while BitButilTrimScripts stays true for the rest, and how to silence a scan that cannot see the app. All three are ignored when PublishTrimmed is true."
+                 Code=@("""
+<PropertyGroup>
+  <!-- exact: the Bit.Butil types the app's assemblies reference (default) -->
+  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
+
+  <!-- coarser: bare type-name matching, over-includes, never misses -->
+  <BitButilScriptScan>TypeNames</BitButilScriptScan>
+
+  <!-- off: publish the full bundle without turning the switch off -->
+  <BitButilScriptScan>None</BitButilScriptScan>
+</PropertyGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="Signal 3 - the modules you name yourself"
+                 Api="BitButilScriptModule"
+                 Description="An item rather than a property, and always ADDED to what the other two concluded - never used instead of them. It takes JavaScript module names, Bit.Butil class names, or full type names interchangeably, and it is the way to keep a module reached from somewhere nothing static can follow: an API resolved by reflection, or one your own JavaScript calls through window.BitButil directly. It is also a signal in its own right rather than only a supplement to one: with no ILLink and the scan turned off, a csproj that names modules trims to exactly those and nothing else. A name that is neither a module nor a Bit.Butil class fails the build rather than being quietly ignored, because MSBuild accepts a misspelled item without a word and a silently dropped name is a module missing from a published bundle."
+                 Code=@("""
+<ItemGroup>
+  <!-- class names, module names and full type names all resolve -->
+  <BitButilScriptModule Include="Clipboard;geolocation;Bit.Butil.WebAuthn" />
+</ItemGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="Both shapes of the JavaScript are narrowed"
+                 Api="BitButilIncludeScriptModules"
+                 Description="Butil ships its JavaScript in two shapes built from the same per-module chunks: one bit-butil.js bundle behind a script tag, and one self-contained file per module that the C# side imports on first use. The same signal narrows both. Wherever the per-module files are published - a lazy-scripts app, or one keeping both shapes - only the modules the app can still import are published and the rest of modules/ is dropped, and nothing can 404 over it, because the identifier that would have imported a dropped module left the assembly with the module. The one exception is asking for the modules by name: BitButilIncludeScriptModules written out in the csproj outranks the trimming and publishes every module file, which is what an app that loads them from outside its own interop calls needs."
+                 Code=@("""
+<PropertyGroup>
+  <!-- keep both shapes, and publish every module file whatever the trimming concluded -->
+  <BitButilIncludeScriptBundle>true</BitButilIncludeScriptBundle>
+  <BitButilIncludeScriptModules>true</BitButilIncludeScriptModules>
+</PropertyGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="Which shape of app writes what"
+                 Api="csproj by hosting model"
+                 Description="Four shapes, and none of them writes more than a single line. A standalone WebAssembly app or PWA publishes trimmed and writes nothing at all. A Blazor Server app, or a Web App's server project, turns the switch on and gets the scan with it. A server host that references a WebAssembly client is the case worth thinking about: the scan covers the host and the client alike, because the client's assembly is one of the host's references, whereas ILLink's answer for such a host is about the host's own code only - which is why trimming there wants the scan rather than PublishTrimmed, and why the switch goes in the host project that serves bit-butil.js. A Blazor Hybrid head is the one shape where none of it applies: it packages its wwwroot at build time rather than through a publish of a web app's static web assets, so it ships the full bundle and reaches for lazy scripts instead."
+                 Code=@("""
+<!-- MyApp.Client.csproj - standalone Blazor WebAssembly: nothing at all -->
+
+<!-- MyApp.csproj - Blazor Server -->
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+</PropertyGroup>
+
+<!-- MyApp.Server.csproj - the HOST of a Blazor Web App, which is what serves the script -->
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+</PropertyGroup>
+
+<!-- MyApp.Maui.csproj - Blazor Hybrid: the trimming does not apply, lazy scripts do -->
+<PropertyGroup>
+  <BitButilLazyScripts>true</BitButilLazyScripts>
+</PropertyGroup>
+""")
+                 Language="xml" />
+</div>
+
+<Callout Type="warning" Title="These go in the project you publish, not in Directory.Build.props">
+    <code>BitButilScriptScan</code> and <code>BitButilScriptModule</code> describe what <em>the app</em>
+    calls, so they belong to the one project that publishes the app's static web assets: the WebAssembly
+    head, or a Blazor Web App's server project. A shared <code>Directory.Build.props</code> looks like the
+    obvious home and is the one place they should not go - from there they also reach every Razor class
+    library and every MAUI/Blazor Hybrid head in the solution, and a class library asked what "the app"
+    calls would answer from its own references, which are not the app's. Butil settles this rather than
+    trusting it: trimming runs only where the SDK set <code>StaticWebAssetProjectMode</code> to
+    <code>Root</code> - the Web SDK and the Blazor WebAssembly SDK do, every class library and hybrid head
+    is left at <code>Default</code> - and anywhere else it stands down, saying so in the build output when
+    what reached that project describes what the app calls rather than being only the switch. So a shared
+    props file costs you a message rather than a wrong bundle. <code>BitButilTrimScripts</code> is the
+    exception worth sharing: it is only a switch, it already defaults to on exactly where it applies, and
+    the scan it turns on is read per project, so only the project that publishes the app ever acts on one.
+</Callout>
+
+<div class="stack">
+    <DemoSection Title="When the scan cannot see the whole app"
+                 Api="BitButilScriptScanAssembly / BitButilUntrimmedAssembly"
+                 Description="Two escape hatches for the layouts where the defaults look in the wrong place, and neither is needed by an ordinary app. The scan reads this project's own assembly plus its copy-local references, which for a head is the app; BitButilScriptScanAssembly replaces that list for an app whose Bit.Butil calls live somewhere the head cannot see. And the scan has to read the untrimmed Bit.Butil.dll itself to know which module answers each Bit.Butil class - it finds it among those same copy-local references, and BitButilUntrimmedAssembly names it outright for a layout where that lookup comes back empty or turns up more than one. A scan you asked for by writing BitButilScriptScan out fails the build when it cannot read that assembly, since there the answer is this property rather than silence; the scan the switch turned on by itself stands down to the full bundle instead, because nobody asked for it."
+                 Code=@("""
+<ItemGroup>
+  <BitButilScriptScanAssembly Include="$(OutputPath)MyApp.Shared.dll" />
+</ItemGroup>
+
+<PropertyGroup>
+  <BitButilUntrimmedAssembly>$(NuGetPackageRoot)bit.butil\10.6.0\lib\net10.0\Bit.Butil.dll</BitButilUntrimmedAssembly>
+</PropertyGroup>
+""")
+                 Language="xml" />
+
+    <DemoSection Title="What the build tells you"
+                 Api="BUTIL001 / BUTIL002"
+                 Description="The trimming reports what it concluded at normal verbosity - publish with -v:n and there is a line naming the modules it kept and the bytes it wrote, which is the fastest way to confirm the feature ran at all. Two warnings can come out of it, both carrying a code so they can be silenced through NoWarn without turning the trimming off. BUTIL001 says the app calls a BitButil.&lt;module&gt; that this version of the library does not have: not an error, since that C# call would fail regardless of trimming, but it means the two halves drifted. BUTIL002 says none of the assemblies scanned references Bit.Butil at all - the list was not the app's - and the full bundle is kept rather than trimming to nothing on an answer that cannot be right."
+                 Code=@("""
+dotnet publish -c Release -v:n
+
+# Bit.Butil: scanned 2 assembly(s) referencing Bit.Butil and found 48 Bit.Butil type(s): ...
+# Bit.Butil: bit-butil.js trimmed to 44 of 65 modules (81,227 bytes): butil, utils, battery, ...
+""")
+                 Language="shell" />
+
+    <DemoSection Title="IL trimming and AOT"
+                 Api="PublishTrimmed / PublishAot"
+                 Description="The JavaScript half rests on the C# half. Butil is annotated for trimming throughout: service registration discovers classes by reflection but each one carries an attribute that preserves its constructor, and every type crossing the interop boundary is annotated so System.Text.Json keeps the members it reflects over. A trimmed publish therefore keeps only the wrappers the app injects, which is what makes the trimmed assembly a trustworthy answer to which JavaScript it needs. What is yours rather than the library's is your own models: anything you serialise into a Butil call or deserialise out of one has to be reachable by the trimmer, or it comes back with silently null properties rather than an error. The one Butil API that warns under trimming is the FastInvoke* extension method pair on IJSRuntime, for the same reason - see fast invoke on the render-modes page."
+                 Code=@("""
+// Your payload types, not Butil's: annotate anything you serialise into a Butil
+// call or deserialise out of one, or keep it in a project that is not trimmed.
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+public class MyPayload
+{
+    public string Name { get; set; } = "";
+}
+""") />
+
+    <DemoSection Title="Lazy scripts - the other way to ship less"
+                 Api="BitButilLazyScripts"
+                 Description="Trimming makes the bundle smaller; lazy scripts remove the bundle. The first call into an API imports that API's own module - _content/Bit.Butil/modules/clipboard.js for Clipboard - so the browser downloads the JavaScript for the APIs the app actually calls and nothing else, in every hosting model, trimmed or not, with no script tag anywhere. The two are not alternatives to choose between: a publish with both on trims the module files to the reachable set and then loads them one at a time, which is the smallest shape there is. The cost is one extra request the first time each API is used, and the property belongs in every project that uses Butil - a Blazor Web App's server and client both, since the prerender pass runs in the server's."
+                 Code=@("""
+<!-- No <script> tag needed anywhere. Combine with the trimming above: the module
+     files are narrowed to what the app can reach, then loaded on first use. -->
+<PropertyGroup>
+  <BitButilLazyScripts>true</BitButilLazyScripts>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+</PropertyGroup>
+""")
+                 Language="xml" />
+</div>
+
+<Callout Type="warning" Title="What no signal can follow">
+    Neither ILLink nor the scan can see an API reached only by reflection, or one called from your own
+    JavaScript through <code>window.BitButil</code> rather than from C#. Both are correct to drop it - there
+    is genuinely no C# reference to it - and the symptom is
+    <em>Could not find 'BitButil.something' in 'window'</em> for that one API, in the published app only.
+    Name it in <code>BitButilScriptModule</code>, which is added to whatever the signals concluded. If you
+    are not sure that is the cause, set <code>BitButilTrimScripts</code> to <code>false</code>, publish
+    again and see whether the symptom goes away before changing anything else.
+</Callout>
+
+<Callout Type="info" Title="Where to next?">
+    <a href="getting-started">Getting started</a> has the short version of this page as part of the setup.
+    <a href="troubleshooting">Troubleshooting</a> covers the failures a published app produces - a module
+    that 404s, one API missing from a bundle, and a publish that stayed at the full bundle.
+    <a href="render-modes">Render modes</a> covers the runtime toggles that sit beside these build ones.
+</Callout>
+
+<ApiTable Title="MSBuild reference">
+    <ApiMember Name="BitButilTrimScripts" Signature="&lt;BitButilTrimScripts&gt;true|false&lt;/BitButilTrimScripts&gt;" Description="Whether a publish rebuilds bit-butil.js - and narrows the published modules/ folder - from the modules the app can still reach. Defaults to true in a Blazor WebAssembly project and false elsewhere. Publish-only, and only in the project that publishes the app's static web assets. Turning it on turns BitButilScriptScan on with it, so it is enough on its own." />
+    <ApiMember Name="PublishTrimmed" Signature="&lt;PublishTrimmed&gt;true&lt;/PublishTrimmed&gt;" Description="Not a Bit.Butil property. When ILLink runs, the BitButil.&lt;module&gt; literals left in the trimmed Bit.Butil.dll are exactly what the surviving code can call, and that supersedes BitButilScriptScan - the same question, answered from what survived rather than from what was referenced." />
+    <ApiMember Name="BitButilScriptScan" Signature="&lt;BitButilScriptScan&gt;TypeReferences|TypeNames|None&lt;/BitButilScriptScan&gt;" Description="How to answer 'what does this app call' on a publish ILLink never touched. TypeReferences (the default wherever BitButilTrimScripts is true) reads the metadata tables; TypeNames matches bare type names and deliberately over-includes; None reads nothing and publishes the full bundle. Ignored when PublishTrimmed is true." />
+    <ApiMember Name="BitButilScriptModule" Signature="&lt;BitButilScriptModule Include=&quot;Clipboard;geolocation&quot; /&gt;" Description="An item, not a property: JavaScript module names, Bit.Butil class names or full type names to keep whatever the other signals concluded. Always added to what they found, never instead of it, and the way to keep a module reached by reflection or from your own JavaScript. A name that resolves to neither fails the build." />
+    <ApiMember Name="BitButilScriptScanAssembly" Signature="&lt;BitButilScriptScanAssembly Include=&quot;...dll&quot; /&gt;" Description="Which assemblies the scan reads. Defaults to this project's own assembly plus its copy-local references, which for a head is the app; set it only when the code calling Bit.Butil lives somewhere that list does not cover." />
+    <ApiMember Name="BitButilUntrimmedAssembly" Signature="&lt;BitButilUntrimmedAssembly&gt;...\Bit.Butil.dll&lt;/BitButilUntrimmedAssembly&gt;" Description="The untrimmed Bit.Butil.dll the class-to-module map is read from. Defaults to whichever copy-local reference is Bit.Butil.dll, which is right in every ordinary layout; set it for one where that lookup comes back empty or ambiguous, rather than turning the feature off." />
+    <ApiMember Name="BitButilIncludeScriptBundle" Signature="&lt;BitButilIncludeScriptBundle&gt;true|false&lt;/BitButilIncludeScriptBundle&gt;" Description="Whether bit-butil.js ends up in the app's static web assets. Defaults to the opposite of BitButilLazyScripts; set both include switches to true to keep both shapes, for example to flip BitButil.UseLazyScripts() at runtime." />
+    <ApiMember Name="BitButilIncludeScriptModules" Signature="&lt;BitButilIncludeScriptModules&gt;true|false&lt;/BitButilIncludeScriptModules&gt;" Description="Whether the per-module files end up in the app's static web assets. Defaults to BitButilLazyScripts. Written out as true in the csproj it also outranks the trimming, publishing every module file rather than only the reachable ones - which is what an app loading them from outside its own interop calls needs." />
+    <ApiMember Name="BitButilLazyScripts" Signature="&lt;BitButilLazyScripts&gt;true&lt;/BitButilLazyScripts&gt;" Description="Loads the JavaScript per module on first use instead of from the bundle, and no script tag is needed. Sets the runtime switch and selects the module files instead of the bundle in one property. Composes with the trimming: the modules published are narrowed to the reachable set first." />
+</ApiTable>
+
+@code {
+    private DemoConsole bundleOutput = default!;
+    private bool _busy;
+
+    /// <summary>
+    /// The guard every chunk opens with - <c>if (window.BitButil &amp;&amp; window.BitButil.&lt;key&gt;) return;</c>.
+    /// Minification rewrites the statement around it but never the two property accesses, so this
+    /// substring reads the same in a development build and in a published, minified bundle.
+    /// </summary>
+    private const string GuardAnchor = "window.BitButil&&window.BitButil.";
+
+    private async Task InspectBundle()
+    {
+        _busy = true;
+
+        try
+        {
+            var url = navManager.ToAbsoluteUri("_content/Bit.Butil/bit-butil.js");
+            var response = await fetch.Send(new FetchRequest { Url = url.ToString(), Cache = "no-store" });
+
+            if (response.Ok is false)
+            {
+                await bundleOutput.Error("Fetch failed →", $"{response.Status} {response.StatusText} {response.Error}".Trim());
+                return;
+            }
+
+            var script = System.Text.Encoding.UTF8.GetString(response.Body);
+            var modules = ReadGuardedModules(script);
+
+            await bundleOutput.Info("bit-butil.js →", $"{response.Body.Length:N0} bytes of JavaScript (the wire is smaller - it is served compressed)");
+            await bundleOutput.Success($"{modules.Count} modules in the bundle →", string.Join(", ", modules));
+            await bundleOutput.Info("What that means here →",
+                "this site has a page for every API and leaves the trimming off, so it keeps all of them - an app injecting three or four services trims to a fraction of this.");
+        }
+        catch (Exception ex)
+        {
+            await bundleOutput.Error("Inspection failed →", $"{ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private async Task ProbeModuleFile()
+    {
+        _busy = true;
+
+        try
+        {
+            var url = navManager.ToAbsoluteUri("_content/Bit.Butil/modules/clipboard.js");
+            var response = await fetch.Send(new FetchRequest { Url = url.ToString(), Cache = "no-store" });
+
+            if (response.Ok)
+            {
+                await bundleOutput.Success("modules/clipboard.js →",
+                    $"{response.Body.Length:N0} bytes - this app publishes the per-module files as well as the bundle, which is what lazy scripts load from.");
+            }
+            else
+            {
+                await bundleOutput.Warn($"modules/clipboard.js → {response.Status}",
+                    "not a fault: this app is in plain bundle mode, so the modules/ folder is dropped from its static web assets and there is nothing there to request.");
+            }
+        }
+        catch (Exception ex)
+        {
+            await bundleOutput.Error("Probe failed →", $"{ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    /// <summary>The modules a bundle registers, read off the guard each of its chunks opens with.</summary>
+    private static List<string> ReadGuardedModules(string script)
+    {
+        var modules = new List<string>();
+
+        for (var at = script.IndexOf(GuardAnchor, StringComparison.Ordinal); at >= 0;
+             at = script.IndexOf(GuardAnchor, at + 1, StringComparison.Ordinal))
+        {
+            var start = at + GuardAnchor.Length;
+            var end = start;
+            while (end < script.Length && (char.IsLetterOrDigit(script[end]) || script[end] == '_')) end++;
+
+            if (end == start) continue;
+
+            // The prelude chunk has no module of its own, so it guards on `version` instead.
+            var name = script[start..end];
+            modules.Add(name == "version" ? "butil" : name);
+        }
+
+        modules.Sort(StringComparer.Ordinal);
+        return modules;
+    }
+}

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/RenderModesPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/RenderModesPage.razor
@@ -85,7 +85,7 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
 
     <DemoSection Title="Fast invoke"
                  Api="BitButil.UseFastInvoke / BitButil.UseNormalInvoke"
-                 Description="On WebAssembly the runtime can call JavaScript synchronously, skipping the task machinery and JSON round trip that the async path pays for. Fast invoke turns that path on for the APIs whose JavaScript is genuinely synchronous - LocalStorage, SessionStorage, Cookie, Console and Location. Anything wrapping a Promise-returning API keeps running asynchronously no matter what this is set to, so turning it on cannot break those calls. It is a process-wide static switch meant to be set once at startup, and on Blazor Server it does nothing at all: there is no in-process runtime to use, so the calls fall back to the async path."
+                 Description="On WebAssembly the runtime can call JavaScript synchronously, skipping the task machinery and JSON round trip that the async path pays for. Fast invoke turns that path on for the APIs whose JavaScript is genuinely synchronous - LocalStorage, SessionStorage, Cookie, Console and Location. Anything wrapping a Promise-returning API keeps running asynchronously no matter what this is set to, so turning it on cannot break those calls. It is a process-wide static switch meant to be set once at startup, and on Blazor Server it does nothing at all: there is no in-process runtime to use, so the calls fall back to the async path. One trimming note belongs here rather than on the trimming page: the public FastInvoke* extension methods on IJSRuntime carry [RequiresUnreferencedCode] because they serialise arbitrary payloads, so calling one of them directly from a trimmed app warns at your call site - the Butil classes themselves do not, since they only pass trim-safe primitives down that path."
                  Code=@("""
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -128,13 +128,6 @@ await builder.Build().RunAsync();
 }
 """)
                  Language="razor" />
-
-    <DemoSection Title="Trimming and AOT"
-                 Description="Butil is annotated for trimming, so a published WebAssembly app keeps only the wrappers it actually uses. The one thing to know: the public FastInvoke* extension methods on IJSRuntime carry [RequiresUnreferencedCode] because they serialise arbitrary payloads, so calling them directly from a trimmed app produces a warning at your call site. The Butil classes themselves do not - they only pass trim-safe primitives down that path."
-                 Code=@("""
-<PublishTrimmed>true</PublishTrimmed>
-""")
-                 Language="xml" />
 </div>
 
 <Callout Type="warning" Title="The same call, three different costs">
@@ -145,8 +138,10 @@ await builder.Build().RunAsync();
 
 <Callout Type="info" Title="Where to next?">
     <a href="browser-support">Browser support</a> lists which APIs need a secure context, a permission or a
-    specific engine. <a href="troubleshooting">Troubleshooting</a> covers the errors these rules produce when
-    they are broken.
+    specific engine. <a href="javascript-trimming">JavaScript trimming</a> covers the other half of picking a
+    hosting model - how much of Butil's JavaScript each one ends up shipping, and what to set so it ships
+    less. <a href="troubleshooting">Troubleshooting</a> covers the errors these rules produce when they are
+    broken.
 </Callout>
 
 <ApiTable Title="Reference">

--- a/src/Butil/Bit.Butil.Demo/Client/Pages/TroubleshootingPage.razor
+++ b/src/Butil/Bit.Butil.Demo/Client/Pages/TroubleshootingPage.razor
@@ -129,6 +129,21 @@ if (await crypto.IsSupported() is false) { /* SubtleCrypto is https-only */ }
 """)
                  Language="xml" />
 
+    <DemoSection Title="I set the trimming properties and the bundle is still the full one"
+                 Description="Start with which project BitButilTrimScripts is on in. It only ever trims in the one that publishes the app's static web assets - the WebAssembly head, or a Blazor Web App's server project - and a shared Directory.Build.props hands it to every Razor class library and every MAUI/Blazor Hybrid head as well, none of which publish anything. That is harmless: the switch is fine to share, and the scan it brings with it is read per project, so only the head acts on it. What is not harmless is the switch being nowhere near the head - it defaults to on in a WebAssembly project and off everywhere else, so a Blazor Server app or a Web App's server project has to turn it on. If it is on in the right project, look for a Bit.Butil message in the build output saying the trimming stood down, which means a scan or a BitButilScriptModule list was written out somewhere that is not the head. Two other explanations: BitButilScriptScan is set to None, which leaves the switch on with nothing to trim against on an untrimmed publish - or you are looking at a build. A build always keeps the full bundle, dotnet run and dotnet watch included, so the comparison to make is between two publishes."
+                 Code=@("""
+<!-- src/Directory.Build.props - the switch is fine to share, and brings the scan with it -->
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+</PropertyGroup>
+
+<!-- MyApp.Server.csproj - but what the app CALLS belongs to the head that publishes it -->
+<ItemGroup>
+  <BitButilScriptModule Include="WebAuthn" />
+</ItemGroup>
+""")
+                 Language="xml" />
+
     <DemoSection Title="It works in debug and breaks after publish"
                  Description="Trimming removed a type that only the JSON serializer ever referenced. Butil's own types are annotated and survive, but your models crossing the interop boundary - anything you serialize into a Butil call or deserialize out of one - need to be reachable by the trimmer. Either keep them in a project that is not trimmed, or annotate them so the linker keeps their members."
                  Code=@("""
@@ -139,6 +154,12 @@ public class MyPayload
 }
 """) />
 </div>
+
+<Callout Type="info" Title="Anything to do with a published bundle">
+    The three sections above about trimming are the symptoms; <a href="javascript-trimming">JavaScript
+    trimming</a> is the feature they come from - the switch, the three signals it works from, where the
+    properties go, and a live check that reads back which modules the app you are looking at downloaded.
+</Callout>
 
 <Callout Type="info" Title="Narrowing it down quickly">
     Most reports resolve to one of three questions. Is the bridge loaded - does

--- a/src/Butil/Bit.Butil.Demo/Server/Controllers/McpPrompts.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Controllers/McpPrompts.cs
@@ -130,9 +130,15 @@ public static class McpPrompts
                container - a missing registration surfaces during prerendering, a missing script surfaces as every
                call doing nothing. If the project sets `BitButilLazyScripts` there is deliberately no script tag,
                and the equivalent failure is a 404 on `_content/Bit.Butil/modules/<module>.js` in the network tab.
-            4. Confirm the member with `GetButilApiDetails` before concluding it is a bug - check the actual
+            4. If it fails only in a published app and only for ONE API, the JavaScript trimming is the first
+               suspect: a publish rebuilds `bit-butil.js` from the modules it can still reach, and neither the
+               trimmer nor the scan can follow an API reached by reflection or from your own JavaScript. It is
+               publish-only, so a build never reproduces it - compare two publishes, one with
+               `<BitButilTrimScripts>false</BitButilTrimScripts>`, and read
+               `GetButilDocsPage(slug: "javascript-trimming")` for the fix.
+            5. Confirm the member with `GetButilApiDetails` before concluding it is a bug - check the actual
                signature and the default arguments, and read the XML remarks, which carry the per-member caveats.
-            5. Call `SearchButil` with the symptom for anything the above did not cover.
+            6. Call `SearchButil` with the symptom for anything the above did not cover.
 
             Tell me the cause and the fix, and cite the tool call that established it.
             """;

--- a/src/Butil/Bit.Butil.Demo/Server/Services/ButilSetupGuide.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Services/ButilSetupGuide.cs
@@ -44,9 +44,10 @@ public static partial class ButilSetupGuide
                 This is also the one hosting model where the JavaScript tree-shaking of step 2 needs nothing said:
                 a WebAssembly publish trims `Bit.Butil.dll`, and it is the same assembly that calls the JavaScript
                 being served, so `bit-butil.js` is rebuilt from just the modules the app can still reach. Publish
-                this app with `<PublishTrimmed>false</PublishTrimmed>` and that signal is gone - add
-                `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` to keep the tree-shaking, which then reads
-                the Bit.Butil classes the app's own assemblies reference instead.
+                this app with `<PublishTrimmed>false</PublishTrimmed>` and that signal is gone, and
+                `<BitButilScriptScan>` takes over - it defaults to `TypeReferences` wherever the trimming is on, so
+                the tree-shaking survives with nothing said there either, reading the Bit.Butil classes the app's own
+                assemblies reference instead. `None` is how you turn it off.
 
                 Two things in the sample below are this repository's rather than yours, and both should be
                 dropped when you copy it: its `.csproj` imports Bit.Butil's consumer-side targets by hand and
@@ -85,18 +86,18 @@ public static partial class ButilSetupGuide
                 `<BitButilLazyScripts>true</BitButilLazyScripts>` belongs in both `.csproj` files, because both of
                 them run components that call Butil.
 
-                Bundle trimming in this shape wants `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` in the
-                HOST `.csproj` - the host is the project that serves `bit-butil.js`, and the scan reads its own
-                assemblies and the client's alike, because the client is one of its references. What it must not do
-                is trim from `PublishTrimmed`: the host's trimmed assembly set is about the host's own code and says
-                nothing about what the WebAssembly client calls, which is why the trimmed signal is off in this
-                shape and should stay off.
+                Bundle trimming in this shape belongs in the HOST `.csproj`, and one line does it: the host is the
+                project that serves `bit-butil.js`, and `<BitButilTrimScripts>true</BitButilTrimScripts>` brings
+                `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` with it by default - a scan that reads the
+                host's own assemblies and the client's alike, because the client is one of its references. What it
+                must not do is trim from `PublishTrimmed`: the host's trimmed assembly set is about the host's own
+                code and says nothing about what the WebAssembly client calls, which is why the trimmed signal is off
+                in this shape and should stay off.
 
                 ```xml
                 <!-- in the HOST .csproj -->
                 <PropertyGroup>
                   <BitButilTrimScripts>true</BitButilTrimScripts>
-                  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
                 </PropertyGroup>
                 ```
 
@@ -115,6 +116,21 @@ public static partial class ButilSetupGuide
                 BlazorWebView loads it, so the script tag goes there exactly as it would in a standalone WebAssembly
                 app. The WebView is a real browser engine, so what works depends on which engine the platform ships
                 (WebView2 on Windows, WKWebView on Apple, Chromium on Android) rather than on .NET.
+
+                The one shape where the bundle trimming does NOT apply. A hybrid head packages its `wwwroot` into
+                the app at BUILD time, not through a publish of a web app's static web assets, so
+                `<BitButilTrimScripts>`, `<BitButilScriptScan>` and `<BitButilScriptModule>` do nothing here - set
+                on this project, or inherited from a shared `Directory.Build.props`, they stand down rather than
+                trimming, and say so in the build output when what was set describes what the app calls (a scan
+                written out by hand, or a module list) rather than being only the switch. That is deliberate: trimming JavaScript during a build is not what a
+                developer debugging the app wants, and a hybrid head's reference closure is not a published web
+                app's. The head therefore ships the full `bit-butil.js`, and `<BitButilLazyScripts>true</BitButilLazyScripts>`
+                is the lever that shrinks what it actually loads - it works in every hosting model, this one
+                included, and needs no publish to take effect.
+
+                One consequence worth knowing: because nothing is trimmed here, a module reached only from the
+                head's own JavaScript rather than from C# - `window.BitButil.webAuthn` called from a `.ts` file of
+                yours - is present regardless. There is nothing to keep alive with `<BitButilScriptModule>`.
                 """,
                 ["Sample/Bit.Butil.Samples.Maui/", "Sample/Bit.Butil.Samples.Core/Extentions/"]),
 
@@ -195,14 +211,15 @@ public static partial class ButilSetupGuide
             (pre-.NET 8) Blazor Server app. If the app prerenders - the default - the same rule as everywhere else
             applies: touch the browser from `OnAfterRenderAsync`, not from `OnInitializedAsync`.
 
-            Nothing here is ever trimmed, so the JavaScript tree-shaking of step 2 has to be told what to work from:
-            `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` reads the Bit.Butil classes this project's own
-            assemblies reference. Lazy scripts are the alternative, and cost one request per API instead of a bundle.
+            Nothing here is ever trimmed, so the JavaScript tree-shaking of step 2 works from a scan of the app's
+            own assemblies instead - `<BitButilScriptScan>`, which defaults to `TypeReferences` wherever the trimming
+            is on and reads the Bit.Butil classes those assemblies reference. Turning the trimming on is therefore
+            the whole of it; it is off by default here, since this is not a WebAssembly project. Lazy scripts are the
+            alternative, and cost one request per API instead of a bundle.
 
             ```xml
             <PropertyGroup>
               <BitButilTrimScripts>true</BitButilTrimScripts>
-              <BitButilScriptScan>TypeReferences</BitButilScriptScan>
             </PropertyGroup>
             ```
             """).AppendLine();
@@ -281,13 +298,26 @@ public static partial class ButilSetupGuide
            `modules/` too - publish only, never a build. It is on by default in a standalone WebAssembly project,
            where the trimmed `Bit.Butil.dll` says what the app can still call; `false` opts out, and
            `<BitButilIncludeScriptModules>true</BitButilIncludeScriptModules>` publishes every module regardless.
-           Publishing WITHOUT trimming, there is no trimmed assembly to read, so
-           `<BitButilScriptScan>TypeReferences</BitButilScriptScan>` answers the same question from the app's own
-           assemblies - the Bit.Butil classes they reference - and works in every hosting model; it is ignored when
-           the publish IS trimmed. `<BitButilScriptModule Include="Clipboard;geolocation" />` (an ItemGroup) adds
-           modules or Bit.Butil class names on top of whatever either concluded, for an API reached by reflection.
+           Publishing WITHOUT trimming, there is no trimmed assembly to read, so `<BitButilScriptScan>` answers the
+           same question from the app's own assemblies - the Bit.Butil classes they reference - and works in every
+           hosting model that publishes a web app. It defaults to `TypeReferences` wherever `<BitButilTrimScripts>`
+           is on, so turning the trimming on is all such an app writes; `None` turns the scan off, `TypeNames` is a
+           coarser name-matching mode, and any of them is ignored when the publish IS trimmed. `<BitButilScriptModule Include="Clipboard;geolocation" />`
+           (an ItemGroup) adds modules or Bit.Butil class names on top of whatever either concluded, for an API
+           reached by reflection.
+           THESE GO IN THE PROJECT YOU PUBLISH - the WebAssembly head, or a Blazor Web App's server project -
+           and NOT in a shared `Directory.Build.props`. From there they also reach the Razor class libraries and
+           the MAUI/Blazor Hybrid heads in the solution, none of which publish the app's static web assets: such a
+           project would be answering "what does this app call" from its own references rather than the app's. It
+           stands down instead - saying so in the build output when what reached it describes what the app calls -
+           so a shared props file is not a broken build, but the head is where the answer comes from.
+           `<BitButilTrimScripts>` alone is safe to share: it is only a switch, it already defaults to on exactly
+           where it applies, and the scan it turns on is read per project, so only the project that publishes the
+           app ever acts on one.
            `<BitButilLazyScripts>true</BitButilLazyScripts>` instead drops the script tag altogether and has each API
            `import()` its own module on first use, in every hosting model - set it in every project that uses Butil.
+           All of this in full, with the three signals the trimming works from and the failures it can produce:
+           `GetButilDocsPage(slug: "javascript-trimming")`.
         3. Call `AddBitButilServices()` in EVERY DI container that renders your components. A Blazor Web App with an
            interactive WebAssembly client has two of them (the host prerenders, the browser hydrates), and a missing
            registration in either one surfaces at runtime rather than at compile time.

--- a/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
+++ b/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
@@ -398,18 +398,28 @@
                  and hand the app a bundle short of the modules only the app names.
 
                  StaticWebAssetProjectMode is the SDK's own answer to "is this the root of the asset graph
-                 or a library contributing to someone else's": the Web SDK and the Blazor WebAssembly SDK
-                 set Root, every class library and every hybrid head is left Default. Gating on Root keeps
-                 the trimming in the one project whose reference closure IS the app's, which is also the
-                 project whose publish the whole feature was written for. The referenced-project stage then
-                 hands its full bundle up and the root trims it there, which is where the answer is right.
+                 or a library contributing to someone else's", and Root is the answer this wants. It is not
+                 enough on its own, though: only the .NET 10 Web SDK sets it (Sdk.Server.props), while the
+                 .NET 8 and .NET 9 Web SDKs leave a Blazor Server app or a Blazor Web App host on the
+                 'Default' that ResolveStaticWebAssetsConfiguration fills in for everything. Gating on Root
+                 alone would stand the whole feature down on exactly the hosts the scan was written for, on
+                 two of the three frameworks this package targets. So the SDK a project loaded is read
+                 alongside it: UsingMicrosoftNETSdkWeb and the two WebAssembly markers are set identically
+                 on 8, 9 and 10, and between them they name every project shape that publishes an app
+                 rather than contributing to one. A Razor class library (Sdk.Razor) and a hybrid head (the
+                 plain SDK plus UseMaui) match none of them, which is the point.
+
+                 Either way the trimming stays in the one project whose reference closure IS the app's,
+                 which is also the project whose publish the whole feature was written for. The
+                 referenced-project stage then hands its full bundle up and the root trims it there, which
+                 is where the answer is right.
 
                  The remaining two counts are unchanged: the assemblies read here are a publish's, and a
                  design-time build is excluded outright. A build, and so dotnet run and dotnet watch, keeps
                  the JavaScript exactly as the package ships it - what a developer debugs is always the
                  full, untrimmed set. -->
             <_BitButilIsAssetRoot>false</_BitButilIsAssetRoot>
-            <_BitButilIsAssetRoot Condition="'$(StaticWebAssetProjectMode)' == 'Root'">true</_BitButilIsAssetRoot>
+            <_BitButilIsAssetRoot Condition="'$(StaticWebAssetProjectMode)' == 'Root' or '$(UsingMicrosoftNETSdkWeb)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">true</_BitButilIsAssetRoot>
 
             <_BitButilPublishTrimming>false</_BitButilPublishTrimming>
             <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsAssetRoot)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
@@ -447,7 +457,7 @@
                  Text="Bit.Butil: this publish is trimmed, so &lt;BitButilScriptScan&gt;$(BitButilScriptScan)&lt;/BitButilScriptScan&gt; is not used - the trimmed assembly answers the same question more precisely." />
 
         <Message Importance="normal" Condition="'$(_BitButilTrimmingStoodDown)' == 'true'"
-                 Text="Bit.Butil: script trimming is configured here but this project does not publish the app's static web assets (StaticWebAssetProjectMode is '$(StaticWebAssetProjectMode)', not 'Root'), so it is left to the head that does. Set &lt;BitButilTrimScripts&gt;, &lt;BitButilScriptScan&gt; and &lt;BitButilScriptModule&gt; on the project you publish rather than in a shared Directory.Build.props." />
+                 Text="Bit.Butil: script trimming is configured here but this project does not publish an app's static web assets - it is a class library or a hybrid head contributing to someone else's, so the trimming is left to the head that does publish one. Set &lt;BitButilScriptScan&gt; and &lt;BitButilScriptModule&gt; on the project you publish rather than in a shared Directory.Build.props." />
 
     </Target>
 

--- a/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
+++ b/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
@@ -29,9 +29,18 @@
                                          Publish only: a build - and everything development runs on top of
                                          it, dotnet run and dotnet watch included - is left untouched, so
                                          what a developer debugs is always the full, untrimmed JavaScript.
+                                         And head only: it takes effect in the project that publishes the
+                                         app's static web assets (StaticWebAssetProjectMode=Root, which the
+                                         Web SDK and the Blazor WebAssembly SDK set), never in a Razor class
+                                         library or a hybrid head that only contributes to one. See the gate
+                                         in _BitButilResolveScriptTrimming for why that is not the same as
+                                         "hangs off a publish target".
                                          Default: true in a Blazor WebAssembly project (the one case where
                                          the assembly that is trimmed is the assembly that calls the served
                                          JavaScript), false elsewhere.
+                                         On its own it is enough: turning it on turns BitButilScriptScan on
+                                         with it, so an app that wants the trimming asks for the trimming
+                                         and not for a scan mode as well.
                                  false   Publish the full bundle, whatever the signals below say.
 
                                          The switch decides *whether* to trim; the three below are *what it
@@ -43,13 +52,18 @@
                                          publish is trimmed, and it then supersedes BitButilScriptScan -
                                          the same question, better answered.
 
-      BitButilScriptScan         None    (default) Do not read the app's own assemblies.
-                       TypeReferences    Read them, and take every Bit.Butil type they reference - an
-                                         @inject Clipboard is a reference to Bit.Butil.Clipboard - through
-                                         to the modules that type needs. The signal for an app published
-                                         WITHOUT trimming, and the mode to use of the two: on this
-                                         repository's own trimming harness it produces the same module set
-                                         ILLink does, exactly.
+      BitButilScriptScan  TypeReferences Read the app's own assemblies, and take every Bit.Butil type they
+                                         reference - an @inject Clipboard is a reference to
+                                         Bit.Butil.Clipboard - through to the modules that type needs. The
+                                         signal for an app published WITHOUT trimming, and the precise mode
+                                         of the two: on this repository's own trimming harness it produces
+                                         the same module set ILLink does, exactly.
+                                         Default wherever BitButilTrimScripts is true, which is what makes
+                                         that switch enough on its own; None wherever it is false, since
+                                         there is nothing to answer for then.
+                                 None    Do not read the app's own assemblies. The way to publish the full
+                                         bundle from a project that keeps BitButilTrimScripts on for
+                                         somewhere else - or to silence a scan that cannot see the app.
                             TypeNames    The same idea without reading the metadata tables: match the
                                          library's type names against the names in each assembly's string
                                          heap. Cheaper to reason about, and coarser - an app with a class
@@ -73,6 +87,11 @@
                                          is the app; set it only if that is not where the code calling
                                          Bit.Butil lives.
 
+      BitButilUntrimmedAssembly          The untrimmed Bit.Butil.dll to read the class-to-module map from.
+                                         Defaults to whichever copy-local reference is Bit.Butil.dll, which
+                                         is right in every ordinary layout; set it for one where that lookup
+                                         comes back empty or ambiguous, rather than turning the feature off.
+
       BitButilIncludeScriptBundle / BitButilIncludeScriptModules
                                          Fine-grained overrides of which shape ends up in the app's static
                                          web assets. Default to the mode above; set both to true to keep
@@ -82,15 +101,28 @@
                                          asking for them by name outranks the trimming, which otherwise
                                          keeps only the ones the app can reach.
 
-    Which signal suits which app. A standalone Blazor WebAssembly app (or PWA) publishes trimmed by default
-    and is the one case where the assembly ILLink trims is the assembly that calls the served JavaScript, so
-    BitButilTrimScripts defaults to true there and needs nothing else. An app published untrimmed - a
-    WebAssembly app with PublishTrimmed off, a Blazor Server app, a server host that prerenders - has no
-    ILLink to ask, and BitButilScriptScan=TypeReferences is what replaces it. A server host that references
-    a WebAssembly client is the case to think about: scanning covers the host and the client alike, because
-    the client's assembly is one of the host's references, but ILLink's answer for such a host is about the
-    host's own code only - which is why trimming there wants the scan (or lazy scripts) rather than
-    PublishTrimmed.
+    Where these properties go. On the project you publish - the Blazor WebAssembly head, or the server
+    project of a Blazor Web App - and not in a shared Directory.Build.props: from there they also reach the
+    Razor class libraries and the hybrid heads that share the solution, and none of those publish the app's
+    static web assets. Such a project stands down with a message rather than trimming (see the gate in
+    _BitButilResolveScriptTrimming), so a shared props file is not a broken build - but it is not where the
+    answer comes from either, since a class library asked what "the app" calls would answer from its own
+    references, which are not the app's. BitButilTrimScripts alone is the exception worth sharing: it is only
+    a switch, and already defaults to true exactly where it applies.
+
+    Which signal suits which app, and none of it has to be chosen by hand. A standalone Blazor WebAssembly
+    app (or PWA) publishes trimmed by default and is the one case where the assembly ILLink trims is the
+    assembly that calls the served JavaScript, so BitButilTrimScripts defaults to true there and needs
+    nothing else. An app published untrimmed - a WebAssembly app with PublishTrimmed off, a Blazor Server
+    app, a server host that prerenders - has no ILLink to ask, and the scan is what replaces it; it comes on
+    with the switch, so <BitButilTrimScripts>true</BitButilTrimScripts> is the whole of what such an app
+    writes. A server host that references a WebAssembly client is the case to think about: scanning covers
+    the host and the client alike, because the client's assembly is one of the host's references, but
+    ILLink's answer for such a host is about the host's own code only - which is why trimming there wants the
+    scan (or lazy scripts) rather than PublishTrimmed. What is left to write by hand is the exceptions:
+    BitButilScriptModule for a module reached where no signal can follow, BitButilScriptScan=None to keep the
+    full bundle in one project without turning the switch off, and the two assembly overrides for a layout
+    where the defaults look in the wrong place.
     -->
 
     <!-- The package carries the same targets file under buildTransitive\ and build\, and tooling that
@@ -109,9 +141,22 @@
         <BitButilLazyScripts Condition="'$(BitButilLazyScripts)' == ''">false</BitButilLazyScripts>
         <BitButilTrimScripts Condition="'$(BitButilTrimScripts)' == '' and ('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true')">true</BitButilTrimScripts>
         <BitButilTrimScripts Condition="'$(BitButilTrimScripts)' == ''">false</BitButilTrimScripts>
-        <!-- Off by default everywhere. Reading a publish's assemblies is a cost and a judgement about what
-             the app calls, and neither belongs in a default: an app gets the scan because its csproj asked
-             for it, having decided which of the two modes it wants. -->
+        <!-- On wherever the switch above is on, and off wherever it is off. BitButilTrimScripts=true says
+             "trim this app's JavaScript", and on a publish ILLink never touched the scan is the only thing
+             that can answer which JavaScript that is - so without it the switch would be on and the feature
+             inert, which is a silent dead end rather than a default. TypeReferences of the two modes: it
+             reads the metadata tables rather than matching bare type names, over-includes nothing, and on
+             this repository's own trimming harness produces exactly the module set ILLink does. The cost is
+             a read of the publish's own assemblies, paid only where the switch already asked for trimming -
+             a trimmed publish supersedes the scan, and a build never reaches it at all.
+             <BitButilScriptScan>None</BitButilScriptScan> is the way back to the full bundle for an app that
+             wants the trimming elsewhere, and TypeNames the way to the coarser mode. -->
+        <!-- Whether the consumer wrote the scan out, read while the property is still unset: an explicit
+             scan is worth a word when a trimmed publish makes it redundant, and worth failing the build over
+             when the assembly it needs cannot be read. A defaulted one is neither - nobody asked for it, so
+             it stands down quietly instead (see _BitButilAssembleTrimmedBundle). -->
+        <_BitButilScriptScanRequested Condition="'$(BitButilScriptScan)' != ''">true</_BitButilScriptScanRequested>
+        <BitButilScriptScan Condition="'$(BitButilScriptScan)' == '' and '$(BitButilTrimScripts)' == 'true'">TypeReferences</BitButilScriptScan>
         <BitButilScriptScan Condition="'$(BitButilScriptScan)' == ''">None</BitButilScriptScan>
         <BitButilIncludeScriptBundle Condition="'$(BitButilIncludeScriptBundle)' == '' and '$(BitButilLazyScripts)' == 'true'">false</BitButilIncludeScriptBundle>
         <BitButilIncludeScriptBundle Condition="'$(BitButilIncludeScriptBundle)' == ''">true</BitButilIncludeScriptBundle>
@@ -344,12 +389,41 @@
             <_BitButilHasSignal>false</_BitButilHasSignal>
             <_BitButilHasSignal Condition="'$(PublishTrimmed)' == 'true' or ('$(_BitButilScanMode)' != '' and '$(_BitButilScanMode)' != 'None') or '@(BitButilScriptModule)' != ''">true</_BitButilHasSignal>
 
-            <!-- Publish only, on three counts: every target these gate hangs off ResolvePublishStaticWebAssets,
-                 which no build reaches; the assemblies read here are a publish's; and a design-time build is
-                 excluded outright. A build, and so dotnet run and dotnet watch, keeps the JavaScript exactly
-                 as the package ships it - what a developer debugs is always the full, untrimmed set. -->
+            <!-- Only the project that publishes the app. ResolvePublishStaticWebAssets is not the
+                 publish-only stage it looks like: the SDK runs it on REFERENCED projects too, through
+                 ComputeReferencedStaticWebAssetsPublishManifest, and a head that packages its wwwroot at
+                 build time (a MAUI/Android hybrid head) reaches it during a plain build. A Razor class
+                 library asked for its publish assets that way would trim the bundle against its own
+                 references, which are not the app's - it cannot know what the app that consumes it calls -
+                 and hand the app a bundle short of the modules only the app names.
+
+                 StaticWebAssetProjectMode is the SDK's own answer to "is this the root of the asset graph
+                 or a library contributing to someone else's": the Web SDK and the Blazor WebAssembly SDK
+                 set Root, every class library and every hybrid head is left Default. Gating on Root keeps
+                 the trimming in the one project whose reference closure IS the app's, which is also the
+                 project whose publish the whole feature was written for. The referenced-project stage then
+                 hands its full bundle up and the root trims it there, which is where the answer is right.
+
+                 The remaining two counts are unchanged: the assemblies read here are a publish's, and a
+                 design-time build is excluded outright. A build, and so dotnet run and dotnet watch, keeps
+                 the JavaScript exactly as the package ships it - what a developer debugs is always the
+                 full, untrimmed set. -->
+            <_BitButilIsAssetRoot>false</_BitButilIsAssetRoot>
+            <_BitButilIsAssetRoot Condition="'$(StaticWebAssetProjectMode)' == 'Root'">true</_BitButilIsAssetRoot>
+
             <_BitButilPublishTrimming>false</_BitButilPublishTrimming>
-            <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
+            <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsAssetRoot)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
+
+            <!-- Said out loud, because "I set the properties and nothing happened" is otherwise a silent
+                 dead end - and because the properties landing in a shared Directory.Build.props, where they
+                 reach every project in the solution rather than the head, is exactly how that happens.
+                 Only for the properties that describe THIS app, though: BitButilTrimScripts is the one worth
+                 sharing, and the scan it brings with it is on in every project the switch is on in, so
+                 saying it for those would mean a line per class library in a solution that has the switch
+                 shared and everything right. A scan written out by hand, or a module list, is the shape of
+                 the mistake this is here to catch. -->
+            <_BitButilTrimmingStoodDown>false</_BitButilTrimmingStoodDown>
+            <_BitButilTrimmingStoodDown Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsAssetRoot)' != 'true' and '$(DesignTimeBuild)' != 'true' and ('$(_BitButilScriptScanRequested)' == 'true' or '@(BitButilScriptModule)' != '')">true</_BitButilTrimmingStoodDown>
 
             <!-- The bundle half: rebuild bit-butil.js from the modules the app can reach. Needs a bundle to
                  rebuild. -->
@@ -367,20 +441,23 @@
             <_BitButilTrimAnyEnabled Condition="'$(_BitButilTrimEnabled)' == 'true' or '$(_BitButilTrimModulesEnabled)' == 'true'">true</_BitButilTrimAnyEnabled>
         </PropertyGroup>
 
-        <Message Importance="normal" Condition="'$(PublishTrimmed)' == 'true' and '$(BitButilScriptScan)' != '' and '$(BitButilScriptScan)' != 'None'"
+        <!-- Only for a scan the csproj wrote out. The default one is on in every project the switch is on
+             in, so saying it there would be telling every trimmed publish about a property nobody set. -->
+        <Message Importance="normal" Condition="'$(PublishTrimmed)' == 'true' and '$(_BitButilScriptScanRequested)' == 'true' and '$(BitButilScriptScan)' != 'None'"
                  Text="Bit.Butil: this publish is trimmed, so &lt;BitButilScriptScan&gt;$(BitButilScriptScan)&lt;/BitButilScriptScan&gt; is not used - the trimmed assembly answers the same question more precisely." />
 
-        <!-- The app's own assemblies: this project's output and everything copied next to it. Overridable in
-             the csproj for the app whose Bit.Butil calls live somewhere this cannot see. Only gathered when
-             a scan is actually going to read them. -->
-        <ItemGroup Condition="'$(_BitButilScanMode)' != '' and '$(_BitButilScanMode)' != 'None' and '@(BitButilScriptScanAssembly)' == ''">
-            <BitButilScriptScanAssembly Include="@(IntermediateAssembly->'%(FullPath)')" />
-            <BitButilScriptScanAssembly Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
-        </ItemGroup>
+        <Message Importance="normal" Condition="'$(_BitButilTrimmingStoodDown)' == 'true'"
+                 Text="Bit.Butil: script trimming is configured here but this project does not publish the app's static web assets (StaticWebAssetProjectMode is '$(StaticWebAssetProjectMode)', not 'Root'), so it is left to the head that does. Set &lt;BitButilTrimScripts&gt;, &lt;BitButilScriptScan&gt; and &lt;BitButilScriptModule&gt; on the project you publish rather than in a shared Directory.Build.props." />
 
     </Target>
 
-    <Target Name="_BitButilAssembleTrimmedBundle" DependsOnTargets="_BitButilResolveScriptTrimming" Condition="'$(_BitButilTrimAnyEnabled)' == 'true'">
+    <!-- ResolveReferences, because @(ReferenceCopyLocalPaths) is where both the assemblies to scan and the
+         untrimmed Bit.Butil.dll come from, and the stage this hangs off does NOT imply it has run: reached
+         through ComputeReferencedStaticWebAssetsPublishManifest, or through a MSBuild call carrying global
+         properties that fork a fresh project instance, only the requested target chain runs and the item is
+         empty. Named here rather than on _BitButilResolveScriptTrimming so it is paid for only when the
+         trimming is actually on - MSBuild skips a false-conditioned target's DependsOnTargets entirely. -->
+    <Target Name="_BitButilAssembleTrimmedBundle" DependsOnTargets="_BitButilResolveScriptTrimming;ResolveReferences" Condition="'$(_BitButilTrimAnyEnabled)' == 'true'">
 
         <PropertyGroup>
             <!-- Only set when ILLink is in play: the task reads "a path was given but the file is not there"
@@ -391,10 +468,18 @@
             <_BitButilTrimmedBundle>$(_BitButilTrimmedBundleDir)bit-butil.js</_BitButilTrimmedBundle>
         </PropertyGroup>
 
+        <!-- The app's own assemblies: this project's output and everything copied next to it. Overridable in
+             the csproj for the app whose Bit.Butil calls live somewhere this cannot see. Only gathered when
+             a scan is actually going to read them, and only here, where ResolveReferences has run. -->
+        <ItemGroup Condition="'$(_BitButilScanMode)' != '' and '$(_BitButilScanMode)' != 'None' and '@(BitButilScriptScanAssembly)' == ''">
+            <BitButilScriptScanAssembly Include="@(IntermediateAssembly->'%(FullPath)')" />
+            <BitButilScriptScanAssembly Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll'" />
+        </ItemGroup>
+
         <!-- The untrimmed Bit.Butil.dll, which is what says which module each Bit.Butil class needs. Needed
              by a scan, and by a csproj that names classes rather than modules; the task says so itself if it
              turns out to be needed and missing. -->
-        <ItemGroup>
+        <ItemGroup Condition="'$(BitButilUntrimmedAssembly)' == ''">
             <_BitButilReferencedAssembly Include="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)%(Extension)' == 'Bit.Butil.dll'" />
         </ItemGroup>
 
@@ -403,6 +488,20 @@
             <!-- More than one, and there is no telling which is the Bit.Butil this app compiled against.
                  Empty is the honest answer: the task then says what it could not read, and why it needed to. -->
             <_BitButilUntrimmedAssembly Condition="'$(_BitButilUntrimmedAssembly)' != '' and $(_BitButilUntrimmedAssembly.Contains(';'))"></_BitButilUntrimmedAssembly>
+            <!-- The csproj outranks all of that: the escape hatch for a layout where the reference does not
+                 resolve to the Bit.Butil this app compiled against, or resolves to more than one. Without it
+                 the only way out of a failed lookup is turning the feature off. -->
+            <_BitButilUntrimmedAssembly Condition="'$(BitButilUntrimmedAssembly)' != ''">$(BitButilUntrimmedAssembly)</_BitButilUntrimmedAssembly>
+        </PropertyGroup>
+
+        <!-- A scan needs that assembly to know which module each Bit.Butil class uses, and the task fails the
+             build when it asked for one and could not read it - which is right for a csproj that wrote
+             <BitButilScriptScan> out, since there the answer is BitButilUntrimmedAssembly rather than
+             silence. For the scan the switch turned on by itself it is not: nobody asked for it, so a lookup
+             that comes back empty or ambiguous is the feature standing down, and the task then has nothing to
+             go on and keeps the full bundle. -->
+        <PropertyGroup Condition="'$(_BitButilScriptScanRequested)' != 'true' and '$(_BitButilUntrimmedAssembly)' == ''">
+            <_BitButilScanMode>None</_BitButilScanMode>
         </PropertyGroup>
 
         <ItemGroup Condition="'$(_BitButilTrimEnabled)' == 'true'">

--- a/src/Butil/README.md
+++ b/src/Butil/README.md
@@ -341,9 +341,9 @@ app's static web assets: a class library asked what JavaScript "the app" uses wo
 references, which are not the app's, and hand the head a bundle short of the modules only the head names.
 
 The trimming knows this and stands down in those projects rather than trimming against the wrong reference
-closure - the question it decides on is `StaticWebAssetProjectMode`, which the Web SDK and the Blazor
-WebAssembly SDK set to `Root` and every class library and hybrid head leaves at `Default`. Where what
-reached such a project describes what the app calls - a `BitButilScriptScan` written out by hand, or a
+closure - what it decides on is the SDK the project loaded, which is the Web SDK or the Blazor WebAssembly
+SDK for every project that publishes an app and neither of those for a class library or a hybrid head.
+Where what reached such a project describes what the app calls - a `BitButilScriptScan` written out by hand, or a
 `BitButilScriptModule` list - it says so in the build output. So a shared props file is no longer a broken
 build, but it is still not where the answer comes from. Put the
 properties on the head, one per app you publish:

--- a/src/Butil/README.md
+++ b/src/Butil/README.md
@@ -279,8 +279,10 @@ both shapes - only the modules the trimmed assembly can still name are published
 module is gone from the assembly with it. `<BitButilIncludeScriptModules>true</BitButilIncludeScriptModules>`
 in the csproj publishes every module regardless, for an app that reaches them from outside its own interop
 calls. All of this happens in `dotnet publish` only: a build - and `dotnet run` and `dotnet watch` on top of
-it - keeps the full bundle and every module, so what you debug is never the trimmed JavaScript. Opt out with
-`false`, or opt in elsewhere with `true`:
+it - keeps the full bundle and every module, so what you debug is never the trimmed JavaScript. And it
+happens in the project that publishes the app's static web assets only - see
+[where these properties go](#where-these-properties-go). Opt out with `false`, or opt in elsewhere with
+`true`:
 
 ```xml
 <PropertyGroup>
@@ -290,26 +292,32 @@ it - keeps the full bundle and every module, so what you debug is never the trim
 
 **Publishing without trimming?** `BitButilTrimScripts` decides *whether* to trim the JavaScript; what it
 trims against is a separate question, and a publish with `PublishTrimmed` off has no trimmed assembly to
-read. `BitButilScriptScan` answers it from the app's own assemblies instead: an `@inject Clipboard` is a
-reference to `Bit.Butil.Clipboard`, and the package's build logic reads `Bit.Butil.dll` to know which
-JavaScript module answering that class takes - through base classes and internal interop helpers, so
-`LocalStorage` correctly pulls in `storage` and `Window` pulls in `events` as well as `window`. On this
-repository's own trimming harness it reaches exactly the module set ILLink does. It works in every hosting
-model - a WebAssembly app with `PublishTrimmed` off, Blazor Server, a server host that prerenders - and it
-costs the publish one pass over the app's assemblies, tens of milliseconds; a build is untouched either way.
+read. `BitButilScriptScan` answers it from the app's own assemblies instead, and it **defaults to
+`TypeReferences` wherever `BitButilTrimScripts` is `true`** - so turning the trimming on is all an app
+writes, and the switch is never on with nothing behind it. An `@inject Clipboard` is a reference to
+`Bit.Butil.Clipboard`, and the package's build logic reads `Bit.Butil.dll` to know which JavaScript module
+answering that class takes - through base classes and internal interop helpers, so `LocalStorage` correctly
+pulls in `storage` and `Window` pulls in `events` as well as `window`. On this repository's own trimming
+harness it reaches exactly the module set ILLink does. It works in every hosting model - a WebAssembly app
+with `PublishTrimmed` off, Blazor Server, a server host that prerenders - and it costs the publish one pass
+over the app's assemblies, tens of milliseconds; a build is untouched either way. It reads the app's own
+assembly and its copy-local references by default - override with `BitButilScriptScanAssembly` if the code
+calling Bit.Butil lives elsewhere, and with `BitButilUntrimmedAssembly` in the rare layout where the
+reference to `Bit.Butil.dll` itself cannot be resolved from those.
 
 ```xml
+<!-- The whole of it for an app published untrimmed: the scan comes with the switch -->
 <PropertyGroup>
   <BitButilTrimScripts>true</BitButilTrimScripts>
-  <BitButilScriptScan>TypeReferences</BitButilScriptScan>
 </PropertyGroup>
 ```
 
 `TypeNames` is the other mode: it matches the library's type names against the names in each assembly, with
 no metadata tables read at all. It is coarser - an app with a class of its own called `Window`, `Console` or
-`Storage` pulls in that module too - and it over-includes rather than missing anything, so prefer
-`TypeReferences` unless you have a reason not to. Either is ignored when `PublishTrimmed` is `true`: the
-trimmed assembly answers the same question more precisely.
+`Storage` pulls in that module too - and it over-includes rather than missing anything, so the default stays
+`TypeReferences`. Either is ignored when `PublishTrimmed` is `true`: the trimmed assembly answers the same
+question more precisely. `None` is the third value, and the way to publish the full bundle from one project
+while `BitButilTrimScripts` stays `true` for the rest.
 
 **Keeping a module none of that can see.** `BitButilScriptModule` names modules, or the Bit.Butil classes
 behind them, that must survive whatever the scan or the trimmer concluded - for an API reached by reflection,
@@ -322,8 +330,41 @@ that is neither a module nor a Bit.Butil class fails the build rather than being
 </ItemGroup>
 ```
 
-With none of the three in play - no `PublishTrimmed`, no `BitButilScriptScan`, no `BitButilScriptModule` -
-there is nothing to trim against, and the full bundle is published.
+With none of the three in play - no `PublishTrimmed`, `BitButilScriptScan` set to `None`, no
+`BitButilScriptModule` - there is nothing to trim against, and the full bundle is published.
+
+<a id="where-these-properties-go"></a>
+**Where these properties go.** On the project you publish - the Blazor WebAssembly head, or the server
+project of a Blazor Web App - and **not** in a shared `Directory.Build.props`. From there they also reach
+every Razor class library and every MAUI/Blazor Hybrid head in the solution, and none of those publish the
+app's static web assets: a class library asked what JavaScript "the app" uses would answer from its own
+references, which are not the app's, and hand the head a bundle short of the modules only the head names.
+
+The trimming knows this and stands down in those projects rather than trimming against the wrong reference
+closure - the question it decides on is `StaticWebAssetProjectMode`, which the Web SDK and the Blazor
+WebAssembly SDK set to `Root` and every class library and hybrid head leaves at `Default`. Where what
+reached such a project describes what the app calls - a `BitButilScriptScan` written out by hand, or a
+`BitButilScriptModule` list - it says so in the build output. So a shared props file is no longer a broken
+build, but it is still not where the answer comes from. Put the
+properties on the head, one per app you publish:
+
+```xml
+<!-- Boilerplate.Server.Web.csproj - the project that publishes the Blazor Web App -->
+<PropertyGroup>
+  <BitButilTrimScripts>true</BitButilTrimScripts>
+</PropertyGroup>
+
+<ItemGroup>
+  <BitButilScriptModule Include="WebAuthn" />
+</ItemGroup>
+```
+
+`BitButilTrimScripts` on its own is the exception worth keeping shared, since it is only a switch and
+already defaults to `true` exactly where it applies. The scan comes with it wherever it lands, but only the
+project that publishes the app ever acts on one, so sharing the switch is still just sharing a switch.
+
+The demo site has a page of its own for all of this - **JavaScript trimming**, under Overview - including a
+live check that reads back which modules the app you are looking at actually downloaded.
 
 **Lazy scripts.** No script tag at all: the first call into an API `import()`s that API's module
 (`_content/Bit.Butil/modules/clipboard.js` for `Clipboard`), so only the JavaScript for the APIs the

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
@@ -129,7 +129,8 @@ a checkout that can produce the artifacts under test can always run them.
 **Script scanning** ([`ScriptScanning.cs`](ScriptScanning.cs)). Everything above rests on ILLink having
 run. A consumer publishing untrimmed has no trimmed assembly, and an *untrimmed* `Bit.Butil.dll` names every
 module the library has - so the signal has to come from somewhere else: the Bit.Butil types the app's own
-assemblies reference (`BitButilScriptScan`), and the modules its csproj names outright
+assemblies reference (`BitButilScriptScan`, which the trimming switch turns on by itself), and the modules
+its csproj names outright
 (`BitButilScriptModule`). These check that the somewhere else arrives at the same place. Untrimmed runs only,
 since the map is a question about the library as shipped rather than about what one app's trimming left.
 
@@ -167,12 +168,15 @@ is allowed to use, that a csproj list is *added* to what the others found rather
 assets removed from the build list are also removed from the publish list, and that a name meaning nothing
 fails the build. So these publish a real consumer app - a two-class web app next door, published in seconds
 rather than the minutes a WebAssembly one takes - and read the JavaScript back out of its publish output.
-Nine `dotnet publish` runs, about fifteen seconds in total, untrimmed runs only:
+Ten `dotnet publish` runs, about fifteen seconds in total, untrimmed runs only:
 
 - with **no signal at all** the full bundle is published - the case that has to keep working for every
-  consumer who never asked for any of this;
+  consumer who never asked for any of this. Reached by setting `BitButilScriptScan=None`, since the switch
+  brings the scan with it;
+- the **switch on its own** - `BitButilTrimScripts=true` and no scan mode named beside it - scans the app and
+  reaches the same answer the explicit `TypeReferences` below does, which is what makes one property enough;
 - a **scan** trims the bundle to the modules the fixture's two classes need; `TypeNames` finds at least those;
-- a **csproj module list** trims it on its own, with no scan and no ILLink;
+- a **csproj module list** trims it on its own, with the scan turned off and no ILLink;
 - a csproj list **plus** a scan produces the union of the two, which is the whole meaning of "additive";
 - **lazy scripts** publish one file per reachable module and no bundle at all;
 - `BitButilTrimScripts=false` publishes the full bundle even when given a scan and a list to work from;

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
@@ -168,7 +168,7 @@ is allowed to use, that a csproj list is *added* to what the others found rather
 assets removed from the build list are also removed from the publish list, and that a name meaning nothing
 fails the build. So these publish a real consumer app - a two-class web app next door, published in seconds
 rather than the minutes a WebAssembly one takes - and read the JavaScript back out of its publish output.
-Ten `dotnet publish` runs, about fifteen seconds in total, untrimmed runs only:
+Eleven `dotnet publish` runs and one `dotnet msbuild`, about fifteen seconds in total, untrimmed runs only:
 
 - with **no signal at all** the full bundle is published - the case that has to keep working for every
   consumer who never asked for any of this. Reached by setting `BitButilScriptScan=None`, since the switch
@@ -180,8 +180,18 @@ Ten `dotnet publish` runs, about fifteen seconds in total, untrimmed runs only:
 - a csproj list **plus** a scan produces the union of the two, which is the whole meaning of "additive";
 - **lazy scripts** publish one file per reachable module and no bundle at all;
 - `BitButilTrimScripts=false` publishes the full bundle even when given a scan and a list to work from;
+- a project that **does not publish an app's static web assets** - a Razor class library, a hybrid head, the
+  shape a shared `Directory.Build.props` reaches by accident - leaves the JavaScript alone, because its
+  reference closure is not the app's. The fixture stands in for one by unsetting the two things the SDK sets
+  on a project that does publish an app;
 - a **misspelled module name**, and a **scan mode that is not one of the three**, each fail the publish with
   the error naming what was wrong.
+
+The `dotnet msbuild` run is the twelfth, and it is not a publish: it drives the two trimming targets by name
+so they land in a project instance where nothing else has run, which is the position the SDK puts them in on
+a referenced project. The untrimmed `Bit.Butil.dll` has to resolve there too - `@(ReferenceCopyLocalPaths)`
+is only populated because the target names `ResolveReferences` itself - and the scan reporting what it read
+is the assertion.
 
 Every bundle assertion reads the published file and asks which chunk guards are in it - the same thing the
 browser would find - rather than comparing byte counts. Each scenario also asserts the per-module files:

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
@@ -62,10 +62,18 @@ internal static class ScriptPublishing
     private static Scenario[] Scenarios =>
     [
         // Nothing to trim against. The one that has to keep working: a consumer who never asked for any of
-        // this must publish the whole bundle, not an empty one.
+        // this must publish the whole bundle, not an empty one. Reached here by turning the scan off, since
+        // the switch this fixture leaves on brings the scan with it - which is the next scenario.
         new("with no signal at all the full bundle is published",
-            [],
+            ["BitButilScriptScan=None"],
             FullBundle: true),
+
+        // The switch on its own, which is what an app actually writes: BitButilTrimScripts=true (set by this
+        // fixture's csproj, and the default in a WebAssembly project) has to be enough, with no scan mode
+        // named beside it - the same answer as the explicit TypeReferences below.
+        new("the trimming switch alone scans the app, with no scan mode set",
+            [],
+            Bundle: Scanned),
 
         // Option 2/3: the app's own assemblies, for a publish ILLink never touched.
         new("a scan of the app's own assemblies trims the bundle to what its classes need",
@@ -81,9 +89,10 @@ internal static class ScriptPublishing
             BundleIsMinimum: true),
 
         // Option 1 alone: no ILLink, no scan, just a csproj. The whole point of it being a signal in its own
-        // right rather than an addition to one.
+        // right rather than an addition to one - so the scan the switch defaults to is turned off to isolate
+        // it, and what comes out is the csproj's module and nothing else.
         new("a csproj module list is a signal on its own",
-            ["FixtureScriptModules=Cookie"],
+            ["BitButilScriptScan=None", "FixtureScriptModules=Cookie"],
             Bundle: ["butil", "cookie"]),
 
         // Option 1 on top of option 3 - the thing that has to be additive rather than either/or.
@@ -99,6 +108,15 @@ internal static class ScriptPublishing
         // Turning the feature off has to survive being given something to trim against.
         new("BitButilTrimScripts=false publishes the full bundle whatever else is set",
             ["BitButilTrimScripts=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
+            FullBundle: true),
+
+        // The properties in a shared Directory.Build.props reach every project in the solution, and the ones
+        // that do not publish the app's static web assets - a Razor class library, a MAUI/Blazor Hybrid head -
+        // must leave the JavaScript alone: their reference closure is not the app's, so trimming against it
+        // would hand the head a bundle short of the modules only the head names. StaticWebAssetProjectMode is
+        // what the gate reads, and forcing it here is the fixture standing in for such a project.
+        new("a project that does not publish the app's static web assets does not trim",
+            ["StaticWebAssetProjectMode=Default", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
             FullBundle: true),
 
         // MSBuild accepts a misspelled item without a word, so the build is the only thing that can say so.
@@ -149,7 +167,48 @@ internal static class ScriptPublishing
             CheckModules(checks, candidate, Path.Combine(output, ContentPath, "modules"), manifest);
         }
 
+        CheckReferencedPublishStage(checks, fixtureProject);
+
         return (checks.Passed, checks.Failed);
+    }
+
+    /// <summary>
+    /// The publish asset stage reached the way the SDK reaches it on a REFERENCED project, rather than the
+    /// way a publish of this project does.
+    /// </summary>
+    /// <remarks>
+    /// ResolvePublishStaticWebAssets is not the publish-only stage its name suggests. The SDK also runs it on
+    /// referenced projects, through ComputeReferencedStaticWebAssetsPublishManifest, and a head that packages
+    /// its wwwroot at build time reaches it during a plain build. Either way it can land in a project instance
+    /// where only that target chain has run - a MSBuild call carrying global properties of its own forks a
+    /// fresh instance - and ResolveReferences is not part of that chain. @(ReferenceCopyLocalPaths) is then
+    /// empty, and the trimming, which reads the untrimmed Bit.Butil.dll out of it to know which module each
+    /// class needs, used to fail the build with "'' could not be read" and no way out but switching the
+    /// feature off.
+    /// <br/>
+    /// Invoking the target by name is what puts the stage in that position; a `dotnet publish` cannot, because
+    /// by then ResolveReferences has long since run. Only the Bit.Butil error is asserted on, not the exit
+    /// code: driving one internal SDK target straight at a project whose Bit.Butil is a ProjectReference walks
+    /// the library's own asset pipeline down a path no consumer takes, and its noise is not this claim.
+    /// </remarks>
+    private static void CheckReferencedPublishStage(ScriptBundling.Checks checks, string fixtureProject)
+    {
+        const string Claim = "the publish asset stage resolves Bit.Butil.dll when a referencing project drives it";
+
+        string[] arguments =
+        [
+            "msbuild", fixtureProject, "-t:ComputeReferencedStaticWebAssetsPublishManifest",
+            "--nologo", "-v:quiet", "-tl:off", "-p:BitButilScriptScan=TypeReferences",
+        ];
+
+        if (Run(arguments, out var log, out _) is false)
+        {
+            checks.That(false, $"{Claim} was not checked", log);
+            return;
+        }
+
+        checks.That(log.Contains("could not be read", StringComparison.Ordinal) is false, Claim,
+            $"the untrimmed assembly did not resolve: {FirstError(log)}");
     }
 
     /// <summary>
@@ -216,9 +275,15 @@ internal static class ScriptPublishing
     /// </summary>
     private static string Guard(string module) => $"window.BitButil.{(module == "butil" ? "version" : module)}";
 
-    private static bool Publish(ScriptBundling.Checks checks, string project, string output, Scenario scenario, out string log)
+    /// <summary>
+    /// Runs <c>dotnet</c> with the arguments given. False when it could not be started or did not finish, and
+    /// <paramref name="log"/> then says which rather than carrying output; true with the combined output and
+    /// the exit code, whatever that was - a run that failed is an outcome for the caller to read, not an
+    /// error here.
+    /// </summary>
+    private static bool Run(string[] arguments, out string log, out int exitCode)
     {
-        log = string.Empty;
+        exitCode = 0;
 
         var process = new Process
         {
@@ -230,12 +295,7 @@ internal static class ScriptPublishing
             }
         };
 
-        foreach (var argument in new[] { "publish", project, "-c", "Debug", "--nologo", "-v", "quiet", "-tl:off", "-o", output })
-        {
-            process.StartInfo.ArgumentList.Add(argument);
-        }
-
-        foreach (var property in scenario.Properties) process.StartInfo.ArgumentList.Add($"-p:{property}");
+        foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
 
         try
         {
@@ -243,7 +303,7 @@ internal static class ScriptPublishing
         }
         catch (Exception exception)
         {
-            checks.That(false, $"{scenario.Name} was not checked", $"dotnet could not be started ({exception.Message})");
+            log = $"dotnet could not be started ({exception.Message})";
             return false;
         }
 
@@ -255,12 +315,31 @@ internal static class ScriptPublishing
         if (process.WaitForExit((int)PublishTimeout.TotalMilliseconds) is false)
         {
             try { process.Kill(entireProcessTree: true); } catch { /* it is already gone, which is the outcome wanted */ }
-            checks.That(false, $"{scenario.Name} was not checked", $"the publish did not finish within {PublishTimeout.TotalMinutes:N0} minutes");
+            log = $"it did not finish within {PublishTimeout.TotalMinutes:N0} minutes";
             return false;
         }
 
         log = standardOutput.Result + standardError.Result;
-        var failed = process.ExitCode != 0;
+        exitCode = process.ExitCode;
+        return true;
+    }
+
+    private static bool Publish(ScriptBundling.Checks checks, string project, string output, Scenario scenario, out string log)
+    {
+        string[] arguments =
+        [
+            "publish", project, "-c", "Debug", "--nologo", "-v", "quiet", "-tl:off", "-o", output,
+            .. scenario.Properties.Select(property => $"-p:{property}"),
+        ];
+
+        if (Run(arguments, out log, out var exitCode) is false)
+        {
+            checks.That(false, $"{scenario.Name} was not checked", log);
+            log = string.Empty;
+            return false;
+        }
+
+        var failed = exitCode != 0;
 
         if (scenario.Error is not null)
         {

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
@@ -113,10 +113,15 @@ internal static class ScriptPublishing
         // The properties in a shared Directory.Build.props reach every project in the solution, and the ones
         // that do not publish the app's static web assets - a Razor class library, a MAUI/Blazor Hybrid head -
         // must leave the JavaScript alone: their reference closure is not the app's, so trimming against it
-        // would hand the head a bundle short of the modules only the head names. StaticWebAssetProjectMode is
-        // what the gate reads, and forcing it here is the fixture standing in for such a project.
+        // would hand the head a bundle short of the modules only the head names.
+        //
+        // The gate reads both halves of what the SDK says about a project, so both are forced here: Root is
+        // the .NET 10 Web SDK's StaticWebAssetProjectMode (the .NET 8 and 9 Web SDKs leave a head at
+        // 'Default', which is why the marker below is read as well), and UsingMicrosoftNETSdkWeb is what
+        // says a Web SDK was loaded at all. A class library sets neither, and this fixture - a Web SDK app -
+        // stands in for one by unsetting both.
         new("a project that does not publish the app's static web assets does not trim",
-            ["StaticWebAssetProjectMode=Default", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
+            ["StaticWebAssetProjectMode=Default", "UsingMicrosoftNETSdkWeb=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
             FullBundle: true),
 
         // MSBuild accepts a misspelled item without a word, so the build is the only thing that can say so.
@@ -173,8 +178,8 @@ internal static class ScriptPublishing
     }
 
     /// <summary>
-    /// The publish asset stage reached the way the SDK reaches it on a REFERENCED project, rather than the
-    /// way a publish of this project does.
+    /// The trimming stage reached from a project instance where only its own target chain has run, rather
+    /// than the way a publish of this project reaches it.
     /// </summary>
     /// <remarks>
     /// ResolvePublishStaticWebAssets is not the publish-only stage its name suggests. The SDK also runs it on
@@ -184,31 +189,41 @@ internal static class ScriptPublishing
     /// fresh instance - and ResolveReferences is not part of that chain. @(ReferenceCopyLocalPaths) is then
     /// empty, and the trimming, which reads the untrimmed Bit.Butil.dll out of it to know which module each
     /// class needs, used to fail the build with "'' could not be read" and no way out but switching the
-    /// feature off.
+    /// feature off. _BitButilAssembleTrimmedBundle naming ResolveReferences in its DependsOnTargets is the
+    /// fix, and this is what holds it there.
     /// <br/>
-    /// Invoking the target by name is what puts the stage in that position; a `dotnet publish` cannot, because
-    /// by then ResolveReferences has long since run. Only the Bit.Butil error is asserted on, not the exit
-    /// code: driving one internal SDK target straight at a project whose Bit.Butil is a ProjectReference walks
-    /// the library's own asset pipeline down a path no consumer takes, and its noise is not this claim.
+    /// The two Butil targets are driven by name, in order, which is what puts them in that position - a
+    /// `dotnet publish` cannot, because by then ResolveReferences has long since run. In order because
+    /// MSBuild evaluates a target's own Condition before building its DependsOnTargets, so the gate
+    /// _BitButilResolveScriptTrimming sets has to be set by a previous entry in the target list rather than
+    /// by a dependency. Driving the SDK's own ComputeReferencedStaticWebAssetsPublishManifest instead would
+    /// walk Bit.Butil's asset pipeline down a path no consumer takes and die there, before any of this runs.
+    /// <br/>
+    /// Lazy scripts, because in an instance this bare there is no @(StaticWebAsset) to find a bundle among,
+    /// and the per-module half of the trimming is the half that still has work to do without one. The claim
+    /// is asserted positively - the scan's own line, which it only ever writes having read that assembly -
+    /// so that a stage that stood down, or never ran, fails rather than passing by saying nothing.
     /// </remarks>
     private static void CheckReferencedPublishStage(ScriptBundling.Checks checks, string fixtureProject)
     {
-        const string Claim = "the publish asset stage resolves Bit.Butil.dll when a referencing project drives it";
+        const string Claim = "the trimming stage resolves Bit.Butil.dll when only its own targets have run";
 
         string[] arguments =
         [
-            "msbuild", fixtureProject, "-t:ComputeReferencedStaticWebAssetsPublishManifest",
-            "--nologo", "-v:quiet", "-tl:off", "-p:BitButilScriptScan=TypeReferences",
+            "msbuild", fixtureProject, "-t:_BitButilResolveScriptTrimming", "-t:_BitButilAssembleTrimmedBundle",
+            "--nologo", "-v:normal", "-tl:off", "-p:BitButilScriptScan=TypeReferences", "-p:BitButilLazyScripts=true",
         ];
 
-        if (Run(arguments, out var log, out _) is false)
+        if (Run(arguments, out var log, out var exitCode) is false)
         {
             checks.That(false, $"{Claim} was not checked", log);
             return;
         }
 
-        checks.That(log.Contains("could not be read", StringComparison.Ordinal) is false, Claim,
-            $"the untrimmed assembly did not resolve: {FirstError(log)}");
+        checks.That(exitCode == 0 && log.Contains("referencing Bit.Butil and found", StringComparison.Ordinal), Claim,
+            exitCode == 0
+                ? "the stage ran but the scan never reported reading the app's assemblies, so the untrimmed Bit.Butil.dll did not resolve"
+                : $"the stage failed: {FirstError(log)}");
     }
 
     /// <summary>

--- a/src/Butil/tests/Bit.Butil.Tests.PublishFixture/Bit.Butil.Tests.PublishFixture.csproj
+++ b/src/Butil/tests/Bit.Butil.Tests.PublishFixture/Bit.Butil.Tests.PublishFixture.csproj
@@ -41,7 +41,8 @@
         <BitButilChunksDirectory>$(MSBuildThisFileDirectory)..\..\Bit.Butil\obj\butil-js\chunks\</BitButilChunksDirectory>
         <BitButilBuildTasksAssembly>$(MSBuildThisFileDirectory)..\..\Bit.Butil.Build\bin\$(Configuration)\netstandard2.0\Bit.Butil.Build.dll</BitButilBuildTasksAssembly>
         <!-- Not a WebAssembly project, so the trimming is off by default here; every scenario wants it on and
-             differs in what it is given to trim against. -->
+             differs in what it is given to trim against. On brings BitButilScriptScan=TypeReferences with
+             it, which is why the scenarios that isolate one of the other signals turn the scan off by name. -->
         <BitButilTrimScripts Condition="'$(BitButilTrimScripts)' == ''">true</BitButilTrimScripts>
     </PropertyGroup>
 


### PR DESCRIPTION
closes #13137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive JavaScript trimming documentation, examples, diagnostics, and configuration guidance.
  * Added guidance for troubleshooting publish-only issues and understanding trimming limitations.

* **Enhancements**
  * JavaScript trimming now defaults to reference-based scanning when enabled.
  * Trimming runs only for the project publishing the application’s static web assets.
  * Builds fall back to the full bundle when default scanning cannot resolve the required assembly.

* **Documentation**
  * Updated getting-started, rendering, setup, troubleshooting, README, and publishing guidance to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->