### PR TITLE
Re-index pulled changes of the Platform website's codebase memory repository (#13220)

### DIFF
--- a/src/Websites/Platform/src/Bit.Websites.Platform.Server/Services/McpProxyService.cs
+++ b/src/Websites/Platform/src/Bit.Websites.Platform.Server/Services/McpProxyService.cs
@@ -333,6 +333,10 @@ public partial class McpProxyService : IAsyncDisposable
                     // The data directory the index was built in, which no other client on this machine holds.
                     EnvironmentVariables = upstream.Name is codebaseMemoryUpstreamName
                         ? CodebaseMemoryIndexService.BuildEnvironment(appSettings.CurrentValue.CodebaseMemory)
+                        : null,
+                    // The server's git watcher follows its working directory, so pulls into the repository re-index it.
+                    WorkingDirectory = upstream.Name is codebaseMemoryUpstreamName
+                        ? appSettings.CurrentValue.CodebaseMemory?.SourceRepositoryPath
                         : null
                 }, loggerFactory);
 


### PR DESCRIPTION
closes #13220

codebase-memory-mcp registers its git watcher for the working directory of the server process. The CodebaseMemory stdio upstream now starts in `AppSettings:CodebaseMemory:SourceRepositoryPath`, so pulls into that repository re-index it while the site keeps running, rather than only on the next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Codebase Memory updates now correctly detect repository changes after pulls by running in the configured source repository directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->