### PR TITLE
Fix circular dependency issue of Butil trimming (#13218)

### DIFF
--- a/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
+++ b/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
@@ -424,6 +424,19 @@
             <_BitButilIsAssetRoot>false</_BitButilIsAssetRoot>
             <_BitButilIsAssetRoot Condition="'$(StaticWebAssetProjectMode)' == 'Root' or '$(UsingMicrosoftNETSdkWeb)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">true</_BitButilIsAssetRoot>
 
+            <!-- And never on Root alone, which is the correction to the paragraph above: a MAUI hybrid
+                 head IS Root - Microsoft.AspNetCore.Components.WebView.Maui makes it the root of the asset
+                 graph so that it can package its wwwroot - so the disjunction let in exactly the shape it
+                 was written to keep out. It is also the one shape that reaches this stage BEFORE
+                 ResolveReferences rather than after: the assets are converted from
+                 ConvertStaticWebAssetsToMauiAssets while the references are still unresolved, and the
+                 dependency that would force them cannot be taken there without closing a cycle in that
+                 head's target graph (MSB4006 - see _BitButilAssembleTrimmedBundleDependsOn). So one of the
+                 SDK markers is required and Root alone is not enough: the answer is only both reachable
+                 and right in a head that loaded the Web or WebAssembly SDK. A hybrid head publishes the
+                 full bundle, exactly as a build does. -->
+            <_BitButilIsAssetRoot Condition="'$(_BitButilIsScriptTrimmingHead)' != 'true'">false</_BitButilIsAssetRoot>
+
             <_BitButilPublishTrimming>false</_BitButilPublishTrimming>
             <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsAssetRoot)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
 
@@ -464,13 +477,32 @@
 
     </Target>
 
-    <!-- ResolveReferences, because @(ReferenceCopyLocalPaths) is where both the assemblies to scan and the
-         untrimmed Bit.Butil.dll come from, and the stage this hangs off does NOT imply it has run: reached
-         through ComputeReferencedStaticWebAssetsPublishManifest, or through a MSBuild call carrying global
-         properties that fork a fresh project instance, only the requested target chain runs and the item is
-         empty. Named here rather than on _BitButilResolveScriptTrimming so it is paid for only when the
-         trimming is actually on - MSBuild skips a false-conditioned target's DependsOnTargets entirely. -->
-    <Target Name="_BitButilAssembleTrimmedBundle" DependsOnTargets="_BitButilResolveScriptTrimming;ResolveReferences" Condition="'$(_BitButilTrimAnyEnabled)' == 'true'">
+    <!--
+    ResolveReferences, because @(ReferenceCopyLocalPaths) is where both the assemblies to scan and the
+    untrimmed Bit.Butil.dll come from, and the stage this hangs off does NOT imply it has run: reached
+    through ComputeReferencedStaticWebAssetsPublishManifest, or through a MSBuild call carrying global
+    properties that fork a fresh project instance, only the requested target chain runs and the item is
+    empty. Named here rather than on _BitButilResolveScriptTrimming so it is paid for only when the
+    trimming is actually on - MSBuild skips a false-conditioned target's DependsOnTargets entirely.
+
+    Taken through a property rather than written into the attribute, because forcing ResolveReferences is
+    not free of consequence everywhere this file is imported. In a MAUI hybrid head it closes a cycle in
+    the target graph: the publish asset stage is reached from ConvertStaticWebAssetsToMauiAssets, while
+    ResolveReferences pulls in the Android resource targets, one of which runs
+    BeforeTargets="ConvertStaticWebAssetsToMauiAssets", and the build fails with MSB4006 before any of this
+    runs. The gate below keeps that head out of the trimming altogether, and so out of this dependency
+    with it; the property is what says so at the one place the dependency is taken, so that widening the
+    gate cannot quietly put ResolveReferences back into a graph that cannot take it.
+    -->
+    <PropertyGroup>
+        <_BitButilIsScriptTrimmingHead>false</_BitButilIsScriptTrimmingHead>
+        <_BitButilIsScriptTrimmingHead Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">true</_BitButilIsScriptTrimmingHead>
+
+        <_BitButilAssembleTrimmedBundleDependsOn>_BitButilResolveScriptTrimming</_BitButilAssembleTrimmedBundleDependsOn>
+        <_BitButilAssembleTrimmedBundleDependsOn Condition="'$(_BitButilIsScriptTrimmingHead)' == 'true'">$(_BitButilAssembleTrimmedBundleDependsOn);ResolveReferences</_BitButilAssembleTrimmedBundleDependsOn>
+    </PropertyGroup>
+
+    <Target Name="_BitButilAssembleTrimmedBundle" DependsOnTargets="$(_BitButilAssembleTrimmedBundleDependsOn)" Condition="'$(_BitButilTrimAnyEnabled)' == 'true'">
 
         <PropertyGroup>
             <!-- Only set when ILLink is in play: the task reads "a path was given but the file is not there"

--- a/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
+++ b/src/Butil/Bit.Butil/buildTransitive/Bit.Butil.targets
@@ -30,10 +30,10 @@
                                          it, dotnet run and dotnet watch included - is left untouched, so
                                          what a developer debugs is always the full, untrimmed JavaScript.
                                          And head only: it takes effect in the project that publishes the
-                                         app's static web assets (StaticWebAssetProjectMode=Root, which the
-                                         Web SDK and the Blazor WebAssembly SDK set), never in a Razor class
-                                         library or a hybrid head that only contributes to one. See the gate
-                                         in _BitButilResolveScriptTrimming for why that is not the same as
+                                         app's static web assets - the one that loaded the Web or the
+                                         WebAssembly SDK - never in a Razor class library or a hybrid head
+                                         that only contributes to one. See the gate in
+                                         _BitButilResolveScriptTrimming for why that is not the same as
                                          "hangs off a publish target".
                                          Default: true in a Blazor WebAssembly project (the one case where
                                          the assembly that is trimmed is the assembly that calls the served
@@ -400,45 +400,23 @@
                  references, which are not the app's - it cannot know what the app that consumes it calls -
                  and hand the app a bundle short of the modules only the app names.
 
-                 StaticWebAssetProjectMode is the SDK's own answer to "is this the root of the asset graph
-                 or a library contributing to someone else's", and Root is the answer this wants. It is not
-                 enough on its own, though: only the .NET 10 Web SDK sets it (Sdk.Server.props), while the
-                 .NET 8 and .NET 9 Web SDKs leave a Blazor Server app or a Blazor Web App host on the
-                 'Default' that ResolveStaticWebAssetsConfiguration fills in for everything. Gating on Root
-                 alone would stand the whole feature down on exactly the hosts the scan was written for, on
-                 two of the three frameworks this package targets. So the SDK a project loaded is read
-                 alongside it: UsingMicrosoftNETSdkWeb and the two WebAssembly markers are set identically
-                 on 8, 9 and 10, and between them they name every project shape that publishes an app
-                 rather than contributing to one. A Razor class library (Sdk.Razor) and a hybrid head (the
-                 plain SDK plus UseMaui) match none of them, which is the point.
+                 The SDK a project loaded is what says which it is: _BitButilIsScriptTrimmingHead, at the
+                 foot of this file, and it is read here rather than restated, because it is the same
+                 property that arms the ResolveReferences dependency - so the trimming can never be on in a
+                 project where that dependency was not taken. See it for why the SDK markers are the signal
+                 and StaticWebAssetProjectMode is not.
 
-                 Either way the trimming stays in the one project whose reference closure IS the app's,
+                 The trimming therefore stays in the one project whose reference closure IS the app's,
                  which is also the project whose publish the whole feature was written for. The
-                 referenced-project stage then hands its full bundle up and the root trims it there, which
+                 referenced-project stage then hands its full bundle up and the head trims it there, which
                  is where the answer is right.
 
                  The remaining two counts are unchanged: the assemblies read here are a publish's, and a
                  design-time build is excluded outright. A build, and so dotnet run and dotnet watch, keeps
                  the JavaScript exactly as the package ships it - what a developer debugs is always the
                  full, untrimmed set. -->
-            <_BitButilIsAssetRoot>false</_BitButilIsAssetRoot>
-            <_BitButilIsAssetRoot Condition="'$(StaticWebAssetProjectMode)' == 'Root' or '$(UsingMicrosoftNETSdkWeb)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">true</_BitButilIsAssetRoot>
-
-            <!-- And never on Root alone, which is the correction to the paragraph above: a MAUI hybrid
-                 head IS Root - Microsoft.AspNetCore.Components.WebView.Maui makes it the root of the asset
-                 graph so that it can package its wwwroot - so the disjunction let in exactly the shape it
-                 was written to keep out. It is also the one shape that reaches this stage BEFORE
-                 ResolveReferences rather than after: the assets are converted from
-                 ConvertStaticWebAssetsToMauiAssets while the references are still unresolved, and the
-                 dependency that would force them cannot be taken there without closing a cycle in that
-                 head's target graph (MSB4006 - see _BitButilAssembleTrimmedBundleDependsOn). So one of the
-                 SDK markers is required and Root alone is not enough: the answer is only both reachable
-                 and right in a head that loaded the Web or WebAssembly SDK. A hybrid head publishes the
-                 full bundle, exactly as a build does. -->
-            <_BitButilIsAssetRoot Condition="'$(_BitButilIsScriptTrimmingHead)' != 'true'">false</_BitButilIsAssetRoot>
-
             <_BitButilPublishTrimming>false</_BitButilPublishTrimming>
-            <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsAssetRoot)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
+            <_BitButilPublishTrimming Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsScriptTrimmingHead)' == 'true' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(DesignTimeBuild)' != 'true'">true</_BitButilPublishTrimming>
 
             <!-- Said out loud, because "I set the properties and nothing happened" is otherwise a silent
                  dead end - and because the properties landing in a shared Directory.Build.props, where they
@@ -449,7 +427,7 @@
                  shared and everything right. A scan written out by hand, or a module list, is the shape of
                  the mistake this is here to catch. -->
             <_BitButilTrimmingStoodDown>false</_BitButilTrimmingStoodDown>
-            <_BitButilTrimmingStoodDown Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsAssetRoot)' != 'true' and '$(DesignTimeBuild)' != 'true' and ('$(_BitButilScriptScanRequested)' == 'true' or '@(BitButilScriptModule)' != '')">true</_BitButilTrimmingStoodDown>
+            <_BitButilTrimmingStoodDown Condition="'$(BitButilTrimScripts)' == 'true' and '$(_BitButilHasSignal)' == 'true' and '$(_BitButilIsScriptTrimmingHead)' != 'true' and '$(DesignTimeBuild)' != 'true' and ('$(_BitButilScriptScanRequested)' == 'true' or '@(BitButilScriptModule)' != '')">true</_BitButilTrimmingStoodDown>
 
             <!-- The bundle half: rebuild bit-butil.js from the modules the app can reach. Needs a bundle to
                  rebuild. -->
@@ -490,9 +468,25 @@
     the target graph: the publish asset stage is reached from ConvertStaticWebAssetsToMauiAssets, while
     ResolveReferences pulls in the Android resource targets, one of which runs
     BeforeTargets="ConvertStaticWebAssetsToMauiAssets", and the build fails with MSB4006 before any of this
-    runs. The gate below keeps that head out of the trimming altogether, and so out of this dependency
+    runs. The gate above keeps that head out of the trimming altogether, and so out of this dependency
     with it; the property is what says so at the one place the dependency is taken, so that widening the
     gate cannot quietly put ResolveReferences back into a graph that cannot take it.
+
+    Which project that is, is read off the SDK it loaded, and only off that. StaticWebAssetProjectMode
+    looks like the SDK's own answer to "is this the root of the asset graph or a library contributing to
+    someone else's", but it answers neither half of the question this asks. It is not sufficient: a MAUI
+    hybrid head IS Root - Microsoft.AspNetCore.Components.WebView.Maui makes it the root of its own graph
+    so that it can package its wwwroot - which is the one shape the cycle above stands the feature down
+    for. And it is not necessary: only the .NET 10 Web SDK sets Root (Sdk.Server.props), while the .NET 8
+    and .NET 9 Web SDKs leave a Blazor Server app or a Blazor Web App host on the 'Default' that
+    ResolveStaticWebAssetsConfiguration fills in for everything, so requiring it would stand the whole
+    feature down on exactly the hosts the scan was written for, on two of the three frameworks this
+    package targets. Being neither, it is not read at all. UsingMicrosoftNETSdkWeb and the two WebAssembly
+    markers are what is left: set identically on 8, 9 and 10, and between them they name every project
+    shape that publishes an app rather than contributing to one. A Razor class library (Sdk.Razor) and a
+    hybrid head (the plain SDK plus UseMaui) match none of them, which is the point. All three are set in
+    the SDK's .props, so they are readable here, at evaluation time, which is what lets the dependency
+    above be decided in a property at all.
     -->
     <PropertyGroup>
         <_BitButilIsScriptTrimmingHead>false</_BitButilIsScriptTrimmingHead>

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
@@ -209,7 +209,7 @@ is allowed to use, that a csproj list is *added* to what the others found rather
 assets removed from the build list are also removed from the publish list, and that a name meaning nothing
 fails the build. So these publish a real consumer app - a two-class web app next door, published in seconds
 rather than the minutes a WebAssembly one takes - and read the JavaScript back out of its publish output.
-Twelve `dotnet publish` runs and one `dotnet msbuild`, about fifteen seconds in total, untrimmed runs only:
+Fifteen `dotnet publish` runs and one `dotnet msbuild`, about a minute in total, untrimmed runs only:
 
 - with **no signal at all** the full bundle is published - the case that has to keep working for every
   consumer who never asked for any of this. Reached by setting `BitButilScriptScan=None`, since the switch
@@ -226,17 +226,17 @@ Twelve `dotnet publish` runs and one `dotnet msbuild`, about fifteen seconds in 
 - `BitButilTrimScripts=false` publishes the full bundle even when given a scan and a list to work from;
 - a project that **does not publish an app's static web assets** - a Razor class library, a hybrid head, the
   shape a shared `Directory.Build.props` reaches by accident - leaves the JavaScript alone, because its
-  reference closure is not the app's. The fixture stands in for one by unsetting the two things the SDK sets
-  on a project that does publish an app;
+  reference closure is not the app's. The fixture stands in for one by unsetting the SDK marker that says a
+  project publishes an app;
 - a **hybrid head**, which is the root of its own asset graph and still must not trim: it reaches the publish
   asset stage before its references are resolved, and the dependency that would resolve them closes a cycle
-  in its target graph. Being `StaticWebAssetProjectMode=Root` is therefore not enough on its own - a Web or
-  WebAssembly SDK marker has to be there beside it - and the fixture stands in for one by forcing Root with
-  the Web SDK marker off;
+  in its target graph. So `StaticWebAssetProjectMode=Root` is not what the gate reads - the SDK a project
+  loaded is - and the fixture stands in for a hybrid head by forcing Root with the Web SDK marker off, which
+  is the shape that fails the moment anyone reads the mode as "this project is the app's head";
 - a **misspelled module name**, and a **scan mode that is not one of the three**, each fail the publish with
   the error naming what was wrong.
 
-The `dotnet msbuild` run is the thirteenth, and it is not a publish: it drives the two trimming targets by name
+The `dotnet msbuild` run is the sixteenth, and it is not a publish: it drives the two trimming targets by name
 so they land in a project instance where nothing else has run, which is the position the SDK puts them in on
 a referenced project. The untrimmed `Bit.Butil.dll` has to resolve there too - `@(ReferenceCopyLocalPaths)`
 is only populated because the target names `ResolveReferences` itself - and the scan reporting what it read

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/README.md
@@ -209,7 +209,7 @@ is allowed to use, that a csproj list is *added* to what the others found rather
 assets removed from the build list are also removed from the publish list, and that a name meaning nothing
 fails the build. So these publish a real consumer app - a two-class web app next door, published in seconds
 rather than the minutes a WebAssembly one takes - and read the JavaScript back out of its publish output.
-Eleven `dotnet publish` runs and one `dotnet msbuild`, about fifteen seconds in total, untrimmed runs only:
+Twelve `dotnet publish` runs and one `dotnet msbuild`, about fifteen seconds in total, untrimmed runs only:
 
 - with **no signal at all** the full bundle is published - the case that has to keep working for every
   consumer who never asked for any of this. Reached by setting `BitButilScriptScan=None`, since the switch
@@ -228,10 +228,15 @@ Eleven `dotnet publish` runs and one `dotnet msbuild`, about fifteen seconds in 
   shape a shared `Directory.Build.props` reaches by accident - leaves the JavaScript alone, because its
   reference closure is not the app's. The fixture stands in for one by unsetting the two things the SDK sets
   on a project that does publish an app;
+- a **hybrid head**, which is the root of its own asset graph and still must not trim: it reaches the publish
+  asset stage before its references are resolved, and the dependency that would resolve them closes a cycle
+  in its target graph. Being `StaticWebAssetProjectMode=Root` is therefore not enough on its own - a Web or
+  WebAssembly SDK marker has to be there beside it - and the fixture stands in for one by forcing Root with
+  the Web SDK marker off;
 - a **misspelled module name**, and a **scan mode that is not one of the three**, each fail the publish with
   the error naming what was wrong.
 
-The `dotnet msbuild` run is the twelfth, and it is not a publish: it drives the two trimming targets by name
+The `dotnet msbuild` run is the thirteenth, and it is not a publish: it drives the two trimming targets by name
 so they land in a project instance where nothing else has run, which is the position the SDK puts them in on
 a referenced project. The untrimmed `Bit.Butil.dll` has to resolve there too - `@(ReferenceCopyLocalPaths)`
 is only populated because the target names `ResolveReferences` itself - and the scan reporting what it read

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
@@ -134,22 +134,24 @@ internal static class ScriptPublishing
         // must leave the JavaScript alone: their reference closure is not the app's, so trimming against it
         // would hand the head a bundle short of the modules only the head names.
         //
-        // The gate reads both halves of what the SDK says about a project, so both are forced here: Root is
-        // the .NET 10 Web SDK's StaticWebAssetProjectMode (the .NET 8 and 9 Web SDKs leave a head at
-        // 'Default', which is why the marker below is read as well), and UsingMicrosoftNETSdkWeb is what
-        // says a Web SDK was loaded at all. A class library sets neither, and this fixture - a Web SDK app -
-        // stands in for one by unsetting both.
+        // What the gate reads is the SDK a project loaded: UsingMicrosoftNETSdkWeb and the two WebAssembly
+        // markers, which are set identically on 8, 9 and 10. A class library sets none of them, and this
+        // fixture - a Web SDK app - stands in for one by unsetting the one it has. StaticWebAssetProjectMode
+        // is set to the 'Default' a library carries as well, so the shape being stood in for is the whole
+        // shape, even though the gate no longer reads that half.
         new("a project that does not publish the app's static web assets does not trim",
             ["StaticWebAssetProjectMode=Default", "UsingMicrosoftNETSdkWeb=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
             FullBundle: true),
 
-        // Root is not enough on its own, and this is the shape that says so: a MAUI/Blazor Hybrid head IS the
-        // root of its asset graph - the WebView package makes it one so that it can package its wwwroot - and
-        // it reaches the publish asset stage from ConvertStaticWebAssetsToMauiAssets, before ResolveReferences
+        // Root is not the signal, and this is the shape that says so: a MAUI/Blazor Hybrid head IS the root
+        // of its asset graph - the WebView package makes it one so that it can package its wwwroot - and it
+        // reaches the publish asset stage from ConvertStaticWebAssetsToMauiAssets, before ResolveReferences
         // rather than after. Trimming there reads references that are not resolved yet, and the dependency
         // that would resolve them closes a cycle in that head's target graph (MSB4006), which is a failed
-        // build rather than a wrong bundle. So one of the SDK markers is required alongside Root, and the
-        // fixture stands in for a hybrid head by forcing Root with the Web SDK marker off.
+        // build rather than a wrong bundle. Reading StaticWebAssetProjectMode as "this is the app's head" is
+        // therefore the tempting mistake, and this is what catches it: the previous scenario would still pass
+        // if Root were let back into the gate, and this one - Root forced on with the Web SDK marker off -
+        // would not.
         new("the asset root of a hybrid head does not trim",
             ["StaticWebAssetProjectMode=Root", "UsingMicrosoftNETSdkWeb=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
             FullBundle: true),

--- a/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
+++ b/src/Butil/tests/Bit.Butil.Tests.Manual/ScriptPublishing.cs
@@ -143,6 +143,17 @@ internal static class ScriptPublishing
             ["StaticWebAssetProjectMode=Default", "UsingMicrosoftNETSdkWeb=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
             FullBundle: true),
 
+        // Root is not enough on its own, and this is the shape that says so: a MAUI/Blazor Hybrid head IS the
+        // root of its asset graph - the WebView package makes it one so that it can package its wwwroot - and
+        // it reaches the publish asset stage from ConvertStaticWebAssetsToMauiAssets, before ResolveReferences
+        // rather than after. Trimming there reads references that are not resolved yet, and the dependency
+        // that would resolve them closes a cycle in that head's target graph (MSB4006), which is a failed
+        // build rather than a wrong bundle. So one of the SDK markers is required alongside Root, and the
+        // fixture stands in for a hybrid head by forcing Root with the Web SDK marker off.
+        new("the asset root of a hybrid head does not trim",
+            ["StaticWebAssetProjectMode=Root", "UsingMicrosoftNETSdkWeb=false", "BitButilScriptScan=TypeReferences", "FixtureScriptModules=Cookie"],
+            FullBundle: true),
+
         // MSBuild accepts a misspelled item without a word, so the build is the only thing that can say so.
         new("a module name that names nothing fails the publish",
             ["FixtureScriptModules=Clippboard"],


### PR DESCRIPTION
closes #13218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented script trimming for MAUI hybrid applications that are configured as asset roots but do not use Web or WebAssembly SDKs.
  * Ensured these applications publish the complete, untrimmed bundle.
  * Resolved a build dependency cycle that could occur during hybrid application publishing.

* **Tests**
  * Added coverage for hybrid application publishing to verify full bundle output.
  * Updated manual publishing scenario counts and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->