### PR TITLE
Fix Link and Script assets component issues (#13212)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
@@ -1,4 +1,5 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 
@@ -8,7 +9,8 @@ namespace Bit.BlazorUI;
 /// Appends the content hash of an asset to its path.
 /// The file is read through the hosting environment, so this only happens where the ASP.NET Core
 /// hosting assemblies are part of the app (server rendering). On WebAssembly and Blazor Hybrid they
-/// are not, so the path is returned unchanged instead of failing to load the types.
+/// are not, so the value the server persisted while prerendering is reused, and the path is returned
+/// unchanged when there was no prerendering, instead of failing to load the types.
 /// </summary>
 internal static class BitAssetVersion
 {
@@ -17,26 +19,71 @@ internal static class BitAssetVersion
     private static readonly Type? WebHostEnvironmentType =
         Type.GetType("Microsoft.AspNetCore.Hosting.IWebHostEnvironment, Microsoft.AspNetCore.Hosting.Abstractions", throwOnError: false);
 
-    internal static string? TryAppend(IServiceProvider services, string? path)
+    /// <summary>
+    /// Returns the path to render, along with the subscription that carries it over to the render that
+    /// follows prerendering. The subscription is <c>default</c> when there is nothing to carry over,
+    /// and disposing it is safe in either case.
+    /// </summary>
+    internal static (string? Path, PersistingComponentStateSubscription Subscription) Resolve(
+        IServiceProvider services, string component, string? path, bool appendVersion, bool carryOverToClient)
     {
-        if (string.IsNullOrEmpty(path)) return path;
+        if (appendVersion is false || string.IsNullOrEmpty(path)) return (path, default);
 
-        if (WebHostEnvironmentType is null) return path;
+        var state = services.GetService(typeof(PersistentComponentState)) as PersistentComponentState;
+        var key = $"{nameof(BitAssetVersion)}.{component}.{path}";
 
-        if (services.GetService(WebHostEnvironmentType) is null) return path;
+        if (WebHostEnvironmentType is null || services.GetService(WebHostEnvironmentType) is null)
+        {
+            // No web root to hash the file against. Reusing what the prerendering pass persisted keeps the
+            // markup of an interactive component identical on both sides, so the browser is not sent back
+            // for an asset it already has under its versioned path.
+            return (state is not null && TryTakePersisted(state, key, out var persisted) ? persisted : path, default);
+        }
 
-        return Append(services, path);
+        var versionedPath = Append(services, path!, GetPathBase(services));
+
+        if (state is null || carryOverToClient is false) return (versionedPath, default);
+
+        return (versionedPath, state.RegisterOnPersisting(() =>
+        {
+            Persist(state, key, versionedPath);
+            return Task.CompletedTask;
+        }));
     }
 
-    // Kept apart from TryAppend so the hosting types are only ever loaded after the probe above passed.
+    // The persisted value is a string, so nothing the serializer needs is reachable only through reflection.
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The persisted value is a string.")]
+    private static bool TryTakePersisted(PersistentComponentState state, string key, [NotNullWhen(true)] out string? value)
+    {
+        return state.TryTakeFromJson(key, out value) && value is not null;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The persisted value is a string.")]
+    private static void Persist(PersistentComponentState state, string key, string value)
+    {
+        state.PersistAsJson(key, value);
+    }
+
+    /// <summary>
+    /// The path an app hosted under a sub-path is served from, read from the NavigationManager every Blazor
+    /// host registers rather than from IHttpContextAccessor, which an app only has after calling
+    /// AddHttpContextAccessor and whose absence would silently leave the versioning to miss every file.
+    /// </summary>
+    private static string GetPathBase(IServiceProvider services)
+    {
+        if (services.GetService(typeof(NavigationManager)) is not NavigationManager navigationManager) return string.Empty;
+
+        if (Uri.TryCreate(navigationManager.BaseUri, UriKind.Absolute, out var baseUri) is false) return string.Empty;
+
+        return Uri.UnescapeDataString(baseUri.AbsolutePath).TrimEnd('/');
+    }
+
+    // Kept apart from Resolve so the hosting types are only ever loaded after the probe above passed.
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static string Append(IServiceProvider services, string path)
+    private static string Append(IServiceProvider services, string path, string pathBase)
     {
         var webHost = (IWebHostEnvironment)services.GetService(typeof(IWebHostEnvironment))!;
-        var httpContextAccessor = services.GetService(typeof(IHttpContextAccessor)) as IHttpContextAccessor;
 
-        return BitFileVersionProvider.AppendFileVersion(webHost.WebRootFileProvider,
-                                                        httpContextAccessor?.HttpContext?.Request.PathBase ?? PathString.Empty,
-                                                        path);
+        return BitFileVersionProvider.AppendFileVersion(webHost.WebRootFileProvider, new PathString(pathBase), path);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
@@ -1,0 +1,42 @@
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Bit.BlazorUI;
+
+/// <summary>
+/// Appends the content hash of an asset to its path.
+/// The file is read through the hosting environment, so this only happens where the ASP.NET Core
+/// hosting assemblies are part of the app (server rendering). On WebAssembly and Blazor Hybrid they
+/// are not, so the path is returned unchanged instead of failing to load the types.
+/// </summary>
+internal static class BitAssetVersion
+{
+    // Resolved by name: a type reference would make the client load Microsoft.AspNetCore.Hosting.Abstractions,
+    // which is what this indirection exists to avoid.
+    private static readonly Type? WebHostEnvironmentType =
+        Type.GetType("Microsoft.AspNetCore.Hosting.IWebHostEnvironment, Microsoft.AspNetCore.Hosting.Abstractions", throwOnError: false);
+
+    internal static string? TryAppend(IServiceProvider services, string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+
+        if (WebHostEnvironmentType is null) return path;
+
+        if (services.GetService(WebHostEnvironmentType) is null) return path;
+
+        return Append(services, path);
+    }
+
+    // Kept apart from TryAppend so the hosting types are only ever loaded after the probe above passed.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string Append(IServiceProvider services, string path)
+    {
+        var webHost = (IWebHostEnvironment)services.GetService(typeof(IWebHostEnvironment))!;
+        var httpContextAccessor = services.GetService(typeof(IHttpContextAccessor)) as IHttpContextAccessor;
+
+        return BitFileVersionProvider.AppendFileVersion(webHost.WebRootFileProvider,
+                                                        httpContextAccessor?.HttpContext?.Request.PathBase ?? PathString.Empty,
+                                                        path);
+    }
+}

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
@@ -2,15 +2,18 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace Bit.BlazorUI;
 
 /// <summary>
 /// Appends the content hash of an asset to its path.
-/// The file is read through the hosting environment, so this only happens where the ASP.NET Core
-/// hosting assemblies are part of the app (server rendering). On WebAssembly and Blazor Hybrid they
-/// are not, so the value the server persisted while prerendering is reused, and the path is returned
-/// unchanged when there was no prerendering, instead of failing to load the types.
+/// The file is read through the hosting environment, so the hash is only computed where the ASP.NET Core
+/// hosting assemblies are part of the app (server rendering). Whatever prerendering computed is carried over
+/// to the render that follows it and wins there - on WebAssembly and in Blazor Hybrid, where the file cannot
+/// be read, and on a server circuit, where it could be read again but from a request base the browser chose -
+/// so both renders of a component emit the same markup. A path with nothing to reuse and no file to hash is
+/// returned unchanged, instead of failing to load the types.
 /// </summary>
 internal static class BitAssetVersion
 {
@@ -19,71 +22,165 @@ internal static class BitAssetVersion
     private static readonly Type? WebHostEnvironmentType =
         Type.GetType("Microsoft.AspNetCore.Hosting.IWebHostEnvironment, Microsoft.AspNetCore.Hosting.Abstractions", throwOnError: false);
 
+    // Every asset of a page is carried over in a single entry, keyed by the path alone, since the hash is
+    // read off the file and so is the same for every tag pointing at it. A key per tag would instead repeat
+    // the path in the blob for each of them, and two tags on the same asset would collide on it: the second
+    // PersistAsJson throws, and the first TryTakeFromJson takes the entry away from the rest.
+    private const string StateKey = nameof(BitAssetVersion);
+
+    // Keyed on the state rather than held statically, so nothing outlives the request or the circuit it
+    // belongs to, and two of them in flight never see each other's paths. Components initialize and the
+    // persisting callbacks run on the renderer's dispatcher, so a state's entry is never touched concurrently.
+    private static readonly ConditionalWeakTable<PersistentComponentState, PageAssets> Pages = new();
+
+    private static PathBaseMemo? lastPathBase;
+
     /// <summary>
-    /// Returns the path to render, along with the subscription that carries it over to the render that
-    /// follows prerendering. The subscription is <c>default</c> when there is nothing to carry over,
-    /// and disposing it is safe in either case.
+    /// Returns the path to render. <paramref name="interactive"/> says whether the component renders again
+    /// after prerendering, which is when what this render computed is worth carrying over.
     /// </summary>
-    internal static (string? Path, PersistingComponentStateSubscription Subscription) Resolve(
-        IServiceProvider services, string component, string? path, bool appendVersion, bool carryOverToClient)
+    internal static string? Resolve(IServiceProvider services, string? path, bool appendVersion, bool interactive)
     {
-        if (appendVersion is false || string.IsNullOrEmpty(path)) return (path, default);
+        if (appendVersion is false || string.IsNullOrEmpty(path)) return path;
 
         var state = services.GetService(typeof(PersistentComponentState)) as PersistentComponentState;
-        var key = $"{nameof(BitAssetVersion)}.{component}.{path}";
 
-        if (WebHostEnvironmentType is null || services.GetService(WebHostEnvironmentType) is null)
+        if (state is not null && TryGetRestored(state, path, out var restored)) return restored;
+
+        var webHost = WebHostEnvironmentType is null ? null : services.GetService(WebHostEnvironmentType);
+
+        // No web root to hash the file against, and nothing carried over: the path is rendered as written.
+        if (webHost is null) return path;
+
+        var versionedPath = Append(webHost, path, GetPathBase(services));
+
+        if (state is not null && interactive) CarryOver(state, path, versionedPath);
+
+        return versionedPath;
+    }
+
+    /// <summary>
+    /// Adds the path to what the page carries over. The first path of a state registers the one callback
+    /// that persists all of them, with an explicit render mode: the framework infers the mode of a callback
+    /// registered without one from the component it belongs to, and this callback belongs to the page, not
+    /// to a component - it would throw. Auto is accepted by the server store and the WebAssembly store
+    /// alike, so the entry reaches whichever runtime renders the page next, and with no once-only flag
+    /// every store of a composite persist gets its own copy.
+    /// </summary>
+    private static void CarryOver(PersistentComponentState state, string path, string versionedPath)
+    {
+        var page = Pages.GetValue(state, static _ => new PageAssets());
+
+        page.Paths[path] = versionedPath;
+
+        if (page.Subscribed) return;
+
+        page.Subscribed = true;
+
+        // The subscription lives as long as the state does - the request's or the circuit's - so it is
+        // never disposed on its own.
+        _ = state.RegisterOnPersisting(() =>
         {
-            // No web root to hash the file against. Reusing what the prerendering pass persisted keeps the
-            // markup of an interactive component identical on both sides, so the browser is not sent back
-            // for an asset it already has under its versioned path.
-            return (state is not null && TryTakePersisted(state, key, out var persisted) ? persisted : path, default);
+            Persist(state, page.Paths);
+
+            return Task.CompletedTask;
+        }, RenderMode.InteractiveAuto);
+    }
+
+    /// <summary>
+    /// Answers from the page's paths, and takes the persisted entry on a miss. TryTakeFromJson removes what
+    /// it reads, so the entry is merged into the page's paths for the components that initialize after the
+    /// first one. It is taken again on every later miss rather than once per state: on WebAssembly the state
+    /// is the app's for its whole lifetime, and .NET 10 refills it on enhanced navigation, so a page reached
+    /// later has its entry appear after the first take.
+    /// </summary>
+    private static bool TryGetRestored(PersistentComponentState state, string path, [NotNullWhen(true)] out string? value)
+    {
+        var page = Pages.GetValue(state, static _ => new PageAssets());
+
+        if (page.Paths.TryGetValue(path, out value)) return true;
+
+        var taken = TakePersisted(state);
+
+        if (taken is null) return false;
+
+        foreach (var (persistedPath, versionedPath) in taken)
+        {
+            page.Paths[persistedPath] = versionedPath;
         }
 
-        var versionedPath = Append(services, path!, GetPathBase(services));
-
-        if (state is null || carryOverToClient is false) return (versionedPath, default);
-
-        return (versionedPath, state.RegisterOnPersisting(() =>
-        {
-            Persist(state, key, versionedPath);
-            return Task.CompletedTask;
-        }));
+        return page.Paths.TryGetValue(path, out value);
     }
 
-    // The persisted value is a string, so nothing the serializer needs is reachable only through reflection.
-    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The persisted value is a string.")]
-    private static bool TryTakePersisted(PersistentComponentState state, string key, [NotNullWhen(true)] out string? value)
+    // The persisted value is a dictionary of strings, so nothing the serializer needs is reachable only through reflection.
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The persisted value is a dictionary of strings.")]
+    private static Dictionary<string, string>? TakePersisted(PersistentComponentState state)
     {
-        return state.TryTakeFromJson(key, out value) && value is not null;
+        return state.TryTakeFromJson<Dictionary<string, string>>(StateKey, out var value) ? value : null;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The persisted value is a string.")]
-    private static void Persist(PersistentComponentState state, string key, string value)
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The persisted value is a dictionary of strings.")]
+    private static void Persist(PersistentComponentState state, Dictionary<string, string> paths)
     {
-        state.PersistAsJson(key, value);
+        state.PersistAsJson(StateKey, paths);
     }
 
     /// <summary>
     /// The path an app hosted under a sub-path is served from, read from the NavigationManager every Blazor
     /// host registers rather than from IHttpContextAccessor, which an app only has after calling
     /// AddHttpContextAccessor and whose absence would silently leave the versioning to miss every file.
+    /// The answer is the same for every tag of a request, so it is memoized on the base URI.
     /// </summary>
     private static string GetPathBase(IServiceProvider services)
     {
         if (services.GetService(typeof(NavigationManager)) is not NavigationManager navigationManager) return string.Empty;
 
-        if (Uri.TryCreate(navigationManager.BaseUri, UriKind.Absolute, out var baseUri) is false) return string.Empty;
+        string baseUri;
 
-        return Uri.UnescapeDataString(baseUri.AbsolutePath).TrimEnd('/');
+        try
+        {
+            baseUri = navigationManager.BaseUri;
+        }
+        catch (InvalidOperationException)
+        {
+            // A NavigationManager that was never initialized throws on BaseUri. Rendering these tags through
+            // HtmlRenderer outside a Razor Components endpoint - an email template, a generated page - is a
+            // legitimate use, and no base is the same answer there was when there was no request to read one from.
+            return string.Empty;
+        }
+
+        var memo = lastPathBase;
+
+        if (memo is not null && memo.BaseUri == baseUri) return memo.PathBase;
+
+        var pathBase = Uri.TryCreate(baseUri, UriKind.Absolute, out var uri)
+                       ? Uri.UnescapeDataString(uri.AbsolutePath).TrimEnd('/')
+                       : string.Empty;
+
+        // PathString accepts only a rooted value; a base URI without a rooted path (about:blank) means no base.
+        if (pathBase.StartsWith('/') is false) pathBase = string.Empty;
+
+        lastPathBase = new PathBaseMemo(baseUri, pathBase);
+
+        return pathBase;
     }
 
     // Kept apart from Resolve so the hosting types are only ever loaded after the probe above passed.
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static string Append(IServiceProvider services, string path, string pathBase)
+    private static string Append(object webHost, string path, string pathBase)
     {
-        var webHost = (IWebHostEnvironment)services.GetService(typeof(IWebHostEnvironment))!;
-
-        return BitFileVersionProvider.AppendFileVersion(webHost.WebRootFileProvider, new PathString(pathBase), path);
+        return BitFileVersionProvider.AppendFileVersion(((IWebHostEnvironment)webHost).WebRootFileProvider, new PathString(pathBase), path);
     }
+
+
+
+    private sealed class PageAssets
+    {
+        /// <summary>What was restored into this state and what this render computed, both keyed by the path as written.</summary>
+        public Dictionary<string, string> Paths { get; } = new(StringComparer.Ordinal);
+
+        public bool Subscribed { get; set; }
+    }
+
+    private sealed record PathBaseMemo(string BaseUri, string PathBase);
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitAssetVersion.cs
@@ -88,25 +88,25 @@ internal static class BitAssetVersion
     }
 
     /// <summary>
-    /// Answers from the page's paths, and takes the persisted entry on a miss. TryTakeFromJson removes what
+    /// Takes whatever the state is holding, then answers from the page's paths. TryTakeFromJson removes what
     /// it reads, so the entry is merged into the page's paths for the components that initialize after the
-    /// first one. It is taken again on every later miss rather than once per state: on WebAssembly the state
-    /// is the app's for its whole lifetime, and .NET 10 refills it on enhanced navigation, so a page reached
-    /// later has its entry appear after the first take.
+    /// first one. It is taken before the lookup rather than only on a miss: on WebAssembly the state is the
+    /// app's for its whole lifetime and .NET 10 refills it on enhanced navigation, so a page reached later
+    /// brings a fresh entry whose value for a path already in the table is the newer one - answering from the
+    /// table first would leave that entry unread until some other path missed, and render the stale value.
     /// </summary>
     private static bool TryGetRestored(PersistentComponentState state, string path, [NotNullWhen(true)] out string? value)
     {
         var page = Pages.GetValue(state, static _ => new PageAssets());
 
-        if (page.Paths.TryGetValue(path, out value)) return true;
-
         var taken = TakePersisted(state);
 
-        if (taken is null) return false;
-
-        foreach (var (persistedPath, versionedPath) in taken)
+        if (taken is not null)
         {
-            page.Paths[persistedPath] = versionedPath;
+            foreach (var (persistedPath, versionedPath) in taken)
+            {
+                page.Paths[persistedPath] = versionedPath;
+            }
         }
 
         return page.Paths.TryGetValue(path, out value);

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitFileVersionProvider.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitFileVersionProvider.cs
@@ -10,7 +10,7 @@ namespace Bit.BlazorUI;
 public static class BitFileVersionProvider
 {
     // Keyed on everything the answer depends on: the file provider the file is read from, the path as
-    // written, the query key, and the request path base - but the base only when the path starts with it,
+    // written, the query key, and the request path base - but the base only when the path is under it,
     // which is the only case in which it takes part in the lookup. That keeps the table bounded by the
     // paths an app renders, however many bases it is asked to render them under.
     // An entry carries the file's change token, so a file rewritten in place - dotnet watch, a deploy that
@@ -38,9 +38,7 @@ public static class BitFileVersionProvider
             return path;
         }
 
-        var pathBase = requestPathBase.HasValue && resolvedPath.StartsWith(requestPathBase.Value, StringComparison.OrdinalIgnoreCase)
-                       ? requestPathBase.Value
-                       : string.Empty;
+        var pathBase = GetMatchingPathBase(resolvedPath, requestPathBase);
 
         var key = new CacheKey(fileProvider, pathBase, path, versionKey);
 
@@ -54,6 +52,25 @@ public static class BitFileVersionProvider
     }
 
 
+
+    /// <summary>
+    /// The part of the path the base accounts for, or nothing where the path is not under it. Matched by whole
+    /// segments, so an app served from /app never reads /appsettings.css as one of its files and goes looking
+    /// for a settings.css in the web root. The trailing slash a base may be written with is not part of the
+    /// answer, so /app/ and /app take the same path to the same file and to the same cache entry.
+    /// </summary>
+    private static string GetMatchingPathBase(string resolvedPath, PathString requestPathBase)
+    {
+        if (requestPathBase.HasValue is false) return string.Empty;
+
+        var pathBase = requestPathBase.Value!.TrimEnd('/');
+
+        if (pathBase.Length == 0) return string.Empty;
+
+        if (resolvedPath.StartsWith(pathBase, StringComparison.OrdinalIgnoreCase) is false) return string.Empty;
+
+        return resolvedPath.Length == pathBase.Length || resolvedPath[pathBase.Length] == '/' ? pathBase : string.Empty;
+    }
 
     private static CacheEntry GenerateVersionedPath(IFileProvider fileProvider, string pathBase, string path, string versionKey, string resolvedPath)
     {

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitFileVersionProvider.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitFileVersionProvider.cs
@@ -8,7 +8,9 @@ namespace Bit.BlazorUI;
 
 public static class BitFileVersionProvider
 {
-    private static readonly ConcurrentDictionary<string, string> PathCache = new();
+    // Keyed on the path base as well as the path: the same path resolves to a different file under a
+    // different base, and a lookup that missed under one base must not be answered from the cache under another.
+    private static readonly ConcurrentDictionary<(string PathBase, string Path), string> PathCache = new();
 
 
 
@@ -31,7 +33,8 @@ public static class BitFileVersionProvider
             return path;
         }
 
-        return PathCache.GetOrAdd(path, _ => GenerateVersionedPath(fileProvider, requestPathBase, path, versionKey, resolvedPath));
+        return PathCache.GetOrAdd((requestPathBase.Value ?? string.Empty, path),
+                                  _ => GenerateVersionedPath(fileProvider, requestPathBase, path, versionKey, resolvedPath));
     }
 
 

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitFileVersionProvider.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/BitFileVersionProvider.cs
@@ -2,15 +2,20 @@
 using System.Security.Cryptography;
 using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.FileProviders;
 
 namespace Bit.BlazorUI;
 
 public static class BitFileVersionProvider
 {
-    // Keyed on the path base as well as the path: the same path resolves to a different file under a
-    // different base, and a lookup that missed under one base must not be answered from the cache under another.
-    private static readonly ConcurrentDictionary<(string PathBase, string Path), string> PathCache = new();
+    // Keyed on everything the answer depends on: the file provider the file is read from, the path as
+    // written, the query key, and the request path base - but the base only when the path starts with it,
+    // which is the only case in which it takes part in the lookup. That keeps the table bounded by the
+    // paths an app renders, however many bases it is asked to render them under.
+    // An entry carries the file's change token, so a file rewritten in place - dotnet watch, a deploy that
+    // swaps the web root - gets a fresh hash, and a file that appears after the first request gets one at all.
+    private static readonly ConcurrentDictionary<CacheKey, CacheEntry> PathCache = new();
 
 
 
@@ -33,29 +38,40 @@ public static class BitFileVersionProvider
             return path;
         }
 
-        return PathCache.GetOrAdd((requestPathBase.Value ?? string.Empty, path),
-                                  _ => GenerateVersionedPath(fileProvider, requestPathBase, path, versionKey, resolvedPath));
+        var pathBase = requestPathBase.HasValue && resolvedPath.StartsWith(requestPathBase.Value, StringComparison.OrdinalIgnoreCase)
+                       ? requestPathBase.Value
+                       : string.Empty;
+
+        var key = new CacheKey(fileProvider, pathBase, path, versionKey);
+
+        if (PathCache.TryGetValue(key, out var entry) && entry.Token.HasChanged is false) return entry.Value;
+
+        entry = GenerateVersionedPath(fileProvider, pathBase, path, versionKey, resolvedPath);
+
+        PathCache[key] = entry;
+
+        return entry.Value;
     }
 
 
 
-    private static string GenerateVersionedPath(IFileProvider fileProvider, PathString requestPathBase, string path, string versionKey, string resolvedPath)
+    private static CacheEntry GenerateVersionedPath(IFileProvider fileProvider, string pathBase, string path, string versionKey, string resolvedPath)
     {
+        // Watched before it is read, so a change between the two is not missed.
+        var token = fileProvider.Watch(resolvedPath);
         var fileInfo = fileProvider.GetFileInfo(resolvedPath);
 
-        if (fileInfo.Exists is false &&
-            requestPathBase.HasValue &&
-            resolvedPath.StartsWith(requestPathBase.Value, StringComparison.OrdinalIgnoreCase))
+        if (fileInfo.Exists is false && pathBase.Length > 0)
         {
-            var requestPathBaseRelativePath = resolvedPath[requestPathBase.Value.Length..];
+            var requestPathBaseRelativePath = resolvedPath[pathBase.Length..];
+
+            token = new CompositeChangeToken([token, fileProvider.Watch(requestPathBaseRelativePath)]);
             fileInfo = fileProvider.GetFileInfo(requestPathBaseRelativePath);
         }
 
-        if (fileInfo.Exists is false) return path;
+        var value = fileInfo.Exists ? AddQueryString(path, versionKey, GenerateFileHash(fileInfo)) : path;
 
-        var hash = GenerateFileHash(fileInfo);
-
-        return AddQueryString(path, versionKey, hash);
+        return new CacheEntry(value, token);
     }
 
     private static string AddQueryString(string uri, string key, string value)
@@ -102,4 +118,10 @@ public static class BitFileVersionProvider
 
         return $"sha256-{Uri.EscapeDataString(hash)}";
     }
+
+
+
+    private readonly record struct CacheKey(IFileProvider FileProvider, string PathBase, string Path, string VersionKey);
+
+    private sealed record CacheEntry(string Value, IChangeToken Token);
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Link.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Link.razor.cs
@@ -1,11 +1,19 @@
-namespace Bit.BlazorUI;
+﻿namespace Bit.BlazorUI;
 
-public partial class Link
+public partial class Link : IDisposable
 {
     [Parameter(CaptureUnmatchedValues = true)] 
     public Dictionary<string, object> AdditionalAttributes { get; set; } = default!;
 
     [Parameter] public string Href { get; set; } = "";
+
+    /// <summary>
+    /// Appends the content hash of the file to the Href, so that a changed file is never served from the browser cache.
+    /// The hash is read from the web root of the ASP.NET Core host, so it is only appended where that host is part of the
+    /// app: server rendering, including the prerendering pass of an interactive component. A render on WebAssembly or in
+    /// Blazor Hybrid reuses the value that prerendering produced, and renders the Href unchanged when the component was
+    /// not prerendered.
+    /// </summary>
     [Parameter] public bool AppendVersion { get; set; } = true;
 
 
@@ -15,13 +23,32 @@ public partial class Link
 
 
     private string? href;
+    private PersistingComponentStateSubscription stateSubscription;
 
+
+
+    // Only a component that is itself interactive renders again on the client, where the version cannot be
+    // computed, so only that one has anything to carry over. Where the framework does not say (net8.0),
+    // every component carries its value over rather than any of them losing it.
+    private bool CarryOverToClient =>
+#if NET9_0_OR_GREATER
+        AssignedRenderMode is not null;
+#else
+        true;
+#endif
 
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
 
-        href = AppendVersion ? BitAssetVersion.TryAppend(serviceProvider, Href) : Href;
+        (href, stateSubscription) = BitAssetVersion.Resolve(serviceProvider, nameof(Link), Href, AppendVersion, CarryOverToClient);
+    }
+
+    public void Dispose()
+    {
+        stateSubscription.Dispose();
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Link.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Link.razor.cs
@@ -1,6 +1,3 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Hosting;
-
 namespace Bit.BlazorUI;
 
 public partial class Link
@@ -13,8 +10,7 @@ public partial class Link
 
 
 
-    [Inject] private IWebHostEnvironment webHost { get; set; } = default!;
-    [Inject] private IHttpContextAccessor httpContextAccessor { get; set; } = default!;
+    [Inject] private IServiceProvider serviceProvider { get; set; } = default!;
 
 
 
@@ -25,8 +21,7 @@ public partial class Link
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        href = (Href is not null && AppendVersion) 
-                ? BitFileVersionProvider.AppendFileVersion(webHost.WebRootFileProvider, httpContextAccessor?.HttpContext?.Request.PathBase ?? PathString.Empty, Href) 
-                : Href;
+
+        href = AppendVersion ? BitAssetVersion.TryAppend(serviceProvider, Href) : Href;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Link.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Link.razor.cs
@@ -1,18 +1,18 @@
 ﻿namespace Bit.BlazorUI;
 
-public partial class Link : IDisposable
+public partial class Link
 {
-    [Parameter(CaptureUnmatchedValues = true)] 
+    [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = default!;
 
-    [Parameter] public string Href { get; set; } = "";
+    [Parameter] public string? Href { get; set; }
 
     /// <summary>
     /// Appends the content hash of the file to the Href, so that a changed file is never served from the browser cache.
-    /// The hash is read from the web root of the ASP.NET Core host, so it is only appended where that host is part of the
-    /// app: server rendering, including the prerendering pass of an interactive component. A render on WebAssembly or in
-    /// Blazor Hybrid reuses the value that prerendering produced, and renders the Href unchanged when the component was
-    /// not prerendered.
+    /// The hash is read from the web root of the ASP.NET Core host, so it is only computed where that host is part of the
+    /// app: server rendering, including the prerendering pass of an interactive component. The render that follows
+    /// prerendering - on WebAssembly, in Blazor Hybrid, or on a server circuit - reuses the value prerendering produced,
+    /// and a render with nothing to reuse and no web root renders the Href unchanged.
     /// </summary>
     [Parameter] public bool AppendVersion { get; set; } = true;
 
@@ -23,14 +23,13 @@ public partial class Link : IDisposable
 
 
     private string? href;
-    private PersistingComponentStateSubscription stateSubscription;
 
 
 
-    // Only a component that is itself interactive renders again on the client, where the version cannot be
-    // computed, so only that one has anything to carry over. Where the framework does not say (net8.0),
-    // every component carries its value over rather than any of them losing it.
-    private bool CarryOverToClient =>
+    // Whether this component renders again after prerendering, which is when what this render computed is
+    // carried over. Where the framework does not say (net8.0), every component carries its value over: one
+    // entry per page, read by a circuit or a WebAssembly client and otherwise left where the page's state goes.
+    private bool Interactive =>
 #if NET9_0_OR_GREATER
         AssignedRenderMode is not null;
 #else
@@ -42,13 +41,6 @@ public partial class Link : IDisposable
     {
         base.OnInitialized();
 
-        (href, stateSubscription) = BitAssetVersion.Resolve(serviceProvider, nameof(Link), Href, AppendVersion, CarryOverToClient);
-    }
-
-    public void Dispose()
-    {
-        stateSubscription.Dispose();
-
-        GC.SuppressFinalize(this);
+        href = BitAssetVersion.Resolve(serviceProvider, Href, AppendVersion, Interactive);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor
@@ -1,6 +1,6 @@
-@namespace Bit.BlazorUI
+﻿@namespace Bit.BlazorUI
 
-@if (src is not null)
+@if (string.IsNullOrEmpty(src) is false)
 {
     <script src="@src" @attributes="AdditionalAttributes"></script>
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor.cs
@@ -1,6 +1,3 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Hosting;
-
 namespace Bit.BlazorUI;
 
 public partial class Script
@@ -14,8 +11,7 @@ public partial class Script
 
 
 
-    [Inject] private IWebHostEnvironment webHost { get; set; } = default!;
-    [Inject] private IHttpContextAccessor httpContextAccessor { get; set; } = default!;
+    [Inject] private IServiceProvider serviceProvider { get; set; } = default!;
 
 
 
@@ -27,8 +23,6 @@ public partial class Script
     {
         base.OnInitialized();
 
-        src = (Src is not null && AppendVersion)
-                ? BitFileVersionProvider.AppendFileVersion(webHost.WebRootFileProvider, httpContextAccessor?.HttpContext?.Request.PathBase ?? PathString.Empty, Src) 
-                : Src;
+        src = AppendVersion ? BitAssetVersion.TryAppend(serviceProvider, Src) : Src;
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor.cs
@@ -1,12 +1,21 @@
-namespace Bit.BlazorUI;
+﻿namespace Bit.BlazorUI;
 
-public partial class Script
+public partial class Script : IDisposable
 {
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = default!;
 
     [Parameter] public string? Src { get; set; }
+
+    /// <summary>
+    /// Appends the content hash of the file to the Src, so that a changed file is never served from the browser cache.
+    /// The hash is read from the web root of the ASP.NET Core host, so it is only appended where that host is part of the
+    /// app: server rendering, including the prerendering pass of an interactive component. A render on WebAssembly or in
+    /// Blazor Hybrid reuses the value that prerendering produced, and renders the Src unchanged when the component was
+    /// not prerendered.
+    /// </summary>
     [Parameter] public bool AppendVersion { get; set; } = true;
+
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
 
@@ -16,13 +25,32 @@ public partial class Script
 
 
     private string? src;
+    private PersistingComponentStateSubscription stateSubscription;
 
+
+
+    // Only a component that is itself interactive renders again on the client, where the version cannot be
+    // computed, so only that one has anything to carry over. Where the framework does not say (net8.0),
+    // every component carries its value over rather than any of them losing it.
+    private bool CarryOverToClient =>
+#if NET9_0_OR_GREATER
+        AssignedRenderMode is not null;
+#else
+        true;
+#endif
 
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
 
-        src = AppendVersion ? BitAssetVersion.TryAppend(serviceProvider, Src) : Src;
+        (src, stateSubscription) = BitAssetVersion.Resolve(serviceProvider, nameof(Script), Src, AppendVersion, CarryOverToClient);
+    }
+
+    public void Dispose()
+    {
+        stateSubscription.Dispose();
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Assets/Components/Script.razor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.BlazorUI;
 
-public partial class Script : IDisposable
+public partial class Script
 {
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = default!;
@@ -9,10 +9,10 @@ public partial class Script : IDisposable
 
     /// <summary>
     /// Appends the content hash of the file to the Src, so that a changed file is never served from the browser cache.
-    /// The hash is read from the web root of the ASP.NET Core host, so it is only appended where that host is part of the
-    /// app: server rendering, including the prerendering pass of an interactive component. A render on WebAssembly or in
-    /// Blazor Hybrid reuses the value that prerendering produced, and renders the Src unchanged when the component was
-    /// not prerendered.
+    /// The hash is read from the web root of the ASP.NET Core host, so it is only computed where that host is part of the
+    /// app: server rendering, including the prerendering pass of an interactive component. The render that follows
+    /// prerendering - on WebAssembly, in Blazor Hybrid, or on a server circuit - reuses the value prerendering produced,
+    /// and a render with nothing to reuse and no web root renders the Src unchanged.
     /// </summary>
     [Parameter] public bool AppendVersion { get; set; } = true;
 
@@ -25,14 +25,13 @@ public partial class Script : IDisposable
 
 
     private string? src;
-    private PersistingComponentStateSubscription stateSubscription;
 
 
 
-    // Only a component that is itself interactive renders again on the client, where the version cannot be
-    // computed, so only that one has anything to carry over. Where the framework does not say (net8.0),
-    // every component carries its value over rather than any of them losing it.
-    private bool CarryOverToClient =>
+    // Whether this component renders again after prerendering, which is when what this render computed is
+    // carried over. Where the framework does not say (net8.0), every component carries its value over: one
+    // entry per page, read by a circuit or a WebAssembly client and otherwise left where the page's state goes.
+    private bool Interactive =>
 #if NET9_0_OR_GREATER
         AssignedRenderMode is not null;
 #else
@@ -44,13 +43,6 @@ public partial class Script : IDisposable
     {
         base.OnInitialized();
 
-        (src, stateSubscription) = BitAssetVersion.Resolve(serviceProvider, nameof(Script), Src, AppendVersion, CarryOverToClient);
-    }
-
-    public void Dispose()
-    {
-        stateSubscription.Dispose();
-
-        GC.SuppressFinalize(this);
+        src = BitAssetVersion.Resolve(serviceProvider, Src, AppendVersion, Interactive);
     }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Bit.BlazorUI.Tests.csproj
@@ -50,6 +50,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The Link and Script asset components ship in their own package; referenced here so the
+             duplicate-instance tests render the real components against the real BitAssetVersion. -->
+        <ProjectReference Include="..\..\Bit.BlazorUI.Assets\Bit.BlazorUI.Assets.csproj" />
         <ProjectReference Include="..\..\Bit.BlazorUI\Bit.BlazorUI.csproj" />
         <ProjectReference Include="..\..\Bit.BlazorUI.Extras\Bit.BlazorUI.Extras.csproj" />
         <ProjectReference Include="..\..\Bit.BlazorUI.Legacy\Bit.BlazorUI.Legacy.csproj" />

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Assets/BitAssetVersionTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Assets/BitAssetVersionTests.cs
@@ -120,6 +120,23 @@ public class BitAssetVersionTests : BunitTestContext
         Assert.AreEqual($"{JsPath}?v=sha256-restored-js", Src(RenderScript(JsPath)));
     }
 
+    [TestMethod]
+    public void ARefilledEntryShouldWinOverWhatAnEarlierOneRestored()
+    {
+        var state = Context.AddBunitPersistentComponentState();
+
+        state.Persist(StateKey, new Dictionary<string, string> { [CssPath] = $"{CssPath}?v=sha256-restored-css" });
+
+        Assert.AreEqual($"{CssPath}?v=sha256-restored-css", Href(RenderLink(CssPath)));
+
+        // What an enhanced navigation refills the state with: the same path, hashed again after the file
+        // changed. A tag rendering now must take that entry rather than answer from the first one's value.
+        state.Persist(StateKey, new Dictionary<string, string> { [CssPath] = $"{CssPath}?v=sha256-refreshed-css" });
+
+        Assert.AreEqual($"{CssPath}?v=sha256-refreshed-css", Href(RenderLink(CssPath)));
+        Assert.AreEqual($"{CssPath}?v=sha256-refreshed-css", Href(RenderLink(CssPath)));
+    }
+
     private IRenderedComponent<Link> RenderLink(string href)
     {
         return RenderComponent<Link>(parameters => Interactive(parameters.Add(p => p.Href, href)));

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Assets/BitAssetVersionTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Assets/BitAssetVersionTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.BlazorUI.Tests.Components.Assets;
+
+/// <summary>
+/// Link and Script carry the versioned path over to the render that follows prerendering through a single
+/// entry of the page's persistent state, keyed by the path alone. Two tags pointing at the same asset - or
+/// simply two tags on the same page - must both end up in that one entry: a key per tag would make the
+/// second registration collide with the first.
+/// </summary>
+[TestClass]
+public class BitAssetVersionTests : BunitTestContext
+{
+    private const string StateKey = "BitAssetVersion";
+    private const string CssPath = "/styles/app.css";
+    private const string JsPath = "/scripts/app.js";
+
+    private string webRoot = default!;
+
+    [TestInitialize]
+    public void SetupWebRoot()
+    {
+        webRoot = Path.Combine(Path.GetTempPath(), $"bit-assets-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(Path.Combine(webRoot, "styles"));
+        Directory.CreateDirectory(Path.Combine(webRoot, "scripts"));
+
+        File.WriteAllText(Path.Combine(webRoot, "styles", "app.css"), ".a{color:red}");
+        File.WriteAllText(Path.Combine(webRoot, "scripts", "app.js"), "console.log(1)");
+
+        Services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment(webRoot));
+    }
+
+    [TestCleanup]
+    public void CleanupWebRoot()
+    {
+        // The base class initializes first, so a failure there leaves this one's web root unset.
+        if (webRoot is null) return;
+
+        try
+        {
+            Directory.Delete(webRoot, recursive: true);
+        }
+        catch (IOException) { }
+    }
+
+    [TestMethod]
+    public void DuplicateLinksShouldRenderTheSameVersionedHref()
+    {
+        Context.AddBunitPersistentComponentState();
+
+        var first = RenderLink(CssPath);
+        var second = RenderLink(CssPath);
+
+        var href = Href(first);
+
+        Assert.IsTrue(href.StartsWith($"{CssPath}?v=sha256-", StringComparison.Ordinal), href);
+        Assert.AreEqual(href, Href(second));
+    }
+
+    [TestMethod]
+    public void DuplicateScriptsShouldRenderTheSameVersionedSrc()
+    {
+        Context.AddBunitPersistentComponentState();
+
+        var first = RenderScript(JsPath);
+        var second = RenderScript(JsPath);
+
+        var src = Src(first);
+
+        Assert.IsTrue(src.StartsWith($"{JsPath}?v=sha256-", StringComparison.Ordinal), src);
+        Assert.AreEqual(src, Src(second));
+    }
+
+    [TestMethod]
+    public void DuplicateLinksAndScriptsShouldCarryOverInASingleEntry()
+    {
+        var state = Context.AddBunitPersistentComponentState();
+
+        var link = RenderLink(CssPath);
+        RenderLink(CssPath);
+        var script = RenderScript(JsPath);
+        RenderScript(JsPath);
+
+        // The second tag of an asset would throw here when each tag persisted under a key of its own.
+        state.TriggerOnPersisting();
+
+        Assert.IsTrue(state.TryTake<Dictionary<string, string>>(StateKey, out var persisted));
+        Assert.AreEqual(2, persisted!.Count);
+        Assert.AreEqual(Href(link), persisted[CssPath]);
+        Assert.AreEqual(Src(script), persisted[JsPath]);
+    }
+
+    [TestMethod]
+    public void DuplicateLinksAndScriptsShouldAllReadTheCarriedOverPaths()
+    {
+        var state = Context.AddBunitPersistentComponentState();
+
+        // What a prerendering pass carried over: the whole page's assets under the one key.
+        state.Persist(StateKey, new Dictionary<string, string>
+        {
+            [CssPath] = $"{CssPath}?v=sha256-restored-css",
+            [JsPath] = $"{JsPath}?v=sha256-restored-js",
+        });
+
+        // The first tag takes the entry away from the state, so the ones after it are the regression:
+        // they answer from what the first one restored rather than hashing the file again.
+        Assert.AreEqual($"{CssPath}?v=sha256-restored-css", Href(RenderLink(CssPath)));
+        Assert.AreEqual($"{CssPath}?v=sha256-restored-css", Href(RenderLink(CssPath)));
+        Assert.AreEqual($"{JsPath}?v=sha256-restored-js", Src(RenderScript(JsPath)));
+        Assert.AreEqual($"{JsPath}?v=sha256-restored-js", Src(RenderScript(JsPath)));
+    }
+
+    private IRenderedComponent<Link> RenderLink(string href)
+    {
+        return RenderComponent<Link>(parameters => Interactive(parameters.Add(p => p.Href, href)));
+    }
+
+    private IRenderedComponent<Script> RenderScript(string src)
+    {
+        return RenderComponent<Script>(parameters => Interactive(parameters.Add(p => p.Src, src)));
+    }
+
+    // The components only carry their path over where they render again after prerendering, which from
+    // net9.0 on is what the assigned render mode says. On net8.0 the framework does not say, and they
+    // carry it over from every render, so there is no mode to assign there - nor a bUnit API to assign it.
+    private static ComponentParameterCollectionBuilder<TComponent> Interactive<TComponent>(
+        ComponentParameterCollectionBuilder<TComponent> parameters)
+        where TComponent : IComponent
+    {
+#if NET9_0_OR_GREATER
+        parameters.SetAssignedRenderMode(Microsoft.AspNetCore.Components.Web.RenderMode.InteractiveAuto);
+#endif
+
+        return parameters;
+    }
+
+    private static string Href(IRenderedComponent<Link> component) => component.Find("link").GetAttribute("href")!;
+
+    private static string Src(IRenderedComponent<Script> component) => component.Find("script").GetAttribute("src")!;
+
+
+
+    private sealed class TestWebHostEnvironment(string webRootPath) : IWebHostEnvironment
+    {
+        public string WebRootPath { get; set; } = webRootPath;
+        public IFileProvider WebRootFileProvider { get; set; } = new PhysicalFileProvider(webRootPath);
+        public string ContentRootPath { get; set; } = webRootPath;
+        public IFileProvider ContentRootFileProvider { get; set; } = new PhysicalFileProvider(webRootPath);
+        public string ApplicationName { get; set; } = nameof(BitAssetVersionTests);
+        public string EnvironmentName { get; set; } = "Test";
+    }
+}

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Assets/BitFileVersionProviderTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Assets/BitFileVersionProviderTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.BlazorUI.Tests.Components.Assets;
+
+/// <summary>
+/// An app hosted under a sub-path renders its asset paths with that base in them, so the provider retries a
+/// path it cannot find under the web root with the base taken off. What counts as being under the base is
+/// whole segments: /appsettings.css is not a file of an app served from /app, and reading it as one makes the
+/// retry find an unrelated settings.css and stamp its hash on a path pointing somewhere else entirely.
+/// </summary>
+[TestClass]
+public class BitFileVersionProviderTests
+{
+    private string webRoot = default!;
+    private PhysicalFileProvider fileProvider = default!;
+
+    [TestInitialize]
+    public void SetupWebRoot()
+    {
+        webRoot = Path.Combine(Path.GetTempPath(), $"bit-file-version-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(Path.Combine(webRoot, "styles"));
+
+        File.WriteAllText(Path.Combine(webRoot, "settings.css"), ".a{color:red}");
+        File.WriteAllText(Path.Combine(webRoot, "styles", "site.css"), ".b{color:blue}");
+
+        fileProvider = new PhysicalFileProvider(webRoot);
+    }
+
+    [TestCleanup]
+    public void CleanupWebRoot()
+    {
+        fileProvider?.Dispose();
+
+        if (webRoot is null) return;
+
+        try
+        {
+            Directory.Delete(webRoot, recursive: true);
+        }
+        catch (IOException) { }
+    }
+
+    [TestMethod]
+    public void APathUnderTheBaseShouldBeHashedWithTheBaseTakenOff()
+    {
+        var versioned = Append("/app/styles/site.css", "/app");
+
+        Assert.IsTrue(versioned.StartsWith("/app/styles/site.css?v=sha256-", StringComparison.Ordinal), versioned);
+    }
+
+    [TestMethod]
+    public void ABaseWrittenWithATrailingSlashShouldStillMatchBySegments()
+    {
+        var versioned = Append("/app/styles/site.css", "/app/");
+
+        Assert.IsTrue(versioned.StartsWith("/app/styles/site.css?v=sha256-", StringComparison.Ordinal), versioned);
+    }
+
+    [TestMethod]
+    public void APathMerelySharingThePrefixOfTheBaseShouldNotBeReadAsBaseRelative()
+    {
+        // The regression: with the base taken off by characters this is "settings.css", which does exist -
+        // and the path would come back carrying the hash of a file that is not the one it points at.
+        Assert.AreEqual("/appsettings.css", Append("/appsettings.css", "/app"));
+    }
+
+    [TestMethod]
+    public void ARelativePathShouldNotBeReadAsBaseRelative()
+    {
+        Assert.AreEqual("appsettings.css", Append("appsettings.css", "/app"));
+    }
+
+    private string Append(string path, string pathBase)
+    {
+        return BitFileVersionProvider.AppendFileVersion(fileProvider, new PathString(pathBase), path);
+    }
+}


### PR DESCRIPTION
closes #13212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Asset links and scripts can include content-based version identifiers.
  - Versioned asset paths persist across server-side rendering and interactive client rendering.
  - Inline script content now renders when no external script source is provided.

- **Bug Fixes**
  - Asset versioning works more reliably across hosting environments and application base paths.
  - Versioned URLs refresh when underlying asset files change.
  - Assets retain their original paths when versioning is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->