### PR TITLE
Add safe methods to IBrouter (#13202)

### DIFF
--- a/src/Brouter/Bit.Brouter.Demo/Client/DocsCatalog.cs
+++ b/src/Brouter/Bit.Brouter.Demo/Client/DocsCatalog.cs
@@ -66,7 +66,7 @@ public static class DocsCatalog
         [
             new("navigation", "Navigation & history",
                 "Programmatic navigation with awaited outcomes, history entry state, query updates, named routes and BrouterLink.",
-                "navigate NavigateAsync outcome back forward history state NavigateWithQuery named routes relative BrouterLink",
+                "navigate NavigateAsync outcome back forward history state NavigateWithQuery named routes relative BrouterLink IsMounted mounted TryNavigate Try safe",
                 typeof(NavigationPage)),
             new("guards", "Guards & navigation locks",
                 "Enter guards, preventive leave guards, component-level locks with custom dialogs, redirects and global hooks.",

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/ApiPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/ApiPage.razor
@@ -130,6 +130,7 @@
         <thead><tr><th>Member</th><th>Notes</th></tr></thead>
         <tbody>
             <tr><td>Location</td><td><code>BrouterLocation</code> for the current URL. Never null.</td></tr>
+            <tr><td>IsMounted</td><td>Whether a <code>&lt;Brouter&gt;</code> is mounted in this scope. While it's false the members below that act on the router throw - except <code>ClearLoaderCache</code> and <code>SetConfirmExternalNavigationAsync</code>, which never need one.</td></tr>
             <tr><td>Navigate(url, replace, forceLoad, historyState)</td><td>Fire-and-forget. <code>forceLoad</code> does a full document load and skips the pipeline entirely.</td></tr>
             <tr><td>NavigateAsync(url, replace, historyState)</td><td>Awaits the whole pipeline and returns a <code>BrouterNavigationOutcome</code>. No <code>forceLoad</code> - nothing would survive to resolve the task.</td></tr>
             <tr><td>Back() / BackAsync(delta = 1)</td><td>Move back; the async form is awaitable and can jump several entries.</td></tr>
@@ -144,6 +145,7 @@
             <tr><td>ClearKeepAlive()</td><td>Disposes every retained keep-alive component. The visible page keeps its instance.</td></tr>
             <tr><td>ClearKeepAlive(includeActive)</td><td>With <code>includeActive: true</code> the page on screen is disposed and rebuilt in place too - fresh instance, no navigation, no guards or loaders re-run.</td></tr>
             <tr><td>SetConfirmExternalNavigationAsync(enabled)</td><td>Arms/disarms the browser's "leave site?" dialog at runtime. Idempotent.</td></tr>
+            <tr><td>TryNavigate, TryNavigateAsync, TryBack(Async), TryForward(Async), TryNavigateToName, TryResolveUrl, TryNavigateWithQuery, TryRevalidateAsync, TryReloadAsync, TryPreloadAsync, TryClearKeepAlive</td><td>Safe counterparts for when the router may not be mounted: they do nothing and return <code>false</code> (<code>TryNavigateAsync</code>: <code>null</code>) instead of throwing. Once mounted they behave exactly like the originals, argument errors included.</td></tr>
         </tbody>
     </table>
 </div>

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/ApiPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/ApiPage.razor
@@ -130,7 +130,7 @@
         <thead><tr><th>Member</th><th>Notes</th></tr></thead>
         <tbody>
             <tr><td>Location</td><td><code>BrouterLocation</code> for the current URL. Never null.</td></tr>
-            <tr><td>IsMounted</td><td>Whether a <code>&lt;Brouter&gt;</code> is mounted in this scope. While it's false the members below that act on the router throw - except <code>ClearLoaderCache</code> and <code>SetConfirmExternalNavigationAsync</code>, which never need one.</td></tr>
+            <tr><td>IsMounted</td><td>Whether a <code>&lt;Brouter&gt;</code> is mounted in this scope. While it's false the non-<code>Try...</code> members below that act on the router throw - except <code>ClearLoaderCache</code> and <code>SetConfirmExternalNavigationAsync</code>, which never need one. The <code>Try...</code> members don't throw: they return <code>false</code> (<code>TryNavigateAsync</code>: <code>null</code>), and <code>TryResolveUrl</code> sets its <code>url</code> to <code>null</code>.</td></tr>
             <tr><td>Navigate(url, replace, forceLoad, historyState)</td><td>Fire-and-forget. <code>forceLoad</code> does a full document load and skips the pipeline entirely.</td></tr>
             <tr><td>NavigateAsync(url, replace, historyState)</td><td>Awaits the whole pipeline and returns a <code>BrouterNavigationOutcome</code>. No <code>forceLoad</code> - nothing would survive to resolve the task.</td></tr>
             <tr><td>Back() / BackAsync(delta = 1)</td><td>Move back; the async form is awaitable and can jump several entries.</td></tr>

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/NavigationPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/NavigationPage.razor
@@ -103,12 +103,13 @@ brouter.NavigateWithQuery(q =&gt; q.SetAll(<span class="s">"tag"</span>, tags).R
         - before the router initializes, after it's disposed, or in a scope that never renders one.
         Code that can't be sure (a scoped service reacting to an event, a teardown path) checks
         <code>IsMounted</code> or calls the <code>Try...</code> counterpart, which skips the call and
-        returns <code>false</code> instead. Only the mount state is forgiven: once mounted, a
+        returns <code>false</code> instead (<code>TryNavigateAsync</code> returns <code>null</code>, and
+        <code>TryResolveUrl</code> sets its <code>url</code> to <code>null</code>). Only the mount state is forgiven: once mounted, a
         <code>Try...</code> call is the original, so an unknown route name still throws.
     </p>
     <pre class="bb-code">brouter.TryNavigate(<span class="s">"/login"</span>);                          <span class="c">// false when nothing is mounted</span>
 <span class="k">var</span> outcome = <span class="k">await</span> brouter.TryNavigateAsync(<span class="s">"/admin"</span>); <span class="c">// null when nothing is mounted</span>
-<span class="k">if</span> (brouter.TryResolveUrl(<span class="s">"user"</span>, <span class="k">out var</span> url, parameters)) { … }</pre>
+<span class="k">if</span> (brouter.TryResolveUrl(<span class="s">"user"</span>, <span class="k">out var</span> url, <span class="k">new</span> Dictionary&lt;<span class="k">string</span>, <span class="k">object</span>?&gt; { [<span class="s">"id"</span>] = 42 })) { … }</pre>
 </div>
 
 <div class="bb-card">

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/NavigationPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/NavigationPage.razor
@@ -97,6 +97,21 @@ brouter.NavigateWithQuery(q =&gt; q.SetAll(<span class="s">"tag"</span>, tags).R
 </div>
 
 <div class="bb-card">
+    <h3 class="bb-card-title"><span class="bb-dot bb-dot-primary"></span> When the router may not be mounted</h3>
+    <p class="bb-card-desc">
+        Everything above acts on the mounted <code>&lt;Brouter&gt;</code>, so it throws while none is
+        - before the router initializes, after it's disposed, or in a scope that never renders one.
+        Code that can't be sure (a scoped service reacting to an event, a teardown path) checks
+        <code>IsMounted</code> or calls the <code>Try...</code> counterpart, which skips the call and
+        returns <code>false</code> instead. Only the mount state is forgiven: once mounted, a
+        <code>Try...</code> call is the original, so an unknown route name still throws.
+    </p>
+    <pre class="bb-code">brouter.TryNavigate(<span class="s">"/login"</span>);                          <span class="c">// false when nothing is mounted</span>
+<span class="k">var</span> outcome = <span class="k">await</span> brouter.TryNavigateAsync(<span class="s">"/admin"</span>); <span class="c">// null when nothing is mounted</span>
+<span class="k">if</span> (brouter.TryResolveUrl(<span class="s">"user"</span>, <span class="k">out var</span> url, parameters)) { … }</pre>
+</div>
+
+<div class="bb-card">
     <h3 class="bb-card-title"><span class="bb-dot bb-dot-success"></span> BrouterLink</h3>
     <p class="bb-card-desc">
         <code>&lt;BrouterLink&gt;</code> renders a real anchor - Ctrl/middle/Shift clicks keep

--- a/src/Brouter/Bit.Brouter/Navigation/BrouterService.cs
+++ b/src/Brouter/Bit.Brouter/Navigation/BrouterService.cs
@@ -89,6 +89,10 @@ internal sealed class BrouterService : IBrouter, IAsyncDisposable
 
     public BrouterLocation Location => _activeBrouter?.CurrentLocation ?? BrouterLocation.Empty;
 
+    // The IBrouter Try... members check this and fall back to a no-op; everything else goes
+    // through EnsureMounted and throws.
+    public bool IsMounted => _activeBrouter is not null && _navigationManager is not null;
+
     public void Navigate(string url, bool replace = false, bool forceLoad = false, string? historyState = null)
     {
         EnsureMounted();
@@ -578,8 +582,10 @@ internal sealed class BrouterService : IBrouter, IAsyncDisposable
 
     private void EnsureMounted()
     {
-        if (_activeBrouter is null || _navigationManager is null)
-            throw new InvalidOperationException("No Brouter is currently mounted.");
+        if (IsMounted is false)
+            throw new InvalidOperationException(
+                $"No Brouter is currently mounted. Check {nameof(IBrouter)}.{nameof(IsMounted)}, or use the " +
+                $"Try... counterpart of this member (e.g. {nameof(IBrouter.TryNavigate)}) to skip the call when no router is mounted.");
     }
 
     // Internal (not private): BrouterQueryBuilder formats query values with the identical rules so

--- a/src/Brouter/Bit.Brouter/Navigation/IBrouter.cs
+++ b/src/Brouter/Bit.Brouter/Navigation/IBrouter.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace Bit.Brouter;
 
@@ -10,6 +11,24 @@ public interface IBrouter
 {
     /// <summary>The current parsed location. Always non-null; defaults to <see cref="BrouterLocation.Empty"/> before mount.</summary>
     BrouterLocation Location { get; }
+
+    /// <summary>
+    /// Whether a <see cref="Brouter"/> is currently mounted in this scope, i.e. whether the members
+    /// that act on the router can run. It is <see langword="false"/> before the router initializes
+    /// (e.g. for a service or a component that runs ahead of it), after it has been disposed, and in a
+    /// scope that never renders one. While it is <see langword="false"/> those members throw
+    /// <see cref="InvalidOperationException"/>; each has a <c>Try...</c> counterpart
+    /// (<see cref="TryNavigate"/>, <see cref="TryBackAsync"/>, <see cref="TryResolveUrl"/>, ...) that
+    /// checks this first and returns <see langword="false"/> - doing nothing - instead.
+    /// <see cref="ClearLoaderCache"/> and <see cref="SetConfirmExternalNavigationAsync"/> never
+    /// need a mounted router.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation returns <see langword="true"/>: a custom implementation without a notion
+    /// of mounting is assumed to always serve its members. The shipped <see cref="IBrouter"/> service
+    /// reports the real state.
+    /// </remarks>
+    bool IsMounted => true;
 
     /// <summary>
     /// Imperatively navigate to a URL.
@@ -273,6 +292,151 @@ public interface IBrouter
         throw new NotSupportedException(
             $"This {nameof(IBrouter)} implementation does not support {nameof(SetConfirmExternalNavigationAsync)}. " +
             "Override the method on your custom implementation to enable external-navigation confirmation.");
+
+    // The Try... counterparts below are for call sites that can't be sure a <Brouter/> is mounted -
+    // a service reacting to an event, a component that may outlive or precede the router, a teardown
+    // path. Each one is a no-op returning false (or null) while IsMounted is false and otherwise
+    // behaves exactly like its throwing counterpart, including any exception about the arguments
+    // (a negative delta, an unknown route name, a missing route parameter): only the router's mount
+    // state is tolerated, never a bad call.
+
+    /// <summary>
+    /// <see cref="Navigate"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise does
+    /// nothing. Returns whether the navigation was triggered.
+    /// </summary>
+    bool TryNavigate(string url, bool replace = false, bool forceLoad = false, string? historyState = null)
+    {
+        if (IsMounted is false) return false;
+        Navigate(url, replace, forceLoad, historyState);
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="NavigateAsync"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise
+    /// does nothing and resolves with <see langword="null"/> instead of an outcome.
+    /// </summary>
+    ValueTask<BrouterNavigationOutcome?> TryNavigateAsync(string url, bool replace = false, string? historyState = null) =>
+        IsMounted ? AsNullable(NavigateAsync(url, replace, historyState)) : new((BrouterNavigationOutcome?)null);
+
+    /// <summary>
+    /// <see cref="Back"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise does
+    /// nothing. Returns whether the traversal was triggered.
+    /// </summary>
+    bool TryBack()
+    {
+        if (IsMounted is false) return false;
+        Back();
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="BackAsync"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise does
+    /// nothing. Resolves with whether the traversal was performed.
+    /// </summary>
+    ValueTask<bool> TryBackAsync(int delta = 1) => IsMounted ? AsTrue(BackAsync(delta)) : new(false);
+
+    /// <summary>
+    /// <see cref="Forward"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise does
+    /// nothing. Returns whether the traversal was triggered.
+    /// </summary>
+    bool TryForward()
+    {
+        if (IsMounted is false) return false;
+        Forward();
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="ForwardAsync"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise
+    /// does nothing. Resolves with whether the traversal was performed.
+    /// </summary>
+    ValueTask<bool> TryForwardAsync(int delta = 1) => IsMounted ? AsTrue(ForwardAsync(delta)) : new(false);
+
+    /// <summary>
+    /// <see cref="NavigateToName"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise
+    /// does nothing. Returns whether the navigation was triggered.
+    /// </summary>
+    bool TryNavigateToName(string name, IReadOnlyDictionary<string, object?>? parameters = null,
+                           string? query = null, bool replace = false, string? historyState = null)
+    {
+        if (IsMounted is false) return false;
+        NavigateToName(name, parameters, query, replace, historyState);
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="ResolveUrl"/> when a router is mounted (see <see cref="IsMounted"/>). Returns
+    /// <see langword="false"/> with a <see langword="null"/> <paramref name="url"/> when none is -
+    /// named routes are registered by the mounted router, so there is nothing to resolve against.
+    /// </summary>
+    bool TryResolveUrl(string name, [NotNullWhen(true)] out string? url,
+                       IReadOnlyDictionary<string, object?>? parameters = null, string? query = null)
+    {
+        url = IsMounted ? ResolveUrl(name, parameters, query) : null;
+        return url is not null;
+    }
+
+    /// <summary>
+    /// <see cref="NavigateWithQuery"/> when a router is mounted (see <see cref="IsMounted"/>);
+    /// otherwise does nothing and never invokes <paramref name="mutate"/>. Returns whether the
+    /// navigation was triggered.
+    /// </summary>
+    bool TryNavigateWithQuery(Action<BrouterQueryBuilder> mutate, bool replace = true)
+    {
+        if (IsMounted is false) return false;
+        NavigateWithQuery(mutate, replace);
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="RevalidateAsync"/> when a router is mounted (see <see cref="IsMounted"/>);
+    /// otherwise does nothing. Resolves with whether the revalidation ran.
+    /// </summary>
+    ValueTask<bool> TryRevalidateAsync() => IsMounted ? AsTrue(RevalidateAsync()) : new(false);
+
+    /// <summary>
+    /// <see cref="ReloadAsync"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise
+    /// does nothing. Resolves with whether the reload was requested - a reload the mounted router
+    /// itself declines (a navigation in flight, nothing committed) still resolves with <see langword="true"/>.
+    /// </summary>
+    ValueTask<bool> TryReloadAsync() => IsMounted ? AsTrue(ReloadAsync()) : new(false);
+
+    /// <summary>
+    /// <see cref="PreloadAsync"/> when a router is mounted (see <see cref="IsMounted"/>); otherwise
+    /// does nothing. Resolves with whether the preload ran.
+    /// </summary>
+    ValueTask<bool> TryPreloadAsync(string url) => IsMounted ? AsTrue(PreloadAsync(url)) : new(false);
+
+    /// <summary>
+    /// <see cref="ClearKeepAlive()"/> when a router is mounted (see <see cref="IsMounted"/>);
+    /// otherwise does nothing - with no router there is nothing retained. Returns whether the
+    /// eviction ran.
+    /// </summary>
+    bool TryClearKeepAlive()
+    {
+        if (IsMounted is false) return false;
+        ClearKeepAlive();
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="ClearKeepAlive(bool)"/> when a router is mounted (see <see cref="IsMounted"/>);
+    /// otherwise does nothing. Returns whether the eviction ran.
+    /// </summary>
+    bool TryClearKeepAlive(bool includeActive)
+    {
+        if (IsMounted is false) return false;
+        ClearKeepAlive(includeActive);
+        return true;
+    }
+
+    private static async ValueTask<bool> AsTrue(ValueTask task)
+    {
+        await task;
+        return true;
+    }
+
+    private static async ValueTask<BrouterNavigationOutcome?> AsNullable(ValueTask<BrouterNavigationOutcome> task) => await task;
 
     /// <summary>Async hook fired before any navigation. Inspect/cancel/redirect via the context.</summary>
     event Func<BrouterNavigationContext, ValueTask>? OnNavigating;

--- a/src/Brouter/Bit.Brouter/Navigation/IBrouter.cs
+++ b/src/Brouter/Bit.Brouter/Navigation/IBrouter.cs
@@ -26,7 +26,9 @@ public interface IBrouter
     /// <remarks>
     /// Default implementation returns <see langword="true"/>: a custom implementation without a notion
     /// of mounting is assumed to always serve its members. The shipped <see cref="IBrouter"/> service
-    /// reports the real state.
+    /// reports the real state. A decorator that wraps another <see cref="IBrouter"/> must forward this
+    /// member to the inner instance; otherwise it keeps this default, and its <c>Try...</c> members
+    /// call straight through and throw while the wrapped router isn't mounted.
     /// </remarks>
     bool IsMounted => true;
 

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -137,7 +137,7 @@ code can be exercised in each render mode.
 - **Type-safe `BrouterRouteParameters`** with `TryGet<T>` / `Get<T>` / `GetOrDefault<T>`
 - **Auto-binding** to plain `[Parameter]` properties by name (Blazor-style) and `[SupplyParameterFromQuery]` for query values, plus two opt-in Brouter attributes that extend the built-in tools: `[BrouterParameter(Name = ...)]` remaps a route parameter to a differently-named property, and `[BrouterQuery]` binds query values of types the framework supplier can't parse (e.g. enums)
 - **`<BrouterLink>`** component with active-class and `aria-current` (NavLink-style)
-- **Programmatic navigation** via `IBrouter`: `Navigate`, `Back`, `NavigateToName`, `ResolveUrl`
+- **Programmatic navigation** via `IBrouter`: `Navigate`, `Back`, `NavigateToName`, `ResolveUrl` - plus `IsMounted` and non-throwing `Try...` counterparts (`TryNavigate`, `TryBackAsync`, `TryResolveUrl`, ...) for call sites that can't be sure a router is mounted
 - **Relative navigation**: `./edit` and `../sibling` resolve against the current location (segment math, React Router style) in `Navigate`, guard redirects and `<BrouterLink>`
 - **Global hooks**: `OnNavigating`, `OnNavigated`, `OnError` (Vue Router style)
 - **Navigation type** on `BrouterNavigationContext.NavigationType`: distinguishes `Push` / `Replace` / `Pop` (Back/Forward) for scroll-restoration and analytics logic
@@ -549,6 +549,30 @@ re-resolves after every (matched) navigation.
 
 Bare paths without a leading `.` (e.g. `Navigate("sibling")`) are untouched and keep their usual
 base-relative meaning through `NavigationManager`.
+
+### Safe calls when the router may not be mounted
+
+The members that act on the router - `Navigate`, `NavigateAsync`, `Back`/`Forward` (and their
+async forms), `NavigateToName`, `ResolveUrl`, `NavigateWithQuery`, `RevalidateAsync`,
+`ReloadAsync`, `PreloadAsync` and `ClearKeepAlive` - throw `InvalidOperationException` while no
+`<Brouter>` is mounted in the scope: before it initializes, after it is disposed, or in a scope that
+never renders one. When a call site can't be sure (a scoped service reacting to an event, a
+component that may run ahead of or outlive the router, a teardown path), check `IsMounted` or use
+the `Try...` counterpart, which does nothing and returns `false` instead:
+
+```csharp
+brouter.TryNavigate("/login");                           // false: skipped, nothing mounted
+await brouter.TryRevalidateAsync();                      // ValueTask<bool>
+var outcome = await brouter.TryNavigateAsync("/admin");  // null when nothing is mounted
+
+if (brouter.TryResolveUrl("user", out var url, new Dictionary<string, object?> { ["id"] = 42 }))
+    Console.WriteLine(url);                              // "/users/42"
+```
+
+Only the mount state is tolerated: once a router is mounted a `Try...` member behaves exactly like
+its counterpart, so an unknown route name, a missing route parameter or a `delta` below 1 still
+throws. `ClearLoaderCache` and `SetConfirmExternalNavigationAsync` never need a mounted router and
+have no `Try...` form.
 
 ## Navigation type (push / replace / pop)
 

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -558,7 +558,8 @@ async forms), `NavigateToName`, `ResolveUrl`, `NavigateWithQuery`, `RevalidateAs
 `<Brouter>` is mounted in the scope: before it initializes, after it is disposed, or in a scope that
 never renders one. When a call site can't be sure (a scoped service reacting to an event, a
 component that may run ahead of or outlive the router, a teardown path), check `IsMounted` or use
-the `Try...` counterpart, which does nothing and returns `false` instead:
+the `Try...` counterpart, which does nothing and returns `false` instead (`TryNavigateAsync` returns
+`null`, and `TryResolveUrl` sets its `url` to `null`):
 
 ```csharp
 brouter.TryNavigate("/login");                           // false: skipped, nothing mounted

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -575,6 +575,12 @@ its counterpart, so an unknown route name, a missing route parameter or a `delta
 throws. `ClearLoaderCache` and `SetConfirmExternalNavigationAsync` never need a mounted router and
 have no `Try...` form.
 
+The `Try...` members are default interface members built on `IsMounted`, so a custom `IBrouter`
+gets them for free. `IsMounted` itself defaults to `true` (an implementation without a notion of
+mounting is assumed to always serve calls), which means a decorator wrapping another `IBrouter` must
+forward it - `public bool IsMounted => _inner.IsMounted;` - or its `Try...` calls will throw while
+the wrapped router isn't mounted.
+
 ## Navigation type (push / replace / pop)
 
 `BrouterNavigationContext.NavigationType` tells guards, loaders and hooks how the current navigation

--- a/src/Brouter/Tests/Bit.Brouter.Tests/TryMethodsTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/TryMethodsTests.cs
@@ -1,0 +1,175 @@
+﻿using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+[TestClass]
+public class TryMethodsTests : BunitTestContext
+{
+    private (IRenderedComponent<NamedRouteHost> Cut, IBrouter Brouter, BunitNavigationManager Nav) RenderMounted()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/users/1");
+
+        var cut = RenderComponent<NamedRouteHost>(p => p
+            .Add(h => h.Name, "user")
+            .Add(h => h.Path, "/users/{id:int}"));
+
+        return (cut, Services.GetRequiredService<IBrouter>(), nav);
+    }
+
+    [TestMethod]
+    public async Task Try_methods_are_noops_when_no_brouter_is_mounted()
+    {
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("http://localhost/start");
+        var brouter = Services.GetRequiredService<IBrouter>();
+
+        Assert.IsFalse(brouter.IsMounted);
+
+        Assert.IsFalse(brouter.TryNavigate("/elsewhere"));
+        Assert.IsNull(await brouter.TryNavigateAsync("/elsewhere"));
+        Assert.IsFalse(brouter.TryBack());
+        Assert.IsFalse(await brouter.TryBackAsync(2));
+        Assert.IsFalse(brouter.TryForward());
+        Assert.IsFalse(await brouter.TryForwardAsync(2));
+        Assert.IsFalse(brouter.TryNavigateToName("user", new Dictionary<string, object?> { ["id"] = 1 }));
+        Assert.IsFalse(await brouter.TryRevalidateAsync());
+        Assert.IsFalse(await brouter.TryReloadAsync());
+        Assert.IsFalse(await brouter.TryPreloadAsync("/elsewhere"));
+        Assert.IsFalse(brouter.TryClearKeepAlive());
+        Assert.IsFalse(brouter.TryClearKeepAlive(includeActive: true));
+
+        Assert.IsFalse(brouter.TryResolveUrl("user", out var url, new Dictionary<string, object?> { ["id"] = 1 }));
+        Assert.IsNull(url);
+
+        var mutated = false;
+        Assert.IsFalse(brouter.TryNavigateWithQuery(q => { mutated = true; q.Set("page", 2); }));
+        Assert.IsFalse(mutated, "The query mutation must not run when nothing will navigate.");
+
+        Assert.AreEqual("http://localhost/start", nav.Uri);
+    }
+
+    [TestMethod]
+    public void The_throwing_members_still_throw_when_no_brouter_is_mounted()
+    {
+        var brouter = Services.GetRequiredService<IBrouter>();
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => brouter.Navigate("/elsewhere"));
+        StringAssert.Contains(ex.Message, nameof(IBrouter.IsMounted));
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => brouter.Back());
+        Assert.ThrowsExactly<InvalidOperationException>(() => brouter.ResolveUrl("user"));
+        Assert.ThrowsExactly<InvalidOperationException>(() => brouter.ClearKeepAlive());
+    }
+
+    [TestMethod]
+    public async Task Try_methods_do_the_work_when_a_brouter_is_mounted()
+    {
+        var (cut, brouter, nav) = RenderMounted();
+
+        Assert.IsTrue(brouter.IsMounted);
+
+        Assert.IsTrue(brouter.TryResolveUrl("user", out var url, new Dictionary<string, object?> { ["id"] = 7 }));
+        Assert.AreEqual("/users/7", url);
+
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryNavigate("/users/2")));
+        cut.WaitForAssertion(() => Assert.AreEqual("/users/2", brouter.Location.Path));
+
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryNavigateToName("user", new Dictionary<string, object?> { ["id"] = 3 })));
+        cut.WaitForAssertion(() => Assert.AreEqual("/users/3", brouter.Location.Path));
+
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryNavigateWithQuery(q => q.Set("page", 2))));
+        cut.WaitForAssertion(() => Assert.AreEqual("http://localhost/users/3?page=2", nav.Uri));
+
+        var outcome = await cut.InvokeAsync(() => brouter.TryNavigateAsync("/users/4").AsTask());
+        Assert.IsNotNull(outcome);
+        Assert.AreEqual(BrouterNavigationStatus.Succeeded, outcome.Value.Status);
+
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryRevalidateAsync().AsTask()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryReloadAsync().AsTask()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryPreloadAsync("/users/5").AsTask()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryBackAsync().AsTask()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryForwardAsync().AsTask()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryBack()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryForward()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryClearKeepAlive()));
+        Assert.IsTrue(await cut.InvokeAsync(() => brouter.TryClearKeepAlive(includeActive: true)));
+    }
+
+    [TestMethod]
+    public void Try_methods_still_reject_invalid_arguments_when_a_brouter_is_mounted()
+    {
+        // Only the mount state is tolerated; a bad call is still a bug worth surfacing.
+        var (_, brouter, _) = RenderMounted();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => brouter.TryBackAsync(0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => brouter.TryForwardAsync(0));
+        Assert.ThrowsExactly<InvalidOperationException>(() => brouter.TryResolveUrl("no-such-route", out _));
+        Assert.ThrowsExactly<ArgumentException>(() => brouter.TryResolveUrl("user", out _));
+    }
+
+    [TestMethod]
+    public async Task Try_methods_become_noops_again_once_the_brouter_is_disposed()
+    {
+        var (_, brouter, nav) = RenderMounted();
+        Assert.IsTrue(brouter.IsMounted);
+
+        await Context!.DisposeComponentsAsync();
+
+        Assert.IsFalse(brouter.IsMounted);
+        Assert.IsFalse(brouter.TryNavigate("/users/9"));
+        Assert.IsFalse(await brouter.TryRevalidateAsync());
+        Assert.IsFalse(brouter.TryResolveUrl("user", out _, new Dictionary<string, object?> { ["id"] = 9 }));
+        Assert.AreEqual("http://localhost/users/1", nav.Uri);
+    }
+
+    [TestMethod]
+    public async Task Custom_implementations_get_working_Try_members_from_the_interface_defaults()
+    {
+        IBrouter mounted = new RecordingBrouter();
+        IBrouter unmounted = new UnmountedRecordingBrouter();
+
+        // A custom implementation that doesn't model mounting is assumed to always serve calls.
+        Assert.IsTrue(mounted.IsMounted);
+        Assert.IsTrue(mounted.TryNavigate("/a"));
+        Assert.IsTrue(mounted.TryBack());
+        Assert.IsTrue(mounted.TryResolveUrl("user", out var url));
+        Assert.AreEqual("/resolved/user", url);
+        CollectionAssert.AreEqual(new[] { "Navigate:/a", "Back", "ResolveUrl:user" }, ((RecordingBrouter)mounted).Calls);
+
+        // One that does model it gets the no-op behavior without implementing a single Try member.
+        Assert.IsFalse(unmounted.TryNavigate("/a"));
+        Assert.IsFalse(unmounted.TryBack());
+        Assert.IsFalse(unmounted.TryResolveUrl("user", out _));
+        Assert.IsNull(await unmounted.TryNavigateAsync("/a"));
+        Assert.IsFalse(await unmounted.TryRevalidateAsync());
+        Assert.AreEqual(0, ((RecordingBrouter)unmounted).Calls.Count);
+    }
+
+    // Deliberately leaves IsMounted and every Try... member to the interface defaults.
+    private class RecordingBrouter : IBrouter
+    {
+        public List<string> Calls { get; } = [];
+        public BrouterLocation Location => BrouterLocation.Empty;
+        public void Navigate(string url, bool replace = false, bool forceLoad = false, string? historyState = null) => Calls.Add($"Navigate:{url}");
+        public void Back() => Calls.Add("Back");
+        public void NavigateToName(string name, IReadOnlyDictionary<string, object?>? parameters = null,
+                                   string? query = null, bool replace = false, string? historyState = null) => Calls.Add($"NavigateToName:{name}");
+        public string ResolveUrl(string name, IReadOnlyDictionary<string, object?>? parameters = null, string? query = null)
+        {
+            Calls.Add($"ResolveUrl:{name}");
+            return $"/resolved/{name}";
+        }
+        public event Func<BrouterNavigationContext, ValueTask>? OnNavigating { add { } remove { } }
+        public event Func<BrouterNavigationContext, ValueTask>? OnNavigated { add { } remove { } }
+        public event Func<BrouterNavigationContext, Exception?, ValueTask>? OnError { add { } remove { } }
+    }
+
+    private sealed class UnmountedRecordingBrouter : RecordingBrouter, IBrouter
+    {
+        bool IBrouter.IsMounted => false;
+    }
+}


### PR DESCRIPTION
closes #13202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `IsMounted` to indicate whether the router is currently available.
  - Added non-throwing `Try...` navigation methods that safely return success status or `null` when no router is mounted.
  - Safe methods continue to report errors for invalid navigation requests once applicable.

- **Documentation**
  - Expanded API, navigation, and README documentation with router mount-state behavior and safe-call guidance.
  - Improved search keywords for navigation and history documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->