### PR TITLE
Fix focus issues of overlay components (#13192)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
@@ -6,7 +6,22 @@
     @* While a kept-mounted Dialog is closed it is still in the page, only hidden: inert and aria-hidden
        take it out of the tab sequence and out of the reading order for the browsers that would otherwise
        still reach into a display:none subtree through a stale reference. *@
+    @* The keydown handler sits on the root so that Escape dismisses the Dialog from anywhere inside it -
+       the surface, the overlay, whichever part of it the keyboard happens to be in. The keys stop here:
+       a Dialog opened from inside another one renders inside that one's surface, so an Escape left to
+       carry on up would dismiss the Dialog the keyboard is still working inside of along with the one it
+       was meant for - and it stops only Blazor's own bubbling, so native listeners (the focus trap among
+       them) still see the key.
+       tabindex="-1" makes the root programmatically focusable, which is what a press on the overlay needs:
+       pressing something that cannot hold the focus moves it to the nearest element that can, and the root
+       is the nearest one to the overlay. That keeps the focus inside the Dialog - where this handler and
+       the focus trap both are, the trap being registered on this element for the same reason - while the
+       press itself is left alone, so the input the user was typing into still blurs and still commits what
+       was typed before the click dismisses anything. *@
     <div @ref="RootElement" @attributes="HtmlAttributes"
+         @onkeydown="HandleOnKeyDown"
+         @onkeydown:stopPropagation="true"
+         tabindex="-1"
          id="@_Id"
          style="@StyleBuilder.Value"
          class="@ClassBuilder.Value"
@@ -18,29 +33,20 @@
             @if (IsModeless is false)
             {
                 @* Pressing something that cannot hold the focus is what takes the focus off whatever had it,
-                   and the overlay is the largest such thing on the screen while a Dialog is open. A press on
-                   it would otherwise leave the keyboard on the body: the Escape handler sits on the surface
-                   and the focus trap with it, so neither of them is reached from there, and the next Tab
-                   walks into the page the overlay is there to keep out of reach. The default of the press is
-                   refused so that the focus stays where the Dialog put it - the click itself still arrives,
-                   and still dismisses. The focus is still taken off whatever had it, onto the surface
-                   (data-bit-press-focus, handled by the script): an input only commits what was typed into it
-                   once it loses the focus, and the dismissal handlers the click runs are the ones that most
-                   need to see that value. *@
+                   and the overlay is the largest such thing on the screen while a Dialog is open. The press
+                   is left to do exactly that: the focus lands on the root, which is the nearest element to
+                   the overlay that can hold it and is inside the Dialog, so the Escape handler and the focus
+                   trap keep the keyboard - and the input the focus came off commits what was typed into it
+                   on the way, before the click the press turns into runs any dismissal handler. *@
                 <div style="@Styles?.Overlay" class="bit-dlg-ovl @Classes?.Overlay" aria-hidden="true"
-                     data-bit-press-focus="@_containerId"
-                     @onclick="HandleOnOverlayClick" @onmousedown:preventDefault="true" />
+                     @onclick="HandleOnOverlayClick" />
             }
 
             @* The surface is what carries the role and the accessible name, since that is the element the
                content lives in - a wrapper above the overlay would put the overlay inside the dialog for a
                screen reader. It is made programmatically focusable so that a Dialog holding nothing focusable
-               still has somewhere to put the focus, which is what both the Escape key and the focus trap need:
-               a keydown only reaches Blazor from inside the element it is bound to.
-
-               The keydown stops here rather than carrying on up the tree, which is what keeps a Dialog opened
-               from inside another one from closing both of them with a single Escape - and it stops only
-               Blazor's own bubbling, so native listeners (the focus trap among them) still see the key. *@
+               still has somewhere to put the focus, which is what both the Escape key and the focus trap
+               need: a keydown only reaches the handler on the root from inside it. *@
             <div id="@_containerId"
                  role="@GetRole()"
                  tabindex="-1"
@@ -48,8 +54,6 @@
                  aria-label="@AriaLabel"
                  aria-labelledby="@GetLabelledBy()"
                  aria-describedby="@GetDescribedBy()"
-                 @onkeydown="HandleOnKeyDown"
-                 @onkeydown:stopPropagation="true"
                  style="@GetContainerStyle()"
                  class="bit-dlg-ctn @GetPreventedClasses() @Classes?.Container">
                 @if (HasHeader)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
@@ -23,8 +23,12 @@
                    and the focus trap with it, so neither of them is reached from there, and the next Tab
                    walks into the page the overlay is there to keep out of reach. The default of the press is
                    refused so that the focus stays where the Dialog put it - the click itself still arrives,
-                   and still dismisses. *@
+                   and still dismisses. The focus is still taken off whatever had it, onto the surface
+                   (data-bit-press-focus, handled by the script): an input only commits what was typed into it
+                   once it loses the focus, and the dismissal handlers the click runs are the ones that most
+                   need to see that value. *@
                 <div style="@Styles?.Overlay" class="bit-dlg-ovl @Classes?.Overlay" aria-hidden="true"
+                     data-bit-press-focus="@_containerId"
                      @onclick="HandleOnOverlayClick" @onmousedown:preventDefault="true" />
             }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
@@ -12,13 +12,10 @@
        carry on up would dismiss the Dialog the keyboard is still working inside of along with the one it
        was meant for - and it stops only Blazor's own bubbling, so native listeners (the focus trap among
        them) still see the key.
-       tabindex="-1" makes the root programmatically focusable, which is what a press on the overlay needs:
-       pressing something that cannot hold the focus moves it to the nearest element that can, and the root
-       is the nearest one to the overlay. That keeps the focus inside the Dialog - where this handler and
-       the focus trap both are, the trap being registered on this element for the same reason - while the
-       press itself is left alone, so the input the user was typing into still blurs and still commits what
-       was typed before the click dismisses anything. It is written ahead of the attributes of the consumer
-       so that a tabindex of their own is the one that lands, as it is for every other attribute they pass. *@
+       tabindex="-1" makes the root programmatically focusable so that a press on the overlay lands the focus
+       inside the Dialog rather than on the body. The root only catches it: the focus trap passes it straight
+       on into the surface below, where the dialog role is (Utils.setupFocusTrap has the whole of it). It is
+       written ahead of the attributes of the consumer so that a tabindex of their own is the one that lands. *@
     <div @ref="RootElement"
          tabindex="@(TabIndex ?? "-1")"
          @attributes="HtmlAttributes"
@@ -34,12 +31,10 @@
         <div style="@Styles?.Document" class="bit-dlg-doc @GetPositionClass() @Classes?.Document">
             @if (IsModeless is false)
             {
-                @* Pressing something that cannot hold the focus is what takes the focus off whatever had it,
-                   and the overlay is the largest such thing on the screen while a Dialog is open. The press
-                   is left to do exactly that: the focus lands on the root, which is the nearest element to
-                   the overlay that can hold it and is inside the Dialog, so the Escape handler and the focus
-                   trap keep the keyboard - and the input the focus came off commits what was typed into it
-                   on the way, before the click the press turns into runs any dismissal handler. *@
+                @* The press on the overlay is left its default action: it is what blurs the input the user
+                   was typing into, and an input only commits what was typed once it loses the focus - before
+                   the click the press turns into runs any dismissal handler. Where that focus lands is the
+                   tabindex of the root above. *@
                 <div style="@Styles?.Overlay" class="bit-dlg-ovl @Classes?.Overlay" aria-hidden="true"
                      @onclick="HandleOnOverlayClick" />
             }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor
@@ -17,11 +17,13 @@
        is the nearest one to the overlay. That keeps the focus inside the Dialog - where this handler and
        the focus trap both are, the trap being registered on this element for the same reason - while the
        press itself is left alone, so the input the user was typing into still blurs and still commits what
-       was typed before the click dismisses anything. *@
-    <div @ref="RootElement" @attributes="HtmlAttributes"
+       was typed before the click dismisses anything. It is written ahead of the attributes of the consumer
+       so that a tabindex of their own is the one that lands, as it is for every other attribute they pass. *@
+    <div @ref="RootElement"
+         tabindex="@(TabIndex ?? "-1")"
+         @attributes="HtmlAttributes"
          @onkeydown="HandleOnKeyDown"
          @onkeydown:stopPropagation="true"
-         tabindex="-1"
          id="@_Id"
          style="@StyleBuilder.Value"
          class="@ClassBuilder.Value"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
@@ -982,7 +982,7 @@ public partial class BitDialog : BitComponentBase
 
         _focusTrapped = true;
 
-        await InvokeJs(_js.BitUtilsSetupFocusTrap(_containerId));
+        await InvokeJs(_js.BitUtilsSetupFocusTrap(_Id));
     }
 
     // The same for the trap: a Dialog told to stop holding the keyboard while it is standing lets it go
@@ -995,7 +995,7 @@ public partial class BitDialog : BitComponentBase
 
         _focusTrapped = false;
 
-        await InvokeJs(_js.BitUtilsDisposeFocusTrap(_containerId));
+        await InvokeJs(_js.BitUtilsDisposeFocusTrap(_Id));
     }
 
     private async Task SaveFocus()

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.razor.cs
@@ -982,7 +982,7 @@ public partial class BitDialog : BitComponentBase
 
         _focusTrapped = true;
 
-        await InvokeJs(_js.BitUtilsSetupFocusTrap(_Id));
+        await InvokeJs(_js.BitUtilsSetupFocusTrap(_containerId, _Id));
     }
 
     // The same for the trap: a Dialog told to stop holding the keyboard while it is standing lets it go
@@ -995,7 +995,7 @@ public partial class BitDialog : BitComponentBase
 
         _focusTrapped = false;
 
-        await InvokeJs(_js.BitUtilsDisposeFocusTrap(_Id));
+        await InvokeJs(_js.BitUtilsDisposeFocusTrap(_containerId));
     }
 
     private async Task SaveFocus()

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.scss
@@ -15,10 +15,6 @@
     width: 100%;
     height: 100%;
     position: fixed;
-    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
-    // Dialog to leave the focus. That focus is never one the user moved there themselves, so it is not one
-    // to draw a ring around.
-    outline: none;
     font-weight: $tg-fw-regular;
     z-index: $zindex-modal;
     font-size: $tg-fs-sm;
@@ -29,6 +25,14 @@
     // overlay at all, and without this its invisible frame would swallow every click on the page it is
     // deliberately leaving usable.
     pointer-events: none;
+
+    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
+    // Dialog to leave the focus. That focus is never one the user moved there themselves, so it is not one
+    // to draw a ring around; :focus-visible still does for the consumer who puts the root into the tab
+    // sequence with a TabIndex of their own.
+    &:focus:not(:focus-visible) {
+        outline: none;
+    }
 
     @keyframes bit-dlg-spinner-animation {
         0% {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.scss
@@ -27,12 +27,8 @@
     pointer-events: none;
 
     // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
-    // Dialog to leave the focus. That focus is never one the user moved there themselves, so it is not one
-    // to draw a ring around; :focus-visible still does for the consumer who puts the root into the tab
-    // sequence with a TabIndex of their own.
-    &:focus:not(:focus-visible) {
-        outline: none;
-    }
+    // Dialog to leave the focus.
+    @include focus-anchor;
 
     @keyframes bit-dlg-spinner-animation {
         0% {
@@ -131,6 +127,9 @@
     z-index: 0;
     position: absolute;
     pointer-events: auto;
+    // A press on the overlay is left its default action (see the markup), and the default of a press that
+    // is dragged is a text selection - one that would start at the overlay and run through the surface.
+    user-select: none;
     background-color: $clr-bg-overlay;
     animation: bit-dlg-overlay-animation $mot-duration-short $mot-easing-decelerate;
 }
@@ -159,8 +158,8 @@
     animation: bit-dlg-container-animation $mot-duration $mot-easing-decelerate;
 
     // The surface is made programmatically focusable so the Escape key and the focus trap have somewhere
-    // to land, which is a job the focus ring has no business advertising.
-    outline: none;
+    // to land.
+    @include focus-anchor;
 }
 
 // The refusal replaces the entrance animation for as long as it runs, since both drive transform on the

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Dialog/BitDialog.scss
@@ -15,6 +15,10 @@
     width: 100%;
     height: 100%;
     position: fixed;
+    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
+    // Dialog to leave the focus. That focus is never one the user moved there themselves, so it is not one
+    // to draw a ring around.
+    outline: none;
     font-weight: $tg-fw-regular;
     z-index: $zindex-modal;
     font-size: $tg-fs-sm;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
@@ -11,13 +11,11 @@
     @* While a kept-mounted Modal is closed it is still in the page, only hidden: inert and aria-hidden
        take it out of the tab sequence and out of the reading order for the browsers that would otherwise
        still reach into a display:none subtree through a stale reference. *@
-    @* tabindex="-1" makes the root programmatically focusable, which is what a press on the overlay needs:
-       pressing something that cannot hold the focus moves it to the nearest element that can, and the root
-       is the nearest one to the overlay. That keeps the focus inside the Modal - where the Escape handler
-       and the focus trap both are, the trap being registered on this element for the same reason - while
-       the press itself is left alone, so the input the user was typing into still blurs and still commits
-       what was typed before the click dismisses anything. It is written ahead of the attributes of the
-       consumer so that a tabindex of their own is the one that lands, as every other attribute they pass. *@
+    @* tabindex="-1" makes the root programmatically focusable so that a press on the overlay lands the focus
+       inside the Modal rather than on the body. The root only catches it: the focus trap passes it straight
+       on into the content box below, where the dialog role is (Utils.setupFocusTrap has the whole of it). It
+       is written ahead of the attributes of the consumer so that a tabindex of their own is the one that
+       lands. *@
     <div @ref="RootElement"
          tabindex="@(TabIndex ?? "-1")"
          @attributes="_params.HtmlAttributes"
@@ -30,12 +28,10 @@
          aria-hidden="@(IsOpen ? null : "true")">
         @if (ShowsOverlay)
         {
-            @* Pressing something that cannot hold the focus is what takes the focus off whatever had it, and
-               the overlay is the largest such thing on the screen while a Modal is open. The press is left
-               to do exactly that: the focus lands on the root, which is the nearest element to the overlay
-               that can hold it and is inside the Modal, so the Escape handler and the focus trap keep the
-               keyboard - and the input the focus came off commits what was typed into it on the way, before
-               the click the press turns into runs any dismissal handler. *@
+            @* The press on the overlay is left its default action: it is what blurs the input the user was
+               typing into, and an input only commits what was typed once it loses the focus - before the
+               click the press turns into runs any dismissal handler. Where that focus lands is the tabindex
+               of the root above. *@
             <div @onclick="HandleOnOverlayClick"
                  aria-hidden="true"
                  style="@GetOverlayStyles()"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
@@ -16,10 +16,12 @@
        is the nearest one to the overlay. That keeps the focus inside the Modal - where the Escape handler
        and the focus trap both are, the trap being registered on this element for the same reason - while
        the press itself is left alone, so the input the user was typing into still blurs and still commits
-       what was typed before the click dismisses anything. *@
-    <div @ref="RootElement" @attributes="_params.HtmlAttributes"
+       what was typed before the click dismisses anything. It is written ahead of the attributes of the
+       consumer so that a tabindex of their own is the one that lands, as every other attribute they pass. *@
+    <div @ref="RootElement"
+         tabindex="@(TabIndex ?? "-1")"
+         @attributes="_params.HtmlAttributes"
          @onkeydown="HandleOnKeyDown" @onkeydown:stopPropagation
-         tabindex="-1"
          id="@_Id"
          style="@StyleBuilder.Value"
          class="@GetRootClasses()"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
@@ -11,8 +11,15 @@
     @* While a kept-mounted Modal is closed it is still in the page, only hidden: inert and aria-hidden
        take it out of the tab sequence and out of the reading order for the browsers that would otherwise
        still reach into a display:none subtree through a stale reference. *@
+    @* tabindex="-1" makes the root programmatically focusable, which is what a press on the overlay needs:
+       pressing something that cannot hold the focus moves it to the nearest element that can, and the root
+       is the nearest one to the overlay. That keeps the focus inside the Modal - where the Escape handler
+       and the focus trap both are, the trap being registered on this element for the same reason - while
+       the press itself is left alone, so the input the user was typing into still blurs and still commits
+       what was typed before the click dismisses anything. *@
     <div @ref="RootElement" @attributes="_params.HtmlAttributes"
          @onkeydown="HandleOnKeyDown" @onkeydown:stopPropagation
+         tabindex="-1"
          id="@_Id"
          style="@StyleBuilder.Value"
          class="@GetRootClasses()"
@@ -22,17 +29,12 @@
         @if (ShowsOverlay)
         {
             @* Pressing something that cannot hold the focus is what takes the focus off whatever had it, and
-               the overlay is the largest such thing on the screen while a Modal is open. A press on it would
-               otherwise leave the keyboard on the body: the Escape handler sits on the Modal and the focus
-               trap on its content, so neither of them is reached from there, and the next Tab walks into the
-               page the overlay is there to keep out of reach. The default of the press is refused so that the
-               focus stays where the Modal put it - the click itself still arrives, and still dismisses.
-               The focus is still taken off whatever had it, onto the content (data-bit-press-focus, handled by
-               the script): an input only commits what was typed into it once it loses the focus, and the
-               dismissal handlers the click runs are the ones that most need to see that value. *@
+               the overlay is the largest such thing on the screen while a Modal is open. The press is left
+               to do exactly that: the focus lands on the root, which is the nearest element to the overlay
+               that can hold it and is inside the Modal, so the Escape handler and the focus trap keep the
+               keyboard - and the input the focus came off commits what was typed into it on the way, before
+               the click the press turns into runs any dismissal handler. *@
             <div @onclick="HandleOnOverlayClick"
-                 @onmousedown:preventDefault="true"
-                 data-bit-press-focus="@_containerId"
                  aria-hidden="true"
                  style="@GetOverlayStyles()"
                  class="@GetOverlayClasses()" />

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor
@@ -26,9 +26,13 @@
                otherwise leave the keyboard on the body: the Escape handler sits on the Modal and the focus
                trap on its content, so neither of them is reached from there, and the next Tab walks into the
                page the overlay is there to keep out of reach. The default of the press is refused so that the
-               focus stays where the Modal put it - the click itself still arrives, and still dismisses. *@
+               focus stays where the Modal put it - the click itself still arrives, and still dismisses.
+               The focus is still taken off whatever had it, onto the content (data-bit-press-focus, handled by
+               the script): an input only commits what was typed into it once it loses the focus, and the
+               dismissal handlers the click runs are the ones that most need to see that value. *@
             <div @onclick="HandleOnOverlayClick"
                  @onmousedown:preventDefault="true"
+                 data-bit-press-focus="@_containerId"
                  aria-hidden="true"
                  style="@GetOverlayStyles()"
                  class="@GetOverlayClasses()" />

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
@@ -1217,7 +1217,7 @@ public partial class BitModal : BitComponentBase
 
         try
         {
-            await _js.BitUtilsSetupFocusTrap(_containerId);
+            await _js.BitUtilsSetupFocusTrap(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1230,7 +1230,7 @@ public partial class BitModal : BitComponentBase
 
         try
         {
-            await _js.BitUtilsDisposeFocusTrap(_containerId);
+            await _js.BitUtilsDisposeFocusTrap(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1566,7 +1566,7 @@ public partial class BitModal : BitComponentBase
             {
                 if (trapped)
                 {
-                    await _js.BitUtilsDisposeFocusTrap(_containerId);
+                    await _js.BitUtilsDisposeFocusTrap(_Id);
                 }
 
                 if (locked)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.razor.cs
@@ -1217,7 +1217,7 @@ public partial class BitModal : BitComponentBase
 
         try
         {
-            await _js.BitUtilsSetupFocusTrap(_Id);
+            await _js.BitUtilsSetupFocusTrap(_containerId, _Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1230,7 +1230,7 @@ public partial class BitModal : BitComponentBase
 
         try
         {
-            await _js.BitUtilsDisposeFocusTrap(_Id);
+            await _js.BitUtilsDisposeFocusTrap(_containerId);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1566,7 +1566,7 @@ public partial class BitModal : BitComponentBase
             {
                 if (trapped)
                 {
-                    await _js.BitUtilsDisposeFocusTrap(_Id);
+                    await _js.BitUtilsDisposeFocusTrap(_containerId);
                 }
 
                 if (locked)

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.scss
@@ -17,12 +17,8 @@
     background-color: transparent;
 
     // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
-    // Modal to leave the focus. That focus is never one the user moved there themselves, so it is not one
-    // to draw a ring around; :focus-visible still does for the consumer who puts the root into the tab
-    // sequence with a TabIndex of their own.
-    &:focus:not(:focus-visible) {
-        outline: none;
-    }
+    // Modal to leave the focus.
+    @include focus-anchor;
 }
 
 // Put on the drag handle of a draggable Modal (by the drag-drop script) so that a touch drag moves the
@@ -58,6 +54,9 @@
     z-index: 0;
     position: absolute;
     pointer-events: all;
+    // A press on the overlay is left its default action (see the markup), and the default of a press that
+    // is dragged is a text selection - one that would start at the overlay and run through the content.
+    user-select: none;
     background-color: transparent;
 }
 
@@ -103,9 +102,8 @@
     border-radius: $shp-radius-dialog;
 
     // The content is made programmatically focusable (tabindex="-1") so the focus has somewhere to land in
-    // a Modal that holds nothing focusable. That focus is never one the user moved there themselves, so it
-    // is not one to draw a ring around; :focus-visible still does for the keyboard.
-    outline: none;
+    // a Modal that holds nothing focusable.
+    @include focus-anchor;
 
     // backwards rather than both: the transform of the last keyframe would otherwise stay on the element
     // for good, and an element that carries a transform is the containing block of every fixed-positioned

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Modal/BitModal.scss
@@ -5,7 +5,6 @@
     opacity: 1;
     width: 100%;
     height: 100%;
-    outline: none;
     display: flex;
     position: fixed;
     font-weight: $tg-fw-regular;
@@ -16,6 +15,14 @@
     font-size: $tg-fs-sm;
     font-family: $tg-font-family;
     background-color: transparent;
+
+    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
+    // Modal to leave the focus. That focus is never one the user moved there themselves, so it is not one
+    // to draw a ring around; :focus-visible still does for the consumer who puts the root into the tab
+    // sequence with a TabIndex of their own.
+    &:focus:not(:focus-visible) {
+        outline: none;
+    }
 }
 
 // Put on the drag handle of a draggable Modal (by the drag-drop script) so that a touch drag moves the

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
@@ -19,11 +19,15 @@
        The pointer press on it is refused its default action so that the click never takes the focus out of
        the panel: the overlay is not focusable, so a browser left to itself drops the focus on the body,
        which takes the Escape key away from the panel and starts the next Tab at the top of the very page
-       the overlay is there to keep the user off. *@
+       the overlay is there to keep the user off. The focus is still taken off whatever had it, onto the
+       container (data-bit-press-focus, handled by the script): an input only commits what was typed into it
+       once it loses the focus, and the dismissal handlers the click runs are the ones that most need to see
+       that value. *@
     @if (Modeless is false)
     {
         <div @onclick="HandleOnOverlayClick"
              @onmousedown:preventDefault
+             data-bit-press-focus="@_containerId"
              aria-hidden="true"
              style="@Styles?.Overlay"
              class="@GetOverlayCssClasses()" />

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
@@ -11,13 +11,19 @@
    the nearest one to the overlay. That keeps the focus inside the panel - where the Escape handler and the
    focus trap both are, the trap being registered on this element for the same reason - while the press
    itself is left alone, so the input the user was typing into still blurs and still commits what was typed
-   before the click dismisses anything. *@
-<div @ref="RootElement" @attributes="HtmlAttributes"
+   before the click dismisses anything. It is written ahead of the attributes of the consumer so that a
+   tabindex of their own is the one that lands, as it is for every other attribute the panel writes itself.
+   The whole of the panel is marked inert while it is closed, the root included: neither Tab nor a screen
+   reader ever reaches a content that is off the screen, and the focus a press on the overlay left on the
+   root is let go of as the panel closes rather than parked on something the user can no longer see. *@
+<div @ref="RootElement"
+     tabindex="@(TabIndex ?? "-1")"
+     @attributes="HtmlAttributes"
      @onkeydown="HandleOnKeyDown" @onkeydown:stopPropagation="DismissesOnEscape"
-     tabindex="-1"
      id="@_Id"
      style="@StyleBuilder.Value"
      class="@ClassBuilder.Value"
+     inert="@(IsOpen is false)"
      dir="@Dir?.ToString().ToLower()">
 
     @* The overlay stays in the page while the panel is closed so that it fades out with the panel instead
@@ -39,12 +45,11 @@
     @* The container is the surface the panel actually is, so it is the element that carries the dialog role
        and the name that goes with it - a role on the wrapper around the overlay would name the whole page
        region a dialog. It is made programmatically focusable so that a panel holding nothing focusable still
-       has somewhere to put the keyboard, and it is marked inert while the panel is closed so that neither
-       Tab nor a screen reader ever reaches a content that is off the screen. *@
+       has somewhere to put the keyboard; what keeps it out of the tab sequence and out of the reading order
+       while the panel is closed is the inert of the root above it, which covers the whole of the panel. *@
     <div id="@_containerId"
          tabindex="-1"
          role="@(Role ?? GetRole())"
-         inert="@(IsOpen is false)"
          aria-label="@AriaLabel"
          aria-modal="@GetAriaModal()"
          aria-labelledby="@GetTitleAriaId()"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
@@ -6,16 +6,13 @@
    The key stops here when the panel acts on it: a panel opened from inside another one sits in that one's
    content, where an Escape left to carry on up would dismiss the panel the keyboard is still working inside
    of along with the one it was meant for. *@
-@* tabindex="-1" makes the root programmatically focusable, which is what a press on the overlay needs:
-   pressing something that cannot hold the focus moves it to the nearest element that can, and the root is
-   the nearest one to the overlay. That keeps the focus inside the panel - where the Escape handler and the
-   focus trap both are, the trap being registered on this element for the same reason - while the press
-   itself is left alone, so the input the user was typing into still blurs and still commits what was typed
-   before the click dismisses anything. It is written ahead of the attributes of the consumer so that a
-   tabindex of their own is the one that lands, as it is for every other attribute the panel writes itself.
+@* tabindex="-1" makes the root programmatically focusable so that a press on the overlay lands the focus
+   inside the panel rather than on the body. The root only catches it: the focus trap passes it straight on
+   into the container below, where the dialog role is (Utils.setupFocusTrap has the whole of it). It is
+   written ahead of the attributes of the consumer so that a tabindex of their own is the one that lands.
    The whole of the panel is marked inert while it is closed, the root included: neither Tab nor a screen
-   reader ever reaches a content that is off the screen, and the focus a press on the overlay left on the
-   root is let go of as the panel closes rather than parked on something the user can no longer see. *@
+   reader ever reaches a content that is off the screen, and a focus still inside the panel as it closes is
+   let go of rather than parked on something the user can no longer see. *@
 <div @ref="RootElement"
      tabindex="@(TabIndex ?? "-1")"
      @attributes="HtmlAttributes"
@@ -29,11 +26,9 @@
     @* The overlay stays in the page while the panel is closed so that it fades out with the panel instead
        of vanishing under it in one frame. It is hidden rather than removed, which also takes it out of the
        way of the clicks the page is meant to keep while the panel is closed.
-       The press on it is left its default action, which is what blurs whatever had the focus - an input
-       only commits what was typed into it once it loses the focus, and the dismissal handlers the click
-       runs are the ones that most need to see that value. The focus it moves lands on the root rather than
-       on the body, since that is the nearest element to the overlay that can hold it, so neither the
-       Escape key nor the next Tab leaves the panel. *@
+       The press on it is left its default action: it is what blurs the input the user was typing into, and
+       an input only commits what was typed once it loses the focus - before the click the press turns into
+       runs any dismissal handler. Where that focus lands is the tabindex of the root above. *@
     @if (Modeless is false)
     {
         <div @onclick="HandleOnOverlayClick"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor
@@ -6,8 +6,15 @@
    The key stops here when the panel acts on it: a panel opened from inside another one sits in that one's
    content, where an Escape left to carry on up would dismiss the panel the keyboard is still working inside
    of along with the one it was meant for. *@
+@* tabindex="-1" makes the root programmatically focusable, which is what a press on the overlay needs:
+   pressing something that cannot hold the focus moves it to the nearest element that can, and the root is
+   the nearest one to the overlay. That keeps the focus inside the panel - where the Escape handler and the
+   focus trap both are, the trap being registered on this element for the same reason - while the press
+   itself is left alone, so the input the user was typing into still blurs and still commits what was typed
+   before the click dismisses anything. *@
 <div @ref="RootElement" @attributes="HtmlAttributes"
      @onkeydown="HandleOnKeyDown" @onkeydown:stopPropagation="DismissesOnEscape"
+     tabindex="-1"
      id="@_Id"
      style="@StyleBuilder.Value"
      class="@ClassBuilder.Value"
@@ -16,18 +23,14 @@
     @* The overlay stays in the page while the panel is closed so that it fades out with the panel instead
        of vanishing under it in one frame. It is hidden rather than removed, which also takes it out of the
        way of the clicks the page is meant to keep while the panel is closed.
-       The pointer press on it is refused its default action so that the click never takes the focus out of
-       the panel: the overlay is not focusable, so a browser left to itself drops the focus on the body,
-       which takes the Escape key away from the panel and starts the next Tab at the top of the very page
-       the overlay is there to keep the user off. The focus is still taken off whatever had it, onto the
-       container (data-bit-press-focus, handled by the script): an input only commits what was typed into it
-       once it loses the focus, and the dismissal handlers the click runs are the ones that most need to see
-       that value. *@
+       The press on it is left its default action, which is what blurs whatever had the focus - an input
+       only commits what was typed into it once it loses the focus, and the dismissal handlers the click
+       runs are the ones that most need to see that value. The focus it moves lands on the root rather than
+       on the body, since that is the nearest element to the overlay that can hold it, so neither the
+       Escape key nor the next Tab leaves the panel. *@
     @if (Modeless is false)
     {
         <div @onclick="HandleOnOverlayClick"
-             @onmousedown:preventDefault
-             data-bit-press-focus="@_containerId"
              aria-hidden="true"
              style="@Styles?.Overlay"
              class="@GetOverlayCssClasses()" />

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor.cs
@@ -1113,7 +1113,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsSetupFocusTrap(_containerId);
+            await _js.BitUtilsSetupFocusTrap(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1126,7 +1126,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsDisposeFocusTrap(_containerId);
+            await _js.BitUtilsDisposeFocusTrap(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1139,7 +1139,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsCaptureFocusOrigin(_containerId);
+            await _js.BitUtilsCaptureFocusOrigin(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1150,7 +1150,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsRestoreFocusOrigin(_containerId);
+            await _js.BitUtilsRestoreFocusOrigin(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1305,7 +1305,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsDisposeFocusOrigin(_containerId);
+            await _js.BitUtilsDisposeFocusOrigin(_Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.razor.cs
@@ -1113,7 +1113,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsSetupFocusTrap(_Id);
+            await _js.BitUtilsSetupFocusTrap(_containerId, _Id);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1126,7 +1126,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsDisposeFocusTrap(_Id);
+            await _js.BitUtilsDisposeFocusTrap(_containerId);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1139,7 +1139,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsCaptureFocusOrigin(_Id);
+            await _js.BitUtilsCaptureFocusOrigin(_containerId);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1150,7 +1150,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsRestoreFocusOrigin(_Id);
+            await _js.BitUtilsRestoreFocusOrigin(_containerId);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
     }
@@ -1305,7 +1305,7 @@ public partial class BitPanel : BitComponentBase
 
         try
         {
-            await _js.BitUtilsDisposeFocusOrigin(_Id);
+            await _js.BitUtilsDisposeFocusOrigin(_containerId);
         }
         catch (JSDisconnectedException) { } // we can ignore this exception here
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.scss
@@ -15,12 +15,8 @@
     }
 
     // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
-    // panel to leave the focus. That focus is never one the user moved there themselves, so it is not one
-    // to draw a ring around; :focus-visible still does for the consumer who puts the root into the tab
-    // sequence with a TabIndex of their own.
-    &:focus:not(:focus-visible) {
-        outline: none;
-    }
+    // panel to leave the focus.
+    @include focus-anchor;
 }
 
 // A panel laid out against a container of the page rather than against the screen. The root takes the size
@@ -51,6 +47,9 @@
     height: 100%;
     position: fixed;
     visibility: hidden;
+    // A press on the overlay is left its default action (see the markup), and the default of a press that
+    // is dragged is a text selection - one that would start at the overlay and run through the panel.
+    user-select: none;
     // The two layers are read from the root, where the ZIndex parameter writes them, so that a panel opened
     // from inside another one can be lifted over it as a pair. Unset, they fall back to the layer the whole
     // library shares.
@@ -79,7 +78,9 @@
     position: fixed;
     overflow: auto;
     visibility: hidden;
-    outline: transparent;
+    // The container is made programmatically focusable so that a panel holding nothing focusable still has
+    // somewhere to put the keyboard.
+    @include focus-anchor;
     box-sizing: border-box;
     background-color: $clr-bg-pri;
     box-shadow: $box-shadow-sheet;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.scss
@@ -1,6 +1,10 @@
 ﻿@import "../../../Styles/functions.scss";
 
 .bit-pnl {
+    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
+    // panel to leave the focus. That focus is never one the user moved there themselves, so it is not one
+    // to draw a ring around.
+    outline: none;
     font-weight: $tg-fw-regular;
     font-size: $tg-fs-md;
     z-index: $zindex-modal;

--- a/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Surfaces/Panel/BitPanel.scss
@@ -1,10 +1,6 @@
 ﻿@import "../../../Styles/functions.scss";
 
 .bit-pnl {
-    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
-    // panel to leave the focus. That focus is never one the user moved there themselves, so it is not one
-    // to draw a ring around.
-    outline: none;
     font-weight: $tg-fw-regular;
     font-size: $tg-fs-md;
     z-index: $zindex-modal;
@@ -16,6 +12,14 @@
 
     &.bit-rtl {
         --bit-pnl-transform-factor: -1;
+    }
+
+    // The root is made programmatically focusable so that a press on the overlay has somewhere inside the
+    // panel to leave the focus. That focus is never one the user moved there themselves, so it is not one
+    // to draw a ring around; :focus-visible still does for the consumer who puts the root into the tab
+    // sequence with a TabIndex of their own.
+    &:focus:not(:focus-visible) {
+        outline: none;
     }
 }
 

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor
@@ -5,23 +5,18 @@
    layer - a dim scrim or a transparent click catcher - so it is taken out of the accessibility tree the
    way every surveyed backdrop is; one given content is the very thing a screen reader is meant to reach. *@
 @* Pressing something that cannot hold the focus is what takes the focus off whatever had it, and the layer
-   is the largest such thing on the screen while an Overlay is open. A press on it would otherwise leave the
-   keyboard on the body, walking the next Tab into the page the Overlay is there to keep out of reach. The
-   default of the press is refused so that the focus stays where the content put it - the click itself still
-   arrives, and still dismisses. Only the presses on the layer reach here: the content stops its own.
-   The focus is still taken off whatever had it, onto the layer itself (data-bit-press-focus, handled by the
-   script, which is what tabindex="-1" makes the layer able to hold): an input only commits what was typed
-   into it once it loses the focus, and the handlers the click runs are the ones that most need to see that
-   value. A TabIndex of the consumer's own still wins over it. *@
+   is the largest such thing on the screen while an Overlay is open. The press is left to do exactly that -
+   an input only commits what was typed into it once it loses the focus, and the handlers the click runs are
+   the ones that most need to see that value - and the layer is made focusable instead (GetTabIndex), so the
+   focus it moves lands there rather than on the body, and the next Tab walks into the content rather than
+   into the page the Overlay is there to keep out of reach. *@
 <div @ref="RootElement" @attributes="HtmlAttributes"
-     tabindex="@(TabIndex ?? "-1")"
      @onclick="HandleOnClick"
      @onmousedown="HandleOnMouseDown"
-     @onmousedown:preventDefault="true"
-     data-bit-press-focus="@_Id"
+     tabindex="@GetTabIndex()"
      id="@_Id"
      aria-label="@AriaLabel"
-     aria-hidden="@(ChildContent is null && AriaLabel.HasNoValue() ? "true" : null)"
+     aria-hidden="@(IsDecorative ? "true" : null)"
      class="@ClassBuilder.Value"
      style="@StyleBuilder.Value"
      dir="@Dir?.ToString().ToLower()">

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor
@@ -1,22 +1,25 @@
 @namespace Bit.BlazorUI
 @inherits BitComponentBase
 
-@* An Overlay that hosts no content and carries no accessible name of its own is a purely decorative
-   layer - a dim scrim or a transparent click catcher - so it is taken out of the accessibility tree the
-   way every surveyed backdrop is; one given content is the very thing a screen reader is meant to reach. *@
 @* Pressing something that cannot hold the focus is what takes the focus off whatever had it, and the layer
    is the largest such thing on the screen while an Overlay is open. The press is left to do exactly that -
    an input only commits what was typed into it once it loses the focus, and the handlers the click runs are
-   the ones that most need to see that value - and the layer is made focusable instead (GetTabIndex), so the
-   focus it moves lands there rather than on the body, and the next Tab walks into the content rather than
-   into the page the Overlay is there to keep out of reach. *@
-<div @ref="RootElement" @attributes="HtmlAttributes"
+   the ones that most need to see that value - and the layer is made programmatically focusable instead, so
+   the focus it moves lands here, inside the Overlay, rather than on the body, from where the next Tab would
+   walk into the page the Overlay is there to keep out of reach. The focus the layer took over is handed back
+   to where it came from as the Overlay closes (Utils.captureFocusOrigin / restoreFocusOrigin).
+   That is also why a layer hosting nothing is not marked aria-hidden, the way a backdrop that is only a
+   sibling of its surface is: an element that can take the focus cannot be hidden from assistive technology
+   at the same time, and an empty, unnamed layer is nothing to a screen reader either way.
+   The tabindex is written ahead of the attributes of the consumer so that one of their own is the one that
+   lands, as it is for every other attribute they pass. *@
+<div @ref="RootElement"
+     tabindex="@(TabIndex ?? "-1")"
+     @attributes="HtmlAttributes"
      @onclick="HandleOnClick"
      @onmousedown="HandleOnMouseDown"
-     tabindex="@GetTabIndex()"
      id="@_Id"
      aria-label="@AriaLabel"
-     aria-hidden="@(IsDecorative ? "true" : null)"
      class="@ClassBuilder.Value"
      style="@StyleBuilder.Value"
      dir="@Dir?.ToString().ToLower()">

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor
@@ -8,11 +8,17 @@
    is the largest such thing on the screen while an Overlay is open. A press on it would otherwise leave the
    keyboard on the body, walking the next Tab into the page the Overlay is there to keep out of reach. The
    default of the press is refused so that the focus stays where the content put it - the click itself still
-   arrives, and still dismisses. Only the presses on the layer reach here: the content stops its own. *@
+   arrives, and still dismisses. Only the presses on the layer reach here: the content stops its own.
+   The focus is still taken off whatever had it, onto the layer itself (data-bit-press-focus, handled by the
+   script, which is what tabindex="-1" makes the layer able to hold): an input only commits what was typed
+   into it once it loses the focus, and the handlers the click runs are the ones that most need to see that
+   value. A TabIndex of the consumer's own still wins over it. *@
 <div @ref="RootElement" @attributes="HtmlAttributes"
+     tabindex="@(TabIndex ?? "-1")"
      @onclick="HandleOnClick"
      @onmousedown="HandleOnMouseDown"
      @onmousedown:preventDefault="true"
+     data-bit-press-focus="@_Id"
      id="@_Id"
      aria-label="@AriaLabel"
      aria-hidden="@(ChildContent is null && AriaLabel.HasNoValue() ? "true" : null)"

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
@@ -322,6 +322,17 @@ public partial class BitOverlay : BitComponentBase
         // opening, where it would refuse the first dismissal for no reason the user could see.
         _pressedOnContent = false;
 
+        if (isOpen)
+        {
+            await CaptureFocusOrigin();
+        }
+        else
+        {
+            await RestoreFocusOrigin();
+        }
+
+        if (Overtaken()) return;
+
         var offsetBefore = _offsetTop;
 
         _offsetTop = 0;
@@ -364,20 +375,31 @@ public partial class BitOverlay : BitComponentBase
 
 
 
-    // An Overlay that hosts no content and carries no accessible name of its own is a purely decorative
-    // layer - a dim scrim or a transparent click catcher - which is what takes it out of the accessibility
-    // tree, and out of the focus path with it. A layer the consumer has given a TabIndex of their own is
-    // none of that: something they mean the focus to reach has to be something a screen reader reaches too,
-    // so it stays in the tree rather than being hidden from it and focusable at the same time.
-    private bool IsDecorative => ChildContent is null && AriaLabel.HasNoValue() && TabIndex is null;
+    // The layer takes the focus a press on it moves off an input (see the markup), and a layer that is
+    // then hidden would leave that focus to drop to the body - the top of the page, as far as the next Tab
+    // is concerned. So the element the focus was on as the Overlay opened is remembered, and handed the
+    // focus back as it closes, for as long as the focus is still the Overlay's to hand back.
+    private async Task CaptureFocusOrigin()
+    {
+        if (IsDisposed || IsRendered is false) return;
 
-    // The layer is made programmatically focusable so that a press on it has somewhere inside the Overlay
-    // to put the focus the press takes off whatever had it: the browser moves the focus to the nearest
-    // element that can hold it, which is the body while the layer cannot, and the next Tab from there walks
-    // into the page the Overlay is there to keep out of reach. A decorative layer is left as it is - it
-    // hosts nothing the focus has to stay near, and focusing an aria-hidden element is a contradiction the
-    // browsers report. A TabIndex of the consumer's own wins over it.
-    private string? GetTabIndex() => TabIndex ?? (IsDecorative ? null : "-1");
+        try
+        {
+            await _js.BitUtilsCaptureFocusOrigin(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+    private async Task RestoreFocusOrigin()
+    {
+        if (IsDisposed) return;
+
+        try
+        {
+            await _js.BitUtilsRestoreFocusOrigin(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
 
     // What the overflow toggle acts on, in the order the consumer's intent is expressed: the element it
     // named, then the selector it named, then the scroller of the application shell the Overlay is inside
@@ -595,6 +617,12 @@ public partial class BitOverlay : BitComponentBase
         await ToggleScroll(false);
 
         await StopForwardScroll();
+
+        try
+        {
+            await _js.BitUtilsDisposeFocusOrigin(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
 
         await base.DisposeAsync(disposing);
     }

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
@@ -366,8 +366,10 @@ public partial class BitOverlay : BitComponentBase
 
     // An Overlay that hosts no content and carries no accessible name of its own is a purely decorative
     // layer - a dim scrim or a transparent click catcher - which is what takes it out of the accessibility
-    // tree, and out of the focus path with it.
-    private bool IsDecorative => ChildContent is null && AriaLabel.HasNoValue();
+    // tree, and out of the focus path with it. A layer the consumer has given a TabIndex of their own is
+    // none of that: something they mean the focus to reach has to be something a screen reader reaches too,
+    // so it stays in the tree rather than being hidden from it and focusable at the same time.
+    private bool IsDecorative => ChildContent is null && AriaLabel.HasNoValue() && TabIndex is null;
 
     // The layer is made programmatically focusable so that a press on it has somewhere inside the Overlay
     // to put the focus the press takes off whatever had it: the browser moves the focus to the nearest

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.razor.cs
@@ -364,6 +364,19 @@ public partial class BitOverlay : BitComponentBase
 
 
 
+    // An Overlay that hosts no content and carries no accessible name of its own is a purely decorative
+    // layer - a dim scrim or a transparent click catcher - which is what takes it out of the accessibility
+    // tree, and out of the focus path with it.
+    private bool IsDecorative => ChildContent is null && AriaLabel.HasNoValue();
+
+    // The layer is made programmatically focusable so that a press on it has somewhere inside the Overlay
+    // to put the focus the press takes off whatever had it: the browser moves the focus to the nearest
+    // element that can hold it, which is the body while the layer cannot, and the next Tab from there walks
+    // into the page the Overlay is there to keep out of reach. A decorative layer is left as it is - it
+    // hosts nothing the focus has to stay near, and focusing an aria-hidden element is a contradiction the
+    // browsers report. A TabIndex of the consumer's own wins over it.
+    private string? GetTabIndex() => TabIndex ?? (IsDecorative ? null : "-1");
+
     // What the overflow toggle acts on, in the order the consumer's intent is expressed: the element it
     // named, then the selector it named, then the scroller of the application shell the Overlay is inside
     // of, and the page when it is inside none.

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.scss
@@ -9,19 +9,22 @@
 // scrim that centers a loader and a decision the Overlay has none of its own to make.
 // The layer is made programmatically focusable so that a press on it has somewhere inside the Overlay to
 // put the focus it takes off an input. That focus is never one the user moved there with the keyboard, so
-// it is not one to draw a ring around - and leaving a text input hands :focus-visible on to wherever the
-// focus goes next, which would otherwise ring the whole screen.
+// it is not one to draw a ring around; :focus-visible still does for the consumer who makes the layer
+// reachable with a TabIndex of their own.
 .bit-ovl {
     inset: 0;
     opacity: 0;
     width: 100%;
     height: 100%;
-    outline: none;
     display: flex;
     position: fixed;
     visibility: hidden;
     z-index: $zindex-overlay;
     transition: opacity $mot-duration-short $mot-easing-accelerate, visibility 0s linear $mot-duration-short;
+
+    &:focus:not(:focus-visible) {
+        outline: none;
+    }
 }
 
 .bit-ovl-opn {

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.scss
@@ -8,9 +8,10 @@
 // over the whole of it until the stylesheet of the consumer aligns it, which is two properties for the
 // scrim that centers a loader and a decision the Overlay has none of its own to make.
 // The layer is made programmatically focusable so that a press on it has somewhere inside the Overlay to
-// put the focus it takes off an input. That focus is never one the user moved there with the keyboard, so
-// it is not one to draw a ring around; :focus-visible still does for the consumer who makes the layer
-// reachable with a TabIndex of their own.
+// put the focus it takes off an input.
+// That press is left its default action, and the default of a press that is dragged is a text selection -
+// one that would start at the layer and run through whatever it is showing, or the page beside it. The
+// content is handed the selectability back, so what the consumer put on the layer reads as it always has.
 .bit-ovl {
     inset: 0;
     opacity: 0;
@@ -19,12 +20,11 @@
     display: flex;
     position: fixed;
     visibility: hidden;
+    user-select: none;
     z-index: $zindex-overlay;
     transition: opacity $mot-duration-short $mot-easing-accelerate, visibility 0s linear $mot-duration-short;
 
-    &:focus:not(:focus-visible) {
-        outline: none;
-    }
+    @include focus-anchor;
 }
 
 .bit-ovl-opn {
@@ -38,6 +38,7 @@
 // flex container - the box is there for the events, and for nothing else.
 .bit-ovl-cnt {
     display: contents;
+    user-select: text;
 }
 
 // ModeFull: the Overlay dims what it covers instead of only catching the clicks meant for it. It is a

--- a/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Components/Utilities/Overlay/BitOverlay.scss
@@ -7,11 +7,16 @@
 // The layer is a flex container and lays its content out no further than that: what it hosts stretches
 // over the whole of it until the stylesheet of the consumer aligns it, which is two properties for the
 // scrim that centers a loader and a decision the Overlay has none of its own to make.
+// The layer is made programmatically focusable so that a press on it has somewhere inside the Overlay to
+// put the focus it takes off an input. That focus is never one the user moved there with the keyboard, so
+// it is not one to draw a ring around - and leaving a text input hands :focus-visible on to wherever the
+// focus goes next, which would otherwise ring the whole screen.
 .bit-ovl {
     inset: 0;
     opacity: 0;
     width: 100%;
     height: 100%;
+    outline: none;
     display: flex;
     position: fixed;
     visibility: hidden;

--- a/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/UtilsJsRuntimeExtensions.cs
+++ b/src/BlazorUI/Bit.BlazorUI/Extensions/JsInterop/UtilsJsRuntimeExtensions.cs
@@ -73,9 +73,11 @@ internal static class UtilsJsRuntimeExtensions
     }
 
 
-    internal static ValueTask BitUtilsSetupFocusTrap(this IJSRuntime jsRuntime, string elementId)
+    // `anchorId` is the element around the container that catches the focus a press on the overlay moves
+    // and hands it on into the container; see Utils.setupFocusTrap.
+    internal static ValueTask BitUtilsSetupFocusTrap(this IJSRuntime jsRuntime, string elementId, string? anchorId = null)
     {
-        return jsRuntime.InvokeVoid("BitBlazorUI.Utils.setupFocusTrap", elementId);
+        return jsRuntime.InvokeVoid("BitBlazorUI.Utils.setupFocusTrap", elementId, anchorId);
     }
 
 

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Utils.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Utils.ts
@@ -942,12 +942,19 @@
             const focusables = Array.from(root.querySelectorAll<HTMLElement>(Utils._focusables))
                 .filter(Utils.isFocusable);
 
+            // Where the focus actually is, which is not always one of the elements above: a surface makes
+            // both the element the trap is registered on and the box its content lives in programmatically
+            // focusable - the first for a press on the overlay to land on, the second for a content that
+            // holds nothing focusable - so the focus is regularly on an element the tab sequence itself
+            // never reaches.
+            const active = document.activeElement as HTMLElement | null;
+            const inside = active !== null && (active === root || root.contains(active));
+
             if (focusables.length === 0) {
-                // Nothing inside the container can take the focus, which leaves the container itself
-                // holding it - the components that trap the focus make it programmatically focusable for
-                // exactly this case. Tabbing on from there would walk straight out of the trap and into
-                // the page behind it, so the key is swallowed instead of being left to the browser.
-                if (document.activeElement === root) {
+                // Nothing inside the trap can take the focus, which leaves it on one of those anchors.
+                // Tabbing on from there would walk straight out of the trap and into the page behind it,
+                // so the key is swallowed instead of being left to the browser.
+                if (inside) {
                     e.preventDefault();
                 }
                 return;
@@ -955,18 +962,21 @@
 
             const first = focusables[0];
             const last = focusables[focusables.length - 1];
-            const active = document.activeElement;
 
-            // The focus is on the container itself rather than on anything inside it, which is where a press
-            // on the overlay of a dialog surface leaves it: the container is the nearest element to the
-            // overlay that can hold the focus, and the surfaces make it focusable for that. Tab from there
-            // reaches the content on its own, since the content follows the container in the tab order, but
-            // Shift+Tab walks backwards out of the trap and into the page behind it.
-            if (active === root) {
-                if (e.shiftKey) {
-                    last.focus();
+            // The focus is on one of those anchors rather than on anything the tab sequence reaches. The key
+            // is left to the browser wherever it still has somewhere inside the trap to go - a Tab from an
+            // anchor that precedes the content reaches the content on its own - and the direction that has
+            // nothing left inside it wraps around to the other end, which is what a Shift+Tab from an anchor
+            // above the content does. An anchor in the middle of the content is left both of its neighbours.
+            if (inside && focusables.indexOf(active!) < 0) {
+                const towards = e.shiftKey ? Node.DOCUMENT_POSITION_PRECEDING : Node.DOCUMENT_POSITION_FOLLOWING;
+                const reachable = focusables.some(el => (active!.compareDocumentPosition(el) & towards) !== 0);
+
+                if (reachable === false) {
+                    (e.shiftKey ? last : first).focus();
                     e.preventDefault();
                 }
+
                 return;
             }
 

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Utils.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Utils.ts
@@ -957,6 +957,19 @@
             const last = focusables[focusables.length - 1];
             const active = document.activeElement;
 
+            // The focus is on the container itself rather than on anything inside it, which is where a press
+            // on the overlay of a dialog surface leaves it: the container is the nearest element to the
+            // overlay that can hold the focus, and the surfaces make it focusable for that. Tab from there
+            // reaches the content on its own, since the content follows the container in the tab order, but
+            // Shift+Tab walks backwards out of the trap and into the page behind it.
+            if (active === root) {
+                if (e.shiftKey) {
+                    last.focus();
+                    e.preventDefault();
+                }
+                return;
+            }
+
             if (e.shiftKey && active === first) {
                 last.focus();
                 e.preventDefault();

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/Utils.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/Utils.ts
@@ -202,13 +202,22 @@
         // is what a popup that takes the keyboard over has to do: the tab order runs on into the page behind
         // it otherwise, leaving the focus somewhere an overlay swallows every click that could bring it back.
         // Registering again on the same element replaces the previous registration.
-        public static setupFocusTrap(elementId: string) {
+        // `anchorId` names an element around the container that a surface makes programmatically focusable
+        // (tabindex="-1") for the sake of the press on its overlay: pressing something that cannot hold the
+        // focus moves it to the nearest element that can, and that press is left its default action - it is
+        // what blurs the input the user was typing into, and an input only commits what was typed once it
+        // loses the focus, which the dismissal the click runs is what most needs to see. The anchor only
+        // catches that focus: it is passed straight on into the container, where the dialog role and the
+        // accessible name are - a screen reader confined to the dialog by aria-modal would otherwise hear the
+        // focus leave it - and where this trap and the surface's Escape handler are.
+        public static setupFocusTrap(elementId: string, anchorId?: string | null) {
             Utils.disposeFocusTrap(elementId);
 
             const element = document.getElementById(elementId);
             if (!element) return;
 
             const controller = new AbortController();
+            const signal = controller.signal;
 
             element.addEventListener('keydown', e => {
                 if (e.key !== 'Tab') return;
@@ -220,7 +229,18 @@
                 if (Utils.hasNearerFocusTrap(element, e.target as Element | null)) return;
 
                 Utils.wrapFocus(element, e);
-            }, { signal: controller.signal });
+            }, { signal });
+
+            const anchor = anchorId ? document.getElementById(anchorId) : null;
+            if (anchor && anchor !== element) {
+                anchor.addEventListener('focusin', e => {
+                    // The focus landing on something inside the anchor - the container itself included, once
+                    // it is passed on below - is not the anchor being focused.
+                    if (e.target !== anchor) return;
+
+                    element.focus({ preventScroll: true });
+                }, { signal });
+            }
 
             Utils._focusTraps.set(elementId, controller);
         }
@@ -942,19 +962,14 @@
             const focusables = Array.from(root.querySelectorAll<HTMLElement>(Utils._focusables))
                 .filter(Utils.isFocusable);
 
-            // Where the focus actually is, which is not always one of the elements above: a surface makes
-            // both the element the trap is registered on and the box its content lives in programmatically
-            // focusable - the first for a press on the overlay to land on, the second for a content that
-            // holds nothing focusable - so the focus is regularly on an element the tab sequence itself
-            // never reaches.
-            const active = document.activeElement as HTMLElement | null;
-            const inside = active !== null && (active === root || root.contains(active));
+            const active = document.activeElement;
 
             if (focusables.length === 0) {
-                // Nothing inside the trap can take the focus, which leaves it on one of those anchors.
-                // Tabbing on from there would walk straight out of the trap and into the page behind it,
-                // so the key is swallowed instead of being left to the browser.
-                if (inside) {
+                // Nothing inside the container can take the focus, which leaves the container itself
+                // holding it - the components that trap the focus make it programmatically focusable for
+                // exactly this case. Tabbing on from there would walk straight out of the trap and into
+                // the page behind it, so the key is swallowed instead of being left to the browser.
+                if (active === root) {
                     e.preventDefault();
                 }
                 return;
@@ -963,20 +978,15 @@
             const first = focusables[0];
             const last = focusables[focusables.length - 1];
 
-            // The focus is on one of those anchors rather than on anything the tab sequence reaches. The key
-            // is left to the browser wherever it still has somewhere inside the trap to go - a Tab from an
-            // anchor that precedes the content reaches the content on its own - and the direction that has
-            // nothing left inside it wraps around to the other end, which is what a Shift+Tab from an anchor
-            // above the content does. An anchor in the middle of the content is left both of its neighbours.
-            if (inside && focusables.indexOf(active!) < 0) {
-                const towards = e.shiftKey ? Node.DOCUMENT_POSITION_PRECEDING : Node.DOCUMENT_POSITION_FOLLOWING;
-                const reachable = focusables.some(el => (active!.compareDocumentPosition(el) & towards) !== 0);
-
-                if (reachable === false) {
-                    (e.shiftKey ? last : first).focus();
-                    e.preventDefault();
-                }
-
+            // The container itself holding the focus - where a surface parks it as it opens, and where the
+            // focus a press on its overlay took off an input is passed on to - is inside the trap but on no
+            // edge of it, and the browser's own answer to a Tab from there is not bounded by the trap: its
+            // sequential order puts positive tabindexes first wherever on the page they are, and a Shift+Tab
+            // walks backwards out of the container altogether. Everything the trap holds is inside the
+            // container, so the next stop is its first element and the previous one its last.
+            if (active === root) {
+                (e.shiftKey ? last : first).focus();
+                e.preventDefault();
                 return;
             }
 

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/general.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/general.ts
@@ -95,26 +95,6 @@ document.addEventListener('pointerdown', (e: PointerEvent) => {
     BitBlazorUI.Callouts.dismissOnOutsideInteraction(e.target as Node);
 }, true);
 
-// The overlays the dialog surfaces cover the page with refuse the default of a press on them, so that the
-// focus is not dropped on the body, out of reach of their Escape handling and their focus trap. That same
-// default is what takes the focus off whatever had it, though, and an input commits what was typed into it
-// (its change event, which a binding waits for) only once the focus leaves it: a value typed and then left
-// by pressing the overlay would reach the dismissal handlers uncommitted. So the press moves the focus
-// itself, onto the element the layer names - the surface, which holds the focus where the browser would
-// have dropped it - and the input it leaves commits before the click that follows the press is dispatched.
-// The capture phase is what runs this ahead of the handlers of the press, and of the click after it.
-document.addEventListener('mousedown', (e: MouseEvent) => {
-    if (!(e.target instanceof Element)) return;
-
-    const targetId = e.target.getAttribute('data-bit-press-focus');
-    if (!targetId) return;
-
-    const target = document.getElementById(targetId);
-    if (!target || document.activeElement === target) return;
-
-    target.focus({ preventScroll: true });
-}, true);
-
 // A right-click dismisses the same callouts, except where the page took the click for itself - a handler
 // that opens a context menu of its own calls preventDefault on it - since that is the page moving its own
 // menu to the new point rather than the user leaving it. Whether the click was taken is only known once

--- a/src/BlazorUI/Bit.BlazorUI/Scripts/general.ts
+++ b/src/BlazorUI/Bit.BlazorUI/Scripts/general.ts
@@ -95,6 +95,26 @@ document.addEventListener('pointerdown', (e: PointerEvent) => {
     BitBlazorUI.Callouts.dismissOnOutsideInteraction(e.target as Node);
 }, true);
 
+// The overlays the dialog surfaces cover the page with refuse the default of a press on them, so that the
+// focus is not dropped on the body, out of reach of their Escape handling and their focus trap. That same
+// default is what takes the focus off whatever had it, though, and an input commits what was typed into it
+// (its change event, which a binding waits for) only once the focus leaves it: a value typed and then left
+// by pressing the overlay would reach the dismissal handlers uncommitted. So the press moves the focus
+// itself, onto the element the layer names - the surface, which holds the focus where the browser would
+// have dropped it - and the input it leaves commits before the click that follows the press is dispatched.
+// The capture phase is what runs this ahead of the handlers of the press, and of the click after it.
+document.addEventListener('mousedown', (e: MouseEvent) => {
+    if (!(e.target instanceof Element)) return;
+
+    const targetId = e.target.getAttribute('data-bit-press-focus');
+    if (!targetId) return;
+
+    const target = document.getElementById(targetId);
+    if (!target || document.activeElement === target) return;
+
+    target.focus({ preventScroll: true });
+}, true);
+
 // A right-click dismisses the same callouts, except where the page took the click for itself - a handler
 // that opens a context menu of its own calls preventDefault on it - since that is the page moving its own
 // menu to the new point rather than the user leaving it. Whether the click was taken is only known once

--- a/src/BlazorUI/Bit.BlazorUI/Styles/functions.scss
+++ b/src/BlazorUI/Bit.BlazorUI/Styles/functions.scss
@@ -106,3 +106,19 @@ $html-font-size: 16px;
         outline: #{$shp-focus-ring-width} solid Highlight;
     }
 }
+
+/*
+ * focus-anchor
+ * --------------------------------------------------
+ * For an element that is made programmatically focusable (tabindex="-1") only so that the focus has
+ * somewhere inside a surface to land: the root a press on the overlay focuses, the container a surface
+ * holding nothing focusable parks the keyboard on, the layer of an Overlay. That focus is never one the
+ * user moved there to operate anything, so there is nothing for a ring to advertise - and around a root
+ * that spans the whole screen a ring would be drawn along the edge of the viewport itself.
+ * The outline is dropped outright rather than only outside :focus-visible: a browser turns the focus a
+ * press placed into a "visible" one on the first key pressed afterwards - Escape on a surface that
+ * refuses to dismiss, any letter - and the viewport-sized ring would appear right then.
+ */
+@mixin focus-anchor {
+    outline: none;
+}

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor
@@ -676,7 +676,8 @@
                        ShowCloseButton="false"
                        OkText="Send">
                 <div class="dialog-body">
-                    <BitTextField Label="What happened?" Multiline Rows="4" />
+                    <BitTextField Label="What happened?" Multiline Rows="4" @bind-Value="dialogValue" />
+                    <div><b>Value</b> is: @dialogValue</div>
                 </div>
             </BitDialog>
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
@@ -904,8 +904,10 @@ public partial class BitDialogDemo
     private bool isOpenOuter = false;
     private bool isOpenInner = false;
 
+    private string dialogValue = string.Empty;
     private bool isOpenKeptMounted = false;
     private bool isOpenUnmounted = false;
+
 
     private BitDialog programmaticDialogRef = default!;
 
@@ -1524,7 +1526,8 @@ private bool isOpenInner = false;";
            ShowCloseButton=""false""
            OkText=""Send"">
     <div class=""dialog-body"">
-        <BitTextField Label=""What happened?"" Multiline Rows=""4"" />
+        <BitTextField Label=""What happened?"" Multiline Rows=""4"" @bind-Value=""dialogValue"" />
+        <div><b>Value</b> is: @dialogValue</div>
     </div>
 </BitDialog>
 
@@ -1537,6 +1540,7 @@ private bool isOpenInner = false;";
     </div>
 </BitDialog>";
     private readonly string example15CsharpCode = @"
+private string dialogValue = string.Empty;
 private bool isOpenKeptMounted = false;
 private bool isOpenUnmounted = false;";
 

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Surfaces/Dialog/BitDialogDemo.razor.cs
@@ -905,9 +905,9 @@ public partial class BitDialogDemo
     private bool isOpenInner = false;
 
     private string dialogValue = string.Empty;
+
     private bool isOpenKeptMounted = false;
     private bool isOpenUnmounted = false;
-
 
     private BitDialog programmaticDialogRef = default!;
 

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
@@ -1887,28 +1887,45 @@ public class BitDialogTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitDialogOverlayShouldRefuseTheDefaultOfThePressSoTheFocusNeverLeaves()
+    public void BitDialogOverlayShouldLeaveThePressItsDefaultAndKeepTheFocusOnTheRoot()
     {
         var component = RenderComponent<BitDialog>(parameters => parameters.Add(p => p.IsOpen, true));
 
-        // Pressing the overlay is what would otherwise leave the body holding the focus, outside the trap.
-        // The default of the press is refused, so the focus stays where the Dialog put it.
-        StringAssert.Contains(component.Markup, "onmousedown:preventDefault");
+        // The press on the overlay keeps its default action, which is what blurs the input the user was
+        // typing into - and an input only commits what was typed once it loses the focus, before the click
+        // the press turns into reaches any dismissal handler.
+        Assert.IsFalse(component.Find(".bit-dlg-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
+
+        // The focus that press moves lands on the root rather than on the body: the browser moves it to the
+        // nearest element that can hold it, and the root is made focusable for exactly that. That is what
+        // keeps the Escape handler and the focus trap, both of which sit on the root, reachable.
+        Assert.AreEqual("-1", component.Find(".bit-dlg").GetAttribute("tabindex"));
     }
 
     [TestMethod]
-    public void BitDialogOverlayShouldHandTheFocusOfAPressToTheSurface()
+    public void BitDialogShouldTrapTheFocusOnTheRootTheOverlayPressLandsOn()
     {
         var component = RenderComponent<BitDialog>(parameters => parameters.Add(p => p.IsOpen, true));
 
-        // Refusing the default of the press also keeps the focus on an input the user typed into, which then
-        // never commits its value before the dismissal handlers run. The overlay names the surface for the
-        // script to move the focus onto instead, which takes it off the input without leaving the Dialog.
-        var overlay = component.Find(".bit-dlg-ovl");
-        var surface = component.Find(".bit-dlg-ctn");
+        component.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
 
-        Assert.AreEqual(surface.Id, overlay.GetAttribute("data-bit-press-focus"));
-        Assert.AreEqual("-1", surface.GetAttribute("tabindex"));
+        // The trap is registered on the root rather than on the surface: a press on the overlay leaves the
+        // focus on the root, and a trap on the surface would never see the Tab that follows it.
+        Assert.AreEqual(component.Find(".bit-dlg").Id, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+    }
+
+    [TestMethod]
+    public void BitDialogEscapeShouldDismissFromTheRootTheOverlayPressLandsOn()
+    {
+        var isOpen = true;
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-dlg").KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+        Assert.IsFalse(isOpen);
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
@@ -1897,8 +1897,8 @@ public class BitDialogTests : BunitTestContext
         Assert.IsFalse(component.Find(".bit-dlg-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
 
         // The focus that press moves lands on the root rather than on the body: the browser moves it to the
-        // nearest element that can hold it, and the root is made focusable for exactly that. That is what
-        // keeps the Escape handler and the focus trap, both of which sit on the root, reachable.
+        // nearest element that can hold it, and the root is made focusable for exactly that. The focus trap
+        // then passes it on into the surface, where the dialog role is.
         Assert.AreEqual("-1", component.Find(".bit-dlg").GetAttribute("tabindex"));
     }
 
@@ -1918,15 +1918,18 @@ public class BitDialogTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitDialogShouldTrapTheFocusOnTheRootTheOverlayPressLandsOn()
+    public void BitDialogShouldNameTheRootTheOverlayPressLandsOnToItsFocusTrap()
     {
         var component = RenderComponent<BitDialog>(parameters => parameters.Add(p => p.IsOpen, true));
 
-        component.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
+        Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count);
 
-        // The trap is registered on the root rather than on the surface: a press on the overlay leaves the
-        // focus on the root, and a trap on the surface would never see the Tab that follows it.
-        Assert.AreEqual(component.Find(".bit-dlg").Id, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+        // The trap stays on the surface, which is the element with the dialog role and the id no consumer
+        // can make collide; the root is named to it as the anchor a press on the overlay lands the focus on,
+        // so that the trap can pass that focus on into the surface.
+        var setup = Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1];
+        Assert.AreEqual(component.Find(".bit-dlg-ctn").Id, setup.Arguments[0]);
+        Assert.AreEqual(component.Find(".bit-dlg").Id, setup.Arguments[1]);
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
@@ -1902,6 +1902,21 @@ public class BitDialogTests : BunitTestContext
         Assert.AreEqual("-1", component.Find(".bit-dlg").GetAttribute("tabindex"));
     }
 
+    // The tabindex the Dialog writes is the one it needs to be able to hold the focus itself, which is a
+    // default rather than a decision about where the Dialog sits in the tab sequence: a consumer who names
+    // one keeps it, the way they keep every other attribute they pass.
+    [TestMethod]
+    public void BitDialogShouldLetATabIndexOfTheConsumerWin()
+    {
+        var component = RenderComponent<BitDialog>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.TabIndex, "0");
+        });
+
+        Assert.AreEqual("0", component.Find(".bit-dlg").GetAttribute("tabindex"));
+    }
+
     [TestMethod]
     public void BitDialogShouldTrapTheFocusOnTheRootTheOverlayPressLandsOn()
     {

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Dialog/BitDialogTests.cs
@@ -1897,6 +1897,21 @@ public class BitDialogTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitDialogOverlayShouldHandTheFocusOfAPressToTheSurface()
+    {
+        var component = RenderComponent<BitDialog>(parameters => parameters.Add(p => p.IsOpen, true));
+
+        // Refusing the default of the press also keeps the focus on an input the user typed into, which then
+        // never commits its value before the dismissal handlers run. The overlay names the surface for the
+        // script to move the focus onto instead, which takes it off the input without leaving the Dialog.
+        var overlay = component.Find(".bit-dlg-ovl");
+        var surface = component.Find(".bit-dlg-ctn");
+
+        Assert.AreEqual(surface.Id, overlay.GetAttribute("data-bit-press-focus"));
+        Assert.AreEqual("-1", surface.GetAttribute("tabindex"));
+    }
+
+    [TestMethod]
     public void BitDialogOverlayClickShouldNotChaseTheFocusAcrossTheInterop()
     {
         var isOpen = true;

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
@@ -1853,6 +1853,21 @@ public class BitModalTests : BunitTestContext
         Assert.AreEqual("-1", com.Find(".bit-mdl").GetAttribute("tabindex"));
     }
 
+    // The tabindex the Modal writes is the one it needs to be able to hold the focus itself, which is a
+    // default rather than a decision about where the Modal sits in the tab sequence: a consumer who names
+    // one keeps it, the way they keep every other attribute they pass.
+    [TestMethod]
+    public void BitModalShouldLetATabIndexOfTheConsumerWin()
+    {
+        var com = RenderComponent<BitModal>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.TabIndex, "0");
+        });
+
+        Assert.AreEqual("0", com.Find(".bit-mdl").GetAttribute("tabindex"));
+    }
+
     [TestMethod]
     public void BitModalShouldStillBeDismissedByAClickOnTheOverlay()
     {

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
@@ -181,21 +181,6 @@ public class BitModalTests : BunitTestContext
         Assert.AreEqual(1, currentCount);
     }
 
-    [TestMethod]
-    public void BitModalOverlayShouldHandTheFocusOfAPressToTheContent()
-    {
-        var com = RenderComponent<BitModal>(parameters => parameters.Add(p => p.IsOpen, true));
-
-        // The press on the overlay has its default refused, so the focus would never leave an input the user
-        // typed into - and the input would never commit its value before the dismissal handlers run. The
-        // overlay names the content for the script to move the focus onto instead, which keeps it inside.
-        var overlay = com.Find(".bit-mdl-ovl");
-        var content = com.Find(".bit-mdl-ctn");
-
-        Assert.AreEqual(content.Id, overlay.GetAttribute("data-bit-press-focus"));
-        Assert.AreEqual("-1", content.GetAttribute("tabindex"));
-    }
-
 
 
     // ------------------------------------------------------------------------------------------------
@@ -624,6 +609,7 @@ public class BitModalTests : BunitTestContext
             parameters.Add(p => p.IsOpen, true);
         });
 
+        var rootId = com.Find(".bit-mdl").Id;
         var containerId = com.Find(".bit-mdl-ctn").Id;
 
         com.WaitForAssertion(() =>
@@ -633,7 +619,10 @@ public class BitModalTests : BunitTestContext
             Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.focusFirstElement"].Count);
         });
 
-        Assert.AreEqual(containerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+        // The trap is registered on the root rather than on the content box: a press on the overlay leaves
+        // the focus on the root, and a trap on the content would never see the Tab that follows it. The
+        // focus itself still starts inside the content, which is where everything worth reaching is.
+        Assert.AreEqual(rootId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
         Assert.AreEqual(containerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.focusFirstElement"][^1].Arguments[0]);
     }
 
@@ -1846,21 +1835,26 @@ public class BitModalTests : BunitTestContext
     // ------------------------------------------------------------------------------------------------
 
     [TestMethod]
-    public void BitModalShouldRefuseTheDefaultOfAPressOnItsOverlay()
+    public void BitModalOverlayShouldLeaveThePressItsDefaultAndKeepTheFocusOnTheRoot()
     {
-        // Pressing something that cannot hold the focus is what takes the focus off whatever had it, and a
-        // press on the overlay would otherwise leave the keyboard on the body - out of reach of the Escape
-        // handler on the Modal and of the focus trap on its content.
         var com = RenderComponent<BitModal>(parameters =>
         {
             parameters.Add(p => p.IsOpen, true);
         });
 
-        Assert.IsTrue(com.Find(".bit-mdl-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
+        // The press on the overlay keeps its default action, which is what blurs the input the user was
+        // typing into - and an input only commits what was typed once it loses the focus, before the click
+        // the press turns into reaches any dismissal handler.
+        Assert.IsFalse(com.Find(".bit-mdl-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
+
+        // The focus that press moves lands on the root rather than on the body: the browser moves it to the
+        // nearest element that can hold it, and the root is made focusable for exactly that. That is what
+        // keeps the Escape handler and the focus trap, both of which sit on the root, reachable.
+        Assert.AreEqual("-1", com.Find(".bit-mdl").GetAttribute("tabindex"));
     }
 
     [TestMethod]
-    public void BitModalShouldStillBeDismissedByAClickOnTheOverlayItRefusedTheDefaultOf()
+    public void BitModalShouldStillBeDismissedByAClickOnTheOverlay()
     {
         var isOpen = true;
         var com = RenderComponent<BitModal>(parameters =>
@@ -1937,10 +1931,10 @@ public class BitModalTests : BunitTestContext
 
         com.WaitForAssertion(() => Assert.AreEqual(2, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
 
-        // The inner Modal's trap is registered against its own content box, not against the one it renders
-        // inside of, so Tab cycles within the Modal the keyboard is actually in.
-        var innerContainerId = com.Find(".inner-modal .bit-mdl-ctn").Id;
-        Assert.AreEqual(innerContainerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+        // The inner Modal's trap is registered against its own root, not against the one it renders inside
+        // of, so Tab cycles within the Modal the keyboard is actually in.
+        var innerRootId = com.Find(".inner-modal").Id;
+        Assert.AreEqual(innerRootId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
     }
 
 

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
@@ -619,10 +619,12 @@ public class BitModalTests : BunitTestContext
             Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.focusFirstElement"].Count);
         });
 
-        // The trap is registered on the root rather than on the content box: a press on the overlay leaves
-        // the focus on the root, and a trap on the content would never see the Tab that follows it. The
-        // focus itself still starts inside the content, which is where everything worth reaching is.
-        Assert.AreEqual(rootId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+        // The trap stays on the content box, which is the element with the dialog role; the root is named to
+        // it as the anchor a press on the overlay lands the focus on, so that the trap can pass that focus
+        // on into the content.
+        var setup = Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1];
+        Assert.AreEqual(containerId, setup.Arguments[0]);
+        Assert.AreEqual(rootId, setup.Arguments[1]);
         Assert.AreEqual(containerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.focusFirstElement"][^1].Arguments[0]);
     }
 
@@ -1848,8 +1850,8 @@ public class BitModalTests : BunitTestContext
         Assert.IsFalse(com.Find(".bit-mdl-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
 
         // The focus that press moves lands on the root rather than on the body: the browser moves it to the
-        // nearest element that can hold it, and the root is made focusable for exactly that. That is what
-        // keeps the Escape handler and the focus trap, both of which sit on the root, reachable.
+        // nearest element that can hold it, and the root is made focusable for exactly that. The focus trap
+        // then passes it on into the content box, where the dialog role is.
         Assert.AreEqual("-1", com.Find(".bit-mdl").GetAttribute("tabindex"));
     }
 
@@ -1946,10 +1948,10 @@ public class BitModalTests : BunitTestContext
 
         com.WaitForAssertion(() => Assert.AreEqual(2, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
 
-        // The inner Modal's trap is registered against its own root, not against the one it renders inside
-        // of, so Tab cycles within the Modal the keyboard is actually in.
-        var innerRootId = com.Find(".inner-modal").Id;
-        Assert.AreEqual(innerRootId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+        // The inner Modal's trap is registered against its own content box, not against the one it renders
+        // inside of, so Tab cycles within the Modal the keyboard is actually in.
+        var innerContainerId = com.Find(".inner-modal .bit-mdl-ctn").Id;
+        Assert.AreEqual(innerContainerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
     }
 
 

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Modal/BitModalTests.cs
@@ -181,6 +181,21 @@ public class BitModalTests : BunitTestContext
         Assert.AreEqual(1, currentCount);
     }
 
+    [TestMethod]
+    public void BitModalOverlayShouldHandTheFocusOfAPressToTheContent()
+    {
+        var com = RenderComponent<BitModal>(parameters => parameters.Add(p => p.IsOpen, true));
+
+        // The press on the overlay has its default refused, so the focus would never leave an input the user
+        // typed into - and the input would never commit its value before the dismissal handlers run. The
+        // overlay names the content for the script to move the focus onto instead, which keeps it inside.
+        var overlay = com.Find(".bit-mdl-ovl");
+        var content = com.Find(".bit-mdl-ctn");
+
+        Assert.AreEqual(content.Id, overlay.GetAttribute("data-bit-press-focus"));
+        Assert.AreEqual("-1", content.GetAttribute("tabindex"));
+    }
+
 
 
     // ------------------------------------------------------------------------------------------------

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
@@ -44,7 +44,9 @@ public class BitPanelTests : BunitTestContext
     }
 
     // A closed panel keeps its content in the page so that closing it has something to slide out, so the
-    // content has to be taken out of the tab order and out of the accessibility tree some other way.
+    // content has to be taken out of the tab order and out of the accessibility tree some other way. The
+    // root is what carries it, so the whole of the panel is covered - the focus a press on the overlay
+    // leaves on the root included, which would otherwise stay there for as long as the panel is closed.
     [TestMethod,
         DataRow(false),
         DataRow(true)
@@ -56,9 +58,9 @@ public class BitPanelTests : BunitTestContext
             parameters.Add(p => p.IsOpen, isOpen);
         });
 
-        var container = com.Find(".bit-pnl-cnt");
+        var root = com.Find(".bit-pnl");
 
-        Assert.AreEqual(isOpen is false, container.HasAttribute("inert"));
+        Assert.AreEqual(isOpen is false, root.HasAttribute("inert"));
     }
 
     [TestMethod,
@@ -744,6 +746,21 @@ public class BitPanelTests : BunitTestContext
 
         com.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
         Assert.AreEqual(com.Find(".bit-pnl").Id, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+    }
+
+    // The tabindex the panel writes is the one it needs to be able to hold the focus itself, which is a
+    // default rather than a decision about where the panel sits in the tab sequence: a consumer who names
+    // one keeps it, the way they keep every other attribute they pass.
+    [TestMethod]
+    public void BitPanelShouldLetATabIndexOfTheConsumerWin()
+    {
+        var com = RenderComponent<BitPanel>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.TabIndex, "0");
+        });
+
+        Assert.AreEqual("0", com.Find(".bit-pnl").GetAttribute("tabindex"));
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
@@ -115,21 +115,6 @@ public class BitPanelTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitPanelOverlayShouldHandTheFocusOfAPressToTheContainer()
-    {
-        var com = RenderComponent<BitPanel>(parameters => parameters.Add(p => p.IsOpen, true));
-
-        // Refusing the default of the press also keeps the focus on an input the user typed into, which then
-        // never commits its value before the dismissal handlers run. The overlay names the container for the
-        // script to move the focus onto instead, which takes it off the input without leaving the panel.
-        var overlay = com.Find(".bit-pnl-ovl");
-        var container = com.Find(".bit-pnl-cnt");
-
-        Assert.AreEqual(container.Id, overlay.GetAttribute("data-bit-press-focus"));
-        Assert.AreEqual("-1", container.GetAttribute("tabindex"));
-    }
-
-    [TestMethod]
     public void BitPanelContentTest()
     {
         var com = RenderComponent<BitPanel>(parameters =>
@@ -740,6 +725,25 @@ public class BitPanelTests : BunitTestContext
 
         var released = Context.JSInterop.Invocations["BitBlazorUI.Utils.unlockScroll"][^1];
         Assert.AreEqual(Context.JSInterop.Invocations["BitBlazorUI.Utils.lockScroll"][^1].Arguments[0], released.Arguments[0]);
+    }
+
+    [TestMethod]
+    public void BitPanelOverlayShouldLeaveThePressItsDefaultAndKeepTheFocusOnTheRoot()
+    {
+        var com = RenderComponent<BitPanel>(parameters => parameters.Add(p => p.IsOpen, true));
+
+        // The press on the overlay keeps its default action, which is what blurs the input the user was
+        // typing into - and an input only commits what was typed once it loses the focus, before the click
+        // the press turns into reaches any dismissal handler.
+        Assert.IsFalse(com.Find(".bit-pnl-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
+
+        // The focus that press moves lands on the root rather than on the body: the browser moves it to the
+        // nearest element that can hold it, and the root is made focusable for exactly that. That is what
+        // keeps the Escape handler and the focus trap, both of which sit on the root, reachable.
+        Assert.AreEqual("-1", com.Find(".bit-pnl").GetAttribute("tabindex"));
+
+        com.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
+        Assert.AreEqual(com.Find(".bit-pnl").Id, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
@@ -115,6 +115,21 @@ public class BitPanelTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitPanelOverlayShouldHandTheFocusOfAPressToTheContainer()
+    {
+        var com = RenderComponent<BitPanel>(parameters => parameters.Add(p => p.IsOpen, true));
+
+        // Refusing the default of the press also keeps the focus on an input the user typed into, which then
+        // never commits its value before the dismissal handlers run. The overlay names the container for the
+        // script to move the focus onto instead, which takes it off the input without leaving the panel.
+        var overlay = com.Find(".bit-pnl-ovl");
+        var container = com.Find(".bit-pnl-cnt");
+
+        Assert.AreEqual(container.Id, overlay.GetAttribute("data-bit-press-focus"));
+        Assert.AreEqual("-1", container.GetAttribute("tabindex"));
+    }
+
+    [TestMethod]
     public void BitPanelContentTest()
     {
         var com = RenderComponent<BitPanel>(parameters =>

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Surfaces/Panel/BitPanelTests.cs
@@ -740,12 +740,16 @@ public class BitPanelTests : BunitTestContext
         Assert.IsFalse(com.Find(".bit-pnl-ovl").HasAttribute("blazor:onmousedown:preventdefault"));
 
         // The focus that press moves lands on the root rather than on the body: the browser moves it to the
-        // nearest element that can hold it, and the root is made focusable for exactly that. That is what
-        // keeps the Escape handler and the focus trap, both of which sit on the root, reachable.
+        // nearest element that can hold it, and the root is made focusable for exactly that. The focus trap
+        // then passes it on into the container, where the dialog role is: the trap stays on the container,
+        // and the root is named to it as the anchor the press lands on.
         Assert.AreEqual("-1", com.Find(".bit-pnl").GetAttribute("tabindex"));
 
-        com.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
-        Assert.AreEqual(com.Find(".bit-pnl").Id, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1].Arguments[0]);
+        Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count);
+
+        var setup = Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"][^1];
+        Assert.AreEqual(com.Find(".bit-pnl-cnt").Id, setup.Arguments[0]);
+        Assert.AreEqual(com.Find(".bit-pnl").Id, setup.Arguments[1]);
     }
 
     // The tabindex the panel writes is the one it needs to be able to hold the focus itself, which is a

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTabIndexAttributeTest.razor
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTabIndexAttributeTest.razor
@@ -1,0 +1,1 @@
+﻿<BitOverlay tabindex="0" />

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
@@ -16,7 +16,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -32,7 +32,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = isEnabled ? null : " bit-dis";
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -40,14 +40,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.IsEnabled, false);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -64,11 +64,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (style.HasValue())
         {
-            component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -77,7 +77,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         var style = "padding: 1rem;";
         component.Render(parameters =>
@@ -85,7 +85,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Style, style);
         });
 
-        component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -101,7 +101,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = @class.HasValue() ? $" {@class}" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         var cssClass = "test-class";
 
@@ -118,7 +118,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Class, cssClass);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl {cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl {cssClass}"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -134,7 +134,7 @@ public class BitOverlayTests : BunitTestContext
 
         var expectedId = id.HasValue() ? id : component.Instance.UniqueId.ToString();
 
-        component.MarkupMatches(@$"<div id=""{expectedId}"" tabindex=""-1"" data-bit-press-focus=""{expectedId}"" aria-hidden=""true"" class=""bit-ovl""></div>");
+        component.MarkupMatches(@$"<div id=""{expectedId}"" aria-hidden=""true"" class=""bit-ovl""></div>");
     }
 
     [TestMethod,
@@ -153,11 +153,11 @@ public class BitOverlayTests : BunitTestContext
         if (dir.HasValue)
         {
             var cssClass = dir is BitDir.Rtl ? " bit-rtl" : null;
-            component.MarkupMatches(@$"<div dir=""{dir.Value.ToString().ToLower()}"" aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@$"<div dir=""{dir.Value.ToString().ToLower()}"" aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -166,14 +166,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.Dir, BitDir.Ltr);
         });
 
-        component.MarkupMatches(@"<div dir=""ltr"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div dir=""ltr"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -195,7 +195,7 @@ public class BitOverlayTests : BunitTestContext
             _ => null
         };
 
-        component.MarkupMatches(@$"<div {styleAttribute} aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div {styleAttribute} aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -203,14 +203,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.Visibility, BitVisibility.Collapsed);
         });
 
-        component.MarkupMatches(@$"<div style=""display: none;"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div style=""display: none;"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     // An Overlay with content is no longer decorative, so the content case must not carry aria-hidden.
@@ -231,11 +231,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (childContent is not null)
         {
-            component.MarkupMatches(@$"<div class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore><div class=""bit-ovl-cnt"">{childContent}</div></div>");
+            component.MarkupMatches(@$"<div class=""bit-ovl"" tabindex=""-1"" id:ignore><div class=""bit-ovl-cnt"">{childContent}</div></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -249,7 +249,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.AriaLabel, "loading");
         });
 
-        component.MarkupMatches(@"<div aria-label=""loading"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-label=""loading"" class=""bit-ovl"" tabindex=""-1"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -257,15 +257,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlayHtmlAttributesTest>();
 
-        component.MarkupMatches(@$"<div data-val-test=""bit"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore><div class=""bit-ovl-cnt"">I'm an overlay</div></div>");
+        component.MarkupMatches(@$"<div data-val-test=""bit"" class=""bit-ovl"" tabindex=""-1"" id:ignore><div class=""bit-ovl-cnt"">I'm an overlay</div></div>");
     }
 
-    // The press on the layer has its default refused, so the focus would never leave an input the user typed
-    // into - and the input would never commit its value before the handlers of the click run. The layer
-    // names itself for the script to move the focus onto instead, which is what its tabindex is for. Only the
-    // layer does: a press on the content is the user reaching for the content, and keeps its default.
+    // The press on the layer keeps its default action - an input only commits what was typed into it once it
+    // loses the focus, and the handlers the click runs are the ones that most need to see that value - and
+    // the layer is made focusable instead, so the focus the press moves lands there rather than on the body.
     [TestMethod]
-    public void BitOverlayLayerShouldHandTheFocusOfAPressToItself()
+    public void BitOverlayLayerShouldTakeTheFocusOfAPressOnItInsteadOfTheBody()
     {
         var component = RenderComponent<BitOverlay>(parameters =>
         {
@@ -275,9 +274,22 @@ public class BitOverlayTests : BunitTestContext
 
         var layer = component.Find(".bit-ovl");
 
-        Assert.AreEqual(layer.Id, layer.GetAttribute("data-bit-press-focus"));
         Assert.AreEqual("-1", layer.GetAttribute("tabindex"));
-        Assert.IsFalse(component.Find(".bit-ovl-cnt").HasAttribute("data-bit-press-focus"));
+        Assert.IsFalse(layer.HasAttribute("blazor:onmousedown:preventdefault"));
+    }
+
+    // A layer that hosts nothing and carries no name of its own is out of the accessibility tree, and out of
+    // the focus path with it: it holds nothing the focus has to stay near, and focusing an aria-hidden
+    // element is a contradiction the browsers report.
+    [TestMethod]
+    public void BitOverlayDecorativeLayerShouldNotBeFocusable()
+    {
+        var component = RenderComponent<BitOverlay>(parameters => parameters.Add(p => p.IsOpen, true));
+
+        var layer = component.Find(".bit-ovl");
+
+        Assert.IsFalse(layer.HasAttribute("tabindex"));
+        Assert.AreEqual("true", layer.GetAttribute("aria-hidden"));
     }
 
     [TestMethod]
@@ -301,7 +313,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Blocking, blocking);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         Assert.IsTrue(isOpen);
 
@@ -310,7 +322,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = blocking ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
 
         if (blocking)
         {
@@ -612,7 +624,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = absolutePosition ? " bit-ovl-abs" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -620,14 +632,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.AbsolutePosition, true);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-abs"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-abs"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -643,7 +655,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = modeFull ? " bit-ovl-mfl" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -651,14 +663,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.ModeFull, true);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-mfl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-mfl"" id:ignore></div>");
     }
 
     // The hold is what AutoToggleScroll says it is for as long as the Overlay is open, rather than only what
@@ -786,11 +798,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (zIndex.HasValue)
         {
-            component.MarkupMatches(@$"<div style=""z-index:{zIndex}"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@$"<div style=""z-index:{zIndex}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -799,14 +811,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.ZIndex, 1300);
         });
 
-        component.MarkupMatches(@"<div style=""z-index:1300"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div style=""z-index:1300"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -823,14 +835,14 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = IsOpen ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
 
         Assert.AreEqual(IsOpen, isOpenBind);
 
         var element = component.Find(".bit-ovl");
         element.Click();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         Assert.IsFalse(isOpenBind);
     }
@@ -844,7 +856,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, value => isOpen = value);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         isOpen = true;
         component.Render(parameters =>
@@ -852,7 +864,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, value => isOpen = value);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
     }
 
     // The uncontrolled starting state, which only applies while the consumer is not driving IsOpen itself.
@@ -869,7 +881,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = defaultIsOpen ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -881,7 +893,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.DefaultIsOpen, true);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     // The click only means anything on an Overlay the user can actually see: a closed one is invisible in
@@ -940,7 +952,7 @@ public class BitOverlayTests : BunitTestContext
 
         Assert.AreEqual(1, clickedValue);
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
     }
 
     // The layer is what a dismissal is aimed at: the content it hosts is the thing the user is reaching
@@ -962,7 +974,7 @@ public class BitOverlayTests : BunitTestContext
         component.Find("button").Click();
 
         Assert.IsTrue(isOpen);
-        component.MarkupMatches(@"<div class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore><div class=""bit-ovl-cnt""><button>inside</button></div></div>");
+        component.MarkupMatches(@"<div class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" id:ignore><div class=""bit-ovl-cnt""><button>inside</button></div></div>");
     }
 
     // The click is still reported, which is what makes OnClick the one place a consumer closing the Overlay
@@ -1111,19 +1123,19 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Close());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
     }
 
     // A disabled Overlay takes nothing from the user and is not opened by code either, but the code that
@@ -1137,7 +1149,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
 
         component.Render(parameters =>
         {
@@ -1145,7 +1157,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         component.Render(parameters =>
         {
@@ -1153,7 +1165,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Close());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
     }
 
     // Toggle goes through Open and Close, so it inherits their stance on being disabled: it must not open a
@@ -1167,7 +1179,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
 
         var isOpen = true;
         component.Render(parameters =>
@@ -1176,12 +1188,12 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.IsEnabled, false);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn bit-dis"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
 
         Assert.IsFalse(isOpen);
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
     }
 
     // toggleOverflow reports the scroller's scrollTop, which only an absolutely positioned Overlay uses to

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
@@ -297,7 +297,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>(parameters => parameters.Add(p => p.TabIndex, "0"));
 
-        Assert.AreEqual("0", component.Find(".bit-ovl").GetAttribute("tabindex"));
+        var layer = component.Find(".bit-ovl");
+
+        Assert.AreEqual("0", layer.GetAttribute("tabindex"));
+
+        // A layer the consumer means the keyboard to reach is not a decorative one, whatever else it holds:
+        // hiding it from a screen reader while leaving it in the tab sequence is the contradiction the
+        // aria-hidden of a decorative layer is there to avoid in the first place.
+        Assert.IsFalse(layer.HasAttribute("aria-hidden"));
     }
 
     [TestMethod,

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
@@ -16,7 +16,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -32,7 +32,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = isEnabled ? null : " bit-dis";
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -40,14 +40,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.IsEnabled, false);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -64,11 +64,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (style.HasValue())
         {
-            component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
     }
 
@@ -77,7 +77,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         var style = "padding: 1rem;";
         component.Render(parameters =>
@@ -85,7 +85,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Style, style);
         });
 
-        component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -101,7 +101,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = @class.HasValue() ? $" {@class}" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         var cssClass = "test-class";
 
@@ -118,7 +118,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Class, cssClass);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl {cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl {cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -134,7 +134,7 @@ public class BitOverlayTests : BunitTestContext
 
         var expectedId = id.HasValue() ? id : component.Instance.UniqueId.ToString();
 
-        component.MarkupMatches(@$"<div id=""{expectedId}"" aria-hidden=""true"" class=""bit-ovl""></div>");
+        component.MarkupMatches(@$"<div id=""{expectedId}"" tabindex=""-1"" data-bit-press-focus=""{expectedId}"" aria-hidden=""true"" class=""bit-ovl""></div>");
     }
 
     [TestMethod,
@@ -153,11 +153,11 @@ public class BitOverlayTests : BunitTestContext
         if (dir.HasValue)
         {
             var cssClass = dir is BitDir.Rtl ? " bit-rtl" : null;
-            component.MarkupMatches(@$"<div dir=""{dir.Value.ToString().ToLower()}"" aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+            component.MarkupMatches(@$"<div dir=""{dir.Value.ToString().ToLower()}"" aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
     }
 
@@ -166,14 +166,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.Dir, BitDir.Ltr);
         });
 
-        component.MarkupMatches(@"<div dir=""ltr"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div dir=""ltr"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -195,7 +195,7 @@ public class BitOverlayTests : BunitTestContext
             _ => null
         };
 
-        component.MarkupMatches(@$"<div {styleAttribute} aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div {styleAttribute} aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -203,14 +203,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.Visibility, BitVisibility.Collapsed);
         });
 
-        component.MarkupMatches(@$"<div style=""display: none;"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div style=""display: none;"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // An Overlay with content is no longer decorative, so the content case must not carry aria-hidden.
@@ -231,11 +231,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (childContent is not null)
         {
-            component.MarkupMatches(@$"<div class=""bit-ovl"" id:ignore><div class=""bit-ovl-cnt"">{childContent}</div></div>");
+            component.MarkupMatches(@$"<div class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore><div class=""bit-ovl-cnt"">{childContent}</div></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
     }
 
@@ -249,7 +249,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.AriaLabel, "loading");
         });
 
-        component.MarkupMatches(@"<div aria-label=""loading"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-label=""loading"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -257,7 +257,35 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlayHtmlAttributesTest>();
 
-        component.MarkupMatches(@$"<div data-val-test=""bit"" class=""bit-ovl"" id:ignore><div class=""bit-ovl-cnt"">I'm an overlay</div></div>");
+        component.MarkupMatches(@$"<div data-val-test=""bit"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore><div class=""bit-ovl-cnt"">I'm an overlay</div></div>");
+    }
+
+    // The press on the layer has its default refused, so the focus would never leave an input the user typed
+    // into - and the input would never commit its value before the handlers of the click run. The layer
+    // names itself for the script to move the focus onto instead, which is what its tabindex is for. Only the
+    // layer does: a press on the content is the user reaching for the content, and keeps its default.
+    [TestMethod]
+    public void BitOverlayLayerShouldHandTheFocusOfAPressToItself()
+    {
+        var component = RenderComponent<BitOverlay>(parameters =>
+        {
+            parameters.Add(p => p.IsOpen, true);
+            parameters.AddChildContent("<button>content</button>");
+        });
+
+        var layer = component.Find(".bit-ovl");
+
+        Assert.AreEqual(layer.Id, layer.GetAttribute("data-bit-press-focus"));
+        Assert.AreEqual("-1", layer.GetAttribute("tabindex"));
+        Assert.IsFalse(component.Find(".bit-ovl-cnt").HasAttribute("data-bit-press-focus"));
+    }
+
+    [TestMethod]
+    public void BitOverlayShouldLetATabIndexOfTheConsumerWin()
+    {
+        var component = RenderComponent<BitOverlay>(parameters => parameters.Add(p => p.TabIndex, "0"));
+
+        Assert.AreEqual("0", component.Find(".bit-ovl").GetAttribute("tabindex"));
     }
 
     [TestMethod,
@@ -273,7 +301,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Blocking, blocking);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         Assert.IsTrue(isOpen);
 
@@ -282,7 +310,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = blocking ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         if (blocking)
         {
@@ -584,7 +612,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = absolutePosition ? " bit-ovl-abs" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -592,14 +620,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.AbsolutePosition, true);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-abs"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-abs"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -615,7 +643,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = modeFull ? " bit-ovl-mfl" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -623,14 +651,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.ModeFull, true);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-mfl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-mfl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // The hold is what AutoToggleScroll says it is for as long as the Overlay is open, rather than only what
@@ -758,11 +786,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (zIndex.HasValue)
         {
-            component.MarkupMatches(@$"<div style=""z-index:{zIndex}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@$"<div style=""z-index:{zIndex}"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
         }
     }
 
@@ -771,14 +799,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.ZIndex, 1300);
         });
 
-        component.MarkupMatches(@"<div style=""z-index:1300"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div style=""z-index:1300"" aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod,
@@ -795,14 +823,14 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = IsOpen ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         Assert.AreEqual(IsOpen, isOpenBind);
 
         var element = component.Find(".bit-ovl");
         element.Click();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         Assert.IsFalse(isOpenBind);
     }
@@ -816,7 +844,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, value => isOpen = value);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         isOpen = true;
         component.Render(parameters =>
@@ -824,7 +852,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, value => isOpen = value);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // The uncontrolled starting state, which only applies while the consumer is not driving IsOpen itself.
@@ -841,7 +869,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = defaultIsOpen ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     [TestMethod]
@@ -853,7 +881,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.DefaultIsOpen, true);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // The click only means anything on an Overlay the user can actually see: a closed one is invisible in
@@ -912,7 +940,7 @@ public class BitOverlayTests : BunitTestContext
 
         Assert.AreEqual(1, clickedValue);
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // The layer is what a dismissal is aimed at: the content it hosts is the thing the user is reaching
@@ -934,7 +962,7 @@ public class BitOverlayTests : BunitTestContext
         component.Find("button").Click();
 
         Assert.IsTrue(isOpen);
-        component.MarkupMatches(@"<div class=""bit-ovl bit-ovl-opn"" id:ignore><div class=""bit-ovl-cnt""><button>inside</button></div></div>");
+        component.MarkupMatches(@"<div class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore><div class=""bit-ovl-cnt""><button>inside</button></div></div>");
     }
 
     // The click is still reported, which is what makes OnClick the one place a consumer closing the Overlay
@@ -1083,19 +1111,19 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Close());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // A disabled Overlay takes nothing from the user and is not opened by code either, but the code that
@@ -1109,7 +1137,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
@@ -1117,7 +1145,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         component.Render(parameters =>
         {
@@ -1125,7 +1153,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Close());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // Toggle goes through Open and Close, so it inherits their stance on being disabled: it must not open a
@@ -1139,7 +1167,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         var isOpen = true;
         component.Render(parameters =>
@@ -1148,12 +1176,12 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.IsEnabled, false);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
 
         Assert.IsFalse(isOpen);
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" tabindex=""-1"" data-bit-press-focus:ignore id:ignore></div>");
     }
 
     // toggleOverflow reports the scroller's scrollTop, which only an absolutely positioned Overlay uses to

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Utilities/Overlay/BitOverlayTests.cs
@@ -9,14 +9,16 @@ namespace Bit.BlazorUI.Tests.Components.Utilities.Overlay;
 [TestClass]
 public class BitOverlayTests : BunitTestContext
 {
-    // An Overlay that hosts no content and carries no accessible name is a purely decorative layer, so it
-    // reports itself aria-hidden; one given content is the very thing a screen reader is meant to reach.
+    // The layer is programmatically focusable, content or not: a press on it moves the focus off whatever
+    // had it, and the layer is where that focus is meant to land rather than the body. An element that can
+    // take the focus cannot be hidden from assistive technology at the same time, so an empty layer carries
+    // no aria-hidden either - it is unnamed and empty, which is nothing to a screen reader as it is.
     [TestMethod]
     public void BitOverlayShouldRenderExpectedElement()
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -32,7 +34,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = isEnabled ? null : " bit-dis";
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -40,14 +42,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.IsEnabled, false);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-dis"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -64,11 +66,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (style.HasValue())
         {
-            component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@$"<div style=""{style}"" tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -77,7 +79,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         var style = "padding: 1rem;";
         component.Render(parameters =>
@@ -85,7 +87,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Style, style);
         });
 
-        component.MarkupMatches(@$"<div style=""{style}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div style=""{style}"" tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -101,7 +103,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = @class.HasValue() ? $" {@class}" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -109,7 +111,7 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         var cssClass = "test-class";
 
@@ -118,7 +120,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Class, cssClass);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl {cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl {cssClass}"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -134,7 +136,7 @@ public class BitOverlayTests : BunitTestContext
 
         var expectedId = id.HasValue() ? id : component.Instance.UniqueId.ToString();
 
-        component.MarkupMatches(@$"<div id=""{expectedId}"" aria-hidden=""true"" class=""bit-ovl""></div>");
+        component.MarkupMatches(@$"<div id=""{expectedId}"" tabindex=""-1"" class=""bit-ovl""></div>");
     }
 
     [TestMethod,
@@ -153,11 +155,11 @@ public class BitOverlayTests : BunitTestContext
         if (dir.HasValue)
         {
             var cssClass = dir is BitDir.Rtl ? " bit-rtl" : null;
-            component.MarkupMatches(@$"<div dir=""{dir.Value.ToString().ToLower()}"" aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+            component.MarkupMatches(@$"<div dir=""{dir.Value.ToString().ToLower()}"" tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -166,14 +168,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.Dir, BitDir.Ltr);
         });
 
-        component.MarkupMatches(@"<div dir=""ltr"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div dir=""ltr"" tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -195,7 +197,7 @@ public class BitOverlayTests : BunitTestContext
             _ => null
         };
 
-        component.MarkupMatches(@$"<div {styleAttribute} aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div {styleAttribute} tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -203,17 +205,16 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.Visibility, BitVisibility.Collapsed);
         });
 
-        component.MarkupMatches(@$"<div style=""display: none;"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div style=""display: none;"" tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
-    // An Overlay with content is no longer decorative, so the content case must not carry aria-hidden.
     [TestMethod,
         DataRow("Bit Blazor UI"),
         DataRow("<span>Bit Blazor UI</span>"),
@@ -235,12 +236,10 @@ public class BitOverlayTests : BunitTestContext
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
-    // A content-less Overlay that was given an accessible name is not decorative either, so the name is
-    // what it renders rather than aria-hidden.
     [TestMethod]
     public void BitOverlayShouldRespectAriaLabel()
     {
@@ -278,33 +277,62 @@ public class BitOverlayTests : BunitTestContext
         Assert.IsFalse(layer.HasAttribute("blazor:onmousedown:preventdefault"));
     }
 
-    // A layer that hosts nothing and carries no name of its own is out of the accessibility tree, and out of
-    // the focus path with it: it holds nothing the focus has to stay near, and focusing an aria-hidden
-    // element is a contradiction the browsers report.
+    // A layer that hosts nothing is a click catcher beside a surface of the consumer's own, and the input
+    // the user was typing into is in that surface: the press on the layer has to blur it all the same, and
+    // the focus it moves has to land on the layer all the same - the body is the top of the page as far as
+    // the next Tab is concerned, under a layer that is there to keep the page out of reach.
     [TestMethod]
-    public void BitOverlayDecorativeLayerShouldNotBeFocusable()
+    public void BitOverlayEmptyLayerShouldTakeTheFocusOfAPressOnItToo()
     {
         var component = RenderComponent<BitOverlay>(parameters => parameters.Add(p => p.IsOpen, true));
 
         var layer = component.Find(".bit-ovl");
 
-        Assert.IsFalse(layer.HasAttribute("tabindex"));
-        Assert.AreEqual("true", layer.GetAttribute("aria-hidden"));
+        Assert.AreEqual("-1", layer.GetAttribute("tabindex"));
+        Assert.IsFalse(layer.HasAttribute("blazor:onmousedown:preventdefault"));
+
+        // An element that can take the focus cannot be hidden from assistive technology at the same time.
+        Assert.IsFalse(layer.HasAttribute("aria-hidden"));
     }
 
+    // The tabindex the layer writes is the one it needs to be able to hold the focus itself, which is a
+    // default rather than a decision about where the layer sits in the tab sequence: a consumer who names
+    // one keeps it, the way they keep every other attribute they pass - the parameter and a plain attribute
+    // alike, since the layer writes its own ahead of theirs.
     [TestMethod]
     public void BitOverlayShouldLetATabIndexOfTheConsumerWin()
     {
         var component = RenderComponent<BitOverlay>(parameters => parameters.Add(p => p.TabIndex, "0"));
 
-        var layer = component.Find(".bit-ovl");
+        Assert.AreEqual("0", component.Find(".bit-ovl").GetAttribute("tabindex"));
 
-        Assert.AreEqual("0", layer.GetAttribute("tabindex"));
+        var splatted = RenderComponent<BitOverlayTabIndexAttributeTest>();
 
-        // A layer the consumer means the keyboard to reach is not a decorative one, whatever else it holds:
-        // hiding it from a screen reader while leaving it in the tab sequence is the contradiction the
-        // aria-hidden of a decorative layer is there to avoid in the first place.
-        Assert.IsFalse(layer.HasAttribute("aria-hidden"));
+        Assert.AreEqual("0", splatted.Find(".bit-ovl").GetAttribute("tabindex"));
+    }
+
+    // The focus the layer takes over is handed back to where it came from as the Overlay closes: a layer
+    // that is hidden with the focus still on it would leave the focus to drop to the body.
+    [TestMethod]
+    public void BitOverlayShouldRememberWhereTheFocusCameFromAndHandItBackWhenItCloses()
+    {
+        var isOpen = true;
+        var component = RenderComponent<BitOverlay>(parameters =>
+        {
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        var layerId = component.Find(".bit-ovl").Id;
+
+        component.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.captureFocusOrigin"].Count));
+        Assert.AreEqual(layerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.captureFocusOrigin"][^1].Arguments[0]);
+        Assert.IsEmpty(Context.JSInterop.Invocations["BitBlazorUI.Utils.restoreFocusOrigin"]);
+
+        component.Find(".bit-ovl").Click();
+
+        Assert.IsFalse(isOpen);
+        component.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.restoreFocusOrigin"].Count));
+        Assert.AreEqual(layerId, Context.JSInterop.Invocations["BitBlazorUI.Utils.restoreFocusOrigin"][^1].Arguments[0]);
     }
 
     [TestMethod,
@@ -320,7 +348,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.Blocking, blocking);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         Assert.IsTrue(isOpen);
 
@@ -329,7 +357,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = blocking ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
 
         if (blocking)
         {
@@ -631,7 +659,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = absolutePosition ? " bit-ovl-abs" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -639,14 +667,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.AbsolutePosition, true);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-abs"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl bit-ovl-abs"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -662,7 +690,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = modeFull ? " bit-ovl-mfl" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -670,14 +698,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.ModeFull, true);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-mfl"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl bit-ovl-mfl"" id:ignore></div>");
     }
 
     // The hold is what AutoToggleScroll says it is for as long as the Overlay is open, rather than only what
@@ -805,11 +833,11 @@ public class BitOverlayTests : BunitTestContext
 
         if (zIndex.HasValue)
         {
-            component.MarkupMatches(@$"<div style=""z-index:{zIndex}"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@$"<div style=""z-index:{zIndex}"" tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
         }
         else
         {
-            component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+            component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
         }
     }
 
@@ -818,14 +846,14 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         component.Render(parameters =>
         {
             parameters.Add(p => p.ZIndex, 1300);
         });
 
-        component.MarkupMatches(@"<div style=""z-index:1300"" aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div style=""z-index:1300"" tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     [TestMethod,
@@ -842,14 +870,14 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = IsOpen ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
 
         Assert.AreEqual(IsOpen, isOpenBind);
 
         var element = component.Find(".bit-ovl");
         element.Click();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         Assert.IsFalse(isOpenBind);
     }
@@ -863,7 +891,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, value => isOpen = value);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         isOpen = true;
         component.Render(parameters =>
@@ -871,7 +899,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, value => isOpen = value);
         });
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
     }
 
     // The uncontrolled starting state, which only applies while the consumer is not driving IsOpen itself.
@@ -888,7 +916,7 @@ public class BitOverlayTests : BunitTestContext
 
         var cssClass = defaultIsOpen ? " bit-ovl-opn" : null;
 
-        component.MarkupMatches(@$"<div aria-hidden=""true"" class=""bit-ovl{cssClass}"" id:ignore></div>");
+        component.MarkupMatches(@$"<div tabindex=""-1"" class=""bit-ovl{cssClass}"" id:ignore></div>");
     }
 
     [TestMethod]
@@ -900,7 +928,7 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.DefaultIsOpen, true);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     // The click only means anything on an Overlay the user can actually see: a closed one is invisible in
@@ -959,7 +987,7 @@ public class BitOverlayTests : BunitTestContext
 
         Assert.AreEqual(1, clickedValue);
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
     }
 
     // The layer is what a dismissal is aimed at: the content it hosts is the thing the user is reaching
@@ -1130,19 +1158,19 @@ public class BitOverlayTests : BunitTestContext
     {
         var component = RenderComponent<BitOverlay>();
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Close());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl"" id:ignore></div>");
     }
 
     // A disabled Overlay takes nothing from the user and is not opened by code either, but the code that
@@ -1156,7 +1184,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-dis"" id:ignore></div>");
 
         component.Render(parameters =>
         {
@@ -1164,7 +1192,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Open());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn"" id:ignore></div>");
 
         component.Render(parameters =>
         {
@@ -1172,7 +1200,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Close());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-dis"" id:ignore></div>");
     }
 
     // Toggle goes through Open and Close, so it inherits their stance on being disabled: it must not open a
@@ -1186,7 +1214,7 @@ public class BitOverlayTests : BunitTestContext
         });
 
         await component.InvokeAsync(() => component.Instance.Toggle());
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-dis"" id:ignore></div>");
 
         var isOpen = true;
         component.Render(parameters =>
@@ -1195,12 +1223,12 @@ public class BitOverlayTests : BunitTestContext
             parameters.Add(p => p.IsEnabled, false);
         });
 
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-ovl-opn bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-ovl-opn bit-dis"" id:ignore></div>");
 
         await component.InvokeAsync(() => component.Instance.Toggle());
 
         Assert.IsFalse(isOpen);
-        component.MarkupMatches(@"<div aria-hidden=""true"" class=""bit-ovl bit-dis"" id:ignore></div>");
+        component.MarkupMatches(@"<div tabindex=""-1"" class=""bit-ovl bit-dis"" id:ignore></div>");
     }
 
     // toggleOverflow reports the scroller's scrollTop, which only an absolutely positioned Overlay uses to

--- a/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance.TestHost/Components/Pages/BitModalOverlayCommit.razor
+++ b/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance.TestHost/Components/Pages/BitModalOverlayCommit.razor
@@ -1,0 +1,62 @@
+@page "/regression/modal-overlay-commit"
+
+<PageTitle>BitModal Overlay Commit Regression</PageTitle>
+
+@* A press on the overlay of a non-blocking Modal has to blur the input the user was typing into before the
+   click it turns into dismisses the Modal: the input only commits what was typed once it loses the focus,
+   so a press refused its default would hand OnOverlayClick and OnDismiss the value from before the typing. *@
+<div id="test-controls" style="padding: 20px; background: #f0f0f0; margin-bottom: 20px;">
+    <h3>BitModal Overlay Commit Regression</h3>
+    <div style="margin-bottom: 10px;">
+        <button @onclick="Open" id="btn-open">Open</button>
+    </div>
+    <div id="metrics" style="font-family: monospace;">
+        <p>OnOverlayClick value: <span id="overlay-click-value">@_overlayClickValue</span></p>
+        <p>OnDismiss value: <span id="dismiss-value">@_dismissValue</span></p>
+        <p>Status: <span id="status">@_status</span></p>
+    </div>
+</div>
+
+<BitModal @bind-IsOpen="_isOpen" OnOverlayClick="HandleOnOverlayClick" OnDismiss="HandleOnDismiss">
+    <div style="padding: 20px;">
+        <BitTextField @bind-Value="_value" Label="Value" />
+    </div>
+</BitModal>
+
+@code {
+    private bool _isOpen;
+    private string? _value;
+    private string? _overlayClickValue;
+    private string? _dismissValue;
+    // "Loading" is shown in the SSR pre-rendered HTML before the SignalR circuit connects; only the first
+    // interactive render moves it on, which is what the test waits for before it drives the page.
+    private string _status = "Loading";
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender is false) return;
+
+        _status = "Ready";
+        StateHasChanged();
+    }
+
+    private void Open()
+    {
+        _value = null;
+        _overlayClickValue = null;
+        _dismissValue = null;
+        _isOpen = true;
+        _status = "Open";
+    }
+
+    private void HandleOnOverlayClick(MouseEventArgs e)
+    {
+        _overlayClickValue = _value;
+    }
+
+    private void HandleOnDismiss(MouseEventArgs e)
+    {
+        _dismissValue = _value;
+        _status = "Dismissed";
+    }
+}

--- a/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance.TestHost/Components/Pages/Home.razor
+++ b/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance.TestHost/Components/Pages/Home.razor
@@ -18,6 +18,7 @@
         <li><a href="/perf/dropdown/50">BitDropdown - 50 components (memory leak benchmark)</a></li>
         <li><a href="/perf/dropdown/100">BitDropdown - 100 components</a></li>
         <li><a href="/perf/dropdown/500">BitDropdown - 500 components</a></li>
+        <li><a href="/regression/modal-overlay-commit">BitModal - overlay press commits the typed value</a></li>
     </ul>
     
     <h2>API Endpoints</h2>

--- a/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance/BitModalBrowserTests.cs
+++ b/src/BlazorUI/Tests/Performance/Bit.BlazorUI.Tests.Performance/BitModalBrowserTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+
+namespace Bit.BlazorUI.Tests.Performance;
+
+/// <summary>
+/// Browser regression tests for the overlay of BitModal, driven with real pointer and keyboard input.
+///
+/// A press on the overlay is left its default action so that it blurs the input the user was typing into:
+/// the input only commits what was typed once it loses the focus, and that has to happen before the click
+/// the press turns into reaches OnOverlayClick and OnDismiss. bUnit cannot see that ordering - it has no
+/// focus and no default actions - so the behavior is pinned down here, in a real browser.
+/// </summary>
+[TestClass]
+[TestCategory("Browser")]
+[Ignore("Browser tests must be run explicitly. Use: dotnet test --filter FullyQualifiedName~BitModalBrowserTests")]
+public class BitModalBrowserTests : PerformanceTestBase
+{
+    [TestMethod]
+    public async Task BitModal_OverlayPress_CommitsTheTypedValueBeforeTheDismissalHandlersRun()
+    {
+        const string typed = "committed";
+
+        await Page.GotoAsync($"{BaseUrl}/regression/modal-overlay-commit");
+        await WaitForStatus("Ready"); // wait for Blazor SignalR circuit to be interactive
+
+        await Page.Locator("#btn-open").ClickAsync();
+        await WaitForStatus("Open");
+
+        // The Modal puts the focus on its first focusable element as it opens; typing before that lands
+        // would have the focus move out from under the keyboard.
+        var input = Page.Locator(".bit-mdl input");
+        await Expect(input).ToBeFocusedAsync();
+
+        await Page.Keyboard.TypeAsync(typed);
+
+        // The corner of the page is covered by the overlay and by nothing else of the Modal, whose content
+        // is centered. The mouse is moved there and pressed, as a user would, rather than the click being
+        // dispatched on the element.
+        await Page.Mouse.ClickAsync(5, 5);
+        await WaitForStatus("Dismissed");
+
+        await Expect(Page.Locator("#overlay-click-value")).ToHaveTextAsync(typed);
+        await Expect(Page.Locator("#dismiss-value")).ToHaveTextAsync(typed);
+    }
+}


### PR DESCRIPTION
closes #13192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved focus handling for dialogs, modals, panels, and overlays.
  - Overlay interactions now commit active input values before dismissal.
  - Focus remains within active surfaces and is restored when overlays close.
  - Improved Tab and Shift+Tab keyboard navigation.

- **Accessibility**
  - Consumer-provided tab index values are now respected.
  - Programmatic focus avoids unnecessary outlines while preserving keyboard navigation indicators.

- **Demo**
  - The dialog example now displays the currently entered field value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->