### PR TITLE
Honor `X-Forwarded-Proto` in the websites #13189

### DIFF
--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
@@ -21,16 +21,10 @@ builder.Services.AddMcpServer()
     .WithResourcesFromAssembly()
     .WithPromptsFromAssembly();
 
-// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
-// below answers every request with a redirect to the url it already asked for, and the absolute urls the
-// endpoints build come out as http.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.All;
     options.ForwardedHostHeaderName = "X-Host";
-    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
-    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the
-    // front end appends.
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
     options.ForwardLimit = 1;

--- a/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
+++ b/src/Bmotion/Bit.Bmotion.Demo/Server/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Bmotion.Demo.Server.Components;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,6 +21,21 @@ builder.Services.AddMcpServer()
     .WithResourcesFromAssembly()
     .WithPromptsFromAssembly();
 
+// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
+// below answers every request with a redirect to the url it already asked for, and the absolute urls the
+// endpoints build come out as http.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.All;
+    options.ForwardedHostHeaderName = "X-Host";
+    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
+    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the
+    // front end appends.
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.ForwardLimit = 1;
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -36,6 +52,8 @@ else
 // empty 404. Re-execute it through the app to get the styled page the router shows for the same
 // miss during client-side navigation - keeping the status code at 404.
 app.UseStatusCodePagesWithReExecute("/not-found");
+
+app.UseForwardedHeaders();
 
 app.UseHttpsRedirection();
 

--- a/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
@@ -61,16 +61,10 @@ builder.Services.AddMcpServer(options =>
 // an MCP client as text. Scoped: a renderer belongs to the request that asked for the page.
 builder.Services.AddScoped<HtmlRenderer>();
 
-// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
-// below answers every request with a redirect to the url it already asked for, and the absolute urls the
-// endpoints build come out as http.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.All;
     options.ForwardedHostHeaderName = "X-Host";
-    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
-    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the
-    // front end appends.
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
     options.ForwardLimit = 1;

--- a/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Server/Program.cs
@@ -2,6 +2,7 @@
 using Bit.Brouter.Demo.Server.Controllers;
 using Bit.Brouter.Demo.Server.Services;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.HttpOverrides;
 using ModelContextProtocol.Protocol;
 using System.Text.Json.Serialization;
 
@@ -60,6 +61,21 @@ builder.Services.AddMcpServer(options =>
 // an MCP client as text. Scoped: a renderer belongs to the request that asked for the page.
 builder.Services.AddScoped<HtmlRenderer>();
 
+// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
+// below answers every request with a redirect to the url it already asked for, and the absolute urls the
+// endpoints build come out as http.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.All;
+    options.ForwardedHostHeaderName = "X-Host";
+    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
+    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the
+    // front end appends.
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.ForwardLimit = 1;
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -71,6 +87,8 @@ else
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
     app.UseHsts();
 }
+
+app.UseForwardedHeaders();
 
 app.UseHttpsRedirection();
 app.UseAntiforgery();

--- a/src/Bswup/Bit.Bswup.Demo/Server/Program.cs
+++ b/src/Bswup/Bit.Bswup.Demo/Server/Program.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Threading.RateLimiting;
 using Bit.Bswup.Demo.Client;
 using Bit.Bswup.Demo.Server.Components;
+using Microsoft.AspNetCore.HttpOverrides;
 using Bit.Bswup.Demo.Server.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.ResponseCompression;
@@ -147,6 +148,21 @@ builder.Services.AddResponseCompression(opts =>
     .Configure<BrotliCompressionProviderOptions>(opt => opt.Level = CompressionLevel.Fastest)
     .Configure<GzipCompressionProviderOptions>(opt => opt.Level = CompressionLevel.Fastest);
 
+// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
+// below answers every request with a redirect to the url it already asked for, and the absolute urls the
+// endpoints build come out as http.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.All;
+    options.ForwardedHostHeaderName = "X-Host";
+    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
+    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the
+    // front end appends.
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.ForwardLimit = 1;
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -161,6 +177,8 @@ else
     app.UseHsts();
     app.UseResponseCompression();
 }
+
+app.UseForwardedHeaders();
 
 app.UseHttpsRedirection();
 

--- a/src/Bswup/Bit.Bswup.Demo/Server/Program.cs
+++ b/src/Bswup/Bit.Bswup.Demo/Server/Program.cs
@@ -148,16 +148,10 @@ builder.Services.AddResponseCompression(opts =>
     .Configure<BrotliCompressionProviderOptions>(opt => opt.Level = CompressionLevel.Fastest)
     .Configure<GzipCompressionProviderOptions>(opt => opt.Level = CompressionLevel.Fastest);
 
-// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
-// below answers every request with a redirect to the url it already asked for, and the absolute urls the
-// endpoints build come out as http.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.All;
     options.ForwardedHostHeaderName = "X-Host";
-    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
-    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the
-    // front end appends.
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
     options.ForwardLimit = 1;

--- a/src/Butil/Bit.Butil.Demo/Server/Program.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Program.cs
@@ -101,16 +101,10 @@ builder.Services.AddRateLimiter(options =>
 builder.Services.AddRequestTimeouts(options =>
     options.AddPolicy(StreamingPolicy, new RequestTimeoutPolicy { Timeout = TimeSpan.FromMinutes(5) }));
 
-// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
-// below answers every request with a redirect to the url it already asked for, and the absolute urls
-// Origin() builds for robots.txt, sitemap.xml and llms.txt come out as http.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.All;
     options.ForwardedHostHeaderName = "X-Host";
-    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
-    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the front
-    // end appends - which also decides the rate limiter's partition key above.
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
     options.ForwardLimit = 1;

--- a/src/Butil/Bit.Butil.Demo/Server/Program.cs
+++ b/src/Butil/Bit.Butil.Demo/Server/Program.cs
@@ -5,6 +5,7 @@ using Bit.Butil.Demo.Server.Components;
 using Bit.Butil.Demo.Server.Controllers;
 using Bit.Butil.Demo.Server.Services;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.RateLimiting;
 
@@ -100,6 +101,21 @@ builder.Services.AddRateLimiter(options =>
 builder.Services.AddRequestTimeouts(options =>
     options.AddPolicy(StreamingPolicy, new RequestTimeoutPolicy { Timeout = TimeSpan.FromMinutes(5) }));
 
+// The site is reached through a proxy that forwards over plain http. Without this, UseHttpsRedirection
+// below answers every request with a redirect to the url it already asked for, and the absolute urls
+// Origin() builds for robots.txt, sitemap.xml and llms.txt come out as http.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.All;
+    options.ForwardedHostHeaderName = "X-Host";
+    // The proxy is not on loopback, so the default trust lists would ignore the headers outright. A
+    // ForwardLimit of 1 is what keeps a client's own entry unreachable, to the left of the one the front
+    // end appends - which also decides the rate limiter's partition key above.
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.ForwardLimit = 1;
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -116,6 +132,8 @@ else
 // empty 404. Re-execute it through the app to get the styled page the router shows for the same
 // miss during client-side navigation - keeping the status code at 404.
 app.UseStatusCodePagesWithReExecute("/not-found");
+
+app.UseForwardedHeaders();
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
Closes #13189.

The four library demo servers call `UseHttpsRedirection` without ever reading the forwarded headers, so behind a proxy that forwards over plain http they answer every request with a 307 to the url just requested. One commit, the same change in each:

```csharp
builder.Services.Configure<ForwardedHeadersOptions>(options =>
{
    options.ForwardedHeaders = ForwardedHeaders.All;
    options.ForwardedHostHeaderName = "X-Host";
    options.KnownIPNetworks.Clear();
    options.KnownProxies.Clear();
    options.ForwardLimit = 1;
});
```

```csharp
app.UseForwardedHeaders();

app.UseHttpsRedirection();
```

Configured exactly the way `Bit.Websites.Platform.Server` already does it, including the reasoning for clearing the trust lists: the proxy is not on loopback, and `ForwardLimit` of 1 means only the entry the front end appends is ever read, so a client's own stays to its left and unreachable. That also decides the rate limiter's partition key in the Butil and Bswup demos, which key on `RemoteIpAddress`.

It fixes a second, quieter symptom too: `Request.Scheme` is what these apps build their own absolute urls from, so Butil's `robots.txt`, `sitemap.xml` and `llms.txt` were naming an `http://` origin.

- `Bit.BlazorUI.Demo.Server` is untouched - it does not redirect to https.
- **Verified** by building all four demo servers: 0 errors each. Not run against the live sites, which need this deployed.

Once this is published, the `ASPNETCORE_FORWARDEDHEADERS_ENABLED` entries currently patched into those four sites' `web.config` on the demo host can come out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved behavior when demo sites are accessed through a reverse proxy.
  - HTTPS redirects now correctly reflect the public site address.
  - Generated links and metadata URLs, including sitemap and robots resources, now use the correct public origin instead of an internal server address.
  - Proxy-forwarded request details are handled consistently across the affected demo applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->