### PR TITLE
Rebuild Brouter route content on parameter change by default (#13214)

### DIFF
--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/ApiPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/ApiPage.razor
@@ -1,4 +1,4 @@
-<PageTitle>API reference · Brouter docs</PageTitle>
+﻿<PageTitle>API reference · Brouter docs</PageTitle>
 
 @* The lookup page: every public parameter, option, service member and value type in one place,
    with defaults. Topic pages teach; this one answers "what is that parameter called and what does
@@ -78,6 +78,7 @@
             <tr><td>Meta</td><td>object?</td><td>Static per-route metadata, cascaded as <code>BrouterRouteMeta</code>. No code runs.</td></tr>
             <tr><td>KeepAlive</td><td>bool (false)</td><td>Retain the rendered component (hidden) when navigated away.</td></tr>
             <tr><td>KeepAliveMax</td><td>int?</td><td>Retained-instance budget. Above 1, one instance per distinct parameter set, LRU-evicted. Defaults to <code>DefaultKeepAliveMax</code>.</td></tr>
+            <tr><td>RemountOnParameterChange</td><td>bool?</td><td>Rebuild this route's content when only its parameter values change, instead of re-binding the live instance. Defaults to the <code>RemountOnParameterChange</code> option; ignored on a keep-alive route.</td></tr>
             <tr><td>ErrorContent</td><td>RenderFragment&lt;BrouterErrorContext&gt;?</td><td>Error boundary for this route and its descendants; nearest boundary wins.</td></tr>
         </tbody>
     </table>
@@ -229,6 +230,7 @@
             <tr><td>PersistLoaderState</td><td><code>false</code></td><td>Carry prerender loader results into the interactive pass so they don't double-fetch.</td></tr>
             <tr><td>LoaderStateTypeInfoResolver</td><td><code>null</code></td><td>Source-generated JSON context that makes the above trimming/AOT-safe.</td></tr>
             <tr><td>DefaultKeepAliveMax</td><td><code>1</code></td><td>Retained-instance budget for keep-alive routes that don't set their own.</td></tr>
+            <tr><td>RemountOnParameterChange</td><td><code>false</code></td><td>A parameter-only navigation re-binds the live instance and arrives as a renavigation (the built-in <code>Router</code>'s reuse). Set <code>true</code> to dispose the content and mount a fresh instance instead - it then votes and is notified like a route being left.</td></tr>
         </tbody>
     </table>
 </div>

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/FaqPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/FaqPage.razor
@@ -158,7 +158,7 @@
             </tr>
             <tr>
                 <td><code>LeaveGuard</code> doesn't fire on <code>/edit/1 → /edit/2</code></td>
-                <td>The route stays matched, so nothing is being left. Implement <code>OnRenavigatingAsync</code> on the component - that's exactly the gap it fills.</td>
+                <td>The route stays matched, so nothing is being left. Implement <code>OnRenavigatingAsync</code> on the component - that's exactly the gap it fills. (A route that opted into <code>RemountOnParameterChange</code> is disposed by the change, so there the guard <em>does</em> fire, along with <code>OnDeactivatingAsync</code>.)</td>
             </tr>
             <tr>
                 <td>A dialog closes itself and the navigation proceeds</td>

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/GuardsPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/GuardsPage.razor
@@ -1,4 +1,4 @@
-<PageTitle>Guards &amp; locks · Brouter docs</PageTitle>
+﻿<PageTitle>Guards &amp; locks · Brouter docs</PageTitle>
 
 @* Topic page: enter guards, leave guards, component-level navigation locks, declarative
    redirects, and the global navigation hooks. Live links point at g1/g2/editor/lock routes
@@ -70,7 +70,10 @@
         <code>OnDeactivatingAsync</code> / <code>OnRenavigatingAsync</code>: both are awaited
         before the navigation commits, may show a custom dialog, and cancel or redirect through
         their context. <code>OnRenavigatingAsync</code> closes the gap leave guards can't see -
-        parameter changes on the <em>same</em> route (<code>/lock/1 → /lock/2</code>). The
+        parameter changes on the <em>same</em> route (<code>/lock/1 → /lock/2</code>). A route that
+        opted into <code>RemountOnParameterChange</code> is the exception: its content is disposed by
+        such a change, so it votes through <code>OnDeactivatingAsync</code> and its
+        <code>LeaveGuard</code>, exactly as if it were left. The
         context's <code>CancellationToken</code> fires if a newer navigation supersedes the pending
         one, letting an open dialog dismiss itself. A thrown exception fails closed: the
         navigation is cancelled.

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/LifecycleOverviewPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/LifecycleOverviewPage.razor
@@ -48,7 +48,10 @@
         or through an uncontrolled <code>Default*</code> parameter on a UI component - sees the new
         one; the change is then reported as a <code>Disposing</code> deactivation followed by a first
         activation, never as a renavigation. Individual routes override either default with
-        <code>Broute.RemountOnParameterChange</code>.
+        <code>Broute.RemountOnParameterChange</code>. Rebuilding only ever applies to routes that
+        aren't keep-alive: a <code>KeepAlive</code> route ignores the setting and keeps its content
+        across its own parameter change - no disposal, no fresh activation, the change arrives as a
+        renavigation as usual.
     </p>
     <pre class="bb-code">services.<span class="k">AddBitBrouterServices</span>(o =&gt; o.RemountOnParameterChange = <span class="k">true</span>);</pre>
     <div class="bb-try">

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/LifecycleOverviewPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/LifecycleOverviewPage.razor
@@ -1,4 +1,4 @@
-<PageTitle>Lifecycle &amp; keep-alive · Brouter docs</PageTitle>
+﻿<PageTitle>Lifecycle &amp; keep-alive · Brouter docs</PageTitle>
 
 @* Topic page: route lifecycle callbacks and keep-alive retention. Live links point at
    /lifecycle/{id}, /sticky, /fleeting and /notes/{id} declared in AppRouter.razor. *@
@@ -39,6 +39,18 @@
         any depth - take the cascaded <code>BrouterRouteContext</code> and call
         <code>Register(this)</code> / <code>Unregister(this)</code> yourself.
     </p>
+    <p class="bb-card-desc">
+        <strong>Rebuilding is opt-in.</strong> By default a parameter-only navigation re-binds the
+        live instance - the same reuse the built-in <code>Router</code> gives a page - and
+        <code>OnRenavigated</code> carries the change. Set
+        <code>BrouterOptions.RemountOnParameterChange = true</code> to dispose the content and mount
+        a fresh instance instead, so a page that reads a value once - in <code>OnInitialized</code>,
+        or through an uncontrolled <code>Default*</code> parameter on a UI component - sees the new
+        one; the change is then reported as a <code>Disposing</code> deactivation followed by a first
+        activation, never as a renavigation. Individual routes override either default with
+        <code>Broute.RemountOnParameterChange</code>.
+    </p>
+    <pre class="bb-code">services.<span class="k">AddBitBrouterServices</span>(o =&gt; o.RemountOnParameterChange = <span class="k">true</span>);</pre>
     <div class="bb-try">
         <BrouterLink Href="/lifecycle/1" class="btn btn-outline">/lifecycle/1 - live event log (IBrouterRoute)</BrouterLink>
     </div>

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/LifecyclePage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/LifecyclePage.razor
@@ -34,7 +34,9 @@
     </dl>
     <p class="bb-card-desc">
         This route is a singleton (not keep-alive), so switching between ids re-commits the
-        <strong>same component instance</strong>: <code>OnInitialized</code> does not re-run, and
+        <strong>same component instance</strong> (a route that opts into
+        <code>RemountOnParameterChange</code> would be rebuilt instead):
+        <code>OnInitialized</code> does not re-run, and
         <code>OnRenavigated</code> is the "user arrived here again" signal, carrying both locations.
         Navigating away fires <code>OnDeactivated</code> with reason <code>Disposing</code> (its
         synchronous part is guaranteed to run before <code>Dispose</code>); coming back mounts a fresh

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/NavigationLockPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/NavigationLockPage.razor
@@ -46,7 +46,11 @@
     <p class="bb-card-desc">
         A parameter change (<code>/lock/1 → /lock/2</code>) keeps this route matched, so a
         route-declared <code>LeaveGuard</code> would never fire - <code>OnRenavigating</code> is what
-        protects the dirty draft there.
+        protects the dirty draft there. A route that opts into
+        <code>RemountOnParameterChange</code> is the exception: its content is rebuilt by the change,
+        so the instance about to be disposed votes with <code>OnDeactivating</code> (reason
+        <code>Disposing</code>) and the <code>LeaveGuard</code> runs - either way the dirty draft is
+        protected.
     </p>
 </div>
 

--- a/src/Brouter/Bit.Brouter.Demo/Client/Pages/RecipesPage.razor
+++ b/src/Brouter/Bit.Brouter.Demo/Client/Pages/RecipesPage.razor
@@ -62,7 +62,7 @@
         <thead><tr><th>The user...</th><th>Covered by</th></tr></thead>
         <tbody>
             <tr><td>navigates to another page in the app</td><td><code>OnDeactivatingAsync</code> (custom dialog) or a route <code>LeaveGuard</code> (silent veto)</td></tr>
-            <tr><td>navigates to the same page with different parameters</td><td><code>OnRenavigatingAsync</code> - a <code>LeaveGuard</code> never fires here</td></tr>
+            <tr><td>navigates to the same page with different parameters</td><td><code>OnRenavigatingAsync</code> - a <code>LeaveGuard</code> never fires here (unless the route opted into <code>RemountOnParameterChange</code>, which disposes the content: then <code>OnDeactivatingAsync</code> and the <code>LeaveGuard</code> vote instead)</td></tr>
             <tr><td>closes the tab, reloads, or follows an external link</td><td><code>SetConfirmExternalNavigationAsync(true)</code> - the browser's own dialog</td></tr>
         </tbody>
     </table>

--- a/src/Brouter/Bit.Brouter/Components/Broute.cs
+++ b/src/Brouter/Bit.Brouter/Components/Broute.cs
@@ -443,9 +443,12 @@ public class Broute : ComponentBase, IDisposable
             foreach (var paramName in seg.ParameterNames)
             {
                 values.TryGetValue(paramName, out var value);
-                // U+001F (unit separator) can't appear in a template's parameter name, so the
-                // key is unambiguous even when values themselves contain '=' or '/'.
-                sb.Append(paramName).Append('=').Append(BrouterService.FormatRouteValue(value)).Append('\u001f');
+                var formatted = BrouterService.FormatRouteValue(value);
+                // Length-prefixed so the key stays unambiguous whatever a value contains - '=',
+                // '/' or even the U+001F separator itself (a %1F in the URL decodes to one): with
+                // the length up front a value can never be read as the end of its own field plus
+                // the start of the next one.
+                sb.Append(paramName).Append('=').Append(formatted.Length).Append(':').Append(formatted).Append('\u001f');
             }
         }
         return sb.ToString();

--- a/src/Brouter/Bit.Brouter/Components/Broute.cs
+++ b/src/Brouter/Bit.Brouter/Components/Broute.cs
@@ -103,6 +103,20 @@ public class Broute : ComponentBase, IDisposable
     [Parameter] public int? KeepAliveMax { get; set; }
 
     /// <summary>
+    /// Whether a navigation that stays on this route but changes its parameter values rebuilds the
+    /// route's content instead of re-binding the live instance. Null (the default) follows
+    /// <see cref="BrouterOptions.RemountOnParameterChange"/>, which defaults to <c>false</c>: the
+    /// instance survives and takes the change as a renavigation
+    /// (<see cref="IBrouterRoute.OnRenavigatedAsync"/>), the same reuse the built-in <c>Router</c>
+    /// gives a page. Set it explicitly to opt this one route either way - <c>true</c> to dispose the
+    /// content and mount a fresh instance on every parameter change, <c>false</c> to keep it even
+    /// where the application default is to rebuild. The parameters that count are every parameter
+    /// of the route's full template, ancestors' included. Ignored on a <see cref="KeepAlive"/>
+    /// route, which never remounts.
+    /// </summary>
+    [Parameter] public bool? RemountOnParameterChange { get; set; }
+
+    /// <summary>
     /// Freshness window for this route's <see cref="Loader"/> result, enabling the router's
     /// stale-while-revalidate cache: a navigation (or Back/Forward) to a URL whose cached result is
     /// younger than this skips the loader entirely; an older-but-not-garbage-collected result is
@@ -398,6 +412,59 @@ public class Broute : ComponentBase, IDisposable
     // instead of rendering nothing.
     internal int EffectiveKeepAliveMax => Math.Max(1, KeepAliveMax ?? Brouter?.Options.DefaultKeepAliveMax ?? 1);
 
+    // Whether a parameter-only navigation rebuilds this route's content rather than re-binding the
+    // live instance: the route's own setting, else the global option (off by default). KeepAlive
+    // always wins - retaining the instance is what the route asked for, and a per-parameter
+    // keep-alive route already mounts one instance per parameter set.
+    internal bool EffectiveRemountOnParameterChange =>
+        KeepAlive is false && (RemountOnParameterChange ?? Brouter?.Options.RemountOnParameterChange ?? false);
+
+    /// <summary>
+    /// Builds this route's parameter identity from the values it is currently matched with - see
+    /// <see cref="ComputeParameterKey(IReadOnlyDictionary{string, object?})"/>.
+    /// </summary>
+    internal string ComputeParameterKey() => ComputeParameterKey(Parameters);
+
+    /// <summary>
+    /// Builds this route's parameter identity for <paramref name="values"/>: its template parameter
+    /// values in template order, formatted invariantly. Two matches of the same route produce the
+    /// same key exactly when they bind every template parameter to the same value - the comparison
+    /// behind both per-parameter keep-alive retention and <see cref="WillRemountForParameters"/>.
+    /// The query string is excluded. The navigation pipeline passes a prospective match's values
+    /// to learn, before it commits, whether a route that stays matched is about to be rebuilt.
+    /// </summary>
+    internal string ComputeParameterKey(IReadOnlyDictionary<string, object?> values)
+    {
+        if (RouteTemplate is null) return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var seg in RouteTemplate.TemplateSegments)
+        {
+            foreach (var paramName in seg.ParameterNames)
+            {
+                values.TryGetValue(paramName, out var value);
+                // U+001F (unit separator) can't appear in a template's parameter name, so the
+                // key is unambiguous even when values themselves contain '=' or '/'.
+                sb.Append(paramName).Append('=').Append(BrouterService.FormatRouteValue(value)).Append('\u001f');
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Whether committing a match that binds this route's parameters to <paramref name="values"/>
+    /// rebuilds its content. False when the route doesn't remount at all, when nothing of its
+    /// content is currently mounted (there is nothing to rebuild - the commit mounts it fresh
+    /// anyway), and when the values it is already rendering are the same.
+    /// </summary>
+    internal bool WillRemountForParameters(IReadOnlyDictionary<string, object?> values)
+    {
+        if (EffectiveRemountOnParameterChange is false) return false;
+        if (_renderer?.LastRenderedParameterKey is not { } rendered) return false;
+
+        return string.Equals(rendered, ComputeParameterKey(values), StringComparison.Ordinal) is false;
+    }
+
     /// <summary>
     /// Builds the retention key for the current match of a per-parameter keep-alive route
     /// (<see cref="EffectiveKeepAliveMax"/> &gt; 1): the route's template parameter values, in
@@ -406,22 +473,7 @@ public class Broute : ComponentBase, IDisposable
     /// string is deliberately excluded (documented on <see cref="KeepAliveMax"/>).
     /// </summary>
     internal string ComputeKeepAliveKey()
-    {
-        if (EffectiveKeepAliveMax <= 1 || RouteTemplate is null) return string.Empty;
-
-        var sb = new System.Text.StringBuilder();
-        foreach (var seg in RouteTemplate.TemplateSegments)
-        {
-            foreach (var paramName in seg.ParameterNames)
-            {
-                Parameters.TryGetValue(paramName, out var value);
-                // U+001F (unit separator) can't appear in a template's parameter name, so the
-                // key is unambiguous even when values themselves contain '=' or '/'.
-                sb.Append(paramName).Append('=').Append(BrouterService.FormatRouteValue(value)).Append('\u001f');
-            }
-        }
-        return sb.ToString();
-    }
+        => EffectiveKeepAliveMax <= 1 ? string.Empty : ComputeParameterKey();
 
     // Releases this route's retained keep-alive state - both its own inline hidden content (when it
     // is a kept-but-hidden top-level/inline route, or hidden per-parameter siblings of the active
@@ -546,9 +598,13 @@ public class Broute : ComponentBase, IDisposable
     /// <paramref name="willRemainMatched"/> and <paramref name="contentReplaced"/> contracts.
     /// <paramref name="contentReplaced"/> is only honored by the inline renderer: an outlet-hosted
     /// error render happens inside the surviving child entry, whose context handles the page swap
-    /// via <see cref="BrouterRouteContext.ClearAutoRegistered"/>.
+    /// via <see cref="BrouterRouteContext.ClearAutoRegistered"/>. <paramref name="hostTornDown"/>
+    /// is only honored by the outlet: it says the hosting subtree itself is about to be unmounted
+    /// (the host is being left or rebuilt), so keep-alive retention cannot save this route's content
+    /// and it reports Disposing rather than Hidden.
     /// </summary>
-    internal void NotifyDeparture(BrouterNavigationContext ctx, bool willRemainMatched, bool contentReplaced = false)
+    internal void NotifyDeparture(BrouterNavigationContext ctx, bool willRemainMatched, bool contentReplaced = false,
+        bool hostTornDown = false)
     {
         if (_disposed || _renderer is null) return;
 
@@ -557,7 +613,11 @@ public class Broute : ComponentBase, IDisposable
         var primary = PrimaryOutletOf(outletHost);
         if (primary is not null)
         {
-            primary.NotifyDeparture(this, ctx.To, willRemainMatched, onError);
+            primary.NotifyDeparture(this, ctx.To, willRemainMatched, onError, hostTornDown);
+            // The outlet owns the content session, but the parameter identity that
+            // WillRemountForParameters compares lives on the inline renderer (RenderRoute records it
+            // for both content paths), so end it here too when the session ends.
+            if (willRemainMatched is false) _renderer.ForgetRenderedParameterKey();
         }
         else
         {

--- a/src/Brouter/Bit.Brouter/Components/Brouter.cs
+++ b/src/Brouter/Bit.Brouter/Components/Brouter.cs
@@ -962,9 +962,15 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// EVERYTHING for the duration of the load): then survivors are notified with
     /// willRemainMatched, so retained keep-alive content no-ops while transient content gets its
     /// honest Disposing notification for the instance that render destroys.
+    /// <paramref name="remountFrom"/> is the index in <paramref name="surviving"/> of the shallowest
+    /// route whose content the commit rebuilds (see <see cref="FindRemountStart"/>), or -1: a
+    /// departing keep-alive route hosted at or below it - or below a transient host being left -
+    /// loses its retained subtree with the host, so it is told Disposing rather than Hidden (the
+    /// same call the lock phase made for its vote, see <see cref="KeptContentSurvivesLeave"/>).
     /// </summary>
     private void NotifyChainDepartures(BrouterNavigationContext ctx, Broute[] departingChain,
-        List<Broute>? surviving = null, bool notifySurvivorsAsRemaining = false, Broute? contentReplacedNode = null)
+        List<Broute>? surviving = null, bool notifySurvivorsAsRemaining = false, Broute? contentReplacedNode = null,
+        int remountFrom = -1)
     {
         // A departure callback's synchronous prefix can start a new navigation, superseding this
         // one. The rest of the chain then belongs to that navigation's own departure phase (which
@@ -982,9 +988,12 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             // contentReplacedNode is the error-boundary route whose committed content the coming
             // render REPLACES with its ErrorContent (see RenderNavigationError): its departure is
             // forced to Disposing - keep-alive retention keeps a subtree that no longer holds the
-            // page, so Hidden would be a lie.
+            // page, so Hidden would be a lie. Likewise a kept route whose hosting subtree is about
+            // to be unmounted (hostTornDown).
+            var hostTornDown = survives is false && node.KeepAlive
+                && KeptContentSurvivesLeave(node, surviving, remountFrom) is false;
             node.NotifyDeparture(ctx, willRemainMatched: survives,
-                contentReplaced: ReferenceEquals(node, contentReplacedNode));
+                contentReplaced: ReferenceEquals(node, contentReplacedNode), hostTornDown: hostTornDown);
             if (ctx.CancellationToken.IsCancellationRequested || generation != _lifecycleNavGeneration) return;
         }
     }
@@ -1019,6 +1028,63 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             if (matchedChain.Contains(node)) continue;
             node.Refresh();
             if (version != _navVersion) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// The one rule behind <see cref="BrouterOptions.RemountOnParameterChange"/>: the index in
+    /// <paramref name="chain"/> of the shallowest route that was on screen before the pending
+    /// commit (present in <paramref name="committed"/>) and stays matched, but whose content the
+    /// commit rebuilds because its parameter values changed - or -1 when nothing is rebuilt.
+    /// Everything below that index is rebuilt with it (see <see cref="DropContentForRemount"/>).
+    /// Both chains are root -> leaf parent paths, so the routes they share are a common prefix at
+    /// equal indices; the walk stops at the first route that wasn't committed before (it is
+    /// mounting fresh regardless, and so is everything below it). Shared by the lock phase (which
+    /// passes the prospective match's values) and the commit (which passes null to compare each
+    /// route's just-committed <see cref="Broute.Parameters"/>), so the vote a route casts and what
+    /// then happens to its instance can never disagree.
+    /// </summary>
+    private static int FindRemountStart(List<Broute> chain, Broute[] committed,
+        IReadOnlyDictionary<string, object?>? values, out int sharedPrefix)
+    {
+        var from = -1;
+        var shared = Math.Min(chain.Count, committed.Length);
+        for (sharedPrefix = 0; sharedPrefix < shared; sharedPrefix++)
+        {
+            var node = chain[sharedPrefix];
+            if (ReferenceEquals(committed[sharedPrefix], node) is false) break;
+            if (from < 0 && node.WillRemountForParameters(values ?? node.Parameters)) from = sharedPrefix;
+        }
+        return from;
+    }
+
+    /// <summary>
+    /// Tears down the content of routes that stay matched across this commit but are re-entered
+    /// with different parameter values (<see cref="BrouterOptions.RemountOnParameterChange"/>), so
+    /// the commit render mounts brand-new instances. <paramref name="from"/> is the shallowest such
+    /// route and <paramref name="sharedPrefix"/> the length of the chain's previously-committed
+    /// prefix, both from <see cref="FindRemountStart"/>. Everything nested below the rebuilt route
+    /// is torn down with it: its content lives inside the subtree being replaced, so keeping the
+    /// child's instance would mean keeping a component whose host is gone - except keep-alive
+    /// content that lives elsewhere (inline at its declaration site, or inside a kept host that
+    /// survives), which stays exactly as <see cref="KeptContentSurvivesLeave"/> promised its vote.
+    /// Leaf -> root, and each drop both fires the content's Disposing deactivation and disposes the
+    /// subtree synchronously - the same dispose-before-mount ordering
+    /// <see cref="UnrenderDepartedRoutes"/> exists to preserve (#12752). Returns false when a drop's
+    /// synchronous user code (Dispose, OnDeactivated) started a navigation that superseded this
+    /// commit, which the caller must abandon immediately.
+    /// </summary>
+    private bool DropContentForRemount(List<Broute> matchedChain, int from, int sharedPrefix)
+    {
+        var generation = _lifecycleNavGeneration;
+        var version = _navVersion;
+        for (var i = sharedPrefix - 1; i >= from; i--)
+        {
+            var node = matchedChain[i];
+            if (i > from && node.KeepAlive && KeptContentSurvivesLeave(node, matchedChain, from)) continue;
+            node.DropAllContent();
+            if (_disposed || version != _navVersion || generation != _lifecycleNavGeneration) return false;
         }
         return true;
     }
@@ -2656,9 +2722,18 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
             // runs while the departing components are still alive). Routes present in both chains
             // aren't notified here: their content survives the commit untouched (the
             // no-pending-render path never unmounted it) and resolves as a renavigation below.
+            // Routes that stay matched but are re-entered with different parameter values: under
+            // RemountOnParameterChange their content is rebuilt rather than re-bound. Decided once
+            // here, for the departure notifications (a kept child hosted below the rebuilt route
+            // dies with its subtree and must not be told Hidden) and the teardown further down.
+            // Irrelevant when the pending-UI render already unmounted everything (departuresNotified):
+            // the commit mounts fresh instances anyway.
+            var remountFrom = -1;
+            var remountPrefix = 0;
             if (departuresNotified is false)
             {
-                NotifyChainDepartures(ctx, _committedChain, matchedChain);
+                remountFrom = FindRemountStart(matchedChain, _committedChain, null, out remountPrefix);
+                NotifyChainDepartures(ctx, _committedChain, matchedChain, remountFrom: remountFrom);
                 // Departure callbacks run synchronously into user code and can start a new
                 // navigation; abandon this commit before it mutates state the newer one owns.
                 if (token.IsCancellationRequested || version != _navVersion) return;
@@ -2674,6 +2749,15 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 // reports it; the token check covers cancellation without a version bump.
                 if (UnrenderDepartedRoutes(matchedChain) is false) return;
                 if (token.IsCancellationRequested || version != _navVersion) return;
+
+                // The rebuilt routes' content is torn down here - after the departed routes, before
+                // the commit render mounts the replacement - exactly like a route this commit
+                // removes; same synchronous-supersession hazard as the unrender above.
+                if (remountFrom >= 0)
+                {
+                    if (DropContentForRemount(matchedChain, remountFrom, remountPrefix) is false) return;
+                    if (token.IsCancellationRequested || version != _navVersion) return;
+                }
             }
 
             // Pre-render arrival preparation: per-parameter keep-alive routes deactivate the
@@ -2935,10 +3019,11 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// The leave phase of the pending navigation to <paramref name="to"/>, leaf -> root (children
     /// veto before their parents, mirroring Angular's CanDeactivate order). For every currently
     /// committed route it runs, in order: the component-level navigation locks of its active
-    /// content (<see cref="IBrouterRoute.OnDeactivatingAsync"/> when the route is being left,
-    /// <see cref="IBrouterRoute.OnRenavigatingAsync"/> when it stays matched - so parameter changes
-    /// are voteable too), then - only for routes actually being left - the route-declared
-    /// <see cref="Broute.LeaveGuard"/>. Locks are awaited, so they can hold the navigation open for
+    /// content (<see cref="IBrouterRoute.OnDeactivatingAsync"/> when the route is being left or its
+    /// content rebuilt, <see cref="IBrouterRoute.OnRenavigatingAsync"/> when it stays matched with
+    /// the instance surviving - so parameter changes are voteable too), then - only for routes
+    /// whose content actually goes away - the route-declared <see cref="Broute.LeaveGuard"/>.
+    /// Locks are awaited, so they can hold the navigation open for
     /// user input. Returns false when a lock/guard cancelled/redirected (the decision is on
     /// <paramref name="ctx"/> for the caller to apply) or the navigation was superseded; true to
     /// continue the pipeline. A throwing lock/guard propagates to the caller, which fails closed.
@@ -2959,13 +3044,19 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         if (anyWork is false) return true;
 
         // Which committed routes survive the new URL? Match it (SelectWinner is pure, so this is
-        // safe pre-commit) and collect the new chain; committed routes present in it are updated,
-        // not left. A null match means everything is being left.
-        HashSet<Broute>? staying = null;
+        // safe pre-commit) and collect the new chain, root -> leaf; committed routes present in it
+        // are updated, not left. A null match means everything is being left. remountFrom is the
+        // shallowest staying route whose content the commit will rebuild rather than re-bind
+        // (RemountOnParameterChange) - everything at or below it votes as a departure, because that
+        // is what actually happens to it. Same rule, same routine as the commit (FindRemountStart).
+        List<Broute>? newChain = null;
+        var remountFrom = -1;
         if (SelectWinner(to) is { } newMatch)
         {
-            staying = [];
-            for (var node = newMatch.Route; node is not null; node = node.Parent) staying.Add(node);
+            newChain = [];
+            for (var node = newMatch.Route; node is not null; node = node.Parent) newChain.Add(node);
+            newChain.Reverse();
+            remountFrom = FindRemountStart(newChain, committed, newMatch.Parameters, out _);
         }
 
         // Leaf -> root, and per route the content's own locks run before the route-declared
@@ -2978,7 +3069,13 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
         for (var i = committed.Length - 1; i >= 0; i--)
         {
             var node = committed[i];
-            var stays = staying is not null && staying.Contains(node);
+            // A staying route sits at the same index in both chains (common root -> leaf prefix),
+            // so "at or below the rebuilt route" is an index comparison. Keep-alive content that
+            // lives outside the rebuilt subtree survives it and re-binds like any staying route.
+            var index = newChain?.IndexOf(node) ?? -1;
+            var stays = index >= 0;
+            var remounts = stays && remountFrom >= 0 && index >= remountFrom
+                && (node.KeepAlive && KeptContentSurvivesLeave(node, newChain, remountFrom)) is false;
 
             // 1. Component-level locks. A route being left dispatches OnDeactivatingAsync to its
             // active content; a route that stays matched dispatches OnRenavigatingAsync instead
@@ -3005,15 +3102,18 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 {
                     var context = lockContexts[c];
                     if (ctx.CancellationToken.IsCancellationRequested) return false;
-                    if (stays)
+                    if (stays && remounts is false)
                     {
                         renavigating ??= new BrouterRouteRenavigatingContext(ctx);
                         await context.FireRenavigatingAsync(renavigating);
                     }
                     else
                     {
+                        // Being left - or rebuilt on commit (remounts): either way the instance
+                        // voting here is the one that will be disposed, so it votes as a departure
+                        // rather than as a parameter change it would live through.
                         var reason = c < namedFrom
-                            && node.KeepAlive && KeptContentSurvivesLeave(node, staying)
+                            && node.KeepAlive && KeptContentSurvivesLeave(node, newChain, remountFrom)
                             ? BrouterRouteDeactivationReason.Hidden
                             : BrouterRouteDeactivationReason.Disposing;
                         await context.FireDeactivatingAsync(new BrouterRouteDeactivatingContext(ctx, reason));
@@ -3023,8 +3123,11 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
                 }
             }
 
-            // 2. The route-declared LeaveGuard, only when the route is actually being left.
-            if (stays || node.LeaveGuard is null) continue;
+            // 2. The route-declared LeaveGuard, only when the route's content is actually going
+            // away: the route is being left, or it stays matched but is rebuilt, which disposes the
+            // content just the same (a dirty editor on /doc/1 must get its prompt before /doc/2
+            // replaces it).
+            if ((stays && remounts is false) || node.LeaveGuard is null) continue;
 
             if (ctx.CancellationToken.IsCancellationRequested) return false;
             // Expose the route being left for the duration of its own guard call only.
@@ -3054,12 +3157,18 @@ public class Brouter : ComponentBase, IDisposable, IAsyncDisposable
     /// inside it, kept children included (see
     /// <c>KeepAliveTests.KeepAlive_state_is_lost_across_the_hosting_layout_unmount</c>). Inline
     /// content renders at the route's declaration site, which stays mounted regardless of matching.
+    /// A staying host at or below <paramref name="remountFrom"/> (its index in
+    /// <paramref name="staying"/>, root -> leaf) has its content rebuilt by the commit, which
+    /// unmounts its outlets exactly like being left does - so it counts as left here. Used by the
+    /// lock phase for the vote, and by the commit (departure notification and remount teardown)
+    /// for what it then does, so the two always agree.
     /// </summary>
-    private static bool KeptContentSurvivesLeave(Broute node, HashSet<Broute>? staying)
+    private static bool KeptContentSurvivesLeave(Broute node, List<Broute>? staying, int remountFrom)
     {
         for (var host = node.FindOutletHost(); host is not null; host = host.FindOutletHost())
         {
-            if (staying is not null && staying.Contains(host)) return true;
+            var index = staying?.IndexOf(host) ?? -1;
+            if (index >= 0 && (remountFrom < 0 || index < remountFrom)) return true;
             if (host.KeepAlive is false) return false;
         }
         return true;

--- a/src/Brouter/Bit.Brouter/Components/BrouterOutlet.cs
+++ b/src/Brouter/Bit.Brouter/Components/BrouterOutlet.cs
@@ -219,10 +219,15 @@ public class BrouterOutlet : ComponentBase, IDisposable
     /// Fires the deactivation side of the route lifecycle for an outlet-hosted child, called by the
     /// navigation pipeline BEFORE the render that hides or unmounts its content (see
     /// <see cref="BrouterRouteRenderer.NotifyDeparture"/> for the timing/willRemainMatched contract).
+    /// <paramref name="hostTornDown"/> says the subtree this outlet lives in is itself about to be
+    /// unmounted (its host route is being left or rebuilt): retention cannot save a kept child then,
+    /// so it is deactivated with Disposing and forgotten, and the outlet's own disposal finds nothing
+    /// still active.
     /// </summary>
-    internal void NotifyDeparture(Broute route, BrouterLocation to, bool willRemainMatched, Action<Exception> onError)
+    internal void NotifyDeparture(Broute route, BrouterLocation to, bool willRemainMatched, Action<Exception> onError,
+        bool hostTornDown = false)
     {
-        if (Name.Length == 0 && route.KeepAlive)
+        if (Name.Length == 0 && route.KeepAlive && hostTornDown is false)
         {
             // Kept entries survive; a transient hide (pending-UI render while the route stays
             // matched) is a no-op for them, resolving as a renavigation at commit. Snapshot:
@@ -235,6 +240,27 @@ public class BrouterOutlet : ComponentBase, IDisposable
                     k.Context.FireDeactivated(BrouterRouteDeactivationReason.Hidden, to, onError);
                 }
             }
+            return;
+        }
+
+        if (hostTornDown && route.KeepAlive)
+        {
+            // Same teardown as ForgetChild, reported against the navigation's destination: every
+            // entry of the route dies with the host's subtree (hidden ones already got Hidden and
+            // no-op here), and a later visit starts a fresh session.
+            foreach (var k in _kept.ToArray())
+            {
+                if (ReferenceEquals(k.Route, route))
+                {
+                    k.Context.FireDeactivated(BrouterRouteDeactivationReason.Disposing, to, onError);
+                }
+            }
+            if (_current is not null && ReferenceEquals(_current.Route, route))
+            {
+                _current.Context.FireDeactivated(BrouterRouteDeactivationReason.Disposing, to, onError);
+                _current = null;
+            }
+            _kept.RemoveAll(k => ReferenceEquals(k.Route, route));
             return;
         }
 
@@ -468,6 +494,14 @@ public class BrouterOutlet : ComponentBase, IDisposable
         var parameters = entry.Parameters;
 
         builder.OpenComponent<CascadingValue<BrouterOutlet>>(0);
+        // Key the child's subtree by its entry (the content session), for the same reason the inline
+        // renderer keys by its lifecycle context (see BrouterRouteRenderer.EmitContextCascade): a
+        // session that ends and restarts inside ONE render batch - DropChild + Render collapsed by
+        // ComponentBase into a single render - must diff as a replaced subtree, not as the same
+        // component instance re-bound to a new entry's context. An entry is stable across a
+        // renavigation, so re-binding still re-binds. Kept entries are already keyed by their
+        // wrapper element; keying the inner component too is harmless.
+        builder.SetKey(entry);
         builder.AddAttribute(1, "Name", "Outlet");
         builder.AddAttribute(2, "Value", this);
         builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>

--- a/src/Brouter/Bit.Brouter/Options/BrouterOptions.cs
+++ b/src/Brouter/Bit.Brouter/Options/BrouterOptions.cs
@@ -138,6 +138,40 @@ public sealed class BrouterOptions
     public int DefaultKeepAliveMax { get; set; } = 1;
 
     /// <summary>
+    /// Whether a navigation that stays on the same route but changes its route parameter values
+    /// (<c>/settings/profile</c> -> <c>/settings/account</c>) rebuilds the route's content instead of
+    /// re-binding the live instance. Defaults to <c>false</c>: the component instance survives, the
+    /// new values arrive as parameters, and the route lifecycle reports the navigation as a
+    /// renavigation (<see cref="IBrouterRoute.OnRenavigatingAsync"/> /
+    /// <see cref="IBrouterRoute.OnRenavigatedAsync"/>) rather than a deactivation + activation. That
+    /// is the same instance reuse the built-in <c>Router</c> gives a page (its <c>RouteView</c>
+    /// re-parameterizes the existing component - <c>OnParametersSet</c> runs, <c>OnInitialized</c>
+    /// does not) and what Angular and Vue do; it keeps scroll position, form state and in-flight
+    /// work across the change, at the cost of every such component having to react to the new
+    /// parameters itself.
+    /// <para>
+    /// Set it to <c>true</c> to dispose the old components and mount a brand-new instance on every
+    /// parameter change, so anything a component reads once - <c>OnInitialized</c>, a child that
+    /// captures a parameter when it registers, an uncontrolled <c>Default*</c> value on a UI
+    /// component - sees the new values. The content then votes on the change through
+    /// <see cref="IBrouterRoute.OnDeactivatingAsync"/> (reason Disposing) and the route's
+    /// <see cref="Broute.LeaveGuard"/>, exactly like a route being left. Individual routes can opt
+    /// either way with <see cref="Broute.RemountOnParameterChange"/>. Everything nested below a
+    /// rebuilt route is rebuilt with it - including, for pages rendered through
+    /// <c>Brouter.DefaultLayout</c> / <c>Found</c>, the framework <c>RouteView</c> and the layout it
+    /// composes inside the page's subtree; a layout declared as a parent <c>Broute</c> whose own
+    /// parameters didn't change is untouched.
+    /// </para>
+    /// <para>
+    /// <see cref="Broute.KeepAlive"/> routes are never remounted for their own parameter change:
+    /// retaining the instance is the whole point of keep-alive, and a per-parameter keep-alive route
+    /// (<see cref="Broute.KeepAliveMax"/> &gt; 1) already gives each parameter set its own instance.
+    /// A kept route hosted in the outlet of an ancestor that IS rebuilt dies with that subtree.
+    /// </para>
+    /// </summary>
+    public bool RemountOnParameterChange { get; set; }
+
+    /// <summary>
     /// Debounce for <see cref="BrouterLinkPreload.Intent"/> preloading: the pointer must rest on the
     /// link this long before the preload fires, so merely brushing past links doesn't fetch.
     /// Defaults to 50 ms (TanStack Router's <c>defaultPreloadDelay</c>).

--- a/src/Brouter/Bit.Brouter/Routing/BrouterRouteRenderer.cs
+++ b/src/Brouter/Bit.Brouter/Routing/BrouterRouteRenderer.cs
@@ -39,6 +39,16 @@ internal class BrouterRouteRenderer
     // route matches again, so a later visit rebuilds it fresh.
     private bool _keptDropped;
 
+    // The parameter identity (see Broute.ComputeParameterKey) this route's content was last
+    // rendered with, while it is mounted; null whenever nothing is mounted. Recorded by RenderRoute
+    // for both content paths (the outlet-hosted one too - the outlet owns that session, but the
+    // route's render pass is still where the match lands), and cleared by every path that ends the
+    // session: the inline departure/teardown/drop paths below, and Broute.NotifyDeparture for the
+    // outlet path (ForgetRenderedParameterKey). The navigation pipeline compares it with an incoming
+    // match's values to decide whether a route that stays matched has to be rebuilt
+    // (BrouterOptions.RemountOnParameterChange) or merely re-bound.
+    private string? _renderedParameterKey;
+
     // Per-parameter retention (EffectiveKeepAliveMax > 1) for the inline (non-outlet) render path:
     // one entry per recently-visited parameter set, LRU-ordered with the most recently active at the
     // end. Each entry owns a keyed subtree whose parameters/data are frozen while hidden, so a
@@ -64,6 +74,18 @@ internal class BrouterRouteRenderer
         _route = route;
     }
 
+    /// <summary>
+    /// The parameter identity this route's content currently on screen was rendered with, or null
+    /// when it holds no mounted content (nothing to rebuild). See <see cref="_renderedParameterKey"/>.
+    /// </summary>
+    public string? LastRenderedParameterKey => _renderedParameterKey;
+
+    /// <summary>
+    /// Ends the recorded parameter identity for content this renderer does not own - an
+    /// outlet-hosted session the outlet just closed (see <see cref="Broute.NotifyDeparture"/>).
+    /// </summary>
+    public void ForgetRenderedParameterKey() => _renderedParameterKey = null;
+
     // Drops this route's retained (hidden) keep-alive content on the next render, keeping only the
     // currently active instance (when the route is matched). Backs IBrouter.ClearKeepAlive.
     public void DropKeptContent(bool routeIsMatched)
@@ -86,6 +108,7 @@ internal class BrouterRouteRenderer
         {
             _keptDropped = true;
             _context = null;
+            _renderedParameterKey = null;
         }
     }
 
@@ -147,6 +170,7 @@ internal class BrouterRouteRenderer
         // ending the session.
         _context?.FireDeactivated(BrouterRouteDeactivationReason.Disposing, to, onError);
         _context = null;
+        _renderedParameterKey = null;
     }
 
     /// <summary>
@@ -208,6 +232,7 @@ internal class BrouterRouteRenderer
         }
         _context?.FireDeactivated(BrouterRouteDeactivationReason.Disposing, location, onError);
         _context = null;
+        _renderedParameterKey = null;
     }
 
     /// <summary>
@@ -329,6 +354,12 @@ internal class BrouterRouteRenderer
             _cachedInheritedRef = inherited;
             _cachedLocalRef = local;
         }
+
+        // The content on screen from this render on is the one carrying the route's current values.
+        // Recorded on every matched render rather than only on a parameter-cache miss: the cache can
+        // survive the drop that ended the previous session, and a fresh session must record its
+        // identity regardless. A handful of short string appends per render.
+        if (matched) _renderedParameterKey = _route.ComputeParameterKey();
 
         // Typed wrappers instead of raw object? cascades: a distinct wrapper type per cascade
         // means consumers get compile-time-safe access (Get<T>/TryGet<T>) and match by type

--- a/src/Brouter/README.md
+++ b/src/Brouter/README.md
@@ -23,6 +23,7 @@ builder.Services.AddBitBrouterServices(o =>
     o.ScrollBehavior = BrouterScrollMode.ToTop;
     o.ScrollToFragment = true;            // default: /docs#install scrolls #install into view
     o.FocusOnNavigateSelector = "h1";     // move focus after navigation (accessibility)
+    o.RemountOnParameterChange = false;   // default: /item/1 -> /item/2 re-binds the page instance (true rebuilds it)
 });
 ```
 
@@ -127,6 +128,7 @@ code can be exercised in each render mode.
 - **Source-generated typed routes** (`Bit.Brouter.Generators`): compile-time-safe URL builders generated from your `@page` directives and `<Broute>` declarations - `BrouterRoutes.Counter(1234)` instead of `"/counter/1234"`, with constraint-typed parameters and a `Names` class for named routes
 - **Named outlets**: `<BrouterOutlet Name="sidebar">` + `<BrouterView Name="sidebar">` let one route drive multiple regions of its parent layout (Vue named views / Angular secondary outlets style)
 - **Keep-alive routes**: `<Broute KeepAlive>` keeps the rendered component mounted (hidden) when navigated away, so returning restores its exact state instead of recreating it (Vue `KeepAlive` / Angular `RouteReuseStrategy` style); `KeepAliveMax="N"` upgrades a parameterized route to per-parameter caching (`/item/1` and `/item/2` each resume their own state, LRU-evicted over the budget), and `brouter.ClearKeepAlive()` evicts retained pages on demand - `ClearKeepAlive(includeActive: true)` throws away the page on screen as well and rebuilds it in place
+- **Parameter-change semantics, your choice**: by default a navigation that only changes a route's parameter values (`/settings/profile → /settings/account`) re-binds the live instance and reports the change as `OnRenavigated` - the same reuse Blazor's built-in `Router` gives a page, and what Angular and Vue do. Set `o.RemountOnParameterChange = true` (or `<Broute RemountOnParameterChange="true">` for a single route) to rebuild the content instead, so a page that reads a value once (`OnInitialized`, an uncontrolled `Default*` parameter on a UI component) sees the new one
 - **Route lifecycle**: every routed component (keep-alive or not, at any depth) can receive `OnActivated` / `OnDeactivated` / `OnRenavigated` callbacks - implement `IBrouterRoute` on a page (auto-discovered) or derive from `BrouterRouteBase` (the Ionic `ionViewWillEnter` / Vue `onActivated` idea, with async support and a Disposing-vs-Hidden reason) - plus the pre-commit `OnDeactivating` / `OnRenavigating` lock callbacks above
 - **Async data `Loader`** exposed via the typed cascading `BrouterRouteData` wrapper (`Get<T>` / `TryGet<T>` / `GetOrDefault<T>`) - sequential root → leaf by default, with opt-in **`ParallelLoaders`** for independent loaders
 - Redirects with `RedirectTo`
@@ -929,6 +931,58 @@ Named views receive the route's parameters (the `Context`) and see its data/meta
 Angular's secondary outlets there is no URL serialization - the named regions always follow the
 primary match, which is the common layout case.
 
+## Rebuild or re-bind on a parameter change
+
+A navigation can keep the same route matched and change only its parameter values
+(`/settings/profile → /settings/account`, `/item/1 → /item/2`). By default the component instance
+survives: the new values arrive as parameters and the change is reported as `OnRenavigated` rather
+than a deactivation plus a fresh activation. That is the same reuse Blazor's built-in `Router`
+gives a page (its `RouteView` re-parameterizes the existing component - `OnParametersSet` runs,
+`OnInitialized` does not), and what Angular and Vue do; it preserves scroll position, form state
+and in-flight work across the change, at the cost of every affected component having to react to
+the new parameters itself.
+
+That bites anything that reads a value *once*: `OnInitialized`, a child that captures a parameter
+when it registers with its parent, an uncontrolled `Default*` parameter on a UI component
+(`DefaultExpandedKey`, `DefaultSelectedKey`). With the instance re-bound, those keep showing the
+value the page was first mounted with, and the navigation looks to the user like nothing happened.
+Opt into rebuilding instead - the old content is disposed and a brand-new instance mounts, so
+everything starts from the new values:
+
+```csharp
+services.AddBitBrouterServices(o =>
+{
+    o.RemountOnParameterChange = true; // /item/1 -> /item/2 disposes the page and mounts a fresh one
+});
+```
+
+A single route overrides either default:
+
+```razor
+<Broute Path="/item/{id:int}" RemountOnParameterChange="true">
+    <Content><ItemPage /></Content>
+</Broute>
+```
+
+Notes:
+
+- Only **template parameters** count - every parameter of the route's full template, so a child
+  under `/user/{id}` is rebuilt when `id` changes even though its own segment didn't. A query-only
+  change (`?tab=2`) never rebuilds - the built-in router keeps its page there too, re-supplying
+  `[SupplyParameterFromQuery]` values.
+- A rebuild is a leave as far as the content is concerned: it votes through `OnDeactivating`
+  (reason `Disposing`) and the route's `LeaveGuard`, gets `OnDeactivated` - never `OnRenavigating`
+  / `OnRenavigated` - and the fresh instance starts with a first `OnActivated`.
+- Rebuilding a route rebuilds everything nested inside it: a child's content lives in the subtree
+  being replaced. A parent layout declared as a `<Broute>` whose own parameters didn't change is
+  untouched. Pages rendered through `DefaultLayout` / `Found` are different: the framework
+  `RouteView` composes the layout *inside* the page's subtree, so the layout is rebuilt with the
+  page - the cost of opting in on those routes.
+- `KeepAlive` routes never rebuild for their own parameter change - retaining the instance is what
+  they asked for - and a `KeepAliveMax > 1` route already mounts one instance per parameter set. A
+  kept route hosted in the outlet of an ancestor that *is* rebuilt dies with that subtree (reported
+  as `Disposing`, exactly like a kept child whose layout is left).
+
 ## Keep-alive routes
 
 ```razor
@@ -956,10 +1010,14 @@ component-level hooks Angular's `RouteReuseStrategy` never delivered and Ionic's
   and unlike `Dispose` it carries the destination location). `KeepAlive` only changes which reason
   you get; pages written against the lifecycle keep working when the route's retention changes.
 - **`OnRenavigated`** - a navigation re-committed this route while the *same instance* stayed
-  visible (`/item/1 → /item/2` on a singleton route, or a query-only change): the "user arrived
-  here again" moment that `OnInitialized` misses on instance reuse. On a per-parameter keep-alive
-  route (`KeepAliveMax` > 1) a parameter change mounts a separate instance instead, so it surfaces
-  as an activate/deactivate pair rather than a renavigation.
+  visible (`/item/1 → /item/2` on a singleton route, a query-only change, or moving between the
+  route's descendants): the "user arrived here again" moment that `OnInitialized` misses on
+  instance reuse. A route that opted into
+  [rebuilding on a parameter change](#rebuild-or-re-bind-on-a-parameter-change) never gets it for
+  such a change - the content is disposed, so it sees a `Disposing` deactivation plus a first
+  activation instead. On a per-parameter keep-alive route (`KeepAliveMax` > 1) a parameter change
+  mounts a separate instance too, so it surfaces as an activate/deactivate pair rather than a
+  renavigation.
 
 All callbacks have async variants; returned tasks are observed for errors (surfaced via
 `IBrouter.OnError`) but never delay the navigation. They are not invoked during static prerendering.
@@ -1003,7 +1061,7 @@ automatically:
 @implements IBrouterRoute
 @code {
     public ValueTask OnRenavigatedAsync(BrouterRouteRenavigation renavigation)
-        => RefreshAsync(); // e.g. /item/1 -> /item/2 reused this instance; OnInitialized won't re-run
+        => RefreshAsync(); // e.g. /item/1 -> /item/2 reused this instance (the default); OnInitialized won't re-run
 }
 ```
 
@@ -1036,7 +1094,10 @@ component-side):
   entirely - or `Disposing`).
 - **`OnRenavigating`** - a pending navigation keeps this route matched (a route/query parameter
   change, or moving between its descendants). This is the case `LeaveGuard` deliberately never
-  fires for - without it, a dirty edit form on `/item/1` couldn't veto going to `/item/2`.
+  fires for - without it, a dirty edit form on `/item/1` couldn't veto going to `/item/2`. A route
+  that opted into [rebuilding on a parameter change](#rebuild-or-re-bind-on-a-parameter-change)
+  is the exception: its content is disposed by the change, so it votes through `OnDeactivating`
+  (reason `Disposing`) and its `LeaveGuard` runs, exactly as if the route were left.
 
 Both are **awaited** by the pipeline (unlike the notify-only lifecycle callbacks) and run inside
 the preventive phase, so `context.Cancel()` / `context.Redirect(...)` stop the URL from ever

--- a/src/Brouter/Tests/Bit.Brouter.Tests/NamedOutletTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/NamedOutletTests.cs
@@ -75,4 +75,27 @@ public class NamedOutletTests : BunitTestContext
                 cut.Instance.USideLog);
         });
     }
+
+    [TestMethod]
+    public async Task Parameter_change_rebuilds_outlet_hosted_content_and_named_views_when_opted_in()
+    {
+        Services.Configure<BrouterOptions>(o => o.RemountOnParameterChange = true);
+
+        var (cut, brouter) = RenderAt<NamedOutletHost>("http://localhost/dash/u/1");
+        cut.WaitForAssertion(() => Assert.IsTrue(cut.Find("[data-testid=u-main]").TextContent.Contains("user 1")));
+
+        await cut.InvokeAsync(() => brouter.Navigate("/dash/u/2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.IsTrue(cut.Find("[data-testid=u-main]").TextContent.Contains("user 2"));
+            Assert.IsTrue(cut.Find("[data-testid=u-side]").TextContent.Contains("sidebar for 2"));
+
+            // Fresh sessions in BOTH outlets: the primary content and the named view were each
+            // disposed with the route's rebuild and mounted anew - never re-bound as a renavigation.
+            var rebuilt = new[] { "activated:first=True", "deactivated:Disposing", "activated:first=True" };
+            CollectionAssert.AreEqual(rebuilt, cut.Instance.UMainLog);
+            CollectionAssert.AreEqual(rebuilt, cut.Instance.USideLog);
+        });
+    }
 }

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RemountHost.razor
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RemountHost.razor
@@ -1,0 +1,106 @@
+﻿@* Host for RemountOnParameterChangeTests: the same parameterized route declared four ways -
+   following the application default, opted out of remounting, opted in, and keep-alive (which
+   never remounts) - plus a parent layout with an outlet-hosted parameterized child, a Component
+   route, a route-declared LeaveGuard, and a parameterized host with a kept outlet child, so both
+   content-fragment and directly-instantiated pages and every vote a rebuild triggers are covered. *@
+
+@using Bit.Brouter
+
+<Brouter>
+    <Broute Path="/rm/{id:int}">
+        <Content>
+            <StatefulCounter />
+            <LifecycleProbe Log="Log" />
+        </Content>
+    </Broute>
+
+    <Broute Path="/rmoff/{id:int}" RemountOnParameterChange="false">
+        <Content><StatefulCounter /></Content>
+    </Broute>
+
+    <Broute Path="/rmon/{id:int}" RemountOnParameterChange="true">
+        <Content><StatefulCounter /></Content>
+    </Broute>
+
+    <Broute Path="/rmka/{id:int}" KeepAlive="true">
+        <Content><StatefulCounter /></Content>
+    </Broute>
+
+    <Broute Path="/rmlock/{id:int}">
+        <Content Context="p">
+            <div data-testid="locked">doc @p["id"]</div>
+            <NavigationLockProbe Label="doc" State="LockState" />
+        </Content>
+    </Broute>
+
+    <Broute Path="/rmguard/{id:int}" LeaveGuard="GuardDoc">
+        <Content Context="p"><div data-testid="guarded">doc @p["id"]</div></Content>
+    </Broute>
+
+    <Broute Path="/rmpage/{id:int}" Component="@typeof(StatefulCounter)" />
+
+    <Broute Path="/shell">
+        <Content>
+            <StatefulCounter />
+            <div data-testid="shell-outlet"><BrouterOutlet /></div>
+        </Content>
+        <ChildContent>
+            <Broute Path="/doc/{id:int}">
+                <Content Context="p">
+                    <div data-testid="doc">doc @p["id"]</div>
+                    <KeepAliveParam />
+                </Content>
+            </Broute>
+        </ChildContent>
+    </Broute>
+
+    <Broute Path="/user/{id:int}">
+        <Content>
+            <StatefulCounter />
+            <div data-testid="user-outlet"><BrouterOutlet /></div>
+        </Content>
+        <ChildContent>
+            <Broute Path="/edit">
+                <Content><KeepAliveParam /></Content>
+            </Broute>
+        </ChildContent>
+    </Broute>
+
+    <Broute Path="/acct/{id:int}">
+        <Content Context="p">
+            <div data-testid="acct">acct @p["id"]</div>
+            <div data-testid="acct-outlet"><BrouterOutlet /></div>
+        </Content>
+        <ChildContent>
+            <Broute Path="/draft" KeepAlive="true">
+                <Content>
+                    <KeepAliveParam />
+                    <LifecycleProbe Log="DraftLog" />
+                    <NavigationLockProbe Label="draft" State="DraftLockState" />
+                </Content>
+            </Broute>
+        </ChildContent>
+    </Broute>
+</Brouter>
+
+@code {
+    /// <summary>Outlives the disposed content so remount lifecycle transitions stay assertable.</summary>
+    public List<string> Log { get; } = [];
+
+    public NavigationLockState LockState { get; } = new();
+
+    /// <summary>Every GuardDoc firing; while <see cref="BlockGuard"/> is set the guard cancels.</summary>
+    public List<string> GuardFired { get; } = [];
+    public bool BlockGuard { get; set; }
+
+    private ValueTask GuardDoc(BrouterNavigationContext ctx)
+    {
+        GuardFired.Add("doc");
+        if (BlockGuard) ctx.Cancel();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>The kept /draft child's lifecycle and lock votes, hosted in a rebuildable parent.</summary>
+    public List<string> DraftLog { get; } = [];
+    public NavigationLockState DraftLockState { get; } = new();
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RemountOnParameterChangeTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RemountOnParameterChangeTests.cs
@@ -1,0 +1,308 @@
+﻿using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bit.Brouter.Tests;
+
+/// <summary>
+/// What happens to a route's content when a navigation keeps the route matched but changes its
+/// parameter values (<c>/settings/profile</c> -> <c>/settings/account</c>).
+/// <para>
+/// By default the instance survives and the change arrives as a renavigation - the same reuse the
+/// built-in <c>Router</c> gives a page. <see cref="BrouterOptions.RemountOnParameterChange"/>
+/// (globally) and <see cref="Broute.RemountOnParameterChange"/> (per route) switch to rebuilding
+/// the content instead, so everything a component reads once - <c>OnInitialized</c>, a child that
+/// captures a value when it registers with its parent, an uncontrolled <c>Default*</c> parameter on
+/// a UI component - sees the new values. A rebuild disposes the content, so it votes and is notified
+/// exactly like a route being left.
+/// </para>
+/// </summary>
+[TestClass]
+public class RemountOnParameterChangeTests : BunitTestContext
+{
+    private void UseRemount() => Services.Configure<BrouterOptions>(o => o.RemountOnParameterChange = true);
+
+    private static void Increment(IRenderedComponent<RemountHost> cut) => cut.Find("[data-testid=inc]").Click();
+
+    private static string Counter(IRenderedComponent<RemountHost> cut)
+        => cut.Find("[data-testid=stateful]").TextContent;
+
+    [TestMethod]
+    public async Task Parameter_change_re_binds_the_instance_by_default()
+    {
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rm/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+
+        await cut.InvokeAsync(() => brouter.Navigate("/rm/2"));
+
+        // Same instance, and the lifecycle says renavigation - what the built-in Router's RouteView
+        // does with a page too (OnParametersSet runs, OnInitialized does not).
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+        cut.WaitForAssertion(() => CollectionAssert.AreEqual(
+            new[] { "activated:first=True", "renavigated:/rm/1->/rm/2" }, cut.Instance.Log));
+    }
+
+    [TestMethod]
+    public async Task Option_rebuilds_the_content_on_a_parameter_change()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rm/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+
+        await cut.InvokeAsync(() => brouter.Navigate("/rm/2"));
+
+        // A brand-new instance: the state the old one accumulated is gone, and the lifecycle reports
+        // a Disposing deactivation plus a first activation - never a renavigation.
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+        cut.WaitForAssertion(() => CollectionAssert.AreEqual(
+            new[] { "activated:first=True", "deactivated:Disposing", "activated:first=True" },
+            cut.Instance.Log));
+    }
+
+    [TestMethod]
+    public async Task Query_only_change_does_not_rebuild_the_content()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rm/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+
+        await cut.InvokeAsync(() => brouter.Navigate("/rm/1?tab=2"));
+
+        // The route parameters are unchanged, so there is nothing to rebuild (a
+        // [SupplyParameterFromQuery] property is re-supplied on the live instance).
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+        cut.WaitForAssertion(() => CollectionAssert.AreEqual(
+            new[] { "activated:first=True", "renavigated:/rm/1->/rm/1" }, cut.Instance.Log));
+    }
+
+    [TestMethod]
+    public async Task Route_can_opt_out_of_rebuilding()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rmoff/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+
+        await cut.InvokeAsync(() => brouter.Navigate("/rmoff/2"));
+
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+    }
+
+    [TestMethod]
+    public async Task Route_can_opt_in_under_the_re_binding_default()
+    {
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rmon/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        await cut.InvokeAsync(() => brouter.Navigate("/rmon/2"));
+
+        // The route asked for a rebuild explicitly, so it rebuilds regardless of the default.
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+    }
+
+    [TestMethod]
+    public async Task KeepAlive_route_keeps_its_instance_across_a_parameter_change()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rmka/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        await cut.InvokeAsync(() => brouter.Navigate("/rmka/2"));
+
+        // Retaining the instance is the entire point of KeepAlive: the option must not undo it.
+        cut.WaitForAssertion(() => Assert.AreEqual("count:1", Counter(cut)));
+    }
+
+    [TestMethod]
+    public async Task Component_route_page_is_rebuilt_too()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rmpage/1");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        await cut.InvokeAsync(() => brouter.Navigate("/rmpage/2"));
+
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+    }
+
+    [TestMethod]
+    public async Task Outlet_hosted_child_is_rebuilt_while_its_layout_is_left_alone()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/shell/doc/1");
+        cut.WaitForAssertion(() => StringAssert.Contains(cut.Find("[data-testid=doc]").TextContent, "doc 1"));
+
+        // State in the layout (the shell's own counter) and in the child (the outlet-hosted one).
+        Increment(cut);
+        cut.Find("[data-testid=kpinc]").Click();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("count:1", Counter(cut));
+            StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:1");
+        });
+
+        await cut.InvokeAsync(() => brouter.Navigate("/shell/doc/2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            StringAssert.Contains(cut.Find("[data-testid=doc]").TextContent, "doc 2");
+            // Only the route whose parameters changed is rebuilt; the layout above it never left
+            // the chain and keeps its state.
+            Assert.AreEqual("count:1", Counter(cut));
+            StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:0");
+        });
+    }
+
+    [TestMethod]
+    public async Task Rebuilding_a_parent_rebuilds_the_child_nested_inside_it()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/user/1/edit");
+        cut.WaitForAssertion(() => Assert.AreEqual("count:0", Counter(cut)));
+
+        Increment(cut);
+        cut.Find("[data-testid=kpinc]").Click();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("count:1", Counter(cut));
+            StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:1");
+        });
+
+        await cut.InvokeAsync(() => brouter.Navigate("/user/2/edit"));
+
+        cut.WaitForAssertion(() =>
+        {
+            // The child's own parameters didn't change, but its content lives inside the subtree the
+            // parent's rebuild replaces - keeping that instance would mean keeping a component whose
+            // host is gone.
+            Assert.AreEqual("count:0", Counter(cut));
+            StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:0");
+        });
+    }
+
+    [TestMethod]
+    public void Deactivating_lock_vetoes_a_remounting_parameter_change()
+    {
+        UseRemount();
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rmlock/1");
+        cut.WaitForAssertion(() => cut.Find("[data-testid=locked]"));
+
+        cut.Instance.LockState.Locked = true;
+        cut.InvokeAsync(() => brouter.Navigate("/rmlock/2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            // The instance about to be disposed votes with its deactivating lock (not the
+            // renavigating one, which belongs to content that survives the change) - and the veto
+            // holds: still doc 1, URL untouched.
+            CollectionAssert.Contains(cut.Instance.LockState.Log, "doc:deactivating:Disposing:to=/rmlock/2");
+            CollectionAssert.DoesNotContain(cut.Instance.LockState.Log, "doc:renavigating:to=/rmlock/2");
+            StringAssert.Contains(cut.Find("[data-testid=locked]").TextContent, "doc 1");
+            Assert.IsTrue(nav.Uri.EndsWith("/rmlock/1"));
+        });
+    }
+
+    [TestMethod]
+    public void LeaveGuard_fires_for_a_remounting_parameter_change()
+    {
+        // A parameter change on a route that keeps its instance is not a leave, so LeaveGuard stays
+        // silent there (see LeaveGuardTests). Under a rebuild the content is disposed exactly as if
+        // the route were left, so the route-declared guard gets its veto too.
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/rmguard/1");
+        cut.WaitForAssertion(() => cut.Find("[data-testid=guarded]"));
+
+        cut.Instance.BlockGuard = true;
+        cut.InvokeAsync(() => brouter.Navigate("/rmguard/2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            CollectionAssert.AreEqual(new[] { "doc" }, cut.Instance.GuardFired);
+            StringAssert.Contains(cut.Find("[data-testid=guarded]").TextContent, "doc 1");
+        });
+
+        cut.Instance.BlockGuard = false;
+        cut.InvokeAsync(() => brouter.Navigate("/rmguard/2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            CollectionAssert.AreEqual(new[] { "doc", "doc" }, cut.Instance.GuardFired);
+            StringAssert.Contains(cut.Find("[data-testid=guarded]").TextContent, "doc 2");
+        });
+    }
+
+    [TestMethod]
+    public async Task Kept_child_hosted_in_a_rebuilt_parent_is_disposed_not_hidden()
+    {
+        UseRemount();
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/acct/1/draft");
+        cut.WaitForAssertion(() => StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:0"));
+
+        cut.Find("[data-testid=kpinc]").Click();
+        cut.WaitForAssertion(() => StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:1"));
+
+        // Leaving the kept child while its host is rebuilt: retention cannot save it (the outlet it
+        // lives in goes with the host's content), so its lock vote and its deactivation both say
+        // Disposing - never Hidden, which would promise a survival that doesn't happen.
+        await cut.InvokeAsync(() => brouter.Navigate("/acct/2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            StringAssert.Contains(cut.Find("[data-testid=acct]").TextContent, "acct 2");
+            Assert.AreEqual(0, cut.FindAll("[data-testid=kp]").Count);
+            CollectionAssert.Contains(cut.Instance.DraftLockState.Log, "draft:deactivating:Disposing:to=/acct/2");
+            CollectionAssert.AreEqual(
+                new[] { "activated:first=True", "deactivated:Disposing" }, cut.Instance.DraftLog);
+        });
+
+        // Coming back starts a fresh session, consistent with what the content was told.
+        await cut.InvokeAsync(() => brouter.Navigate("/acct/2/draft"));
+
+        cut.WaitForAssertion(() =>
+        {
+            StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:0");
+            CollectionAssert.AreEqual(
+                new[] { "activated:first=True", "deactivated:Disposing", "activated:first=True" },
+                cut.Instance.DraftLog);
+        });
+    }
+
+    [TestMethod]
+    public async Task Kept_child_hosted_in_a_re_bound_parent_is_hidden_by_default()
+    {
+        // The control for the test above: with the host re-binding (the default), the kept child's
+        // outlet survives the parameter change, so leaving the child is an ordinary Hidden and
+        // returning resumes the retained instance.
+        var (cut, brouter) = RenderAt<RemountHost>("http://localhost/acct/1/draft");
+        cut.WaitForAssertion(() => StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:0"));
+
+        cut.Find("[data-testid=kpinc]").Click();
+        await cut.InvokeAsync(() => brouter.Navigate("/acct/2"));
+        cut.WaitForAssertion(() => CollectionAssert.Contains(cut.Instance.DraftLockState.Log, "draft:deactivating:Hidden:to=/acct/2"));
+
+        await cut.InvokeAsync(() => brouter.Navigate("/acct/2/draft"));
+        cut.WaitForAssertion(() =>
+        {
+            StringAssert.Contains(cut.Find("[data-testid=kp]").TextContent, "count:1");
+            CollectionAssert.AreEqual(
+                new[] { "activated:first=True", "deactivated:Hidden", "activated:first=False" },
+                cut.Instance.DraftLog);
+        });
+    }
+}

--- a/src/Brouter/Tests/Bit.Brouter.Tests/RemountOnParameterChangeTests.cs
+++ b/src/Brouter/Tests/Bit.Brouter.Tests/RemountOnParameterChangeTests.cs
@@ -196,7 +196,7 @@ public class RemountOnParameterChangeTests : BunitTestContext
     }
 
     [TestMethod]
-    public void Deactivating_lock_vetoes_a_remounting_parameter_change()
+    public async Task Deactivating_lock_vetoes_a_remounting_parameter_change()
     {
         UseRemount();
         var nav = Services.GetRequiredService<BunitNavigationManager>();
@@ -204,7 +204,7 @@ public class RemountOnParameterChangeTests : BunitTestContext
         cut.WaitForAssertion(() => cut.Find("[data-testid=locked]"));
 
         cut.Instance.LockState.Locked = true;
-        cut.InvokeAsync(() => brouter.Navigate("/rmlock/2"));
+        await cut.InvokeAsync(() => brouter.Navigate("/rmlock/2"));
 
         cut.WaitForAssertion(() =>
         {
@@ -219,7 +219,7 @@ public class RemountOnParameterChangeTests : BunitTestContext
     }
 
     [TestMethod]
-    public void LeaveGuard_fires_for_a_remounting_parameter_change()
+    public async Task LeaveGuard_fires_for_a_remounting_parameter_change()
     {
         // A parameter change on a route that keeps its instance is not a leave, so LeaveGuard stays
         // silent there (see LeaveGuardTests). Under a rebuild the content is disposed exactly as if
@@ -229,7 +229,7 @@ public class RemountOnParameterChangeTests : BunitTestContext
         cut.WaitForAssertion(() => cut.Find("[data-testid=guarded]"));
 
         cut.Instance.BlockGuard = true;
-        cut.InvokeAsync(() => brouter.Navigate("/rmguard/2"));
+        await cut.InvokeAsync(() => brouter.Navigate("/rmguard/2"));
 
         cut.WaitForAssertion(() =>
         {
@@ -238,7 +238,7 @@ public class RemountOnParameterChangeTests : BunitTestContext
         });
 
         cut.Instance.BlockGuard = false;
-        cut.InvokeAsync(() => brouter.Navigate("/rmguard/2"));
+        await cut.InvokeAsync(() => brouter.Navigate("/rmguard/2"));
 
         cut.WaitForAssertion(() =>
         {


### PR DESCRIPTION
closes #13214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to rebuild routed content when navigation changes only route parameters.
  - Supports global configuration and per-route overrides.
  - Rebuilt routes now dispose the existing instance and mount a fresh one, including updated navigation-guard behavior.
  - Keep-alive routes continue using their existing retained content.

- **Documentation**
  - Updated guides, demos, and lifecycle documentation with parameter-remount behavior and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->