### PR TITLE
Fix demo issues of BitNavPanel (#13246)

### DIFF
--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
@@ -2,10 +2,12 @@
 @inherits BitComponentBase
 @typeparam TItem
 
-@if (IsOpen && NoOverlay is false)
+@if (IsOpen && NoOverlay is false && IsEnabled)
 {
     @* The overlay is a duplicate of what the Escape key and the swipe gesture already do, so it is left out
-       of the accessibility tree instead of being announced as a control of its own. *@
+       of the accessibility tree instead of being announced as a control of its own. A disabled panel draws
+       none at all: nothing of it answers a click while it is disabled, and an overlay over a page that
+       nothing left can dismiss is a page that cannot be used any more. *@
     <div style="@Styles?.Overlay"
          class="bit-npn-ovl @Classes?.Overlay"
          aria-hidden="true"
@@ -18,10 +20,7 @@
 <BitMediaQuery NoWrapper ScreenQuery="BitScreenQuery.LtMd" OnChange="HandleScreenChange" />
 
 @{
-    // A rail that expands on hover renders everything the open panel does while the pointer is over it - or
-    // while the keyboard is inside it - so its own state is what the whole markup below reads instead of
-    // IsToggled.
-    var isToggled = (NoToggle is false) && IsToggled && (ExpandOnHover is false || (_isHovered is false && _isFocused is false));
+    var isToggled = _IsToggled;
     var items = Items ?? [];
     var isEmpty = items.Count > 0 && _filteredNavItems.Count == 0;
     var searchAnnouncement = GetSearchAnnouncement();
@@ -152,11 +151,11 @@
             }
 
             @* The only channel a screen reader has for the outcome of a search: how many items it matched, or
-               that it matched none. A filtered list of links reports nothing of its own. *@
-            @if (searchAnnouncement.HasValue())
-            {
-                <div role="status" aria-live="polite" aria-atomic="true" class="bit-npn-lvr">@searchAnnouncement</div>
-            }
+               that it matched none. A filtered list of links reports nothing of its own.
+               The region itself is always rendered, empty until there is something to say: a live region that
+               enters the DOM together with its first message is not announced at all - only a change of the
+               text of one that was already there is. *@
+            <div role="status" aria-live="polite" aria-atomic="true" class="bit-npn-lvr">@searchAnnouncement</div>
 
             @* The empty message is rendered beside the nav rather than in place of it, so the nav keeps its
                registrations (and the expansion state of the branches) while a search matches nothing. *@
@@ -223,10 +222,9 @@
         </div>;
 }
 
-@* The hover handlers are splatted rather than written out, so a panel that does not expand on hover has no
-   listener to re-render it every time the pointer crosses it. *@
+@* Every listener of the panel's own is added to the splatted attributes rather than written out beside them,
+   where one of the same name silently replaces what the caller passed. *@
 <div @ref="RootElement" @attributes="GetRootAttributes()"
-     @onkeydown="HandleOnKeyDown"
      id="@_Id"
      role="@(isModal ? "dialog" : null)"
      aria-modal="@(isModal && NoFocusTrap is false ? "true" : null)"

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
@@ -12,31 +12,26 @@
          @onclick="HandleOverlayClick"></div>
 }
 
+@* Reports which of its two shapes the panel currently has: the off-canvas drawer of a small screen, or the
+   column of a wide one. Nothing is rendered through it - the shape itself is CSS - but the page it covers
+   and the focus it holds while it covers one are decided in C#, and only the browser knows which it is. *@
+<BitMediaQuery NoWrapper ScreenQuery="BitScreenQuery.LtMd" OnChange="HandleScreenChange" />
+
 @{
-    // A rail that expands on hover renders everything the open panel does while the pointer is over it, so
-    // its own state is what the whole markup below reads instead of IsToggled.
-    var isToggled = (NoToggle is false) && IsToggled && (ExpandOnHover is false || _isHovered is false);
+    // A rail that expands on hover renders everything the open panel does while the pointer is over it - or
+    // while the keyboard is inside it - so its own state is what the whole markup below reads instead of
+    // IsToggled.
+    var isToggled = (NoToggle is false) && IsToggled && (ExpandOnHover is false || (_isHovered is false && _isFocused is false));
     var items = Items ?? [];
     var isEmpty = items.Count > 0 && _filteredNavItems.Count == 0;
     var searchAnnouncement = GetSearchAnnouncement();
-}
+    // The drawer that covers the page is a modal surface, and says so. Only the one that holds the focus
+    // reports itself as a modal one, though: a drawer the keyboard can walk out of is not a surface the rest
+    // of the page is inert behind, whatever the overlay in front of it looks like.
+    var isModal = _IsModalDrawer;
 
-@* The hover handlers are splatted rather than written out, so a panel that does not expand on hover has no
-   listener to re-render it every time the pointer crosses it. *@
-<div @ref="RootElement" @attributes="GetRootAttributes()"
-     @onkeydown="HandleOnKeyDown"
-     id="@_Id"
-     style="@GetPanelStyle(isToggled)"
-     class="@((ClassBuilder.Value + $"{(isToggled ? $" bit-npn-tgl {Classes?.Toggled}" : "")}").Trim())"
-     dir="@Dir?.ToString().ToLower()">
-    <BitSwipeTrap Style="width:100%; height:100%"
-                  Threshold="5"
-                  Throttle="10"
-                  OnEnd="HandleOnSwipeEnd"
-                  OnMove="HandleOnSwipeMove"
-                  OnTrigger="HandleOnSwipeTrigger"
-                  OrientationLock="BitSwipeOrientation.Horizontal">
-        <div style="@Styles?.Container" class="bit-npn-cnt @Classes?.Container">
+    RenderFragment content =
+        @<div style="@Styles?.Container" class="bit-npn-cnt @Classes?.Container">
             @if (Header is not null)
             {
                 @Header
@@ -46,11 +41,13 @@
                 <div style="@Styles?.Header" class="bit-npn-hdr @Classes?.Header">
                     @if (IconUrl.HasValue())
                     {
+                        var logoLabel = IconAriaLabel ?? AriaLabel ?? DefaultLogoAriaLabel;
+
                         if (IconNavUrl.HasValue())
                         {
                             @* The logo itself is decorative, so the link it sits in is the one carrying the
                                name: a link whose only content is an image with an empty alt has none at all. *@
-                            <a href="@IconNavUrl" aria-label="@(AriaLabel ?? DefaultLogoAriaLabel)">
+                            <a href="@IconNavUrl" aria-label="@logoLabel">
                                 <img src="@IconUrl"
                                      alt=""
                                      class="bit-npn-img @Classes?.HeaderIcon"
@@ -60,7 +57,7 @@
                         else
                         {
                             <img src="@IconUrl"
-                                 alt="@(AriaLabel ?? string.Empty)"
+                                 alt="@(IconAriaLabel ?? AriaLabel ?? string.Empty)"
                                  class="bit-npn-img @Classes?.HeaderIcon"
                                  style="@(isToggled ? "display:none;" : "") @Styles?.HeaderIcon" />
                         }
@@ -87,8 +84,33 @@
                                    Icon="@customToggleIcon"
                                    IconName="@(customToggleIcon is null ? "ColumnRightTwoThirds" : null)"
                                    Class="@($"bit-npn-tbn {Classes?.ToggleButton}".Trim())"
+                                   aria-controls="@_Id"
                                    aria-expanded="@(isToggled ? "false" : "true")"
                                    Classes="@(customToggleIcon is null ? new() { Icon = "bit-icon-ex bit-icon-ex--ColumnRightTwoThirds" } : null)" />
+                    }
+
+                    @if (ShowCloseButton)
+                    {
+                        @* The button belongs to the drawer, so the wrapper is what the stylesheet takes away
+                           on the screens the panel is a column on: hiding the button itself would mean giving
+                           its own display back later, and a display is not this component's to decide. *@
+                        var customCloseIcon = BitIconInfo.From(CloseIcon, CloseIconName);
+                        var closeLabel = CloseAriaLabel ?? DefaultCloseAriaLabel;
+
+                        <div class="bit-npn-cbw">
+                            <BitButton IconOnly
+                                       Color="Color"
+                                       Size="BitSize.Large"
+                                       Title="@closeLabel"
+                                       IsEnabled="IsEnabled"
+                                       OnClick="ClosePanel"
+                                       AriaLabel="@closeLabel"
+                                       Icon="@customCloseIcon"
+                                       Variant="BitVariant.Text"
+                                       Style="@Styles?.CloseButton"
+                                       IconName="@(customCloseIcon is null ? "Cancel" : null)"
+                                       Class="@($"bit-npn-cbn {Classes?.CloseButton}".Trim())" />
+                        </div>
                     }
                 </div>
             }
@@ -112,14 +134,17 @@
 
                 @if (isToggled)
                 {
+                    var customSearchIcon = BitIconInfo.From(SearchIcon, SearchIconName);
+
                     <BitButton IconOnly
                                Color="Color"
-                               IconName="Search"
                                Size="BitSize.Large"
                                IsEnabled="IsEnabled"
+                               Icon="@customSearchIcon"
                                OnClick="ToggleForSearch"
                                Variant="BitVariant.Text"
                                Style="@Styles?.ToggleSearchButton"
+                               IconName="@(customSearchIcon is null ? "Search" : null)"
                                Class="@($"bit-npn-tsb {Classes?.ToggleSearchButton}".Trim())"
                                Title="@(SearchBoxPlaceholder ?? DefaultSearchAriaLabel)"
                                AriaLabel="@(SearchBoxPlaceholder ?? DefaultSearchAriaLabel)" />
@@ -150,6 +175,7 @@
             }
 
             <BitNav @ref=_bitNavRef
+                    TItem="TItem"
                     Accent="Accent"
                     AllExpanded="AllExpanded"
                     AriaLabel="@AriaLabel"
@@ -194,6 +220,37 @@
             {
                 @Footer
             }
-        </div>
-    </BitSwipeTrap>
+        </div>;
+}
+
+@* The hover handlers are splatted rather than written out, so a panel that does not expand on hover has no
+   listener to re-render it every time the pointer crosses it. *@
+<div @ref="RootElement" @attributes="GetRootAttributes()"
+     @onkeydown="HandleOnKeyDown"
+     id="@_Id"
+     role="@(isModal ? "dialog" : null)"
+     aria-modal="@(isModal && NoFocusTrap is false ? "true" : null)"
+     aria-label="@(isModal ? (AriaLabel ?? DefaultPanelAriaLabel) : null)"
+     style="@GetPanelStyle(isToggled)"
+     class="@((ClassBuilder.Value + $"{(isToggled ? $" bit-npn-tgl {Classes?.Toggled}" : "")}").Trim())"
+     dir="@Dir?.ToString().ToLower()">
+    @* A panel whose swipe gesture is turned off gets a plain wrapper instead: the trap of a gesture nothing
+       listens for is a set of pointer listeners installed on every panel of every page for nothing. *@
+    @if (NoSwipe)
+    {
+        <div class="bit-npn-swp">@content</div>
+    }
+    else
+    {
+        <BitSwipeTrap Class="bit-npn-swp"
+                      Style="width:100%; height:100%"
+                      Threshold="5"
+                      Throttle="10"
+                      OnEnd="HandleOnSwipeEnd"
+                      OnMove="HandleOnSwipeMove"
+                      OnTrigger="HandleOnSwipeTrigger"
+                      OrientationLock="BitSwipeOrientation.Horizontal">
+            @content
+        </BitSwipeTrap>
+    }
 </div>

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor
@@ -2,16 +2,29 @@
 @inherits BitComponentBase
 @typeparam TItem
 
-@if (IsOpen)
+@if (IsOpen && NoOverlay is false)
 {
-    <div style="@Styles?.Overlay" class="bit-npn-ovl @Classes?.Overlay" @onclick="ClosePanel"></div>
+    @* The overlay is a duplicate of what the Escape key and the swipe gesture already do, so it is left out
+       of the accessibility tree instead of being announced as a control of its own. *@
+    <div style="@Styles?.Overlay"
+         class="bit-npn-ovl @Classes?.Overlay"
+         aria-hidden="true"
+         @onclick="HandleOverlayClick"></div>
 }
 
 @{
-    var isToggled = (NoToggle is false) && IsToggled;
+    // A rail that expands on hover renders everything the open panel does while the pointer is over it, so
+    // its own state is what the whole markup below reads instead of IsToggled.
+    var isToggled = (NoToggle is false) && IsToggled && (ExpandOnHover is false || _isHovered is false);
+    var items = Items ?? [];
+    var isEmpty = items.Count > 0 && _filteredNavItems.Count == 0;
+    var searchAnnouncement = GetSearchAnnouncement();
 }
 
-<div @ref="RootElement" @attributes="HtmlAttributes"
+@* The hover handlers are splatted rather than written out, so a panel that does not expand on hover has no
+   listener to re-render it every time the pointer crosses it. *@
+<div @ref="RootElement" @attributes="GetRootAttributes()"
+     @onkeydown="HandleOnKeyDown"
      id="@_Id"
      style="@GetPanelStyle(isToggled)"
      class="@((ClassBuilder.Value + $"{(isToggled ? $" bit-npn-tgl {Classes?.Toggled}" : "")}").Trim())"
@@ -35,8 +48,11 @@
                     {
                         if (IconNavUrl.HasValue())
                         {
-                            <a href="@IconNavUrl">
+                            @* The logo itself is decorative, so the link it sits in is the one carrying the
+                               name: a link whose only content is an image with an empty alt has none at all. *@
+                            <a href="@IconNavUrl" aria-label="@(AriaLabel ?? DefaultLogoAriaLabel)">
                                 <img src="@IconUrl"
+                                     alt=""
                                      class="bit-npn-img @Classes?.HeaderIcon"
                                      style="@(isToggled ? "display:none;" : "") @Styles?.HeaderIcon" />
                             </a>
@@ -44,6 +60,7 @@
                         else
                         {
                             <img src="@IconUrl"
+                                 alt="@(AriaLabel ?? string.Empty)"
                                  class="bit-npn-img @Classes?.HeaderIcon"
                                  style="@(isToggled ? "display:none;" : "") @Styles?.HeaderIcon" />
                         }
@@ -53,15 +70,25 @@
 
                     @if (NoToggle is false && HideToggle is false)
                     {
+                        @* The default glyph ships with the Extras package rather than with the icon font of the
+                           core library, so it is drawn from its own class instead of from an icon name. *@
+                        var customToggleIcon = BitIconInfo.From(ToggleIcon, ToggleIconName);
+                        var toggleLabel = ToggleAriaLabel ?? (isToggled ? DefaultExpandAriaLabel : DefaultCollapseAriaLabel);
+
                         <BitButton IconOnly
                                    Color="Color"
                                    Size="BitSize.Large"
+                                   Title="@toggleLabel"
+                                   IsEnabled="IsEnabled"
+                                   AriaLabel="@toggleLabel"
                                    OnClick="ToggleNavPanel"
                                    Variant="BitVariant.Text"
                                    Style="@Styles?.ToggleButton"
-                                   IconName="ColumnRightTwoThirds"
+                                   Icon="@customToggleIcon"
+                                   IconName="@(customToggleIcon is null ? "ColumnRightTwoThirds" : null)"
                                    Class="@($"bit-npn-tbn {Classes?.ToggleButton}".Trim())"
-                                   Classes="@(new() { Icon = "bit-icon-ex bit-icon-ex--ColumnRightTwoThirds" })" />
+                                   aria-expanded="@(isToggled ? "false" : "true")"
+                                   Classes="@(customToggleIcon is null ? new() { Icon = "bit-icon-ex bit-icon-ex--ColumnRightTwoThirds" } : null)" />
                     }
                 </div>
             }
@@ -71,12 +98,16 @@
                 <BitSearchBox @ref="_searchBoxRef"
                               Underlined
                               Color="Color"
-                              OnChange="SearchNavItems"
+                              Immediate
+                              IsEnabled="IsEnabled"
+                              Value="@_searchText"
                               Styles="SearchBoxStyles"
                               Classes="SearchBoxClasses"
                               Class="@Classes?.SearchBox"
-                              Immediate DebounceTime="500"
+                              OnChange="HandleSearchChange"
+                              DebounceTime="SearchDebounceTime"
                               Placeholder="@SearchBoxPlaceholder"
+                              AriaLabel="@(SearchBoxPlaceholder ?? DefaultSearchAriaLabel)"
                               Style="@($"{(isToggled ? "display:none;" : "")}{Styles?.SearchBox}".Trim())" />
 
                 @if (isToggled)
@@ -85,62 +116,77 @@
                                Color="Color"
                                IconName="Search"
                                Size="BitSize.Large"
+                               IsEnabled="IsEnabled"
                                OnClick="ToggleForSearch"
                                Variant="BitVariant.Text"
                                Style="@Styles?.ToggleSearchButton"
-                               Class="@Classes?.ToggleSearchButton" />
+                               Class="@($"bit-npn-tsb {Classes?.ToggleSearchButton}".Trim())"
+                               Title="@(SearchBoxPlaceholder ?? DefaultSearchAriaLabel)"
+                               AriaLabel="@(SearchBoxPlaceholder ?? DefaultSearchAriaLabel)" />
                 }
             }
 
-            @if (Items.Any() && _filteredNavItems.Any() is false)
+            @* The only channel a screen reader has for the outcome of a search: how many items it matched, or
+               that it matched none. A filtered list of links reports nothing of its own. *@
+            @if (searchAnnouncement.HasValue())
             {
-                if (isToggled is false)
+                <div role="status" aria-live="polite" aria-atomic="true" class="bit-npn-lvr">@searchAnnouncement</div>
+            }
+
+            @* The empty message is rendered beside the nav rather than in place of it, so the nav keeps its
+               registrations (and the expansion state of the branches) while a search matches nothing. *@
+            @if (isEmpty && isToggled is false)
+            {
+                if (EmptyListTemplate is not null)
                 {
-                    if (EmptyListTemplate is not null)
-                    {
-                        @EmptyListTemplate
-                    }
-                    else
-                    {
-                        <BitText Style="@Styles?.EmptyListMessage" Class="@Classes?.EmptyListMessage">
-                            @(EmptyListMessage ?? "Nothing found!")
-                        </BitText>
-                    }
+                    @EmptyListTemplate
+                }
+                else
+                {
+                    <BitText Style="@Styles?.EmptyListMessage" Class="@Classes?.EmptyListMessage">
+                        @(EmptyListMessage ?? "Nothing found!")
+                    </BitText>
                 }
             }
-            else
-            {
-                <BitNav @ref=_bitNavRef
-                        Accent="Accent"
-                        AllExpanded="AllExpanded"
-                        ChevronDownIcon="@ChevronDownIcon"
-                        Classes="NavClasses"
-                        Color="Color"
-                        DefaultSelectedItem="_filteredNavItems.Any() ? _filteredNavItems[0] : null"
-                        FullWidth
-                        HeaderTemplate="HeaderTemplate"
-                        HeaderTemplateRenderMode="HeaderTemplateRenderMode"
-                        IconOnly="isToggled"
-                        IndentPadding="IndentPadding"
-                        IndentReversedPadding="IndentReversedPadding"
-                        IndentValue="IndentValue"
-                        Items="_filteredNavItems"
-                        ItemTemplate="ItemTemplate"
-                        ItemTemplateRenderMode="ItemTemplateRenderMode"
-                        Match="NavMatch"
-                        Mode="NavMode"
-                        NoCollapse="NoCollapse"
-                        OnItemClick="(TItem item) => HandleNavItemClick(item)"
-                        OnItemToggle="OnItemToggle"
-                        OnSelectItem="OnSelectItem"
-                        RenderType="RenderType"
-                        Reselectable="Reselectable"
-                        ReversedChevron="ReversedChevron"
-                        SingleExpand="SingleExpand"
-                        Styles="NavStyles"
-                        Class="@Classes?.Nav"
-                        Style="@Styles?.Nav" />
-            }
+
+            <BitNav @ref=_bitNavRef
+                    Accent="Accent"
+                    AllExpanded="AllExpanded"
+                    AriaLabel="@AriaLabel"
+                    ChevronDownIcon="ChevronDownIcon"
+                    ChevronDownIconName="@ChevronDownIconName"
+                    Classes="NavClasses"
+                    CollapseAriaLabel="@CollapseAriaLabel"
+                    Color="Color"
+                    ExpandAriaLabel="@ExpandAriaLabel"
+                    FullWidth
+                    HeaderTemplate="HeaderTemplate"
+                    HeaderTemplateRenderMode="HeaderTemplateRenderMode"
+                    IconOnly="isToggled"
+                    IndentPadding="IndentPadding"
+                    IndentReversedPadding="IndentReversedPadding"
+                    IndentValue="IndentValue"
+                    IsEnabled="IsEnabled"
+                    Items="_filteredNavItems"
+                    ItemTemplate="ItemTemplate"
+                    ItemTemplateRenderMode="ItemTemplateRenderMode"
+                    Match="NavMatch"
+                    Mode="NavMode"
+                    NameSelectors="NameSelectors"
+                    NoCollapse="NoCollapse"
+                    OnItemClick="(TItem item) => HandleNavItemClick(item)"
+                    OnItemToggle="OnItemToggle"
+                    OnSelectItem="OnSelectItem"
+                    RenderType="RenderType"
+                    Reselectable="Reselectable"
+                    ReversedChevron="ReversedChevron"
+                    SelectedItem="SelectedItem"
+                    SelectedItemChanged="@((TItem? item) => HandleSelectedItemChanged(item))"
+                    SingleExpand="SingleExpand"
+                    Size="Size"
+                    Styles="NavStyles"
+                    Class="@Classes?.Nav"
+                    Style="@Styles?.Nav" />
 
             <BitSpacer />
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -3,13 +3,30 @@
 /// <summary>
 /// BitNavPanel is a navigation component specialized to be rendered in a vertical panel.
 /// </summary>
+/// <remarks>
+/// The panel wraps a <see cref="BitNav{TItem}"/> in the chrome a side navigation needs: a header with a logo
+/// and the button that collapses the panel down to a rail of icons, a search box that filters the items as
+/// they are typed, and a footer. On small screens it turns into an off-canvas drawer that opens over the page
+/// with an overlay behind it, and closes on a click on that overlay, on the Escape key, on a swipe towards the
+/// side it came from, and on the navigation of an item.
+/// </remarks>
 public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 {
-    private decimal diffXPanel;
+    // The accessible names the panel falls back to. They are only ever read where the API offers no name of
+    // its own (ToggleAriaLabel, SearchBoxPlaceholder), so a localized app overrides them through those.
+    private const string DefaultLogoAriaLabel = "Home";
+    private const string DefaultSearchAriaLabel = "Search";
+    private const string DefaultExpandAriaLabel = "Expand the navigation panel";
+    private const string DefaultCollapseAriaLabel = "Collapse the navigation panel";
+
+    private bool _isHovered;
+    private decimal _diffXPanel;
+    private string? _searchText;
+    private bool _focusOnOpenPending;
+    private bool _focusSearchBoxPending;
     private BitNav<TItem>? _bitNavRef;
     private BitSearchBox? _searchBoxRef;
     private IList<TItem> _filteredNavItems = [];
-    private IEnumerable<TItem> _flatNavItemList = [];
 
 
 
@@ -25,9 +42,23 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public bool AllExpanded { get; set; }
 
     /// <summary>
+    /// Moves the focus into the nav panel as it opens - onto the search box, or onto the first item of a panel
+    /// without one - which is what the drawer of a small screen is expected to do.
+    /// </summary>
+    [Parameter] public bool AutoFocus { get; set; }
+
+    /// <summary>
+    /// The icon for the chevron-down element of each nav item.
+    /// Takes precedence over <see cref="ChevronDownIconName"/> when both are set.
+    /// Use this property to render icons from external libraries like FontAwesome, Material Icons, or Bootstrap Icons.
+    /// For built-in Fluent UI icons, use <see cref="ChevronDownIconName"/> instead.
+    /// </summary>
+    [Parameter] public BitIconInfo? ChevronDownIcon { get; set; }
+
+    /// <summary>
     /// The custom icon name of the chevron-down element of each nav item.
     /// </summary>
-    [Parameter] public string? ChevronDownIcon { get; set; }
+    [Parameter] public string? ChevronDownIconName { get; set; }
 
     /// <summary>
     /// Custom CSS classes for different parts of the nav panel.
@@ -35,10 +66,20 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public BitNavPanelClassStyles? Classes { get; set; }
 
     /// <summary>
+    /// The default aria-label of the expand/collapse button of an expanded item of the nav.
+    /// </summary>
+    [Parameter] public string? CollapseAriaLabel { get; set; }
+
+    /// <summary>
     /// The general color of the nav.
     /// </summary>
     [Parameter]
     public BitColor? Color { get; set; }
+
+    /// <summary>
+    /// The initially selected item of the nav in manual mode.
+    /// </summary>
+    [Parameter] public TItem? DefaultSelectedItem { get; set; }
 
     /// <summary>
     /// The custom template for when the search result is empty.
@@ -49,6 +90,18 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// The custom message for when the search result is empty.
     /// </summary>
     [Parameter] public string? EmptyListMessage { get; set; }
+
+    /// <summary>
+    /// The default aria-label of the expand/collapse button of a collapsed item of the nav.
+    /// </summary>
+    [Parameter] public string? ExpandAriaLabel { get; set; }
+
+    /// <summary>
+    /// Expands the toggled (rail) nav panel back to its full width while the pointer is over it.
+    /// The panel widens in place, so the content beside it moves along with it.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public bool ExpandOnHover { get; set; }
 
     /// <summary>
     /// Renders the nav panel with fit-content width.
@@ -69,6 +122,8 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 
     /// <summary>
     /// The custom template to render as the header of the nav panel.
+    /// Replacing the header also replaces the toggle button it holds, so a custom header that wants to keep
+    /// the toggle feature renders a control of its own that calls <see cref="Toggle"/>.
     /// </summary>
     [Parameter] public RenderFragment? Header { get; set; }
 
@@ -115,7 +170,7 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// <summary>
     /// Determines if the nav panel is open in small screens.
     /// </summary>
-    [Parameter, TwoWayBound, ResetClassBuilder]
+    [Parameter, TwoWayBound, ResetClassBuilder, CallOnSet(nameof(OnIsOpenSet))]
     public bool IsOpen { get; set; }
 
     /// <summary>
@@ -141,6 +196,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     public IList<TItem> Items { get; set; } = [];
 
     /// <summary>
+    /// Names and selectors of the custom input type properties.
+    /// </summary>
+    [Parameter] public BitNavNameSelectors<TItem>? NameSelectors { get; set; }
+
+    /// <summary>
     /// Custom CSS classes for different parts of the nav component of the nav panel.
     /// </summary>
     [Parameter] public BitNavClassStyles? NavClasses { get; set; }
@@ -161,9 +221,19 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public BitNavClassStyles? NavStyles { get; set; }
 
     /// <summary>
+    /// Keeps the nav panel open when an item with a URL is clicked, instead of closing it.
+    /// </summary>
+    [Parameter] public bool NoAutoClose { get; set; }
+
+    /// <summary>
     /// Disables and hides all collapse/expand buttons of the nav component.
     /// </summary>
     [Parameter] public bool NoCollapse { get; set; }
+
+    /// <summary>
+    /// Removes the overlay that is rendered behind the open nav panel in small screens.
+    /// </summary>
+    [Parameter] public bool NoOverlay { get; set; }
 
     /// <summary>
     /// Disables the padded mode of the nav panel.
@@ -175,6 +245,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// Removes the search box from the nav panel.
     /// </summary>
     [Parameter] public bool NoSearchBox { get; set; }
+
+    /// <summary>
+    /// Disables the swipe gesture that closes the open nav panel in small screens.
+    /// </summary>
+    [Parameter] public bool NoSwipe { get; set; }
 
     /// <summary>
     /// Disables the toggle feature of the nav panel.
@@ -190,6 +265,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// Callback invoked when a group header is clicked and Expanded or Collapse.
     /// </summary>
     [Parameter] public EventCallback<TItem> OnItemToggle { get; set; }
+
+    /// <summary>
+    /// Callback invoked when the search text of the nav panel changes.
+    /// </summary>
+    [Parameter] public EventCallback<string?> OnSearch { get; set; }
 
     /// <summary>
     /// Callback invoked when an item is selected.
@@ -227,9 +307,44 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public BitSearchBoxClassStyles? SearchBoxStyles { get; set; }
 
     /// <summary>
+    /// Builds the text that the screen reader announces through the live region of the nav panel whenever the
+    /// search filters the items, in place of the built-in English announcement. The argument is the number of
+    /// items the search matched. Returning null or an empty string announces nothing.
+    /// </summary>
+    [Parameter] public Func<int, string?>? SearchAnnouncementProvider { get; set; }
+
+    /// <summary>
+    /// The debounce time in milliseconds of the search box of the nav panel.
+    /// </summary>
+    [Parameter] public int SearchDebounceTime { get; set; } = 500;
+
+    /// <summary>
+    /// The custom function to decide whether an item matches a search term, replacing the default matching
+    /// over the text, the description and the data of an item.
+    /// </summary>
+    [Parameter] public Func<TItem, string, bool>? SearchFilter { get; set; }
+
+    /// <summary>
+    /// The search text of the nav panel that filters its items.
+    /// </summary>
+    [Parameter, TwoWayBound, CallOnSet(nameof(OnSearchTextSet))]
+    public string? SearchText { get; set; }
+
+    /// <summary>
+    /// The selected item of the nav in manual mode.
+    /// </summary>
+    [Parameter, TwoWayBound]
+    public TItem? SelectedItem { get; set; }
+
+    /// <summary>
     /// Enables the single-expand mode in the BitNav.
     /// </summary>
     [Parameter] public bool SingleExpand { get; set; }
+
+    /// <summary>
+    /// The size of the nav items.
+    /// </summary>
+    [Parameter] public BitSize? Size { get; set; }
 
     /// <summary>
     /// Custom CSS styles for different parts of the nav panel.
@@ -237,12 +352,124 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public BitNavPanelClassStyles? Styles { get; set; }
 
     /// <summary>
+    /// The aria-label of the toggle button of the nav panel.
+    /// </summary>
+    [Parameter] public string? ToggleAriaLabel { get; set; }
+
+    /// <summary>
+    /// The icon of the toggle button of the nav panel.
+    /// Takes precedence over <see cref="ToggleIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? ToggleIcon { get; set; }
+
+    /// <summary>
+    /// The name of the icon of the toggle button of the nav panel.
+    /// </summary>
+    [Parameter] public string? ToggleIconName { get; set; }
+
+    /// <summary>
+    /// The width of the nav panel in px in its toggled (rail) state.
+    /// </summary>
+    [Parameter, ResetStyleBuilder]
+    public int ToggledWidth { get; set; }
+
+    /// <summary>
     /// The top CSS property value of the root element of the nav panel in px.
     /// </summary>
     [Parameter, ResetStyleBuilder]
     public int Top { get; set; }
 
+    /// <summary>
+    /// The width of the nav panel in px. It is ignored in the FitWidth and FullWidth modes.
+    /// </summary>
+    [Parameter, ResetStyleBuilder]
+    public int Width { get; set; }
 
+
+
+    /// <summary>
+    /// Clears the search text of the nav panel, so the whole list of items is shown again.
+    /// Nothing happens when there is no search in place.
+    /// </summary>
+    public async Task ClearSearch()
+    {
+        if (_searchText.HasNoValue() && SearchText.HasNoValue()) return;
+
+        _searchText = null;
+
+        await AssignSearchText(null);
+
+        SearchNavItems(null);
+
+        await OnSearch.InvokeAsync(null);
+
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Closes the nav panel.
+    /// </summary>
+    public async Task Close()
+    {
+        await AssignIsOpen(false);
+    }
+
+    /// <summary>
+    /// Collapses all items of the nav.
+    /// </summary>
+    public void CollapseAll() => _bitNavRef?.CollapseAll();
+
+    /// <summary>
+    /// Collapses an item of the nav, and does nothing when it is already collapsed.
+    /// </summary>
+    public Task CollapseItem(TItem item) => _bitNavRef?.CollapseItem(item) ?? Task.CompletedTask;
+
+    /// <summary>
+    /// Expands all items of the nav in non-SingleExpand mode.
+    /// </summary>
+    public void ExpandAll() => _bitNavRef?.ExpandAll();
+
+    /// <summary>
+    /// Expands an item of the nav, and does nothing when it is already expanded.
+    /// </summary>
+    public Task ExpandItem(TItem item) => _bitNavRef?.ExpandItem(item) ?? Task.CompletedTask;
+
+    /// <summary>
+    /// Moves the focus to an item of the nav, opening the branches it is nested in when it is not rendered yet.
+    /// </summary>
+    public ValueTask FocusItem(TItem item) => _bitNavRef?.FocusItem(item) ?? ValueTask.CompletedTask;
+
+    /// <summary>
+    /// Moves the focus to the search box of the nav panel, opening the panel out of its toggled state first
+    /// when the search box is not on screen.
+    /// </summary>
+    public async Task FocusSearchBox()
+    {
+        if (NoSearchBox) return;
+
+        if (IsToggled && NoToggle is false)
+        {
+            await ToggleForSearch();
+            return;
+        }
+
+        if (_searchBoxRef is null) return;
+
+        await _searchBoxRef.FocusAsync();
+    }
+
+    /// <summary>
+    /// Opens the nav panel.
+    /// </summary>
+    public async Task Open()
+    {
+        await AssignIsOpen(true);
+    }
+
+    /// <summary>
+    /// Selects an item of the nav programmatically, exactly like a click on that item would in the manual mode.
+    /// </summary>
+    public Task SelectItem(TItem? item) => _bitNavRef?.SelectItem(item) ?? Task.CompletedTask;
 
     /// <summary>
     /// Toggles the nav panel if possible.
@@ -251,6 +478,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     {
         await ToggleNavPanel();
     }
+
+    /// <summary>
+    /// Toggles an item of the nav.
+    /// </summary>
+    public Task ToggleItem(TItem item) => _bitNavRef?.ToggleItem(item) ?? Task.CompletedTask;
 
 
 
@@ -265,6 +497,7 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 
         ClassBuilder.Register(() => IsOpen ? string.Empty : "bit-npn-cls");
         ClassBuilder.Register(() => NoPad ? "bit-npn-npd" : string.Empty);
+        ClassBuilder.Register(() => ExpandOnHover ? "bit-npn-eoh" : string.Empty);
 
         ClassBuilder.Register(() => Accent switch
         {
@@ -293,24 +526,114 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     {
         StyleBuilder.Register(() => Styles?.Root);
         StyleBuilder.Register(() => Top > 0 ? $"top:{Top}px;height:calc(var(--bit-env-height-avl) - {Top}px)" : string.Empty);
+        // The widths travel as custom properties instead of as a width declaration, so the stylesheet stays
+        // the one deciding which of them applies to the current state (rail, padded, small screen, ...).
+        StyleBuilder.Register(() => Width > 0 ? $"--bit-npn-w:{Width}px" : string.Empty);
+        StyleBuilder.Register(() => ToggledWidth > 0 ? $"--bit-npn-tw:{ToggledWidth}px" : string.Empty);
     }
 
     protected override async Task OnInitializedAsync()
     {
-        SearchNavItems(null);
+        _searchText = SearchText;
+
+        SearchNavItems(_searchText);
+
+        // The nav reads its own DefaultSelectedItem only while nothing has assigned its SelectedItem, and the
+        // panel always hands it one (it two-way binds the selection through), so the initial selection is
+        // resolved here instead, where the two parameters of the panel are the ones being read.
+        if (SelectedItem is null && DefaultSelectedItem is not null)
+        {
+            await AssignSelectedItem(DefaultSelectedItem);
+        }
+
+        await base.OnInitializedAsync();
     }
+
+    protected override void OnParametersSet()
+    {
+        // The Items collection is re-read here rather than only when the parameter is assigned a new
+        // instance, so a collection that is mutated in place (an item appended to the same list) reaches
+        // the filtered list a search is showing as well.
+        if (_searchText.HasValue())
+        {
+            SearchNavItems(_searchText);
+        }
+
+        base.OnParametersSet();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // The item accessors of the nav (which know how to read a custom item type) are only reachable once
+        // the nav itself is rendered, so a search text that arrived as a parameter is applied here rather
+        // than being dropped on the first pass.
+        if (firstRender && _searchText.HasValue())
+        {
+            SearchNavItems(_searchText);
+            StateHasChanged();
+        }
+
+        // The search box only exists once the panel has left its toggled state, so the focus is moved in the
+        // render that brought it back rather than after a guessed delay.
+        if (_focusSearchBoxPending && _searchBoxRef is not null)
+        {
+            _focusSearchBoxPending = false;
+
+            await _searchBoxRef.FocusAsync();
+        }
+
+        // The panel that has just opened takes the focus with it, so the keyboard lands in the drawer that
+        // covers the page rather than on the page behind it.
+        if (_focusOnOpenPending)
+        {
+            _focusOnOpenPending = false;
+
+            await FocusFirstElement();
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+
 
     private async Task HandleNavItemClick(TItem item)
     {
         await OnItemClick.InvokeAsync(item);
 
+        // An item without a URL navigates nowhere: it only expands its children, so the panel stays open and
+        // the search that led to it stays in place.
         if (_bitNavRef?.GetUrl(item).HasNoValue() is true) return;
 
-        _filteredNavItems = Items;
+        await ClearSearch();
 
-        _ = _searchBoxRef?.Clear();
+        if (NoAutoClose) return;
 
         await ClosePanel();
+    }
+
+    private Task HandleSelectedItemChanged(TItem? item) => AssignSelectedItem(item);
+
+    private void OnIsOpenSet()
+    {
+        if (AutoFocus is false) return;
+        if (IsOpen is false) return;
+
+        _focusOnOpenPending = true;
+    }
+
+    // Where the focus goes when the panel opens: the search box is the first thing in it, and a panel without
+    // one hands the focus to its first item instead. A panel with neither keeps the focus where it was.
+    private async Task FocusFirstElement()
+    {
+        if (NoSearchBox is false && IsToggled is false && _searchBoxRef is not null)
+        {
+            await _searchBoxRef.FocusAsync();
+            return;
+        }
+
+        if (_bitNavRef is null || _filteredNavItems.Count == 0) return;
+
+        await _bitNavRef.FocusItem(_filteredNavItems[0]);
     }
 
     private async Task ClosePanel()
@@ -318,13 +641,57 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         await AssignIsOpen(false);
     }
 
+    private async Task HandleOverlayClick()
+    {
+        if (IsEnabled is false) return;
+
+        await ClosePanel();
+    }
+
+    private async Task HandleOnKeyDown(KeyboardEventArgs e)
+    {
+        if (IsEnabled is false) return;
+        if (e.Key is not "Escape") return;
+
+        // The first Escape empties an active search - which is what the search box does on its own when the
+        // focus is in it, and what the key is expected to do from anywhere else in the panel - and only the
+        // next one closes the panel, exactly like a filtered list inside any other dismissible surface.
+        if (_searchText.HasValue())
+        {
+            await ClearSearch();
+            return;
+        }
+
+        if (IsOpen is false) return;
+
+        await ClosePanel();
+    }
+
+    // The attributes of the root element: the ones the caller passed, plus the hover handlers of a panel that
+    // expands on hover. They are only attached in that mode, since an attached handler re-renders the whole
+    // panel every time the pointer enters or leaves it, whether it changes anything or not.
+    private Dictionary<string, object> GetRootAttributes()
+    {
+        if (ExpandOnHover is false) return HtmlAttributes;
+
+        return new(HtmlAttributes)
+        {
+            ["onmouseenter"] = EventCallback.Factory.Create<MouseEventArgs>(this, () => _isHovered = true),
+            ["onmouseleave"] = EventCallback.Factory.Create<MouseEventArgs>(this, () => _isHovered = false),
+        };
+    }
+
     private async Task ToggleNavPanel()
     {
-        if (await AssignIsToggled(!IsToggled)) return;
+        if (NoToggle) return;
 
+        if (await AssignIsToggled(!IsToggled) is false) return;
+
+        // A rail has no room for a search box, so the panel that collapses into one drops the search it was
+        // showing instead of keeping a filtered list the user can no longer see the reason for.
         if (IsToggled)
         {
-            SearchNavItems(null);
+            await ClearSearch();
         }
     }
 
@@ -332,55 +699,119 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     {
         if (await AssignIsToggled(false) is false) return;
 
-        if (_searchBoxRef is null) return;
-
-        await Task.Delay(1);
-        await _searchBoxRef.FocusAsync();
+        _focusSearchBoxPending = true;
     }
 
+    private async Task HandleSearchChange(string? searchText)
+    {
+        _searchText = searchText;
+
+        await AssignSearchText(searchText);
+
+        SearchNavItems(searchText);
+
+        await OnSearch.InvokeAsync(searchText);
+    }
+
+    private void OnSearchTextSet()
+    {
+        _searchText = SearchText;
+
+        SearchNavItems(_searchText);
+    }
+
+    // Reduces the items to the ones the search text points at: an item that matches keeps the whole branch
+    // under it, so the items it groups stay reachable and no descendant of a match is listed a second time
+    // on its own.
     private void SearchNavItems(string? searchText)
     {
-        _filteredNavItems = Items;
+        var items = Items ?? [];
+
+        _filteredNavItems = items;
+
         if (searchText.HasNoValue() || _bitNavRef is null) return;
 
-        _flatNavItemList = Items.Flatten(_bitNavRef.GetChildItems).Where(item => _bitNavRef.GetUrl(item).HasValue());
+        var terms = searchText!.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (terms.Length == 0) return;
 
-        var mainItems = _flatNavItemList.Where(item => searchText!.Split(' ')
-                                                                  .Where(t => t.HasValue())
-                                                                  .Any(t => $"{_bitNavRef.GetText(item)} {_bitNavRef.GetDescription(item)}"
-                                                                             .Contains(t, StringComparison.InvariantCultureIgnoreCase)));
+        List<TItem> result = [];
 
-        var subItems = _flatNavItemList.Where(item => searchText!.Split(' ')
-                                                                 .Where(t => t.HasValue())
-                                                                 .Any(t => _bitNavRef.GetData(item)?.ToString()?
-                                                                                     .Contains(t, StringComparison.InvariantCultureIgnoreCase) ?? false));
+        Collect(items);
 
-        _filteredNavItems = [.. mainItems, .. subItems];
+        _filteredNavItems = result;
+
+        void Collect(IList<TItem> list)
+        {
+            foreach (var item in list)
+            {
+                if (IsSearchMatch(item, terms))
+                {
+                    result.Add(item);
+                    continue;
+                }
+
+                Collect(_bitNavRef.GetChildItems(item));
+            }
+        }
+    }
+
+    // What the live region announces once a search has filtered the list: how many items it matched, or
+    // nothing at all while there is no search in place.
+    private string? GetSearchAnnouncement()
+    {
+        if (_searchText.HasNoValue()) return null;
+
+        var count = _filteredNavItems.Count;
+
+        if (SearchAnnouncementProvider is not null) return SearchAnnouncementProvider(count);
+
+        return count switch
+        {
+            0 => "No item found.",
+            1 => "1 item found.",
+            _ => $"{count} items found."
+        };
+    }
+
+    private bool IsSearchMatch(TItem item, string[] terms)
+    {
+        if (SearchFilter is not null)
+        {
+            return terms.Any(t => SearchFilter(item, t));
+        }
+
+        var haystack = $"{_bitNavRef!.GetText(item)} {_bitNavRef.GetDescription(item)} {_bitNavRef.GetData(item)}";
+
+        return terms.Any(t => haystack.Contains(t, StringComparison.InvariantCultureIgnoreCase));
     }
 
     private void HandleOnSwipeMove(BitSwipeTrapEventArgs args)
     {
+        if (NoSwipe) return;
         if (IsOpen is false) return;
 
-        diffXPanel = args.DiffX;
+        _diffXPanel = args.DiffX;
         StateHasChanged();
-
     }
+
     private void HandleOnSwipeEnd(BitSwipeTrapEventArgs args)
     {
+        if (NoSwipe) return;
         if (IsOpen is false) return;
 
-        diffXPanel = 0;
+        _diffXPanel = 0;
         StateHasChanged();
     }
+
     private async Task HandleOnSwipeTrigger(BitSwipeTrapTriggerArgs args)
     {
+        if (NoSwipe) return;
         if (IsOpen is false) return;
 
         if ((Dir != BitDir.Rtl && args.Direction == BitSwipeDirection.Left) ||
             (Dir == BitDir.Rtl && args.Direction == BitSwipeDirection.Right))
         {
-            diffXPanel = 0;
+            _diffXPanel = 0;
             await ClosePanel();
             StateHasChanged();
         }
@@ -390,14 +821,14 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     {
         if (IsOpen is false) return $"{StyleBuilder.Value};{(isToggled ? Styles?.Toggled : string.Empty)}".Trim(';');
 
-        var translate = ((Dir != BitDir.Rtl && diffXPanel < 0) || (Dir == BitDir.Rtl && diffXPanel > 0))
-                            ? FormattableString.Invariant($"transform: translateX({diffXPanel}px)")
+        var translate = ((Dir != BitDir.Rtl && _diffXPanel < 0) || (Dir == BitDir.Rtl && _diffXPanel > 0))
+                            ? FormattableString.Invariant($"transform: translateX({_diffXPanel}px)")
                             : string.Empty;
         return $"{translate};{StyleBuilder.Value};{(isToggled ? Styles?.Toggled : string.Empty)}".Trim(';');
     }
 
-    private async Task OnItemsSet()
+    private void OnItemsSet()
     {
-        SearchNavItems(_searchBoxRef?.Value);
+        SearchNavItems(_searchText);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -35,6 +35,7 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     private bool _isHovered;
     private bool _isDrawer;
     private bool _isFocused;
+    private bool _screenChecked;
     private int _focusOutToken;
     private bool _scrollLocked;
     private bool _focusTrapped;
@@ -73,9 +74,13 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public bool AllExpanded { get; set; }
 
     /// <summary>
-    /// Moves the focus into the nav panel as it opens - onto the search box, or onto the first item of a panel
-    /// without one - which is what the drawer of a small screen is expected to do.
+    /// Moves the focus into the drawer of a small screen as it opens - onto the search box, or onto the first
+    /// item of a panel without one - which is what a surface covering the page is expected to do.
     /// </summary>
+    /// <remarks>
+    /// Only the drawer takes the focus: on a wide screen the panel is a column that was on screen all along,
+    /// and nothing opened for the keyboard to be moved into.
+    /// </remarks>
     [Parameter] public bool AutoFocus { get; set; }
 
     /// <summary>
@@ -561,7 +566,10 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     {
         if (NoSearchBox) return;
 
-        if (IsToggled && NoToggle is false)
+        // The state the markup renders rather than the parameter behind it: a rail that is currently expanded
+        // over its neighbours (ExpandOnHover) already shows the search box, and un-toggling it for good is not
+        // what asking for the focus asked for.
+        if (_IsToggled)
         {
             await ToggleForSearch();
             return;
@@ -715,12 +723,19 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         }
 
         // The panel that has just opened takes the focus with it, so the keyboard lands in the drawer that
-        // covers the page rather than on the page behind it.
-        if (_focusOnOpenPending)
+        // covers the page rather than on the page behind it. Only the drawer does: on a wide screen the panel
+        // is a column that was on screen all along, and nothing opened for the focus to be moved into - which
+        // is also why nothing is recorded there to hand the focus back to.
+        // The move waits for the browser to report which of the two shapes the panel has, since the first
+        // render of the panel happens before the media query has answered for the first time.
+        if (_focusOnOpenPending && _screenChecked)
         {
             _focusOnOpenPending = false;
 
-            await FocusFirstElement();
+            if (_isDrawer && IsOpen)
+            {
+                await FocusFirstElement();
+            }
         }
 
         await base.OnAfterRenderAsync(firstRender);
@@ -757,7 +772,7 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     // one hands the focus to its first item instead. A panel with neither keeps the focus where it was.
     private async Task FocusFirstElement()
     {
-        if (NoSearchBox is false && IsToggled is false && _searchBoxRef is not null)
+        if (NoSearchBox is false && _IsToggled is false && _searchBoxRef is not null)
         {
             await _searchBoxRef.FocusAsync();
             return;
@@ -796,25 +811,58 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 
         if (IsOpen is false) return;
 
+        // Only the drawer of a small screen is dismissed by the key: the column of a wide one is not a surface
+        // over the page, and closing it there would flip the open state - and report it - with nothing on
+        // screen to show for it.
+        if (_isDrawer is false) return;
+
         await ClosePanel();
     }
 
-    // The attributes of the root element: the ones the caller passed, plus the hover handlers of a panel that
-    // expands on hover. They are only attached in that mode, since an attached handler re-renders the whole
-    // panel every time the pointer enters or leaves it, whether it changes anything or not.
+    // The attributes of the root element: the ones the caller passed, plus the listeners of the panel itself.
+    // Those are added to the splatted set rather than written out beside it in the markup, where an attribute
+    // of the same name silently replaces the caller's - so a panel handed an onkeydown of its own still closes
+    // on Escape, and still runs the handler it was given.
+    // The hover listeners are only added in the mode that reads them, since an attached handler re-renders the
+    // whole panel every time the pointer enters or leaves it, whether it changes anything or not.
     private Dictionary<string, object> GetRootAttributes()
     {
-        if (ExpandOnHover is false) return HtmlAttributes;
+        Dictionary<string, object> attributes = new(HtmlAttributes);
 
-        return new(HtmlAttributes)
+        AddRootHandler<KeyboardEventArgs>(attributes, "onkeydown", HandleOnKeyDown);
+
+        if (ExpandOnHover)
         {
-            ["onmouseenter"] = EventCallback.Factory.Create<MouseEventArgs>(this, () => _isHovered = true),
-            ["onmouseleave"] = EventCallback.Factory.Create<MouseEventArgs>(this, () => _isHovered = false),
+            AddRootHandler<MouseEventArgs>(attributes, "onmouseenter", _ => { _isHovered = true; return Task.CompletedTask; });
+            AddRootHandler<MouseEventArgs>(attributes, "onmouseleave", _ => { _isHovered = false; return Task.CompletedTask; });
             // The keyboard reaches the rail the way the pointer does: an item that takes the focus opens the
             // panel it sits in, otherwise the text of the items would be readable by pointer only.
-            ["onfocusin"] = EventCallback.Factory.Create<FocusEventArgs>(this, () => _isFocused = true),
-            ["onfocusout"] = EventCallback.Factory.Create<FocusEventArgs>(this, HandleOnFocusOut),
-        };
+            AddRootHandler<FocusEventArgs>(attributes, "onfocusin", _ => { _isFocused = true; return Task.CompletedTask; });
+            AddRootHandler<FocusEventArgs>(attributes, "onfocusout", _ => HandleOnFocusOut());
+        }
+
+        return attributes;
+    }
+
+    // Adds a listener of the panel's own without dropping one the caller splatted under the same name: both
+    // run, the panel's first, so nothing the panel does for itself can be turned off by accident.
+    private void AddRootHandler<T>(Dictionary<string, object> attributes, string name, Func<T, Task> handler)
+    {
+        attributes.TryGetValue(name, out var splatted);
+
+        attributes[name] = EventCallback.Factory.Create<T>(this, async (T args) =>
+        {
+            await handler(args);
+
+            switch (splatted)
+            {
+                case EventCallback<T> callback: await callback.InvokeAsync(args); break;
+                case EventCallback callback: await callback.InvokeAsync(args); break;
+                case Func<T, Task> func: await func(args); break;
+                case Action<T> action: action(args); break;
+                case Action action: action(); break;
+            }
+        });
     }
 
     // The focus leaving an item and landing on the next one arrives as two events, in that order, so the
@@ -995,6 +1043,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         SearchNavItems(_searchText);
     }
 
+    // A rail that expands on hover renders everything the open panel does while the pointer is over it - or
+    // while the keyboard is inside it - so this, rather than IsToggled, is the rail state everything reads: the
+    // markup that lays the panel out, and the two focus moves that go to what that markup put on screen.
+    private bool _IsToggled => (NoToggle is false) && IsToggled && (ExpandOnHover is false || (_isHovered is false && _isFocused is false));
+
     // Which edge the drawer is docked to, and so which way the swipe that closes it goes. The position is
     // expressed in the text direction, so the End of a right-to-left layout is the left of the screen.
     private bool _IsDockedAtEnd => (Position is BitNavPanelPosition.End) != (Dir is BitDir.Rtl);
@@ -1007,7 +1060,13 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     // column of the page. A render is only asked for when the answer actually changes.
     private async Task HandleScreenChange(bool isDrawer)
     {
-        if (_isDrawer == isDrawer) return;
+        // The first report is acted on whatever it says: it is the render that follows it which everything
+        // waiting for the shape of the panel to be known runs in.
+        var reported = _screenChecked;
+
+        _screenChecked = true;
+
+        if (reported && _isDrawer == isDrawer) return;
 
         _isDrawer = isDrawer;
 

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -911,7 +911,7 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
                     continue;
                 }
 
-                Collect(_bitNavRef.GetChildItems(item));
+                Collect(_bitNavRef!.GetChildItems(item));
             }
         }
     }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.razor.cs
@@ -9,6 +9,12 @@
 /// they are typed, and a footer. On small screens it turns into an off-canvas drawer that opens over the page
 /// with an overlay behind it, and closes on a click on that overlay, on the Escape key, on a swipe towards the
 /// side it came from, and on the navigation of an item.
+/// <br />
+/// The drawer is a modal surface for as long as it covers the page: it reports itself as a dialog, holds the
+/// page it covers from scrolling and the focus from leaving it, and hands the focus back to whatever had it
+/// once it closes - each of which <see cref="NoScrollLock"/>, <see cref="NoFocusTrap"/> and
+/// <see cref="NoRestoreFocus"/> give back, and none of which a panel with <see cref="NoOverlay"/> takes in
+/// the first place.
 /// </remarks>
 public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 {
@@ -16,17 +22,42 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     // its own (ToggleAriaLabel, SearchBoxPlaceholder), so a localized app overrides them through those.
     private const string DefaultLogoAriaLabel = "Home";
     private const string DefaultSearchAriaLabel = "Search";
+    private const string DefaultPanelAriaLabel = "Navigation";
+    private const string DefaultCloseAriaLabel = "Close the navigation panel";
     private const string DefaultExpandAriaLabel = "Expand the navigation panel";
     private const string DefaultCollapseAriaLabel = "Collapse the navigation panel";
 
+    // The rail that expands while the keyboard is inside it collapses again a moment after the focus has
+    // left, since the focus leaving one item and landing on the next arrives as two separate events: a
+    // collapse applied to the first of them would flicker the rail shut and open again on every arrow key.
+    private const int FOCUS_OUT_DELAY_MS = 250;
+
     private bool _isHovered;
+    private bool _isDrawer;
+    private bool _isFocused;
+    private int _focusOutToken;
+    private bool _scrollLocked;
+    private bool _focusTrapped;
     private decimal _diffXPanel;
     private string? _searchText;
     private bool _focusOnOpenPending;
+    private bool _focusOriginCaptured;
     private bool _focusSearchBoxPending;
     private BitNav<TItem>? _bitNavRef;
     private BitSearchBox? _searchBoxRef;
     private IList<TItem> _filteredNavItems = [];
+
+
+
+    [Inject] private IJSRuntime _js { get; set; } = default!;
+
+
+
+    // The scroller of the application shell the panel was declared inside of, cascaded by BitAppShell under
+    // this name. What the drawer holds while it covers the page is whatever actually scrolls behind it,
+    // which in a shell is the region the shell scrolls rather than the document.
+    [CascadingParameter(Name = "BitAppShell.Container")]
+    private ElementReference? AppShellContainer { get; set; }
 
 
 
@@ -69,6 +100,22 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// The default aria-label of the expand/collapse button of an expanded item of the nav.
     /// </summary>
     [Parameter] public string? CollapseAriaLabel { get; set; }
+
+    /// <summary>
+    /// The aria-label and the tooltip of the close button of the nav panel.
+    /// </summary>
+    [Parameter] public string? CloseAriaLabel { get; set; }
+
+    /// <summary>
+    /// The icon of the close button of the nav panel.
+    /// Takes precedence over <see cref="CloseIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? CloseIcon { get; set; }
+
+    /// <summary>
+    /// The name of the icon of the close button of the nav panel.
+    /// </summary>
+    [Parameter] public string? CloseIconName { get; set; }
 
     /// <summary>
     /// The general color of the nav.
@@ -122,8 +169,9 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 
     /// <summary>
     /// The custom template to render as the header of the nav panel.
-    /// Replacing the header also replaces the toggle button it holds, so a custom header that wants to keep
-    /// the toggle feature renders a control of its own that calls <see cref="Toggle"/>.
+    /// Replacing the header also replaces the buttons it holds - the toggle button, and the close button of
+    /// <see cref="ShowCloseButton"/> - so a custom header that wants either of them renders a control of its
+    /// own that calls <see cref="Toggle"/> or <see cref="Close"/>.
     /// </summary>
     [Parameter] public RenderFragment? Header { get; set; }
 
@@ -141,6 +189,14 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// Removes the toggle button.
     /// </summary>
     [Parameter] public bool HideToggle { get; set; }
+
+    /// <summary>
+    /// The accessible name of the logo in the header of the nav panel: the name of the link an
+    /// <see cref="IconNavUrl"/> wraps it in, and the alternative text of the image otherwise.
+    /// The panel falls back to <see cref="BitComponentBase.AriaLabel"/> and then to a built-in name, so set
+    /// this whenever the name of the navigation landmark is not what the logo itself should be called.
+    /// </summary>
+    [Parameter] public string? IconAriaLabel { get; set; }
 
     /// <summary>
     /// Renders an anchor wrapping the icon to navigate to the specified url.
@@ -231,7 +287,16 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public bool NoCollapse { get; set; }
 
     /// <summary>
+    /// Stops the open drawer of a small screen from holding the focus inside itself.
+    /// The focus is only ever held while the panel actually covers the page, which is the state its overlay
+    /// is rendered in, so a panel with <see cref="NoOverlay"/> never holds it in the first place.
+    /// </summary>
+    [Parameter] public bool NoFocusTrap { get; set; }
+
+    /// <summary>
     /// Removes the overlay that is rendered behind the open nav panel in small screens.
+    /// Without it the drawer no longer covers the page: it stops holding the focus and the page behind it
+    /// keeps scrolling.
     /// </summary>
     [Parameter] public bool NoOverlay { get; set; }
 
@@ -240,6 +305,20 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// </summary>
     [Parameter, ResetClassBuilder]
     public bool NoPad { get; set; }
+
+    /// <summary>
+    /// Stops the closing drawer of a small screen from handing the focus back to the element that had it
+    /// when the drawer opened. Only ever read by a panel that took the focus in the first place
+    /// (see <see cref="AutoFocus"/>).
+    /// </summary>
+    [Parameter] public bool NoRestoreFocus { get; set; }
+
+    /// <summary>
+    /// Lets the page behind the open drawer of a small screen keep scrolling.
+    /// The page is only ever held while the panel actually covers it, which is the state its overlay is
+    /// rendered in, so a panel with <see cref="NoOverlay"/> never holds it in the first place.
+    /// </summary>
+    [Parameter] public bool NoScrollLock { get; set; }
 
     /// <summary>
     /// Removes the search box from the nav panel.
@@ -275,6 +354,14 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     /// Callback invoked when an item is selected.
     /// </summary>
     [Parameter] public EventCallback<TItem> OnSelectItem { get; set; }
+
+    /// <summary>
+    /// The edge the off-canvas drawer of a small screen comes from, and the side it is docked to while it
+    /// is open. The default is the starting edge of the text direction.
+    /// It has no effect on a wide screen, where the panel is a column in the normal flow of the page.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public BitNavPanelPosition Position { get; set; }
 
     /// <summary>
     /// The way to render nav items.
@@ -325,6 +412,18 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public Func<TItem, string, bool>? SearchFilter { get; set; }
 
     /// <summary>
+    /// The icon of the button that the collapsed (rail) nav panel shows in place of its search box.
+    /// Takes precedence over <see cref="SearchIconName"/> when both are set.
+    /// </summary>
+    [Parameter] public BitIconInfo? SearchIcon { get; set; }
+
+    /// <summary>
+    /// The name of the icon of the button that the collapsed (rail) nav panel shows in place of its search
+    /// box.
+    /// </summary>
+    [Parameter] public string? SearchIconName { get; set; }
+
+    /// <summary>
     /// The search text of the nav panel that filters its items.
     /// </summary>
     [Parameter, TwoWayBound, CallOnSet(nameof(OnSearchTextSet))]
@@ -342,9 +441,24 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     [Parameter] public bool SingleExpand { get; set; }
 
     /// <summary>
+    /// Renders a close button in the header of the nav panel, on the screens the panel is an off-canvas
+    /// drawer on. It is the control the toggle button is not there: the toggle collapses a permanent panel
+    /// into a rail, which a drawer that is either open or gone has no state for, and a drawer that is only
+    /// dismissed by its overlay, the Escape key or a swipe offers a touch user nothing to aim at.
+    /// </summary>
+    [Parameter] public bool ShowCloseButton { get; set; }
+
+    /// <summary>
     /// The size of the nav items.
     /// </summary>
     [Parameter] public BitSize? Size { get; set; }
+
+    /// <summary>
+    /// Pins the two ends of the nav panel - the header with its search box, and the footer - in place and
+    /// scrolls only the items between them, instead of scrolling the whole panel as one.
+    /// </summary>
+    [Parameter, ResetClassBuilder]
+    public bool StickyEnds { get; set; }
 
     /// <summary>
     /// Custom CSS styles for different parts of the nav panel.
@@ -459,6 +573,11 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     }
 
     /// <summary>
+    /// Whether an item of the nav is currently expanded.
+    /// </summary>
+    public bool IsItemExpanded(TItem item) => _bitNavRef?.IsItemExpanded(item) is true;
+
+    /// <summary>
     /// Opens the nav panel.
     /// </summary>
     public async Task Open()
@@ -498,6 +617,8 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         ClassBuilder.Register(() => IsOpen ? string.Empty : "bit-npn-cls");
         ClassBuilder.Register(() => NoPad ? "bit-npn-npd" : string.Empty);
         ClassBuilder.Register(() => ExpandOnHover ? "bit-npn-eoh" : string.Empty);
+        ClassBuilder.Register(() => Position is BitNavPanelPosition.End ? "bit-npn-end" : string.Empty);
+        ClassBuilder.Register(() => StickyEnds ? "bit-npn-ste" : string.Empty);
 
         ClassBuilder.Register(() => Accent switch
         {
@@ -541,7 +662,9 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         // The nav reads its own DefaultSelectedItem only while nothing has assigned its SelectedItem, and the
         // panel always hands it one (it two-way binds the selection through), so the initial selection is
         // resolved here instead, where the two parameters of the panel are the ones being read.
-        if (SelectedItem is null && DefaultSelectedItem is not null)
+        // The automatic mode has no initial selection of its own to make: the current URL is what decides
+        // there, and seeding a selection would light up an item the page is not on.
+        if (NavMode is BitNavMode.Manual && SelectedItem is null && DefaultSelectedItem is not null)
         {
             await AssignSelectedItem(DefaultSelectedItem);
         }
@@ -572,6 +695,15 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
             SearchNavItems(_searchText);
             StateHasChanged();
         }
+
+        // Everything the drawer of a small screen holds while it covers the page - the page it stops from
+        // scrolling, the focus it keeps inside itself - is taken and handed back here rather than at the
+        // moment a single parameter changes: whether the panel covers the page at all is decided by three
+        // of them together (the screen, the open state and the overlay), and each step of it does nothing
+        // unless it is the one that has actually changed.
+        // It runs before the two focus moves below: the element the focus is handed back to on the way out
+        // is the one that had it on the way in, which is no longer true once the panel has taken it.
+        await UpdateModalState();
 
         // The search box only exists once the panel has left its toggled state, so the focus is moved in the
         // render that brought it back rather than after a guessed delay.
@@ -678,7 +810,36 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         {
             ["onmouseenter"] = EventCallback.Factory.Create<MouseEventArgs>(this, () => _isHovered = true),
             ["onmouseleave"] = EventCallback.Factory.Create<MouseEventArgs>(this, () => _isHovered = false),
+            // The keyboard reaches the rail the way the pointer does: an item that takes the focus opens the
+            // panel it sits in, otherwise the text of the items would be readable by pointer only.
+            ["onfocusin"] = EventCallback.Factory.Create<FocusEventArgs>(this, () => _isFocused = true),
+            ["onfocusout"] = EventCallback.Factory.Create<FocusEventArgs>(this, HandleOnFocusOut),
         };
+    }
+
+    // The focus leaving an item and landing on the next one arrives as two events, in that order, so the
+    // collapse waits to see whether anything inside the panel has taken the focus in the meantime.
+    private async Task HandleOnFocusOut()
+    {
+        var token = ++_focusOutToken;
+
+        await Task.Delay(FOCUS_OUT_DELAY_MS);
+
+        if (IsDisposed || token != _focusOutToken) return;
+
+        try
+        {
+            // The delay above leaves the renderer's thread behind, so the state change is handed back to it
+            // rather than applied from whichever thread the timer completed on. A component torn down while
+            // the delay was running has no renderer to hand it back to, and nothing left to render either.
+            await InvokeAsync(() =>
+            {
+                _isFocused = false;
+
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException) { } // we can ignore this exception here
     }
 
     private async Task ToggleNavPanel()
@@ -775,14 +936,16 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
 
     private bool IsSearchMatch(TItem item, string[] terms)
     {
+        // Every word of the search term has to be somewhere in the item, which is what narrows the list as
+        // more of them are typed. Matching any one of them would widen it with every keystroke instead.
         if (SearchFilter is not null)
         {
-            return terms.Any(t => SearchFilter(item, t));
+            return terms.All(t => SearchFilter(item, t));
         }
 
         var haystack = $"{_bitNavRef!.GetText(item)} {_bitNavRef.GetDescription(item)} {_bitNavRef.GetData(item)}";
 
-        return terms.Any(t => haystack.Contains(t, StringComparison.InvariantCultureIgnoreCase));
+        return terms.All(t => haystack.Contains(t, StringComparison.InvariantCultureIgnoreCase));
     }
 
     private void HandleOnSwipeMove(BitSwipeTrapEventArgs args)
@@ -808,8 +971,8 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
         if (NoSwipe) return;
         if (IsOpen is false) return;
 
-        if ((Dir != BitDir.Rtl && args.Direction == BitSwipeDirection.Left) ||
-            (Dir == BitDir.Rtl && args.Direction == BitSwipeDirection.Right))
+        // The swipe that closes the drawer goes towards the edge the drawer came from.
+        if (args.Direction == (_IsDockedAtEnd ? BitSwipeDirection.Right : BitSwipeDirection.Left))
         {
             _diffXPanel = 0;
             await ClosePanel();
@@ -821,7 +984,7 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     {
         if (IsOpen is false) return $"{StyleBuilder.Value};{(isToggled ? Styles?.Toggled : string.Empty)}".Trim(';');
 
-        var translate = ((Dir != BitDir.Rtl && _diffXPanel < 0) || (Dir == BitDir.Rtl && _diffXPanel > 0))
+        var translate = (_IsDockedAtEnd ? _diffXPanel > 0 : _diffXPanel < 0)
                             ? FormattableString.Invariant($"transform: translateX({_diffXPanel}px)")
                             : string.Empty;
         return $"{translate};{StyleBuilder.Value};{(isToggled ? Styles?.Toggled : string.Empty)}".Trim(';');
@@ -830,5 +993,158 @@ public partial class BitNavPanel<TItem> : BitComponentBase where TItem : class
     private void OnItemsSet()
     {
         SearchNavItems(_searchText);
+    }
+
+    // Which edge the drawer is docked to, and so which way the swipe that closes it goes. The position is
+    // expressed in the text direction, so the End of a right-to-left layout is the left of the screen.
+    private bool _IsDockedAtEnd => (Position is BitNavPanelPosition.End) != (Dir is BitDir.Rtl);
+
+    // The panel is a modal drawer while it covers the page: only on a small screen, only while it is open,
+    // and only with the overlay that is what makes it cover anything at all.
+    private bool _IsModalDrawer => _isDrawer && IsOpen && NoOverlay is false && IsEnabled;
+
+    // Reports the screen the panel renders on: below the breakpoint it is an off-canvas drawer, above it a
+    // column of the page. A render is only asked for when the answer actually changes.
+    private async Task HandleScreenChange(bool isDrawer)
+    {
+        if (_isDrawer == isDrawer) return;
+
+        _isDrawer = isDrawer;
+
+        await UpdateModalState();
+
+        StateHasChanged();
+    }
+
+    private async Task UpdateModalState()
+    {
+        if (_IsModalDrawer)
+        {
+            await CaptureFocusOrigin();
+            await LockScroll();
+            await SetupFocusTrap();
+        }
+        else
+        {
+            await DisposeFocusTrap();
+            await UnlockScroll();
+            await RestoreFocusOrigin();
+        }
+    }
+
+    private async Task SetupFocusTrap()
+    {
+        if (NoFocusTrap || _focusTrapped || IsDisposed || IsRendered is false) return;
+
+        _focusTrapped = true;
+
+        try
+        {
+            await _js.BitUtilsSetupFocusTrap(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+    private async Task DisposeFocusTrap()
+    {
+        // Only what was taken is handed back, and the hold is given up whether or not the call goes
+        // through, so the panel can never end up holding a focus it has already let go of.
+        if (_focusTrapped is false) return;
+
+        _focusTrapped = false;
+
+        try
+        {
+            await _js.BitUtilsDisposeFocusTrap(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+    private async Task CaptureFocusOrigin()
+    {
+        // Nothing is handed back by a panel that never takes the focus, or by one that was told not to hand
+        // anything back, so nothing is recorded for either of them.
+        if (AutoFocus is false || NoRestoreFocus || _focusOriginCaptured || IsDisposed || IsRendered is false) return;
+
+        _focusOriginCaptured = true;
+
+        try
+        {
+            await _js.BitUtilsCaptureFocusOrigin(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+    private async Task RestoreFocusOrigin()
+    {
+        if (_focusOriginCaptured is false) return;
+
+        _focusOriginCaptured = false;
+
+        if (NoRestoreFocus || IsDisposed) return;
+
+        try
+        {
+            await _js.BitUtilsRestoreFocusOrigin(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+    private async Task LockScroll()
+    {
+        if (NoScrollLock || _scrollLocked || IsDisposed || IsRendered is false) return;
+
+        _scrollLocked = true;
+
+        try
+        {
+            if (AppShellContainer.HasValue)
+            {
+                await _js.BitUtilsLockScroll(_Id, AppShellContainer.Value);
+            }
+            else
+            {
+                await _js.BitUtilsLockScroll(_Id);
+            }
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+    private async Task UnlockScroll()
+    {
+        if (_scrollLocked is false) return;
+
+        _scrollLocked = false;
+
+        try
+        {
+            await _js.BitUtilsUnlockScroll(_Id);
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+    }
+
+
+
+    protected override async ValueTask DisposeAsync(bool disposing)
+    {
+        if (IsDisposed || disposing is false) return;
+
+        // The page and the focus are handed back before the component goes: a drawer disposed while it is
+        // open would otherwise leave the page held by a key nothing will ever release again.
+        await DisposeFocusTrap();
+        await UnlockScroll();
+
+        try
+        {
+            if (_focusOriginCaptured)
+            {
+                _focusOriginCaptured = false;
+
+                await _js.BitUtilsDisposeFocusOrigin(_Id);
+            }
+        }
+        catch (JSDisconnectedException) { } // we can ignore this exception here
+
+        await base.DisposeAsync(disposing);
     }
 }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
@@ -9,22 +9,32 @@
     overflow: hidden auto;
     background-color: $clr-bg-pri;
     height: $bit-env-height-available;
+    // The Width parameter is a custom property rather than a width of its own, so the state-dependent widths
+    // below (the rail, the small-screen drawer) keep deciding on their own and a panel that is given no width
+    // still takes the one its container hands it.
+    width: var(--bit-npn-w, auto);
 
     &.bit-npn-tgl {
-        min-width: spacing(12);
-        max-width: spacing(12);
+        min-width: var(--bit-npn-tw, #{spacing(12)});
+        max-width: var(--bit-npn-tw, #{spacing(12)});
 
         .bit-npn-cnt {
             align-items: center;
         }
     }
 
+    // A rail that expands on hover widens in place, so the two widths are the two ends of a transition
+    // rather than a jump.
+    &.bit-npn-eoh {
+        transition: min-width 150ms $mot-easing, max-width 150ms $mot-easing;
+    }
+
     &.bit-npn-npd {
         padding: 0;
 
         &.bit-npn-tgl {
-            min-width: spacing(6);
-            max-width: spacing(6);
+            min-width: var(--bit-npn-tw, #{spacing(6)});
+            max-width: var(--bit-npn-tw, #{spacing(6)});
         }
 
         .bit-npn-cnt {
@@ -46,6 +56,7 @@
         padding: 0;
         opacity: 1;
         position: fixed;
+        visibility: visible;
         height: unset !important;
         z-index: $zindex-callout;
         bottom: $bit-env-inset-bottom;
@@ -60,6 +71,11 @@
         &.bit-npn-cls {
             opacity: 0;
             transform: translateX(-100%);
+            // A panel that is only moved off screen keeps its links in the tab order and in the accessibility
+            // tree, so the closed one is hidden outright once it has finished sliding away.
+            visibility: hidden;
+            pointer-events: none;
+            transition: transform 150ms $mot-easing, opacity 100ms $mot-easing, visibility 0s linear 150ms;
 
             &.bit-rtl {
                 transform: translateX(100%);
@@ -67,13 +83,13 @@
         }
 
         &.bit-npn-tgl {
-            min-width: spacing(8);
-            max-width: spacing(8);
+            min-width: var(--bit-npn-tw, #{spacing(8)});
+            max-width: var(--bit-npn-tw, #{spacing(8)});
         }
 
         &.bit-npn-npd.bit-npn-tgl {
-            min-width: spacing(6);
-            max-width: spacing(6);
+            min-width: var(--bit-npn-tw, #{spacing(6)});
+            max-width: var(--bit-npn-tw, #{spacing(6)});
         }
 
         .bit-npn-tbn {
@@ -136,6 +152,19 @@
 
 .bit-npn-spc {
     flex-grow: 1;
+}
+
+// The live region of the search: read by a screen reader, invisible on the page.
+.bit-npn-lvr {
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    border: 0;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    clip-path: inset(50%);
 }
 
 .bit-nav-apri {

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
@@ -27,9 +27,13 @@
     }
 
     // A rail that expands on hover widens in place, so the two widths are the two ends of a transition
-    // rather than a jump.
+    // rather than a jump. Only on the screens the panel is a column of the page on: below the breakpoint it
+    // is an off-canvas drawer, and a transition declared here outranks the one the drawer slides in with
+    // (two classes against one) and would replace it with a widening the drawer never does.
     &.bit-npn-eoh {
-        transition: min-width 150ms $mot-easing, max-width 150ms $mot-easing;
+        @include gt-sm {
+            transition: min-width 150ms $mot-easing, max-width 150ms $mot-easing;
+        }
 
         // The expanded end of that transition needs a width of the same kind as the collapsed one: a rail
         // that widens into an unbounded max-width has nothing to travel to and snaps open instead. A panel

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
@@ -1,4 +1,4 @@
-@import "../../Styles/extra-variables.scss";
+﻿@import "../../Styles/extra-variables.scss";
 @import "../../../Bit.BlazorUI/Styles/functions.scss";
 @import "../../../Bit.BlazorUI/Styles/media-queries.scss";
 
@@ -7,6 +7,9 @@
     position: sticky;
     padding: spacing(2);
     overflow: hidden auto;
+    // The panel scrolls its own overflow without drawing a bar for it: the bar would sit between the items
+    // and the edge of a surface that is already narrow, and the rail has no room for one at all.
+    scrollbar-width: none;
     background-color: $clr-bg-pri;
     height: $bit-env-height-available;
     // The Width parameter is a custom property rather than a width of its own, so the state-dependent widths
@@ -27,6 +30,32 @@
     // rather than a jump.
     &.bit-npn-eoh {
         transition: min-width 150ms $mot-easing, max-width 150ms $mot-easing;
+    }
+
+    // The panel that pins its two ends stops being the scroller: the nav between them takes the overflow,
+    // so the header (with the search box in it) and the footer stay where they are however long the list is.
+    &.bit-npn-ste {
+        overflow: hidden;
+
+        .bit-npn-swp {
+            min-height: 0;
+        }
+
+        .bit-npn-cnt {
+            height: 100%;
+            min-height: 0;
+        }
+
+        .bit-nav {
+            flex: 1 1 auto;
+            min-height: 0;
+            overflow: hidden auto;
+            scrollbar-width: none;
+
+            &::-webkit-scrollbar {
+                width: 0;
+            }
+        }
     }
 
     &.bit-npn-npd {
@@ -53,6 +82,7 @@
 
     @include lt-md {
         left: 0;
+        right: unset;
         padding: 0;
         opacity: 1;
         position: fixed;
@@ -63,9 +93,18 @@
         top: $bit-env-inset-top !important;
         transition: transform 150ms $mot-easing, opacity 100ms $mot-easing;
 
-        &.bit-rtl {
+        // The drawer is docked to the edge it comes from, which the Position expresses in the text direction:
+        // the End of a left-to-right layout and the Start of a right-to-left one are both the right of the
+        // screen, and a panel that is both is back where it started.
+        &.bit-rtl,
+        &.bit-npn-end {
             right: 0;
             left: unset;
+        }
+
+        &.bit-rtl.bit-npn-end {
+            left: 0;
+            right: unset;
         }
 
         &.bit-npn-cls {
@@ -77,8 +116,13 @@
             pointer-events: none;
             transition: transform 150ms $mot-easing, opacity 100ms $mot-easing, visibility 0s linear 150ms;
 
-            &.bit-rtl {
+            &.bit-rtl,
+            &.bit-npn-end {
                 transform: translateX(100%);
+            }
+
+            &.bit-rtl.bit-npn-end {
+                transform: translateX(-100%);
             }
         }
 
@@ -95,6 +139,10 @@
         .bit-npn-tbn {
             display: none;
         }
+
+        .bit-npn-cbw {
+            display: contents;
+        }
     }
 }
 
@@ -103,6 +151,13 @@
 
     .bit-npn-cnt {
         height: -webkit-fill-available;
+    }
+
+    // A panel that pins its ends bounds its own flex column instead, which is what lets the nav between them
+    // take the overflow: a container sized to fill what is available would grow with the list rather than
+    // hand it a scrollbar.
+    &.bit-npn-ste .bit-npn-cnt {
+        height: 100%;
     }
 }
 
@@ -126,6 +181,13 @@
     @include gt-sm {
         display: none;
     }
+}
+
+// The layer between the root element and the content: it is either the swipe trap of a panel that closes on
+// a gesture, or a plain element of the same shape for one that does not.
+.bit-npn-swp {
+    width: 100%;
+    height: 100%;
 }
 
 .bit-npn-cnt {
@@ -152,6 +214,12 @@
 
 .bit-npn-spc {
     flex-grow: 1;
+}
+
+// The close button is the drawer's, so it is out of the layout entirely on the screens where the panel is a
+// column of the page and the toggle button is the control that belongs there.
+.bit-npn-cbw {
+    display: none;
 }
 
 // The live region of the search: read by a screen reader, invisible on the page.

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanel.scss
@@ -30,6 +30,16 @@
     // rather than a jump.
     &.bit-npn-eoh {
         transition: min-width 150ms $mot-easing, max-width 150ms $mot-easing;
+
+        // The expanded end of that transition needs a width of the same kind as the collapsed one: a rail
+        // that widens into an unbounded max-width has nothing to travel to and snaps open instead. A panel
+        // given no Width keeps both ends open (an invalid max-width is dropped) and stays as wide as its
+        // container makes it, and so do the two modes that size the panel themselves - the Width they are
+        // documented to ignore is not allowed back in as a bound.
+        &:not(.bit-npn-tgl):not(.bit-npn-fiw):not(.bit-npn-fuw) {
+            min-width: var(--bit-npn-w, auto);
+            max-width: var(--bit-npn-w, auto);
+        }
     }
 
     // The panel that pins its two ends stops being the scroller: the nav between them takes the overflow,

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelClassStyles.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelClassStyles.cs
@@ -38,6 +38,11 @@ public class BitNavPanelClassStyles
     public string? ToggleButton { get; set; }
 
     /// <summary>
+    /// Custom CSS classes/styles for the close button of the BitNavPanel.
+    /// </summary>
+    public string? CloseButton { get; set; }
+
+    /// <summary>
     /// Custom CSS classes/styles for the search box of the BitNavPanel.
     /// </summary>
     public string? SearchBox { get; set; }

--- a/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelPosition.cs
+++ b/src/BlazorUI/Bit.BlazorUI.Extras/Components/NavPanel/BitNavPanelPosition.cs
@@ -1,0 +1,23 @@
+﻿namespace Bit.BlazorUI;
+
+/// <summary>
+/// The edge of the viewport the off-canvas drawer of a <see cref="BitNavPanel{TItem}"/> comes from.
+/// </summary>
+/// <remarks>
+/// Only the drawer of a small screen is docked to an edge: on a wide screen the panel is a column in the
+/// normal flow of the page, where its place is decided by the layout that holds it.
+/// </remarks>
+public enum BitNavPanelPosition
+{
+    /// <summary>
+    /// The drawer comes from the starting edge of the text direction: the left in a left-to-right layout,
+    /// the right in a right-to-left one.
+    /// </summary>
+    Start,
+
+    /// <summary>
+    /// The drawer comes from the ending edge of the text direction: the right in a left-to-right layout,
+    /// the left in a right-to-left one.
+    /// </summary>
+    End
+}

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
@@ -2,10 +2,10 @@
 
 <PageOutlet Url="components/navpanel"
             Title="NavPanel"
-            Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel: a searchable nav with a header, a footer, a rail mode, and an off-canvas drawer on small screens." />
+            Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel: a searchable nav with a header, a footer, a rail mode, and a modal off-canvas drawer on small screens." />
 
 <DemoPage Name="NavPanel"
-          Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel. It wraps a BitNav in the chrome a side navigation needs: a header holding a logo and the button that collapses the panel into a rail of icons, a search box that filters the items as they are typed, and a footer. On small screens it becomes an off-canvas drawer that opens over the page and closes on an overlay click, the Escape key, a swipe, or the navigation of an item."
+          Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel. It wraps a BitNav in the chrome a side navigation needs: a header holding a logo and the button that collapses the panel into a rail of icons, a search box that filters the items as they are typed, and a footer. On small screens it becomes a modal off-canvas drawer that holds the page and the focus while it covers them, and closes on an overlay click, the Escape key, a swipe, or the navigation of an item."
           Parameters="componentParameters"
           SubClasses="componentSubClasses"
           PublicMembers="componentPublicMembers"
@@ -28,7 +28,7 @@
     <DescriptionTemplate>
         BitNavPanel is a navigation component specialized to be rendered in a vertical panel. In its core it's utilizing the <BitLink Href="/components/nav">BitNav</BitLink> component to render the nav items, so the whole nav API - the item tree, the URL matching, the templates and the keyboard navigation - is available through it.
         <br /><br />
-        The <b>Open</b> button above each example is the one a small screen shows: the panel is a permanent column on a wide screen and an off-canvas drawer below the <b>lg</b> breakpoint, which is what <b>IsOpen</b> drives.
+        The <b>Open</b> button above each example is the one a small screen shows: the panel is a permanent column on a wide screen and an off-canvas drawer below the <b>md</b> breakpoint, which is what <b>IsOpen</b> drives.
     </DescriptionTemplate>
     <Examples>
         <DemoExample Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
@@ -88,9 +88,10 @@
         <DemoExample Title="ExpandOnHover" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
             <div>
                 <b>ExpandOnHover</b> brings the collapsed panel back to its full width while the pointer is over
-                it, so the rail stays a rail and still shows the text of its items on the way to one. The panel
+                it - or while the keyboard is inside it, so the text of the items is reachable without a mouse -
+                so the rail stays a rail and still shows what its icons stand for on the way to one. The panel
                 widens in place, which moves the content beside it along with it. Collapse the panel below with
-                its toggle button, then hover it.
+                its toggle button, then hover it or tab into it.
             </div>
             <br />
             <div class="open-btn">
@@ -106,7 +107,8 @@
                 <b>NoToggle</b> removes the rail mode altogether: the toggle button is gone and the panel can no
                 longer be collapsed, not even through <b>IsToggled</b> or the <b>Toggle</b> method.
                 <b>HideToggle</b> only takes the button away and leaves the mode itself in place, for a panel
-                that is toggled from somewhere else on the page.
+                that is toggled from somewhere else on the page. <b>ToggleAriaLabel</b> renames the button the
+                two of them take away, which otherwise says what it is about to do in English.
             </div>
             <br />
             <div class="open-btn">
@@ -121,7 +123,9 @@
             <div>
                 <b>IconUrl</b> renders a logo at the start of the header, and <b>IconNavUrl</b> wraps it in an
                 anchor pointing at the home page of the app. The logo is hidden while the panel is collapsed
-                into its rail, where there is no room for it.
+                into its rail, where there is no room for it. <b>IconAriaLabel</b> is what a screen reader
+                reads it as - the name of the link, or the alternative text of the bare image - which is not
+                the same thing as the name of the navigation landmark <b>AriaLabel</b> gives the nav.
             </div>
             <br />
             <div class="open-btn">
@@ -136,6 +140,7 @@
             <div>
                 <b>SearchBoxPlaceholder</b> replaces the text shown in the empty search box, and doubles as its
                 accessible name and as the tooltip of the search button the rail shows in place of the box.
+                <b>SearchIcon</b> and <b>SearchIconName</b> replace the glyph of that button.
             </div>
             <br />
             <div class="open-btn">
@@ -161,13 +166,15 @@
 
         <DemoExample Title="Search" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
             <div>
-                An item matches when the term appears in its <b>Text</b>, its <b>Description</b> or its
-                <b>Data</b>, and a matched item keeps the whole branch under it, so a group that matches still
-                shows what it groups. <b>SearchText</b> two-way binds the term, so the search can be driven
-                from anywhere on the page, <b>OnSearch</b> reports every change of it, and
-                <b>SearchDebounceTime</b> sets how long the typing settles before the list is filtered.
-                <b>SearchFilter</b> replaces the matching itself with a function of your own - here only the
-                text of an item is looked at, and only from its start.
+                An item matches when every word of the term appears in its <b>Text</b>, its <b>Description</b>
+                or its <b>Data</b>, so each word typed narrows the list further; a matched item keeps the whole
+                branch under it, so a group that matches still shows what it groups. <b>SearchText</b> two-way
+                binds the term, so the search can be driven from anywhere on the page, <b>OnSearch</b> reports
+                every change of it, and <b>SearchDebounceTime</b> sets how long the typing settles before the
+                list is filtered. <b>SearchFilter</b> replaces the matching itself with a function of your own -
+                here only the text of an item is looked at, and only from its start. However many items the
+                search leaves, a live region announces the count to a screen reader, which
+                <b>SearchAnnouncementProvider</b> rewrites for a localized app.
             </div>
             <br />
             <div class="open-btn">
@@ -206,10 +213,13 @@
         <DemoExample Title="Selection" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
             <div>
                 In the default <b>Automatic</b> mode the panel keeps the selection in sync with the current URL,
-                matched as <b>NavMatch</b> says (exactly, by prefix, by wildcard or by regular expression). The
-                <b>Manual</b> mode hands that over to the app: the clicked item becomes the selected one, the
-                initial selection comes from <b>DefaultSelectedItem</b>, and <b>SelectedItem</b> two-way binds
-                it so the selection can be driven from anywhere else on the page.
+                matched as <b>NavMatch</b> says (exactly, by prefix, by wildcard or by regular expression) and
+                against the <b>AdditionalUrls</b> of an item as well as its own. The <b>Manual</b> mode hands
+                that over to the app: the clicked item becomes the selected one, the initial selection comes
+                from <b>DefaultSelectedItem</b> (which the automatic mode has no use for, since the URL is what
+                decides there), and <b>SelectedItem</b> two-way binds it so the selection can be driven from
+                anywhere else on the page. <b>Reselectable</b> reports a click on the item that is already
+                selected as a selection of its own.
             </div>
             <br />
             <div class="open-btn">
@@ -234,7 +244,8 @@
                 <b>AllExpanded</b> opens every group as it is first rendered, <b>SingleExpand</b> keeps a single
                 open branch at a time - opening one closes the one that was open - and <b>NoCollapse</b> hides
                 the chevrons altogether, for a tree that is only ever opened by the URL or by the selection.
-                The panel below is in single-expand mode.
+                <b>ExpandAriaLabel</b> and <b>CollapseAriaLabel</b> name the chevron in each of its two states,
+                for the items that carry no name of their own for it. The panel below is in single-expand mode.
             </div>
             <br />
             <div class="open-btn">
@@ -284,9 +295,11 @@
         <DemoExample Title="Templates" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
             <div>
                 <b>Header</b> and <b>Footer</b> replace the two ends of the panel - the header replaces the logo
-                and the toggle button with it, so a custom header that wants to keep the rail renders a control
-                of its own calling the <b>Toggle</b> method - while <b>ItemTemplate</b> customizes how the
-                content of every item is rendered.
+                and the buttons beside it, so a custom header that wants to keep the rail renders a control of
+                its own calling the <b>Toggle</b> method - while <b>ItemTemplate</b> customizes how the content
+                of every item is rendered, and <b>HeaderTemplate</b> does the same for the group headers of the
+                <b>Grouped</b> render type. <b>ItemTemplateRenderMode</b> and <b>HeaderTemplateRenderMode</b>
+                decide whether a template fills the link the panel renders, or replaces it outright.
             </div>
             <br />
             <div class="open-btn">
@@ -338,7 +351,10 @@
                 <b>Open</b> and <b>Close</b> drive the small-screen drawer, <b>ExpandAll</b> and
                 <b>CollapseAll</b> open and close every group, <b>ClearSearch</b> empties the search box, and
                 <b>FocusSearchBox</b> moves the focus into it, leaving the rail first when the panel is
-                collapsed.
+                collapsed. One item at a time is reached the same way: <b>ExpandItem</b>, <b>CollapseItem</b>
+                and <b>ToggleItem</b> open and close a single branch, <b>IsItemExpanded</b> reports whether one
+                is open, <b>SelectItem</b> selects an item exactly like a click on it would, and
+                <b>FocusItem</b> moves the focus onto it, opening the branches it is nested in on the way.
             </div>
             <br />
             <div class="open-btn">
@@ -357,7 +373,82 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Color" RazorCode="@example19RazorCode" CsharpCode="@example19CsharpCode" Id="example19">
+        <DemoExample Title="Grouped" RazorCode="@example19RazorCode" CsharpCode="@example19CsharpCode" Id="example19">
+            <div>
+                <b>RenderType</b> set to <b>Grouped</b> turns every root item into the header of the group it
+                holds instead of a link of its own, which is what a long menu split into named sections wants.
+                <b>ReversedChevron</b> moves the expander to the far end of each row, <b>IndentValue</b> sets
+                how far every level of depth is indented - with <b>IndentPadding</b> and
+                <b>IndentReversedPadding</b> for the room a row without children leaves in place of a chevron -
+                and <b>NoPad</b> takes the padding off the panel so its rows run to its edges.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="groupedIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:240px">
+                <BitNavPanel @bind-IsOpen="groupedIsOpen"
+                             Items="singleExpandNavItems"
+                             RenderType="BitNavRenderType.Grouped"
+                             IndentValue="24"
+                             ReversedChevron
+                             NoPad />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Drawer" RazorCode="@example20RazorCode" CsharpCode="@example20CsharpCode" Id="example20">
+            <div>
+                Below the <b>md</b> breakpoint the panel is an off-canvas drawer that covers the page, and it
+                behaves like the modal surface it looks like: it reports itself as a dialog, the page behind it
+                stops scrolling, the focus stays inside it so Tab cannot wander onto the page underneath, and
+                it is handed back to whatever held it once the drawer closes. <b>Position</b> decides which
+                edge the drawer comes from - <b>End</b> docks it to the other side, and the swipe that closes
+                it goes that way too - while <b>NoScrollLock</b>, <b>NoFocusTrap</b> and <b>NoRestoreFocus</b>
+                each give one of those three behaviors back. A panel with <b>NoOverlay</b> never covers the
+                page at all, so none of them apply to it. <b>ShowCloseButton</b> puts a close button in the
+                header for the screens the panel is a drawer on - where the toggle button, which collapses a
+                permanent panel into a rail, has nothing to do - so a touch user has something to aim at
+                besides the overlay and the swipe; <b>CloseIcon</b>, <b>CloseIconName</b> and
+                <b>CloseAriaLabel</b> describe it. Narrow the window below the breakpoint to see all of it.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="drawerIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="drawerIsOpen"
+                             Items="basicNavItems"
+                             AutoFocus
+                             ShowCloseButton
+                             Position="BitNavPanelPosition.End" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="StickyEnds" RazorCode="@example21RazorCode" CsharpCode="@example21CsharpCode" Id="example21">
+            <div>
+                The panel scrolls as one by default, so a long list carries the header and the search box out
+                of sight along with it. <b>StickyEnds</b> hands the overflow to the items instead: the header
+                (with the box that filters them) and the footer stay where they are, and only the list between
+                them scrolls.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="stickyIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:240px">
+                <BitNavPanel @bind-IsOpen="stickyIsOpen"
+                             Items="singleExpandNavItems"
+                             Style="height:264px"
+                             AllExpanded
+                             StickyEnds>
+                    <Footer>
+                        <BitActionButton IconName="@BitIconName.PowerButton">Logout</BitActionButton>
+                    </Footer>
+                </BitNavPanel>
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Color" RazorCode="@example22RazorCode" CsharpCode="@example22CsharpCode" Id="example22">
             <div>
                 <b>Color</b> sets the color of the parts that carry one - the icons, the search box and the
                 selection - and <b>Accent</b> paints the background of the panel itself.
@@ -371,7 +462,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="External Icons" RazorCode="@example20RazorCode" CsharpCode="@example20CsharpCode" Id="example20">
+        <DemoExample Title="External Icons" RazorCode="@example23RazorCode" CsharpCode="@example23CsharpCode" Id="example23">
             <div>
                 Besides the built-in icons, the <b>Icon</b> of an item, the <b>ToggleIcon</b> of the toggle
                 button and the <b>ChevronDownIcon</b> of the expanders all accept the CSS classes of any
@@ -391,7 +482,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Size" RazorCode="@example21RazorCode" CsharpCode="@example21CsharpCode" Id="example21">
+        <DemoExample Title="Size" RazorCode="@example24RazorCode" CsharpCode="@example24CsharpCode" Id="example24">
             <div>
                 <b>Size</b> scales the metrics of every item at once: the height of the rows, the size of their
                 icons, and the size of their text and description.
@@ -416,7 +507,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Style & Class" RazorCode="@example22RazorCode" CsharpCode="@example22CsharpCode" Id="example22">
+        <DemoExample Title="Style & Class" RazorCode="@example25RazorCode" CsharpCode="@example25CsharpCode" Id="example25">
             <div>
                 <b>Styles</b> and <b>Classes</b> reach every part of the panel itself, while <b>NavStyles</b> /
                 <b>NavClasses</b> and <b>SearchBoxStyles</b> / <b>SearchBoxClasses</b> pass the same kind of map
@@ -441,7 +532,7 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="RTL" RazorCode="@example23RazorCode" CsharpCode="@example23CsharpCode" Id="example23">
+        <DemoExample Title="RTL" RazorCode="@example26RazorCode" CsharpCode="@example26CsharpCode" Id="example26">
             <div>
                 Set <b>Dir</b> to <b>BitDir.Rtl</b> to render the panel in a right-to-left layout: it docks to
                 the right, the indentation and the chevrons flip, and the swipe that closes it goes the other

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
@@ -2,10 +2,10 @@
 
 <PageOutlet Url="components/navpanel"
             Title="NavPanel"
-            Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel." />
+            Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel: a searchable nav with a header, a footer, a rail mode, and an off-canvas drawer on small screens." />
 
 <DemoPage Name="NavPanel"
-          Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel."
+          Description="BitNavPanel is a navigation component specialized to be rendered in a vertical panel. It wraps a BitNav in the chrome a side navigation needs: a header holding a logo and the button that collapses the panel into a rail of icons, a search box that filters the items as they are typed, and a footer. On small screens it becomes an off-canvas drawer that opens over the page and closes on an overlay click, the Escape key, a swipe, or the navigation of an item."
           Parameters="componentParameters"
           SubClasses="componentSubClasses"
           PublicMembers="componentPublicMembers"
@@ -26,10 +26,20 @@
         </BitText>
     </NotesTemplate>
     <DescriptionTemplate>
-        BitNavPanel is a navigation component specialized to be rendered in a vertical panel. In its core it's utilizing the <BitLink Href="/components/nav">BitNav</BitLink> component to render the nav items.
+        BitNavPanel is a navigation component specialized to be rendered in a vertical panel. In its core it's utilizing the <BitLink Href="/components/nav">BitNav</BitLink> component to render the nav items, so the whole nav API - the item tree, the URL matching, the templates and the keyboard navigation - is available through it.
+        <br /><br />
+        The <b>Open</b> button above each example is the one a small screen shows: the panel is a permanent column on a wide screen and an off-canvas drawer below the <b>lg</b> breakpoint, which is what <b>IsOpen</b> drives.
     </DescriptionTemplate>
     <Examples>
         <DemoExample Title="Basic" RazorCode="@example1RazorCode" CsharpCode="@example1CsharpCode" Id="example1">
+            <div>
+                The panel renders the tree given to <b>Items</b>, with a header, a search box and the toggle
+                button on top of it. Each <b>BitNavItem</b> carries its <b>Text</b>, an optional
+                <b>IconName</b>, <b>Description</b> and <b>Url</b>, and the items nested in its
+                <b>ChildItems</b> turn it into an expandable node. Typing in the search box filters the list,
+                and the toggle button collapses the panel down to a rail of icons.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="basicIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -39,6 +49,11 @@
         </DemoExample>
 
         <DemoExample Title="FitWidth" RazorCode="@example2RazorCode" CsharpCode="@example2CsharpCode" Id="example2">
+            <div>
+                By default the panel takes the width its container gives it. <b>FitWidth</b> shrinks it to the
+                width of its widest item, so it takes no more room than the items it holds.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="fitWidthIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -46,13 +61,54 @@
         </DemoExample>
 
         <DemoExample Title="FullWidth" RazorCode="@example3RazorCode" CsharpCode="@example3CsharpCode" Id="example3">
+            <div>
+                <b>FullWidth</b> stretches the panel over the whole width of its container, which is what a
+                panel sitting in a column of its own usually wants.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="fullWidthIsOpen" OnText="Close" OffText="Open" />
             </div>
             <BitNavPanel @bind-IsOpen="fullWidthIsOpen" Items="basicNavItems" FullWidth />
         </DemoExample>
 
-        <DemoExample Title="NoToggle" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
+        <DemoExample Title="Width" RazorCode="@example4RazorCode" CsharpCode="@example4CsharpCode" Id="example4">
+            <div>
+                <b>Width</b> gives the panel a width of its own in px, and <b>ToggledWidth</b> does the same for
+                the rail it collapses into, so the two states are sized without a stylesheet. Both are ignored
+                in the <b>FitWidth</b> and <b>FullWidth</b> modes, which decide the width themselves.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="widthIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <BitNavPanel @bind-IsOpen="widthIsOpen" Items="basicNavItems" Width="260" ToggledWidth="72" />
+        </DemoExample>
+
+        <DemoExample Title="ExpandOnHover" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+            <div>
+                <b>ExpandOnHover</b> brings the collapsed panel back to its full width while the pointer is over
+                it, so the rail stays a rail and still shows the text of its items on the way to one. The panel
+                widens in place, which moves the content beside it along with it. Collapse the panel below with
+                its toggle button, then hover it.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="expandOnHoverIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="expandOnHoverIsOpen" Items="basicNavItems" ExpandOnHover />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="NoToggle" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+            <div>
+                <b>NoToggle</b> removes the rail mode altogether: the toggle button is gone and the panel can no
+                longer be collapsed, not even through <b>IsToggled</b> or the <b>Toggle</b> method.
+                <b>HideToggle</b> only takes the button away and leaves the mode itself in place, for a panel
+                that is toggled from somewhere else on the page.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="noToggleIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -61,7 +117,13 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Icon" RazorCode="@example5RazorCode" CsharpCode="@example5CsharpCode" Id="example5">
+        <DemoExample Title="Icon" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+            <div>
+                <b>IconUrl</b> renders a logo at the start of the header, and <b>IconNavUrl</b> wraps it in an
+                anchor pointing at the home page of the app. The logo is hidden while the panel is collapsed
+                into its rail, where there is no room for it.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="iconUrlIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -70,7 +132,12 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="SearchBoxPlaceholder" RazorCode="@example6RazorCode" CsharpCode="@example6CsharpCode" Id="example6">
+        <DemoExample Title="SearchBoxPlaceholder" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+            <div>
+                <b>SearchBoxPlaceholder</b> replaces the text shown in the empty search box, and doubles as its
+                accessible name and as the tooltip of the search button the rail shows in place of the box.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="searchBoxPlaceholderIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -79,7 +146,11 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="NoSearchBox" RazorCode="@example7RazorCode" CsharpCode="@example7CsharpCode" Id="example7">
+        <DemoExample Title="NoSearchBox" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+            <div>
+                <b>NoSearchBox</b> removes the search box, for a short menu that has nothing to filter.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="noSearchBoxIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -88,7 +159,42 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="EmptyListMessage" RazorCode="@example8RazorCode" CsharpCode="@example8CsharpCode" Id="example8">
+        <DemoExample Title="Search" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
+            <div>
+                An item matches when the term appears in its <b>Text</b>, its <b>Description</b> or its
+                <b>Data</b>, and a matched item keeps the whole branch under it, so a group that matches still
+                shows what it groups. <b>SearchText</b> two-way binds the term, so the search can be driven
+                from anywhere on the page, <b>OnSearch</b> reports every change of it, and
+                <b>SearchDebounceTime</b> sets how long the typing settles before the list is filtered.
+                <b>SearchFilter</b> replaces the matching itself with a function of your own - here only the
+                text of an item is looked at, and only from its start.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="searchIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div class="example-content">
+                <BitTextField Label="Search text" @bind-Value="searchText" Immediate />
+                <div>Last searched term: <b>@lastSearchedTerm</b></div>
+            </div>
+            <br />
+            <div style="width:240px">
+                <BitNavPanel @bind-IsOpen="searchIsOpen"
+                             Items="basicNavItems"
+                             @bind-SearchText="searchText"
+                             SearchDebounceTime="200"
+                             OnSearch="v => lastSearchedTerm = v"
+                             SearchFilter="(item, term) => item.Text.StartsWith(term, StringComparison.OrdinalIgnoreCase)" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="EmptyListMessage" RazorCode="@example11RazorCode" CsharpCode="@example11CsharpCode" Id="example11">
+            <div>
+                Searching for something that is nowhere in the list replaces it with a message.
+                <b>EmptyListMessage</b> changes the text of that message, and <b>EmptyListTemplate</b> replaces
+                it with markup of your own.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="emptyListMessageIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -97,7 +203,92 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Templates" RazorCode="@example9RazorCode" CsharpCode="@example9CsharpCode" Id="example9">
+        <DemoExample Title="Selection" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
+            <div>
+                In the default <b>Automatic</b> mode the panel keeps the selection in sync with the current URL,
+                matched as <b>NavMatch</b> says (exactly, by prefix, by wildcard or by regular expression). The
+                <b>Manual</b> mode hands that over to the app: the clicked item becomes the selected one, the
+                initial selection comes from <b>DefaultSelectedItem</b>, and <b>SelectedItem</b> two-way binds
+                it so the selection can be driven from anywhere else on the page.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="selectionIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div class="example-content">
+                <div>Selected item: <b>@selectedItem?.Text</b></div>
+                <BitButton OnClick="() => selectedItem = basicNavItems[3]">Select Settings</BitButton>
+            </div>
+            <br />
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="selectionIsOpen"
+                             Items="basicNavItems"
+                             NavMode="BitNavMode.Manual"
+                             @bind-SelectedItem="selectedItem"
+                             DefaultSelectedItem="basicNavItems[0]" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Expansion" RazorCode="@example13RazorCode" CsharpCode="@example13CsharpCode" Id="example13">
+            <div>
+                <b>AllExpanded</b> opens every group as it is first rendered, <b>SingleExpand</b> keeps a single
+                open branch at a time - opening one closes the one that was open - and <b>NoCollapse</b> hides
+                the chevrons altogether, for a tree that is only ever opened by the URL or by the selection.
+                The panel below is in single-expand mode.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="singleExpandIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="singleExpandIsOpen" Items="singleExpandNavItems" SingleExpand />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Custom items" RazorCode="@example14RazorCode" CsharpCode="@example14CsharpCode" Id="example14">
+            <div>
+                The panel is generic, so any class can be the item type. <b>NameSelectors</b> is what tells it
+                where to read each field from: a property name, or a selector function when the value is
+                computed. Anything left out keeps the name it has on <b>BitNavItem</b>.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="customIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="customIsOpen"
+                             Items="customNavItems"
+                             NameSelectors="customSelectors" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Behavior" RazorCode="@example15RazorCode" CsharpCode="@example15CsharpCode" Id="example15">
+            <div>
+                On a small screen the open panel closes on a click on the overlay behind it, on the Escape key,
+                on a swipe towards the side it came from, and on the navigation of an item.
+                <b>NoAutoClose</b> keeps it open after a navigation, <b>NoOverlay</b> drops the overlay so the
+                page behind it stays clickable, and <b>NoSwipe</b> turns the swipe gesture off. The panel below
+                shows all three, so it can only be closed through its own button. <b>AutoFocus</b> goes the
+                other way and moves the focus into the panel as it opens - onto the search box, or onto the
+                first item of a panel without one - which is what a drawer covering the page is expected to do.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="behaviorIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="behaviorIsOpen" Items="basicNavItems" AutoFocus NoAutoClose NoOverlay NoSwipe />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Templates" RazorCode="@example16RazorCode" CsharpCode="@example16CsharpCode" Id="example16">
+            <div>
+                <b>Header</b> and <b>Footer</b> replace the two ends of the panel - the header replaces the logo
+                and the toggle button with it, so a custom header that wants to keep the rail renders a control
+                of its own calling the <b>Toggle</b> method - while <b>ItemTemplate</b> customizes how the
+                content of every item is rendered.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="templateIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -119,7 +310,12 @@
             </BitNavPanel>
         </DemoExample>
 
-        <DemoExample Title="Events" RazorCode="@example10RazorCode" CsharpCode="@example10CsharpCode" Id="example10">
+        <DemoExample Title="Events" RazorCode="@example17RazorCode" CsharpCode="@example17CsharpCode" Id="example17">
+            <div>
+                <b>OnItemClick</b> reports every click on an item, <b>OnItemToggle</b> every expand and collapse
+                of a group, and <b>OnSelectItem</b> the item that became the selected one.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="eventIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -136,17 +332,37 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Public APIs" RazorCode="@example11RazorCode" CsharpCode="@example11CsharpCode" Id="example11">
+        <DemoExample Title="Public APIs" RazorCode="@example18RazorCode" CsharpCode="@example18CsharpCode" Id="example18">
+            <div>
+                A reference to the panel drives it from the outside: <b>Toggle</b> switches the rail on and off,
+                <b>Open</b> and <b>Close</b> drive the small-screen drawer, <b>ExpandAll</b> and
+                <b>CollapseAll</b> open and close every group, <b>ClearSearch</b> empties the search box, and
+                <b>FocusSearchBox</b> moves the focus into it, leaving the rail first when the panel is
+                collapsed.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="publicApiIsOpen" OnText="Close" OffText="Open" />
             </div>
-            <BitButton OnClick="async () => await navPanelRef.Toggle()">Toggle</BitButton>
+            <div class="example-content">
+                <BitButton OnClick="() => navPanelRef.Toggle()">Toggle</BitButton>
+                <BitButton OnClick="() => navPanelRef.ExpandAll()">Expand all</BitButton>
+                <BitButton OnClick="() => navPanelRef.CollapseAll()">Collapse all</BitButton>
+                <BitButton OnClick="() => navPanelRef.FocusSearchBox()">Focus search</BitButton>
+                <BitButton OnClick="() => navPanelRef.ClearSearch()">Clear search</BitButton>
+            </div>
+            <br />
             <div style="width:222px">
                 <BitNavPanel @bind-IsOpen="publicApiIsOpen" @ref="navPanelRef" Items="basicNavItems" HideToggle />
             </div>
         </DemoExample>
 
-        <DemoExample Title="Color" RazorCode="@example12RazorCode" CsharpCode="@example12CsharpCode" Id="example12">
+        <DemoExample Title="Color" RazorCode="@example19RazorCode" CsharpCode="@example19CsharpCode" Id="example19">
+            <div>
+                <b>Color</b> sets the color of the parts that carry one - the icons, the search box and the
+                selection - and <b>Accent</b> paints the background of the panel itself.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="colorIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -155,7 +371,58 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="Style & Class" RazorCode="@example13RazorCode" CsharpCode="@example13CsharpCode" Id="example13">
+        <DemoExample Title="External Icons" RazorCode="@example20RazorCode" CsharpCode="@example20CsharpCode" Id="example20">
+            <div>
+                Besides the built-in icons, the <b>Icon</b> of an item, the <b>ToggleIcon</b> of the toggle
+                button and the <b>ChevronDownIcon</b> of the expanders all accept the CSS classes of any
+                external icon library, such as FontAwesome or Bootstrap Icons, and take precedence over their
+                name-based counterparts.
+            </div>
+            <br />
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="externalIconIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div style="width:222px">
+                <BitNavPanel @bind-IsOpen="externalIconIsOpen"
+                             Items="externalIconNavItems"
+                             ToggleIcon="@BitIconInfo.Fa("solid bars")"
+                             ChevronDownIcon="@BitIconInfo.Fa("solid chevron-down")" />
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Size" RazorCode="@example21RazorCode" CsharpCode="@example21CsharpCode" Id="example21">
+            <div>
+                <b>Size</b> scales the metrics of every item at once: the height of the rows, the size of their
+                icons, and the size of their text and description.
+            </div>
+            <br />
+            <div class="open-btn">
+                <BitToggleButton @bind-IsChecked="sizeIsOpen" OnText="Close" OffText="Open" />
+            </div>
+            <div class="example-content">
+                <div style="width:180px">
+                    <div>Small</div>
+                    <BitNavPanel @bind-IsOpen="sizeIsOpen" Items="basicNavItems" Size="BitSize.Small" NoSearchBox NoToggle />
+                </div>
+                <div style="width:180px">
+                    <div>Medium</div>
+                    <BitNavPanel @bind-IsOpen="sizeIsOpen" Items="basicNavItems" Size="BitSize.Medium" NoSearchBox NoToggle />
+                </div>
+                <div style="width:180px">
+                    <div>Large</div>
+                    <BitNavPanel @bind-IsOpen="sizeIsOpen" Items="basicNavItems" Size="BitSize.Large" NoSearchBox NoToggle />
+                </div>
+            </div>
+        </DemoExample>
+
+        <DemoExample Title="Style & Class" RazorCode="@example22RazorCode" CsharpCode="@example22CsharpCode" Id="example22">
+            <div>
+                <b>Styles</b> and <b>Classes</b> reach every part of the panel itself, while <b>NavStyles</b> /
+                <b>NavClasses</b> and <b>SearchBoxStyles</b> / <b>SearchBoxClasses</b> pass the same kind of map
+                on to the nav and the search box inside it.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="classStyleIsOpen" OnText="Close" OffText="Open" />
             </div>
@@ -163,8 +430,8 @@
                 <BitNavPanel @bind-IsOpen="classStyleIsOpen"
                              Items="basicNavItems"
                              Styles="@(new() { Container = "background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);" })"
-                             NavClasses="@(new() { ItemContainer = "custom-nav-item", 
-                                                   ItemIcon = "custom-nav-item-ico", 
+                             NavClasses="@(new() { ItemContainer = "custom-nav-item",
+                                                   ItemIcon = "custom-nav-item-ico",
                                                    ItemText = "custom-nav-item-txt" })"
                              SearchBoxClasses="@(new() { Icon = "custom-icon-searchbox",
                                                          Focused = "custom-focused-searchbox",
@@ -174,7 +441,13 @@
             </div>
         </DemoExample>
 
-        <DemoExample Title="RTL" RazorCode="@example14RazorCode" CsharpCode="@example14CsharpCode" Id="example14">
+        <DemoExample Title="RTL" RazorCode="@example23RazorCode" CsharpCode="@example23CsharpCode" Id="example23">
+            <div>
+                Set <b>Dir</b> to <b>BitDir.Rtl</b> to render the panel in a right-to-left layout: it docks to
+                the right, the indentation and the chevrons flip, and the swipe that closes it goes the other
+                way.
+            </div>
+            <br />
             <div class="open-btn">
                 <BitToggleButton @bind-IsChecked="rtlIsOpen" OnText="Close" OffText="Open" />
             </div>

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor
@@ -280,8 +280,10 @@
                 <b>NoAutoClose</b> keeps it open after a navigation, <b>NoOverlay</b> drops the overlay so the
                 page behind it stays clickable, and <b>NoSwipe</b> turns the swipe gesture off. The panel below
                 shows all three, so it can only be closed through its own button. <b>AutoFocus</b> goes the
-                other way and moves the focus into the panel as it opens - onto the search box, or onto the
-                first item of a panel without one - which is what a drawer covering the page is expected to do.
+                other way and moves the focus into the drawer as it opens - onto the search box, or onto the
+                first item of a panel without one - which is what a surface covering the page is expected to
+                do. All of these belong to the drawer of a small screen: the column of a wide one is not a
+                surface over the page, so it neither closes on the Escape key nor takes the focus.
             </div>
             <br />
             <div class="open-btn">

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -22,10 +22,26 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "AutoFocus",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Moves the focus into the nav panel as it opens - onto the search box, or onto the first item of a panel without one.",
+        },
+        new()
+        {
             Name = "ChevronDownIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "The icon of the chevron-down element of each nav item, for icons of external libraries. It takes precedence over ChevronDownIconName.",
+            Href = "#bit-icon-info",
+            LinkType = LinkType.Link,
+        },
+        new()
+        {
+            Name = "ChevronDownIconName",
             Type = "string?",
             DefaultValue = "null",
-            Description = "The custom icon name of the chevron-down element of the BitNav component.",
+            Description = "The custom icon name of the chevron-down element of each nav item.",
         },
         new()
         {
@@ -38,12 +54,26 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "CollapseAriaLabel",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The default aria-label of the expand/collapse button of an expanded item of the nav.",
+        },
+        new()
+        {
             Name = "Color",
             Type = "BitColor?",
             DefaultValue = "null",
             Description = "The general color of the nav.",
             LinkType = LinkType.Link,
             Href = "#color-enum",
+        },
+        new()
+        {
+            Name = "DefaultSelectedItem",
+            Type = "TItem?",
+            DefaultValue = "null",
+            Description = "The initially selected item of the nav in manual mode.",
         },
         new()
         {
@@ -58,6 +88,20 @@ public partial class BitNavPanelDemo
             Type = "string?",
             DefaultValue = "null",
             Description = "The custom message for when the search result is empty.",
+        },
+        new()
+        {
+            Name = "ExpandAriaLabel",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The default aria-label of the expand/collapse button of a collapsed item of the nav.",
+        },
+        new()
+        {
+            Name = "ExpandOnHover",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Expands the toggled (rail) nav panel back to its full width while the pointer is over it.",
         },
         new()
         {
@@ -165,6 +209,8 @@ public partial class BitNavPanelDemo
             Type = "IList<TItem>",
             DefaultValue = "[]",
             Description = "A collection of items to display in the nav panel.",
+            Href = "#nav-item",
+            LinkType = LinkType.Link,
         },
         new()
         {
@@ -184,10 +230,21 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "NameSelectors",
+            Type = "BitNavNameSelectors<TItem>?",
+            DefaultValue = "null",
+            Description = "Names and selectors of the custom input type properties.",
+            Href = "#name-selectors",
+            LinkType = LinkType.Link,
+        },
+        new()
+        {
             Name = "NavClasses",
             Type = "BitNavClassStyles?",
             DefaultValue = "null",
             Description = "Custom CSS classes for different parts of the nav component of the nav panel.",
+            Href = "#nav-class-styles",
+            LinkType = LinkType.Link,
         },
         new()
         {
@@ -213,6 +270,15 @@ public partial class BitNavPanelDemo
            Type = "BitNavClassStyles?",
            DefaultValue = "null",
            Description = "Custom CSS styles for different parts of the nav component of the nav panel.",
+           Href = "#nav-class-styles",
+           LinkType = LinkType.Link,
+        },
+        new()
+        {
+            Name = "NoAutoClose",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Keeps the nav panel open when an item with a URL is clicked, instead of closing it.",
         },
         new()
         {
@@ -220,6 +286,13 @@ public partial class BitNavPanelDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Disables and hides all collapse/expand buttons of the nav component.",
+        },
+        new()
+        {
+            Name = "NoOverlay",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Removes the overlay that is rendered behind the open nav panel in small screens.",
         },
         new()
         {
@@ -234,6 +307,13 @@ public partial class BitNavPanelDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Removes the search box from the nav panel.",
+        },
+        new()
+        {
+            Name = "NoSwipe",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Disables the swipe gesture that closes the open nav panel in small screens.",
         },
         new()
         {
@@ -254,6 +334,12 @@ public partial class BitNavPanelDemo
             Name = "OnItemToggle",
             Type = "EventCallback<TItem>",
             Description = "Callback invoked when a group header is clicked and Expanded or Collapse."
+        },
+        new()
+        {
+            Name = "OnSearch",
+            Type = "EventCallback<string?>",
+            Description = "Callback invoked when the search text of the nav panel changes."
         },
         new()
         {
@@ -307,10 +393,54 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "SearchAnnouncementProvider",
+            Type = "Func<int, string?>?",
+            DefaultValue = "null",
+            Description = "Builds the text that the screen reader announces through the live region of the nav panel whenever the search filters the items, in place of the built-in English announcement. The argument is the number of matched items.",
+        },
+        new()
+        {
+            Name = "SearchDebounceTime",
+            Type = "int",
+            DefaultValue = "500",
+            Description = "The debounce time in milliseconds of the search box of the nav panel.",
+        },
+        new()
+        {
+            Name = "SearchFilter",
+            Type = "Func<TItem, string, bool>?",
+            DefaultValue = "null",
+            Description = "The custom function to decide whether an item matches a search term, replacing the default matching over the text, the description and the data of an item.",
+        },
+        new()
+        {
+            Name = "SearchText",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The search text of the nav panel that filters its items.",
+        },
+        new()
+        {
+            Name = "SelectedItem",
+            Type = "TItem?",
+            DefaultValue = "null",
+            Description = "The selected item of the nav in manual mode.",
+        },
+        new()
+        {
             Name = "SingleExpand",
             Type = "bool",
             DefaultValue = "false",
             Description = "Enables the single-expand mode in the BitNav."
+        },
+        new()
+        {
+            Name = "Size",
+            Type = "BitSize?",
+            DefaultValue = "null",
+            Description = "The size of the nav items.",
+            Href = "#size-enum",
+            LinkType = LinkType.Link,
         },
         new()
         {
@@ -323,10 +453,47 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "ToggleAriaLabel",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The aria-label of the toggle button of the nav panel.",
+        },
+        new()
+        {
+            Name = "ToggledWidth",
+            Type = "int",
+            DefaultValue = "0",
+            Description = "The width of the nav panel in px in its toggled (rail) state.",
+        },
+        new()
+        {
+            Name = "ToggleIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "The icon of the toggle button of the nav panel. It takes precedence over ToggleIconName.",
+            Href = "#bit-icon-info",
+            LinkType = LinkType.Link,
+        },
+        new()
+        {
+            Name = "ToggleIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The name of the icon of the toggle button of the nav panel.",
+        },
+        new()
+        {
             Name = "Top",
             Type = "int",
             DefaultValue = "0",
             Description = "The top CSS property value of the root element of the nav panel in px.",
+        },
+        new()
+        {
+            Name = "Width",
+            Type = "int",
+            DefaultValue = "0",
+            Description = "The width of the nav panel in px. It is ignored in the FitWidth and FullWidth modes.",
         },
     ];
 
@@ -416,6 +583,502 @@ public partial class BitNavPanelDemo
                     Description = "Custom CSS classes/styles for the nav component of the BitNavPanel.",
                 },
             ]
+        },
+        new()
+        {
+            Id = "nav-item",
+            Title = "BitNavItem",
+            Parameters =
+            [
+               new()
+               {
+                   Name = "AriaCurrent",
+                   Type = "BitNavAriaCurrent",
+                   DefaultValue = "BitNavAriaCurrent.Page",
+                   Description = "Aria-current token for active nav item. Must be a valid token value, and defaults to 'page'.",
+                   Href = "#nav-aria-current-enum",
+                   LinkType = LinkType.Link,
+               },
+               new()
+               {
+                   Name = "AriaLabel",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Aria label for nav item. Ignored if CollapseAriaLabel or ExpandAriaLabel is provided.",
+               },
+               new()
+               {
+                   Name = "Class",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS class for the nav item.",
+               },
+               new()
+               {
+                   Name = "ChildItems",
+                   Type = "List<BitNavItem>",
+                   DefaultValue = "[]",
+                   Description = "A list of items to render as children of the current nav item.",
+               },
+               new()
+               {
+                   Name = "CollapseAriaLabel",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Aria label of the toggle button when the nav item is expanded and can be collapsed.",
+               },
+               new()
+               {
+                   Name = "Data",
+                   Type = "object?",
+                   DefaultValue = "null",
+                   Description = "The custom data for the nav item to provide additional state.",
+               },
+               new()
+               {
+                   Name = "Description",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "The description for the nav item.",
+               },
+               new()
+               {
+                   Name = "ExpandAriaLabel",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Aria label of the toggle button when the nav item is collapsed and can be expanded.",
+               },
+               new()
+               {
+                   Name = "ForceAnchor",
+                   Type = "bool",
+                   DefaultValue = "false",
+                   Description = "Forces an anchor element render instead of button.",
+               },
+               new()
+               {
+                   Name = "Icon",
+                   Type = "BitIconInfo?",
+                   DefaultValue = "null",
+                   Description = "The icon to render next to the nav item. Takes precedence over IconName when both are set.",
+                   LinkType = LinkType.Link,
+                   Href = "#bit-icon-info",
+               },
+               new()
+               {
+                   Name = "IconName",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Name of an icon to render next to the nav item.",
+               },
+               new()
+               {
+                   Name = "IsEnabled",
+                   Type = "bool",
+                   DefaultValue = "true",
+                   Description = "Whether or not the nav item is enabled.",
+               },
+               new()
+               {
+                   Name = "IsExpanded",
+                   Type = "bool",
+                   DefaultValue = "false",
+                   Description = "Whether or not the nav item is in an expanded state.",
+               },
+               new()
+               {
+                   Name = "IsSeparator",
+                   Type = "bool",
+                   DefaultValue = "false",
+                   Description = "Indicates that the nav item should render as a separator.",
+               },
+               new()
+               {
+                   Name = "Key",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "A unique value to use as a key or id of the nav item.",
+               },
+               new()
+               {
+                   Name = "Match",
+                   Type = "BitNavMatch?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets a value representing the URL matching behavior of the nav item.",
+                   Href = "#nav-match-enum",
+                   LinkType = LinkType.Link,
+               },
+               new()
+               {
+                   Name = "Style",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS style for the nav item.",
+               },
+               new()
+               {
+                   Name = "Target",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Link target, specifies how to open the nav item's link.",
+               },
+               new()
+               {
+                   Name = "Template",
+                   Type = "RenderFragment<BitNavItem>?",
+                   DefaultValue = "null",
+                   Description = "The custom template for the nav item to render.",
+               },
+               new()
+               {
+                   Name = "TemplateRenderMode",
+                   Type = "BitNavItemTemplateRenderMode",
+                   DefaultValue = "BitNavItemTemplateRenderMode.Normal",
+                   Description = "The render mode of the nav item's custom template.",
+                   Href = "#nav-itemtemplate-rendermode",
+                   LinkType = LinkType.Link,
+               },
+               new()
+               {
+                   Name = "Text",
+                   Type = "string",
+                   DefaultValue = "string.Empty",
+                   Description = "Text to render for the nav item.",
+               },
+               new()
+               {
+                   Name = "Title",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Text for the tooltip of the nav item.",
+               },
+               new()
+               {
+                   Name = "Url",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "The nav item's link URL.",
+               },
+               new()
+               {
+                   Name = "AdditionalUrls",
+                   Type = "IEnumerable<string>?",
+                   DefaultValue = "null",
+                   Description = "Alternative URLs to be considered when auto mode tries to detect the selected nav item by the current URL.",
+               }
+            ]
+        },
+        new()
+        {
+            Id = "name-selectors",
+            Title = "BitNavNameSelectors<TItem>",
+            Parameters =
+            [
+               new()
+               {
+                   Name = "AriaCurrent",
+                   Type = "BitNameSelectorPair<TItem, BitNavAriaCurrent?>",
+                   DefaultValue = "new(nameof(BitNavItem.AriaCurrent))",
+                   Description = "The AriaCurrent field name and selector of the custom input class.",
+                   Href = "#nav-aria-current-enum",
+                   LinkType = LinkType.Link,
+               },
+               new()
+               {
+                   Name = "AriaLabel",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.AriaLabel))",
+                   Description = "The AriaLabel field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Class",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Class))",
+                   Description = "The Class field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "ChildItems",
+                   Type = "BitNameSelectorPair<TItem, List<TItem>?>",
+                   DefaultValue = "new(nameof(BitNavItem.ChildItems))",
+                   Description = "The ChildItems field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "CollapseAriaLabel",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.CollapseAriaLabel))",
+                   Description = "The CollapseAriaLabel field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Data",
+                   Type = "BitNameSelectorPair<TItem, object?>",
+                   DefaultValue = "new(nameof(BitNavItem.Data))",
+                   Description = "The Data field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Description",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Description))",
+                   Description = "The Description field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "ExpandAriaLabel",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.ExpandAriaLabel))",
+                   Description = "The ExpandAriaLabel field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "ForceAnchor",
+                   Type = "BitNameSelectorPair<TItem, bool?>",
+                   DefaultValue = "new(nameof(BitNavItem.ForceAnchor))",
+                   Description = "The ForceAnchor field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Icon",
+                   Type = "BitNameSelectorPair<TItem, BitIconInfo?>",
+                   DefaultValue = "new(nameof(BitNavItem.Icon))",
+                   Description = "The Icon field name and selector of the custom input class.",
+                   LinkType = LinkType.Link,
+                   Href = "#bit-icon-info",
+               },
+               new()
+               {
+                   Name = "IconName",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.IconName))",
+                   Description = "The IconName field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "IsEnabled",
+                   Type = "BitNameSelectorPair<TItem, bool?>",
+                   DefaultValue = "new(nameof(BitNavItem.IsEnabled))",
+                   Description = "The IsEnabled field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "IsExpanded",
+                   Type = "BitNameSelectorPair<TItem, bool?>",
+                   DefaultValue = "new(nameof(BitNavItem.IsExpanded))",
+                   Description = "The IsExpanded field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "IsSeparator",
+                   Type = "BitNameSelectorPair<TItem, bool?>",
+                   DefaultValue = "new(nameof(BitNavItem.IsSeparator))",
+                   Description = "The IsSeparator field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Key",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Key))",
+                   Description = "The Key field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Match",
+                   Type = "BitNameSelectorPair<TItem, BitNavMatch?>",
+                   DefaultValue = "new(nameof(BitNavItem.Match))",
+                   Description = "The Match field name and selector of the custom input class.",
+                   Href = "#nav-match-enum",
+                   LinkType = LinkType.Link,
+               },
+               new()
+               {
+                   Name = "Style",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Style))",
+                   Description = "The Style field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Target",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Target))",
+                   Description = "The Target field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Template",
+                   Type = "BitNameSelectorPair<TItem, RenderFragment<TItem>?>",
+                   DefaultValue = "new(nameof(BitNavItem.Template))",
+                   Description = "The Template field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "TemplateRenderMode",
+                   Type = "BitNameSelectorPair<TItem, BitNavItemTemplateRenderMode?>",
+                   DefaultValue = "new(nameof(BitNavItem.TemplateRenderMode))",
+                   Description = "The TemplateRenderMode field name and selector of the custom input class.",
+                   Href = "#nav-itemtemplate-rendermode",
+                   LinkType = LinkType.Link,
+               },
+               new()
+               {
+                   Name = "Text",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Text))",
+                   Description = "The Text field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Title",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Title))",
+                   Description = "The Title field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "Url",
+                   Type = "BitNameSelectorPair<TItem, string?>",
+                   DefaultValue = "new(nameof(BitNavItem.Url))",
+                   Description = "The Url field name and selector of the custom input class."
+               },
+               new()
+               {
+                   Name = "AdditionalUrls",
+                   Type = "BitNameSelectorPair<TItem, IEnumerable<string>?>",
+                   DefaultValue = "new(nameof(BitNavItem.AdditionalUrls))",
+                   Description = "The AdditionalUrls field name and selector of the custom input class."
+               },
+            ]
+        },
+        new()
+        {
+            Id = "nav-class-styles",
+            Title = "BitNavClassStyles",
+            Parameters =
+            [
+               new()
+               {
+                   Name = "Root",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the root element of the BitNav."
+               },
+               new()
+               {
+                   Name = "Description",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the description of the BitNav."
+               },
+               new()
+               {
+                   Name = "Header",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the group header button of the BitNav in the Grouped render type."
+               },
+               new()
+               {
+                   Name = "HeaderText",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the text of the group header of the BitNav in the Grouped render type."
+               },
+               new()
+               {
+                   Name = "Item",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the item of the BitNav."
+               },
+               new()
+               {
+                   Name = "SelectedItem",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the selected item of the BitNav."
+               },
+               new()
+               {
+                   Name = "ItemContainer",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the item container of the BitNav."
+               },
+               new()
+               {
+                   Name = "ItemIcon",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the item icon of the BitNav."
+               },
+               new()
+               {
+                   Name = "ItemText",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the item text of the BitNav."
+               },
+               new()
+               {
+                   Name = "SelectedItemContainer",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the selected item container of the BitNav."
+               },
+               new()
+               {
+                   Name = "ToggleButton",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the toggle button of the BitNav."
+               },
+               new()
+               {
+                   Name = "ToggleIcon",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the chevron icon inside the toggle button of the BitNav."
+               },
+               new()
+               {
+                   Name = "Separator",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Custom CSS classes/styles for the separator of the BitNav."
+               },
+            ]
+        },
+        new()
+        {
+            Id = "bit-icon-info",
+            Title = "BitIconInfo",
+            Parameters =
+            [
+               new()
+               {
+                   Name = "Name",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the name of the icon."
+               },
+               new()
+               {
+                   Name = "BaseClass",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the base CSS class for the icon. For built-in Fluent UI icons, this defaults to \"bit-icon\". For external icon libraries like FontAwesome, you might set this to \"fa\" or leave empty."
+               },
+               new()
+               {
+                   Name = "Prefix",
+                   Type = "string?",
+                   DefaultValue = "null",
+                   Description = "Gets or sets the CSS class prefix used before the icon name. For built-in Fluent UI icons, this defaults to \"bit-icon--\". For external icon libraries, you might set this to \"fa-\" or leave empty."
+               },
+            ]
         }
     ];
 
@@ -423,9 +1086,75 @@ public partial class BitNavPanelDemo
     [
         new()
         {
+            Name = "ClearSearch",
+            Type = "Task",
+            Description = "Clears the search text of the nav panel, so the whole list of items is shown again.",
+        },
+        new()
+        {
+            Name = "Close",
+            Type = "Task",
+            Description = "Closes the nav panel.",
+        },
+        new()
+        {
+            Name = "CollapseAll",
+            Type = "void",
+            Description = "Collapses all items of the nav.",
+        },
+        new()
+        {
+            Name = "CollapseItem",
+            Type = "Task",
+            Description = "Collapses an item of the nav, and does nothing when it is already collapsed.",
+        },
+        new()
+        {
+            Name = "ExpandAll",
+            Type = "void",
+            Description = "Expands all items of the nav in non-SingleExpand mode.",
+        },
+        new()
+        {
+            Name = "ExpandItem",
+            Type = "Task",
+            Description = "Expands an item of the nav, and does nothing when it is already expanded.",
+        },
+        new()
+        {
+            Name = "FocusItem",
+            Type = "ValueTask",
+            Description = "Moves the focus to an item of the nav, opening the branches it is nested in when it is not rendered yet.",
+        },
+        new()
+        {
+            Name = "FocusSearchBox",
+            Type = "Task",
+            Description = "Moves the focus to the search box of the nav panel, opening the panel out of its toggled state first when the search box is not on screen.",
+        },
+        new()
+        {
+            Name = "Open",
+            Type = "Task",
+            Description = "Opens the nav panel.",
+        },
+        new()
+        {
+            Name = "SelectItem",
+            Type = "Task",
+            Description = "Selects an item of the nav programmatically, exactly like a click on that item would in the manual mode.",
+        },
+        new()
+        {
             Name = "Toggle",
             Type = "Task",
             Description = "Toggles the nav panel if possible.",
+        },
+        new()
+        {
+            Name = "ToggleItem",
+            Type = "Task",
+            Description = "Toggles an item of the nav.",
         }
     ];
 
@@ -636,6 +1365,33 @@ public partial class BitNavPanelDemo
                 }
             ]
         },
+        new()
+        {
+            Id = "size-enum",
+            Name = "BitSize",
+            Description = "Defines the sizes available for a component.",
+            Items =
+            [
+                new()
+                {
+                    Name = "Small",
+                    Description = "The small size.",
+                    Value = "0",
+                },
+                new()
+                {
+                    Name = "Medium",
+                    Description = "The medium size.",
+                    Value = "1",
+                },
+                new()
+                {
+                    Name = "Large",
+                    Description = "The large size.",
+                    Value = "2",
+                }
+            ]
+        },
     ];
 
 
@@ -643,20 +1399,33 @@ public partial class BitNavPanelDemo
     private bool basicIsOpen;
     private bool fitWidthIsOpen;
     private bool fullWidthIsOpen;
+    private bool widthIsOpen;
+    private bool expandOnHoverIsOpen;
     private bool noToggleIsOpen;
     private bool iconUrlIsOpen;
     private bool searchBoxPlaceholderIsOpen;
     private bool noSearchBoxIsOpen;
+    private bool searchIsOpen;
     private bool emptyListMessageIsOpen;
+    private bool selectionIsOpen;
     private bool singleExpandIsOpen;
+    private bool customIsOpen;
+    private bool behaviorIsOpen;
     private bool templateIsOpen;
     private bool eventIsOpen;
     private bool colorIsOpen;
+    private bool externalIconIsOpen;
+    private bool sizeIsOpen;
     private bool classStyleIsOpen;
     private bool rtlIsOpen;
 
     private bool publicApiIsOpen;
     private BitNavPanel<BitNavItem> navPanelRef = default!;
+
+    private string? searchText;
+    private string? lastSearchedTerm;
+
+    private BitNavItem? selectedItem;
 
     private BitNavItem? onItemClick;
     private BitNavItem? onItemToggle;
@@ -872,6 +1641,76 @@ public partial class BitNavPanelDemo
             Url = "TermsPage",
         }
     ];
+
+    // Only the members whose names differ from the ones of BitNavItem are mapped here; the rest (Url, for
+    // instance) keep matching by convention.
+    private static readonly BitNavNameSelectors<CustomNavItem> customSelectors = new()
+    {
+        Text = { Name = nameof(CustomNavItem.Name) },
+        IconName = { Name = nameof(CustomNavItem.Glyph) },
+        ChildItems = { Name = nameof(CustomNavItem.Children) },
+    };
+
+    private readonly List<CustomNavItem> customNavItems =
+    [
+        new()
+        {
+            Name = "Home",
+            Glyph = BitIconName.Home,
+            Url = "HomePage",
+        },
+        new()
+        {
+            Name = "AdminPanel",
+            Glyph = BitIconName.Admin,
+            Children =
+            [
+                new() { Name = "Dashboard", Glyph = BitIconName.BarChartVerticalFill, Url = "DashboardPage" },
+                new() { Name = "Categories", Glyph = BitIconName.BuildQueue, Url = "CategoriesPage" },
+                new() { Name = "Products", Glyph = BitIconName.Product, Url = "ProductsPage" }
+            ]
+        },
+        new()
+        {
+            Name = "Settings",
+            Glyph = BitIconName.Equalizer,
+            Url = "SettingsPage",
+        }
+    ];
+
+    private readonly List<BitNavItem> externalIconNavItems =
+    [
+        new()
+        {
+            Text = "Home",
+            Icon = BitIconInfo.Fa("solid house"),
+            Url = "HomePage",
+        },
+        new()
+        {
+            Text = "AdminPanel",
+            Icon = BitIconInfo.Fa("solid user-shield"),
+            ChildItems =
+            [
+                new() { Text = "Dashboard", Icon = BitIconInfo.Fa("solid chart-simple"), Url = "DashboardPage" },
+                new() { Text = "Products", Icon = BitIconInfo.Fa("solid box"), Url = "ProductsPage" }
+            ]
+        },
+        new()
+        {
+            Text = "Settings",
+            Icon = BitIconInfo.Fa("solid gear"),
+            Url = "SettingsPage",
+        }
+    ];
+
+    public class CustomNavItem
+    {
+        public string? Name { get; set; }
+        public string? Glyph { get; set; }
+        public string? Url { get; set; }
+        public List<CustomNavItem>? Children { get; set; }
+    }
 
     private void HandleOnItemClick(BitNavItem item)
     {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -61,6 +61,27 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "CloseAriaLabel",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The aria-label and the tooltip of the close button of the nav panel.",
+        },
+        new()
+        {
+            Name = "CloseIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "The icon of the close button of the nav panel. Takes precedence over CloseIconName when both are set.",
+        },
+        new()
+        {
+            Name = "CloseIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The name of the icon of the close button of the nav panel.",
+        },
+        new()
+        {
             Name = "Color",
             Type = "BitColor?",
             DefaultValue = "null",
@@ -153,6 +174,13 @@ public partial class BitNavPanelDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Removes the toggle button.",
+        },
+        new()
+        {
+            Name = "IconAriaLabel",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The accessible name of the logo in the header of the nav panel: the name of the link an IconNavUrl wraps it in, and the alternative text of the image otherwise. Falls back to AriaLabel and then to a built-in name.",
         },
         new()
         {
@@ -289,10 +317,17 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "NoFocusTrap",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Stops the open drawer of a small screen from holding the focus inside itself. The focus is only ever held while the panel covers the page, which is the state its overlay is rendered in.",
+        },
+        new()
+        {
             Name = "NoOverlay",
             Type = "bool",
             DefaultValue = "false",
-            Description = "Removes the overlay that is rendered behind the open nav panel in small screens.",
+            Description = "Removes the overlay that is rendered behind the open nav panel in small screens. Without it the drawer no longer covers the page: it stops holding the focus and the page behind it keeps scrolling.",
         },
         new()
         {
@@ -300,6 +335,20 @@ public partial class BitNavPanelDemo
             Type = "bool",
             DefaultValue = "false",
             Description = "Disables the padded mode of the nav panel.",
+        },
+        new()
+        {
+            Name = "NoRestoreFocus",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Stops the closing drawer of a small screen from handing the focus back to the element that had it when the drawer opened. Only ever read by a panel that took the focus in the first place (see AutoFocus).",
+        },
+        new()
+        {
+            Name = "NoScrollLock",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Lets the page behind the open drawer of a small screen keep scrolling. The page is only ever held while the panel covers it, which is the state its overlay is rendered in.",
         },
         new()
         {
@@ -346,6 +395,15 @@ public partial class BitNavPanelDemo
             Name = "OnSelectItem",
             Type = "EventCallback<TItem>",
             Description = "Callback invoked when an item is selected."
+        },
+        new()
+        {
+            Name = "Position",
+            Type = "BitNavPanelPosition",
+            DefaultValue = "BitNavPanelPosition.Start",
+            Description = "The edge the off-canvas drawer of a small screen comes from, and the side it is docked to while it is open. It has no effect on a wide screen, where the panel is a column in the normal flow of the page.",
+            LinkType = LinkType.Link,
+            Href = "#nav-panel-position-enum",
         },
         new()
         {
@@ -414,6 +472,20 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "SearchIcon",
+            Type = "BitIconInfo?",
+            DefaultValue = "null",
+            Description = "The icon of the button that the collapsed (rail) nav panel shows in place of its search box. Takes precedence over SearchIconName when both are set.",
+        },
+        new()
+        {
+            Name = "SearchIconName",
+            Type = "string?",
+            DefaultValue = "null",
+            Description = "The name of the icon of the button that the collapsed (rail) nav panel shows in place of its search box.",
+        },
+        new()
+        {
             Name = "SearchText",
             Type = "string?",
             DefaultValue = "null",
@@ -435,12 +507,26 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "ShowCloseButton",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Renders a close button in the header of the nav panel, on the screens the panel is an off-canvas drawer on. It is the control the toggle button is not: the toggle collapses a permanent panel into a rail, which a drawer that is either open or gone has no state for.",
+        },
+        new()
+        {
             Name = "Size",
             Type = "BitSize?",
             DefaultValue = "null",
             Description = "The size of the nav items.",
             Href = "#size-enum",
             LinkType = LinkType.Link,
+        },
+        new()
+        {
+            Name = "StickyEnds",
+            Type = "bool",
+            DefaultValue = "false",
+            Description = "Pins the two ends of the nav panel - the header with its search box, and the footer - in place and scrolls only the items between them, instead of scrolling the whole panel as one.",
         },
         new()
         {
@@ -553,6 +639,13 @@ public partial class BitNavPanelDemo
                     Type = "string?",
                     DefaultValue = "null",
                     Description = "Custom CSS classes/styles for the toggle button of the BitNavPanel.",
+                },
+                new()
+                {
+                    Name = "CloseButton",
+                    Type = "string?",
+                    DefaultValue = "null",
+                    Description = "Custom CSS classes/styles for the close button of the BitNavPanel.",
                 },
                 new()
                 {
@@ -1134,6 +1227,12 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Name = "IsItemExpanded",
+            Type = "bool",
+            Description = "Whether an item of the nav is currently expanded.",
+        },
+        new()
+        {
             Name = "Open",
             Type = "Task",
             Description = "Opens the nav panel.",
@@ -1326,6 +1425,27 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Id = "nav-panel-position-enum",
+            Name = "BitNavPanelPosition",
+            Description = "The edge of the viewport the off-canvas drawer of a BitNavPanel comes from.",
+            Items =
+            [
+                new()
+                {
+                    Name = "Start",
+                    Description = "The drawer comes from the starting edge of the text direction: the left in a left-to-right layout, the right in a right-to-left one.",
+                    Value = "0",
+                },
+                new()
+                {
+                    Name = "End",
+                    Description = "The drawer comes from the ending edge of the text direction: the right in a left-to-right layout, the left in a right-to-left one.",
+                    Value = "1",
+                }
+            ]
+        },
+        new()
+        {
             Id = "nav-render-type-enum",
             Name = "BitNavRenderType",
             Description="Determines how the nav items are rendered visually.",
@@ -1418,6 +1538,9 @@ public partial class BitNavPanelDemo
     private bool sizeIsOpen;
     private bool classStyleIsOpen;
     private bool rtlIsOpen;
+    private bool groupedIsOpen;
+    private bool drawerIsOpen;
+    private bool stickyIsOpen;
 
     private bool publicApiIsOpen;
     private BitNavPanel<BitNavItem> navPanelRef = default!;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -25,7 +25,7 @@ public partial class BitNavPanelDemo
             Name = "AutoFocus",
             Type = "bool",
             DefaultValue = "false",
-            Description = "Moves the focus into the nav panel as it opens - onto the search box, or onto the first item of a panel without one.",
+            Description = "Moves the focus into the drawer of a small screen as it opens - onto the search box, or onto the first item of a panel without one. The column of a wide screen was on screen all along and takes nothing.",
         },
         new()
         {

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.cs
@@ -1372,6 +1372,44 @@ public partial class BitNavPanelDemo
         },
         new()
         {
+            Id = "nav-aria-current-enum",
+            Name = "BitNavAriaCurrent",
+            Items =
+            [
+                new()
+                {
+                    Name = "Page",
+                    Value = "0",
+                },
+                new()
+                {
+                    Name = "Step",
+                    Value = "1",
+                },
+                new()
+                {
+                    Name = "Location",
+                    Value = "2",
+                },
+                new()
+                {
+                    Name = "Date",
+                    Value = "3",
+                },
+                new()
+                {
+                    Name = "Time",
+                    Value = "4",
+                },
+                new()
+                {
+                    Name = "True",
+                    Value = "5",
+                }
+            ]
+        },
+        new()
+        {
             Id = "nav-match-enum",
             Name = "BitNavMatch",
             Description = "Modifies the URL matching behavior for a BitNav<TItem>.",

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.samples.cs
@@ -1,4 +1,3 @@
-﻿
 namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.NavPanel;
 
 public partial class BitNavPanelDemo
@@ -19,6 +18,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -30,6 +30,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -53,7 +54,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -77,6 +79,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -88,6 +91,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -111,7 +115,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -135,6 +140,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -146,6 +152,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -169,7 +176,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -180,13 +188,11 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example4RazorCode = @"
-<BitToggleButton @bind-IsChecked=""noToggleIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""widthIsOpen"" OnText=""Close"" OffText=""Open"" />
 
-<div style=""width:222px"">
-    <BitNavPanel @bind-IsOpen=""noToggleIsOpen"" Items=""basicNavItems"" NoToggle />
-</div>";
+<BitNavPanel @bind-IsOpen=""widthIsOpen"" Items=""basicNavItems"" Width=""260"" ToggledWidth=""72"" />";
     private readonly string example4CsharpCode = @"
-private bool noToggleIsOpen;
+private bool widthIsOpen;
 
 private List<BitNavItem> basicNavItems =
 [
@@ -195,6 +201,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -206,6 +213,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -229,7 +237,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -240,13 +249,13 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example5RazorCode = @"
-<BitToggleButton @bind-IsChecked=""iconUrlIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""expandOnHoverIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div style=""width:222px"">
-    <BitNavPanel @bind-IsOpen=""iconUrlIsOpen"" Items=""basicNavItems"" IconNavUrl=""https://bitplatform.dev"" IconUrl=""/images/icon.png"" />
+    <BitNavPanel @bind-IsOpen=""expandOnHoverIsOpen"" Items=""basicNavItems"" ExpandOnHover />
 </div>";
     private readonly string example5CsharpCode = @"
-private bool iconUrlIsOpen;
+private bool expandOnHoverIsOpen;
 
 private List<BitNavItem> basicNavItems =
 [
@@ -255,6 +264,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -266,6 +276,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -289,7 +300,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -300,13 +312,13 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example6RazorCode = @"
-<BitToggleButton @bind-IsChecked=""searchBoxPlaceholderIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""noToggleIsOpen"" OnText=""Close"" OffText=""Open"" />
 
-<div style=""width:240px"">
-    <BitNavPanel @bind-IsOpen=""searchBoxPlaceholderIsOpen"" Items=""basicNavItems"" SearchBoxPlaceholder=""Search in menu items..."" />
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""noToggleIsOpen"" Items=""basicNavItems"" NoToggle />
 </div>";
     private readonly string example6CsharpCode = @"
-private bool searchBoxPlaceholderIsOpen;
+private bool noToggleIsOpen;
 
 private List<BitNavItem> basicNavItems =
 [
@@ -315,6 +327,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -326,6 +339,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -349,7 +363,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -360,13 +375,16 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example7RazorCode = @"
-<BitToggleButton @bind-IsChecked=""noSearchBoxIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""iconUrlIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div style=""width:222px"">
-    <BitNavPanel @bind-IsOpen=""noSearchBoxIsOpen"" Items=""basicNavItems"" NoSearchBox />
+    <BitNavPanel @bind-IsOpen=""iconUrlIsOpen""
+                 Items=""basicNavItems""
+                 IconUrl=""/images/icon.png""
+                 IconNavUrl=""https://bitplatform.dev"" />
 </div>";
     private readonly string example7CsharpCode = @"
-private bool noSearchBoxIsOpen;
+private bool iconUrlIsOpen;
 
 private List<BitNavItem> basicNavItems =
 [
@@ -375,6 +393,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -386,6 +405,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -409,7 +429,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -420,13 +441,13 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example8RazorCode = @"
-<BitToggleButton @bind-IsChecked=""emptyListMessageIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""searchBoxPlaceholderIsOpen"" OnText=""Close"" OffText=""Open"" />
 
-<div style=""width:222px"">
-    <BitNavPanel @bind-IsOpen=""emptyListMessageIsOpen"" Items=""basicNavItems"" EmptyListMessage=""There is no item found."" />
+<div style=""width:240px"">
+    <BitNavPanel @bind-IsOpen=""searchBoxPlaceholderIsOpen"" Items=""basicNavItems"" SearchBoxPlaceholder=""Search in menu items..."" />
 </div>";
     private readonly string example8CsharpCode = @"
-private bool emptyListMessageIsOpen;
+private bool searchBoxPlaceholderIsOpen;
 
 private List<BitNavItem> basicNavItems =
 [
@@ -435,6 +456,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -446,6 +468,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -469,7 +492,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -480,28 +504,15 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example9RazorCode = @"
-<BitToggleButton @bind-IsChecked=""templateIsOpen"" OnText=""Close"" OffText=""Open"" />
+<BitToggleButton @bind-IsChecked=""noSearchBoxIsOpen"" OnText=""Close"" OffText=""Open"" />
 
-<BitNavPanel @bind-IsOpen=""templateIsOpen"" Items=""basicNavItems"" FitWidth NoToggle>
-    <Header>
-        <BitText Typography=""BitTypography.H5""><b>NavPanel</b> header</BitText>
-    </Header>
-    <ItemTemplate Context=""item"">
-        <BitText><i><b>@item.Text</b></i></BitText>
-        <BitSpacer />
-        @if (item.Data is not null)
-        {
-            <BitTag Size=""BitSize.Small"" Color=""BitColor.Info"">@item.Data</BitTag>
-        }
-    </ItemTemplate>
-    <Footer>
-        <BitActionButton IconName=""@BitIconName.PowerButton"">Logout</BitActionButton>
-    </Footer>
-</BitNavPanel>";
+<div style=""width:240px"">
+    <BitNavPanel @bind-IsOpen=""noSearchBoxIsOpen"" Items=""basicNavItems"" NoSearchBox />
+</div>";
     private readonly string example9CsharpCode = @"
-private bool templateIsOpen;
+private bool noSearchBoxIsOpen;
 
-private List<BitNavItem> templateNavItems =
+private List<BitNavItem> basicNavItems =
 [
     new()
     {
@@ -556,6 +567,455 @@ private List<BitNavItem> templateNavItems =
 ];";
 
     private readonly string example10RazorCode = @"
+<BitToggleButton @bind-IsChecked=""searchIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<BitTextField Label=""Search text"" @bind-Value=""searchText"" Immediate />
+<div>Last searched term: <b>@lastSearchedTerm</b></div>
+
+<div style=""width:240px"">
+    <BitNavPanel @bind-IsOpen=""searchIsOpen""
+                 Items=""basicNavItems""
+                 @bind-SearchText=""searchText""
+                 SearchDebounceTime=""200""
+                 OnSearch=""v => lastSearchedTerm = v""
+                 SearchFilter=""(item, term) => item.Text.StartsWith(term, StringComparison.OrdinalIgnoreCase)"" />
+</div>";
+    private readonly string example10CsharpCode = @"
+private bool searchIsOpen;
+private string? searchText;
+private string? lastSearchedTerm;
+
+private List<BitNavItem> basicNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() {
+                Text = ""Dashboard"",
+                IconName = BitIconName.BarChartVerticalFill,
+                Url = ""DashboardPage"",
+                Data = 63,
+            },
+            new() {
+                Text = ""Categories"",
+                IconName = BitIconName.BuildQueue,
+                Url = ""CategoriesPage"",
+            },
+            new() {
+                Text = ""Products"",
+                IconName = BitIconName.Product,
+                Url = ""ProductsPage"",
+            }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+        Data = 85,
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example11RazorCode = @"
+<BitToggleButton @bind-IsChecked=""emptyListMessageIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""emptyListMessageIsOpen"" Items=""basicNavItems"" EmptyListMessage=""There is no item found."" />
+</div>";
+    private readonly string example11CsharpCode = @"
+private bool emptyListMessageIsOpen;
+
+private List<BitNavItem> basicNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() {
+                Text = ""Dashboard"",
+                IconName = BitIconName.BarChartVerticalFill,
+                Url = ""DashboardPage"",
+                Data = 63,
+            },
+            new() {
+                Text = ""Categories"",
+                IconName = BitIconName.BuildQueue,
+                Url = ""CategoriesPage"",
+            },
+            new() {
+                Text = ""Products"",
+                IconName = BitIconName.Product,
+                Url = ""ProductsPage"",
+            }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+        Data = 85,
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example12RazorCode = @"
+<BitToggleButton @bind-IsChecked=""selectionIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div>Selected item: <b>@selectedItem?.Text</b></div>
+<BitButton OnClick=""() => selectedItem = basicNavItems[3]"">Select Settings</BitButton>
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""selectionIsOpen""
+                 Items=""basicNavItems""
+                 NavMode=""BitNavMode.Manual""
+                 @bind-SelectedItem=""selectedItem""
+                 DefaultSelectedItem=""basicNavItems[0]"" />
+</div>";
+    private readonly string example12CsharpCode = @"
+private bool selectionIsOpen;
+private BitNavItem? selectedItem;
+
+private List<BitNavItem> basicNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() {
+                Text = ""Dashboard"",
+                IconName = BitIconName.BarChartVerticalFill,
+                Url = ""DashboardPage"",
+                Data = 63,
+            },
+            new() {
+                Text = ""Categories"",
+                IconName = BitIconName.BuildQueue,
+                Url = ""CategoriesPage"",
+            },
+            new() {
+                Text = ""Products"",
+                IconName = BitIconName.Product,
+                Url = ""ProductsPage"",
+            }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+        Data = 85,
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example13RazorCode = @"
+<BitToggleButton @bind-IsChecked=""singleExpandIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""singleExpandIsOpen"" Items=""singleExpandNavItems"" SingleExpand />
+</div>";
+    private readonly string example13CsharpCode = @"
+private bool singleExpandIsOpen;
+
+private List<BitNavItem> singleExpandNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() { Text = ""Dashboard"", IconName = BitIconName.BarChartVerticalFill, Url = ""DashboardPage"" },
+            new() { Text = ""Categories"", IconName = BitIconName.BuildQueue, Url = ""CategoriesPage"" },
+            new() { Text = ""Products"", IconName = BitIconName.Product, Url = ""ProductsPage"" }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        ChildItems =
+        [
+            new() { Text = ""Views"", IconName = BitIconName.BarChartVerticalFill, Url = ""ViewsPage"" },
+            new() { Text = ""Users"", IconName = BitIconName.BuildQueue, Url = ""UsersPage"" }
+        ]
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example14RazorCode = @"
+<BitToggleButton @bind-IsChecked=""customIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""customIsOpen"" Items=""customNavItems"" NameSelectors=""customSelectors"" />
+</div>";
+    private readonly string example14CsharpCode = @"
+private bool customIsOpen;
+
+private static readonly BitNavNameSelectors<CustomNavItem> customSelectors = new()
+{
+    Text = { Name = nameof(CustomNavItem.Name) },
+    IconName = { Name = nameof(CustomNavItem.Glyph) },
+    ChildItems = { Name = nameof(CustomNavItem.Children) },
+};
+
+public class CustomNavItem
+{
+    public string? Name { get; set; }
+    public string? Glyph { get; set; }
+    public string? Url { get; set; }
+    public List<CustomNavItem>? Children { get; set; }
+}
+
+private readonly List<CustomNavItem> customNavItems =
+[
+    new()
+    {
+        Name = ""Home"",
+        Glyph = BitIconName.Home,
+        Url = ""HomePage"",
+    },
+    new()
+    {
+        Name = ""AdminPanel"",
+        Glyph = BitIconName.Admin,
+        Children =
+        [
+            new() { Name = ""Dashboard"", Glyph = BitIconName.BarChartVerticalFill, Url = ""DashboardPage"" },
+            new() { Name = ""Categories"", Glyph = BitIconName.BuildQueue, Url = ""CategoriesPage"" },
+            new() { Name = ""Products"", Glyph = BitIconName.Product, Url = ""ProductsPage"" }
+        ]
+    },
+    new()
+    {
+        Name = ""Settings"",
+        Glyph = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+    }
+];";
+
+    private readonly string example15RazorCode = @"
+<BitToggleButton @bind-IsChecked=""behaviorIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""behaviorIsOpen"" Items=""basicNavItems"" AutoFocus NoAutoClose NoOverlay NoSwipe />
+</div>";
+    private readonly string example15CsharpCode = @"
+private bool behaviorIsOpen;
+
+private List<BitNavItem> basicNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() {
+                Text = ""Dashboard"",
+                IconName = BitIconName.BarChartVerticalFill,
+                Url = ""DashboardPage"",
+                Data = 63,
+            },
+            new() {
+                Text = ""Categories"",
+                IconName = BitIconName.BuildQueue,
+                Url = ""CategoriesPage"",
+            },
+            new() {
+                Text = ""Products"",
+                IconName = BitIconName.Product,
+                Url = ""ProductsPage"",
+            }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+        Data = 85,
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example16RazorCode = @"
+<BitToggleButton @bind-IsChecked=""templateIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<BitNavPanel @bind-IsOpen=""templateIsOpen"" Items=""basicNavItems"" FitWidth NoToggle>
+    <Header>
+        <BitText Typography=""BitTypography.H5""><b>NavPanel</b> header</BitText>
+    </Header>
+    <ItemTemplate Context=""item"">
+        <BitText><i><b>@item.Text</b></i></BitText>
+        <BitSpacer />
+        @if (item.Data is not null)
+        {
+            <BitTag Size=""BitSize.Small"" Color=""BitColor.Info"">@item.Data</BitTag>
+        }
+    </ItemTemplate>
+    <Footer>
+        <BitActionButton IconName=""@BitIconName.PowerButton"">Logout</BitActionButton>
+    </Footer>
+</BitNavPanel>";
+    private readonly string example16CsharpCode = @"
+private bool templateIsOpen;
+
+private List<BitNavItem> basicNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() {
+                Text = ""Dashboard"",
+                IconName = BitIconName.BarChartVerticalFill,
+                Url = ""DashboardPage"",
+                Data = 63,
+            },
+            new() {
+                Text = ""Categories"",
+                IconName = BitIconName.BuildQueue,
+                Url = ""CategoriesPage"",
+            },
+            new() {
+                Text = ""Products"",
+                IconName = BitIconName.Product,
+                Url = ""ProductsPage"",
+            }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+        Data = 85,
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example17RazorCode = @"
 <BitToggleButton @bind-IsChecked=""eventIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div>
@@ -566,11 +1026,11 @@ private List<BitNavItem> templateNavItems =
 
 <div style=""width:222px"">
     <BitNavPanel @bind-IsOpen=""eventIsOpen""
-                    Items=""eventNavItems""
-                    OnItemClick=""(BitNavItem item) => HandleOnItemClick(item)""
-                    OnItemToggle=""(BitNavItem item) => HandleOnItemToggle(item)"" />
+                 Items=""eventNavItems""
+                 OnItemClick=""(BitNavItem item) => HandleOnItemClick(item)""
+                 OnItemToggle=""(BitNavItem item) => HandleOnItemToggle(item)"" />
 </div>";
-    private readonly string example10CsharpCode = @"
+    private readonly string example17CsharpCode = @"
 private bool eventIsOpen;
 private BitNavItem? onItemClick;
 private BitNavItem? onItemToggle;
@@ -598,18 +1058,9 @@ private List<BitNavItem> eventNavItems =
         IconName = BitIconName.Admin,
         ChildItems =
         [
-            new() {
-                Text = ""Dashboard"",
-                IconName = BitIconName.BarChartVerticalFill,
-            },
-            new() {
-                Text = ""Categories"",
-                IconName = BitIconName.BuildQueue,
-            },
-            new() {
-                Text = ""Products"",
-                IconName = BitIconName.Product,
-            }
+            new() { Text = ""Dashboard"", IconName = BitIconName.BarChartVerticalFill },
+            new() { Text = ""Categories"", IconName = BitIconName.BuildQueue },
+            new() { Text = ""Products"", IconName = BitIconName.Product }
         ]
     },
     new()
@@ -629,14 +1080,19 @@ private List<BitNavItem> eventNavItems =
     }
 ];";
 
-    private readonly string example11RazorCode = @"
+    private readonly string example18RazorCode = @"
 <BitToggleButton @bind-IsChecked=""publicApiIsOpen"" OnText=""Close"" OffText=""Open"" />
 
-<BitButton OnClick=""async () => await navPanelRef.Toggle()"">Toggle</BitButton>
+<BitButton OnClick=""() => navPanelRef.Toggle()"">Toggle</BitButton>
+<BitButton OnClick=""() => navPanelRef.ExpandAll()"">Expand all</BitButton>
+<BitButton OnClick=""() => navPanelRef.CollapseAll()"">Collapse all</BitButton>
+<BitButton OnClick=""() => navPanelRef.FocusSearchBox()"">Focus search</BitButton>
+<BitButton OnClick=""() => navPanelRef.ClearSearch()"">Clear search</BitButton>
+
 <div style=""width:222px"">
     <BitNavPanel @bind-IsOpen=""publicApiIsOpen"" @ref=""navPanelRef"" Items=""basicNavItems"" HideToggle />
 </div>";
-    private readonly string example11CsharpCode = @"
+    private readonly string example18CsharpCode = @"
 private bool publicApiIsOpen;
 private BitNavPanel<BitNavItem> navPanelRef = default!;
 
@@ -647,6 +1103,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -658,6 +1115,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -681,7 +1139,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -691,22 +1150,23 @@ private List<BitNavItem> basicNavItems =
     }
 ];";
 
-    private readonly string example12RazorCode = @"
+    private readonly string example19RazorCode = @"
 <BitToggleButton @bind-IsChecked=""colorIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div style=""width:222px"">
-    <BitNavPanel @bind-IsOpen=""colorIsOpen"" Items=""colorNavItems"" Color=""BitColor.Secondary"" Accent=""BitColor.SecondaryBackground"" />
+    <BitNavPanel @bind-IsOpen=""colorIsOpen"" Items=""basicNavItems"" Color=""BitColor.Secondary"" Accent=""BitColor.SecondaryBackground"" />
 </div>";
-    private readonly string example12CsharpCode = @"
+    private readonly string example19CsharpCode = @"
 private bool colorIsOpen;
 
-private List<BitNavItem> colorNavItems =
+private List<BitNavItem> basicNavItems =
 [
     new()
     {
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -718,6 +1178,7 @@ private List<BitNavItem> colorNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -741,7 +1202,8 @@ private List<BitNavItem> colorNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -751,7 +1213,119 @@ private List<BitNavItem> colorNavItems =
     }
 ];";
 
-    private readonly string example13RazorCode = @"
+    private readonly string example20RazorCode = @"
+<link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
+
+<BitToggleButton @bind-IsChecked=""externalIconIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""externalIconIsOpen""
+                 Items=""externalIconNavItems""
+                 ToggleIcon=""@BitIconInfo.Fa(""solid bars"")""
+                 ChevronDownIcon=""@BitIconInfo.Fa(""solid chevron-down"")"" />
+</div>";
+    private readonly string example20CsharpCode = @"
+private bool externalIconIsOpen;
+
+private readonly List<BitNavItem> externalIconNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        Icon = BitIconInfo.Fa(""solid house""),
+        Url = ""HomePage"",
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        Icon = BitIconInfo.Fa(""solid user-shield""),
+        ChildItems =
+        [
+            new() { Text = ""Dashboard"", Icon = BitIconInfo.Fa(""solid chart-simple""), Url = ""DashboardPage"" },
+            new() { Text = ""Products"", Icon = BitIconInfo.Fa(""solid box""), Url = ""ProductsPage"" }
+        ]
+    },
+    new()
+    {
+        Text = ""Settings"",
+        Icon = BitIconInfo.Fa(""solid gear""),
+        Url = ""SettingsPage"",
+    }
+];";
+
+    private readonly string example21RazorCode = @"
+<BitToggleButton @bind-IsChecked=""sizeIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:180px"">
+    <div>Small</div>
+    <BitNavPanel @bind-IsOpen=""sizeIsOpen"" Items=""basicNavItems"" Size=""BitSize.Small"" NoSearchBox NoToggle />
+</div>
+<div style=""width:180px"">
+    <div>Medium</div>
+    <BitNavPanel @bind-IsOpen=""sizeIsOpen"" Items=""basicNavItems"" Size=""BitSize.Medium"" NoSearchBox NoToggle />
+</div>
+<div style=""width:180px"">
+    <div>Large</div>
+    <BitNavPanel @bind-IsOpen=""sizeIsOpen"" Items=""basicNavItems"" Size=""BitSize.Large"" NoSearchBox NoToggle />
+</div>";
+    private readonly string example21CsharpCode = @"
+private bool sizeIsOpen;
+
+private List<BitNavItem> basicNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() {
+                Text = ""Dashboard"",
+                IconName = BitIconName.BarChartVerticalFill,
+                Url = ""DashboardPage"",
+                Data = 63,
+            },
+            new() {
+                Text = ""Categories"",
+                IconName = BitIconName.BuildQueue,
+                Url = ""CategoriesPage"",
+            },
+            new() {
+                Text = ""Products"",
+                IconName = BitIconName.Product,
+                Url = ""ProductsPage"",
+            }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        Url = ""SettingsPage"",
+        Data = 85,
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example22RazorCode = @"
 <style>
 
 @media(hover: hover) {
@@ -803,16 +1377,16 @@ private List<BitNavItem> colorNavItems =
 
 <div style=""width:222px"">
     <BitNavPanel @bind-IsOpen=""classStyleIsOpen""
-                Items=""basicNavItems""
-                Styles=""@(new() { Container = ""background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);"" })""
-                NavClasses=""@(new() { ItemContainer = ""custom-nav-item"", ItemIcon = ""custom-nav-item-ico"", ItemText = ""custom-nav-item-txt"" })""
-                SearchBoxClasses=""@(new() { Icon = ""custom-icon-searchbox"",
-                                            Focused = ""custom-focused-searchbox"",
-                                            ClearButton = ""custom-clear-searchbox"",
-                                            IconWrapper = ""custom-icon-wrapper-searchbox"",
-                                            InputContainer = ""custom-input-container-searchbox"" })"" />
+                 Items=""basicNavItems""
+                 Styles=""@(new() { Container = ""background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);"" })""
+                 NavClasses=""@(new() { ItemContainer = ""custom-nav-item"", ItemIcon = ""custom-nav-item-ico"", ItemText = ""custom-nav-item-txt"" })""
+                 SearchBoxClasses=""@(new() { Icon = ""custom-icon-searchbox"",
+                                             Focused = ""custom-focused-searchbox"",
+                                             ClearButton = ""custom-clear-searchbox"",
+                                             IconWrapper = ""custom-icon-wrapper-searchbox"",
+                                             InputContainer = ""custom-input-container-searchbox"" })"" />
 </div>";
-    private readonly string example13CsharpCode = @"
+    private readonly string example22CsharpCode = @"
 private bool classStyleIsOpen;
 
 private List<BitNavItem> basicNavItems =
@@ -822,6 +1396,7 @@ private List<BitNavItem> basicNavItems =
         Text = ""Home"",
         IconName = BitIconName.Home,
         Url = ""HomePage"",
+        Data = 13,
     },
     new()
     {
@@ -833,6 +1408,7 @@ private List<BitNavItem> basicNavItems =
                 Text = ""Dashboard"",
                 IconName = BitIconName.BarChartVerticalFill,
                 Url = ""DashboardPage"",
+                Data = 63,
             },
             new() {
                 Text = ""Categories"",
@@ -856,7 +1432,8 @@ private List<BitNavItem> basicNavItems =
     {
         Text = ""Settings"",
         IconName = BitIconName.Equalizer,
-        Url = ""SettingsPage""
+        Url = ""SettingsPage"",
+        Data = 85,
     },
     new()
     {
@@ -866,11 +1443,11 @@ private List<BitNavItem> basicNavItems =
     }
 ];";
 
-    private readonly string example14RazorCode = @"
+    private readonly string example23RazorCode = @"
 <BitToggleButton @bind-IsChecked=""rtlIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <BitNavPanel @bind-IsOpen=""rtlIsOpen"" Items=""rtlNavItems"" FitWidth Dir=""BitDir.Rtl"" />";
-    private readonly string example14CsharpCode = @"
+    private readonly string example23CsharpCode = @"
 private bool rtlIsOpen;
 
 private List<BitNavItem> rtlNavItems =
@@ -887,21 +1464,9 @@ private List<BitNavItem> rtlNavItems =
         IconName = BitIconName.Admin,
         ChildItems =
         [
-            new() {
-                Text = ""داشبورد"",
-                IconName = BitIconName.BarChartVerticalFill,
-                Url = ""DashboardPage"",
-            },
-            new() {
-                Text = ""دسته‌ها"",
-                IconName = BitIconName.BuildQueue,
-                Url = ""CategoriesPage"",
-            },
-            new() {
-                Text = ""کالاها"",
-                IconName = BitIconName.Product,
-                Url = ""ProductsPage"",
-            }
+            new() { Text = ""داشبورد"", IconName = BitIconName.BarChartVerticalFill, Url = ""DashboardPage"" },
+            new() { Text = ""دسته‌ها"", IconName = BitIconName.BuildQueue, Url = ""CategoriesPage"" },
+            new() { Text = ""کالاها"", IconName = BitIconName.Product, Url = ""ProductsPage"" }
         ]
     },
     new()

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.samples.cs
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.samples.cs
@@ -1,4 +1,4 @@
-namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.NavPanel;
+﻿namespace Bit.BlazorUI.Demo.Client.Core.Pages.Components.Extras.NavPanel;
 
 public partial class BitNavPanelDemo
 {
@@ -1151,12 +1151,146 @@ private List<BitNavItem> basicNavItems =
 ];";
 
     private readonly string example19RazorCode = @"
+<BitToggleButton @bind-IsChecked=""groupedIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:240px"">
+    <BitNavPanel @bind-IsOpen=""groupedIsOpen""
+                 Items=""singleExpandNavItems""
+                 RenderType=""BitNavRenderType.Grouped""
+                 IndentValue=""24""
+                 ReversedChevron
+                 NoPad />
+</div>";
+    private readonly string example19CsharpCode = @"
+private bool groupedIsOpen;
+
+private List<BitNavItem> singleExpandNavItems =
+[
+    new()
+    {
+        Text = ""Home"",
+        IconName = BitIconName.Home,
+        Url = ""HomePage"",
+        Data = 13,
+    },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() { Text = ""Dashboard"", IconName = BitIconName.BarChartVerticalFill, Url = ""DashboardPage"" },
+            new() { Text = ""Categories"", IconName = BitIconName.BuildQueue, Url = ""CategoriesPage"" },
+            new() { Text = ""Products"", IconName = BitIconName.Product, Url = ""ProductsPage"" }
+        ]
+    },
+    new()
+    {
+        Text = ""Todo"",
+        IconName = BitIconName.ToDoLogoOutline,
+        Url = ""TodoPage"",
+    },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        ChildItems =
+        [
+            new() { Text = ""Views"", IconName = BitIconName.BarChartVerticalFill, Url = ""ViewsPage"" },
+            new() { Text = ""Users"", IconName = BitIconName.BuildQueue, Url = ""UsersPage"" }
+        ]
+    },
+    new()
+    {
+        Text = ""Terms"",
+        IconName = BitIconName.EntityExtraction,
+        Url = ""TermsPage"",
+    }
+];";
+
+    private readonly string example20RazorCode = @"
+<BitToggleButton @bind-IsChecked=""drawerIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:222px"">
+    <BitNavPanel @bind-IsOpen=""drawerIsOpen""
+                 Items=""basicNavItems""
+                 AutoFocus
+                 ShowCloseButton
+                 Position=""BitNavPanelPosition.End"" />
+</div>";
+    private readonly string example20CsharpCode = @"
+private bool drawerIsOpen;
+
+private List<BitNavItem> basicNavItems =
+[
+    new() { Text = ""Home"", IconName = BitIconName.Home, Url = ""HomePage"", Data = 13 },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() { Text = ""Dashboard"", IconName = BitIconName.BarChartVerticalFill, Url = ""DashboardPage"" },
+            new() { Text = ""Categories"", IconName = BitIconName.BuildQueue, Url = ""CategoriesPage"" },
+            new() { Text = ""Products"", IconName = BitIconName.Product, Url = ""ProductsPage"" }
+        ]
+    },
+    new() { Text = ""Todo"", IconName = BitIconName.ToDoLogoOutline, Url = ""TodoPage"" },
+    new() { Text = ""Settings"", IconName = BitIconName.Equalizer, Url = ""SettingsPage"" }
+];";
+
+    private readonly string example21RazorCode = @"
+<BitToggleButton @bind-IsChecked=""stickyIsOpen"" OnText=""Close"" OffText=""Open"" />
+
+<div style=""width:240px"">
+    <BitNavPanel @bind-IsOpen=""stickyIsOpen""
+                 Items=""singleExpandNavItems""
+                 Style=""height:264px""
+                 AllExpanded
+                 StickyEnds>
+        <Footer>
+            <BitActionButton IconName=""@BitIconName.PowerButton"">Logout</BitActionButton>
+        </Footer>
+    </BitNavPanel>
+</div>";
+    private readonly string example21CsharpCode = @"
+private bool stickyIsOpen;
+
+private List<BitNavItem> singleExpandNavItems =
+[
+    new() { Text = ""Home"", IconName = BitIconName.Home, Url = ""HomePage"" },
+    new()
+    {
+        Text = ""AdminPanel"",
+        IconName = BitIconName.Admin,
+        ChildItems =
+        [
+            new() { Text = ""Dashboard"", IconName = BitIconName.BarChartVerticalFill, Url = ""DashboardPage"" },
+            new() { Text = ""Categories"", IconName = BitIconName.BuildQueue, Url = ""CategoriesPage"" },
+            new() { Text = ""Products"", IconName = BitIconName.Product, Url = ""ProductsPage"" }
+        ]
+    },
+    new() { Text = ""Todo"", IconName = BitIconName.ToDoLogoOutline, Url = ""TodoPage"" },
+    new()
+    {
+        Text = ""Settings"",
+        IconName = BitIconName.Equalizer,
+        ChildItems =
+        [
+            new() { Text = ""Views"", IconName = BitIconName.BarChartVerticalFill, Url = ""ViewsPage"" },
+            new() { Text = ""Users"", IconName = BitIconName.BuildQueue, Url = ""UsersPage"" }
+        ]
+    },
+    new() { Text = ""Terms"", IconName = BitIconName.EntityExtraction, Url = ""TermsPage"" }
+];";
+
+    private readonly string example22RazorCode = @"
 <BitToggleButton @bind-IsChecked=""colorIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div style=""width:222px"">
     <BitNavPanel @bind-IsOpen=""colorIsOpen"" Items=""basicNavItems"" Color=""BitColor.Secondary"" Accent=""BitColor.SecondaryBackground"" />
 </div>";
-    private readonly string example19CsharpCode = @"
+    private readonly string example22CsharpCode = @"
 private bool colorIsOpen;
 
 private List<BitNavItem> basicNavItems =
@@ -1213,7 +1347,7 @@ private List<BitNavItem> basicNavItems =
     }
 ];";
 
-    private readonly string example20RazorCode = @"
+    private readonly string example23RazorCode = @"
 <link rel=""stylesheet"" href=""https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"" />
 
 <BitToggleButton @bind-IsChecked=""externalIconIsOpen"" OnText=""Close"" OffText=""Open"" />
@@ -1224,7 +1358,7 @@ private List<BitNavItem> basicNavItems =
                  ToggleIcon=""@BitIconInfo.Fa(""solid bars"")""
                  ChevronDownIcon=""@BitIconInfo.Fa(""solid chevron-down"")"" />
 </div>";
-    private readonly string example20CsharpCode = @"
+    private readonly string example23CsharpCode = @"
 private bool externalIconIsOpen;
 
 private readonly List<BitNavItem> externalIconNavItems =
@@ -1253,7 +1387,7 @@ private readonly List<BitNavItem> externalIconNavItems =
     }
 ];";
 
-    private readonly string example21RazorCode = @"
+    private readonly string example24RazorCode = @"
 <BitToggleButton @bind-IsChecked=""sizeIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <div style=""width:180px"">
@@ -1268,7 +1402,7 @@ private readonly List<BitNavItem> externalIconNavItems =
     <div>Large</div>
     <BitNavPanel @bind-IsOpen=""sizeIsOpen"" Items=""basicNavItems"" Size=""BitSize.Large"" NoSearchBox NoToggle />
 </div>";
-    private readonly string example21CsharpCode = @"
+    private readonly string example24CsharpCode = @"
 private bool sizeIsOpen;
 
 private List<BitNavItem> basicNavItems =
@@ -1325,7 +1459,7 @@ private List<BitNavItem> basicNavItems =
     }
 ];";
 
-    private readonly string example22RazorCode = @"
+    private readonly string example25RazorCode = @"
 <style>
 
 @media(hover: hover) {
@@ -1386,7 +1520,7 @@ private List<BitNavItem> basicNavItems =
                                              IconWrapper = ""custom-icon-wrapper-searchbox"",
                                              InputContainer = ""custom-input-container-searchbox"" })"" />
 </div>";
-    private readonly string example22CsharpCode = @"
+    private readonly string example25CsharpCode = @"
 private bool classStyleIsOpen;
 
 private List<BitNavItem> basicNavItems =
@@ -1443,11 +1577,11 @@ private List<BitNavItem> basicNavItems =
     }
 ];";
 
-    private readonly string example23RazorCode = @"
+    private readonly string example26RazorCode = @"
 <BitToggleButton @bind-IsChecked=""rtlIsOpen"" OnText=""Close"" OffText=""Open"" />
 
 <BitNavPanel @bind-IsOpen=""rtlIsOpen"" Items=""rtlNavItems"" FitWidth Dir=""BitDir.Rtl"" />";
-    private readonly string example23CsharpCode = @"
+    private readonly string example26CsharpCode = @"
 private bool rtlIsOpen;
 
 private List<BitNavItem> rtlNavItems =

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.scss
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.scss
@@ -1,5 +1,12 @@
 ﻿@import "../../../../Styles/abstracts/_media-queries.scss";
 
+.example-content {
+    gap: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
 .open-btn {
     display: none;
     justify-content: center;

--- a/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.scss
+++ b/src/BlazorUI/Demo/Client/Bit.BlazorUI.Demo.Client.Core/Pages/Components/Extras/NavPanel/BitNavPanelDemo.razor.scss
@@ -11,7 +11,9 @@
     display: none;
     justify-content: center;
 
-    @include lt-lg {
+    // The panel is an off-canvas drawer below the md breakpoint, so that is where the button that opens it
+    // has anything to do.
+    @include lt-md {
         display: flex;
     }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
@@ -1154,7 +1154,10 @@ public class BitNavPanelTests : BunitTestContext
         {
             var focused = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].ToList();
             Assert.AreEqual(1, focused.Count);
-            focused[0].Arguments[0].ShouldBeElementReferenceTo(component.Find(".bit-srb-inp"));
+            // Before .NET 10 a re-render drops the reference id from the rendered markup, so the focused
+            // reference is compared against the search box's own input reference instead of the element.
+            var input = component.FindComponent<BitSearchBox>().Instance.InputElement;
+            Assert.AreEqual(input.Id, ((ElementReference)focused[0].Arguments[0]!).Id);
         });
     }
 

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Bunit;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,6 +16,28 @@ public class BitNavPanelTests : BunitTestContext
         new() { Text = "Home", Url = "/home", Description = "Home page" },
         new() { Text = "Docs", Url = "/docs", Description = "Documentation" }
     ];
+
+    private static IList<BitNavItem> TreeItems() =>
+    [
+        new() { Text = "Home", Url = "/home", Description = "Home page", Data = "dashboard" },
+        new()
+        {
+            Text = "AdminPanel",
+            ChildItems =
+            [
+                new() { Text = "Dashboard", Url = "/dashboard" },
+                new() { Text = "Categories", Url = "/categories" },
+            ]
+        },
+        new() { Text = "Settings", Url = "/settings" }
+    ];
+
+    private class CustomItem
+    {
+        public string? Name { get; set; }
+        public string? Address { get; set; }
+        public List<CustomItem>? Children { get; set; }
+    }
 
     [TestMethod]
     public void BitNavPanelShouldRenderHeaderFooterAndItems()
@@ -57,6 +82,42 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitNavPanelToggleButtonShouldReportItsStateAndName()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        var toggleBtn = component.Find(".bit-npn-tbn");
+
+        Assert.AreEqual("true", toggleBtn.GetAttribute("aria-expanded"));
+        Assert.IsTrue(toggleBtn.GetAttribute("aria-label").HasValue());
+
+        toggleBtn.Click();
+
+        component.WaitForAssertion(() => Assert.AreEqual("false", component.Find(".bit-npn-tbn").GetAttribute("aria-expanded")));
+    }
+
+    [TestMethod]
+    public void BitNavPanelToggleButtonShouldAcceptCustomAriaLabelAndIcon()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.ToggleAriaLabel, "Menu");
+            parameters.Add(p => p.ToggleIcon, BitIconInfo.Fa("solid bars"));
+        });
+
+        var toggleBtn = component.Find(".bit-npn-tbn");
+
+        Assert.AreEqual("Menu", toggleBtn.GetAttribute("aria-label"));
+        Assert.AreEqual("Menu", toggleBtn.GetAttribute("title"));
+        Assert.IsNotNull(component.Find(".bit-npn-tbn i.fa-bars"));
+        Assert.AreEqual(0, component.FindAll(".bit-icon-ex--ColumnRightTwoThirds").Count);
+    }
+
+    [TestMethod]
     public void BitNavPanelOverlayClickShouldClose()
     {
         var isOpen = true;
@@ -69,6 +130,8 @@ public class BitNavPanelTests : BunitTestContext
 
         var overlay = component.Find(".bit-npn-ovl");
 
+        Assert.AreEqual("true", overlay.GetAttribute("aria-hidden"));
+
         overlay.Click();
 
         component.WaitForAssertion(() =>
@@ -76,6 +139,36 @@ public class BitNavPanelTests : BunitTestContext
             Assert.IsFalse(isOpen);
             Assert.IsTrue(component.Find(".bit-npn").ClassList.Contains("bit-npn-cls"));
         });
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldNotRenderOverlayWhenNoOverlay()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.NoOverlay, true);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-npn-ovl").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelDisabledOverlayClickShouldNotClose()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsEnabled, false);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-npn-ovl").Click();
+
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
     }
 
     [TestMethod]
@@ -100,6 +193,39 @@ public class BitNavPanelTests : BunitTestContext
             Assert.AreEqual("Home", clicked);
             Assert.IsFalse(isOpen);
         });
+    }
+
+    [TestMethod]
+    public void BitNavPanelItemClickShouldNotCloseWhenNoAutoClose()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.NoAutoClose, true);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-nav-ict").Click();
+
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelItemWithoutUrlClickShouldNotClose()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.FindAll(".bit-nav-ict")[1].Click();
+
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
     }
 
     [TestMethod]
@@ -129,6 +255,23 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitNavPanelNoToggleShouldIgnoreTheToggleMethod()
+    {
+        var isToggled = false;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.NoToggle, true);
+            parameters.Bind(p => p.IsToggled, isToggled, v => isToggled = v);
+        });
+
+        component.InvokeAsync(() => component.Instance.Toggle());
+
+        component.WaitForAssertion(() => Assert.IsFalse(isToggled));
+    }
+
+    [TestMethod]
     public void BitNavPanelShouldRespectLayoutClassesAndTopStyle()
     {
         var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
@@ -149,6 +292,22 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
+    public void BitNavPanelShouldRenderWidthCssVariables()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.Width, 260);
+            parameters.Add(p => p.ToggledWidth, 72);
+        });
+
+        var style = component.Find(".bit-npn").GetAttribute("style");
+
+        Assert.IsTrue(style?.Contains("--bit-npn-w:260px"));
+        Assert.IsTrue(style?.Contains("--bit-npn-tw:72px"));
+    }
+
+    [TestMethod]
     public void BitNavPanelShouldRenderIconWithNavigation()
     {
         var url = "https://example.com";
@@ -164,6 +323,7 @@ public class BitNavPanelTests : BunitTestContext
         var a = component.Find("a:has(img.bit-npn-img)");
 
         Assert.AreEqual("/logo.png", img.GetAttribute("src"));
+        Assert.IsNotNull(img.GetAttribute("alt"));
         Assert.AreEqual(a.GetAttribute("href"), url);
     }
 
@@ -183,32 +343,18 @@ public class BitNavPanelTests : BunitTestContext
     [TestMethod]
     public void BitNavPanelParentItemBodyClickShouldToggleExpansion()
     {
-        IList<BitNavItem> items =
-        [
-            new() { Text = "Home", Url = "/home" },
-            new()
-            {
-                Text = "AdminPanel",
-                ChildItems =
-                [
-                    new() { Text = "Dashboard", Url = "/dashboard" },
-                    new() { Text = "Categories", Url = "/categories" },
-                ]
-            }
-        ];
-
         var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
         {
-            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.Items, TreeItems());
         });
 
         var parentButton = component.FindAll(".bit-nav-ict")[1];
 
         parentButton.Click();
-        component.WaitForAssertion(() => Assert.AreEqual(4, component.FindAll(".bit-nav-ict").Count));
+        component.WaitForAssertion(() => Assert.AreEqual(5, component.FindAll(".bit-nav-ict").Count));
 
         component.FindAll(".bit-nav-ict")[1].Click();
-        component.WaitForAssertion(() => Assert.AreEqual(2, component.FindAll(".bit-nav-ict").Count));
+        component.WaitForAssertion(() => Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count));
     }
 
     [TestMethod]
@@ -220,5 +366,777 @@ public class BitNavPanelTests : BunitTestContext
         });
 
         Assert.AreEqual(1, component.FindAll(".bit-srb-inp").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchShouldFilterItemsByTextDescriptionAndData()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        // The text of an item.
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() =>
+        {
+            var items = component.FindAll(".bit-nav-ict");
+            Assert.AreEqual(1, items.Count);
+            Assert.IsTrue(items[0].TextContent.Contains("Settings"));
+        });
+
+        // The description of an item.
+        component.Find(".bit-srb-inp").Change("documentation page");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        // The data of an item.
+        component.Find(".bit-srb-inp").Change("dashboard");
+        component.WaitForAssertion(() =>
+        {
+            var items = component.FindAll(".bit-nav-ict");
+            // "Home" matches through its Data and "Dashboard" through its text, and neither is listed twice.
+            Assert.AreEqual(2, items.Count);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchShouldKeepTheBranchOfAMatchedItem()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        component.Find(".bit-srb-inp").Change("admin");
+
+        component.WaitForAssertion(() =>
+        {
+            var items = component.FindAll(".bit-nav-ict");
+            Assert.AreEqual(1, items.Count);
+            Assert.IsTrue(items[0].TextContent.Contains("AdminPanel"));
+        });
+
+        // The matched group still opens onto the items it groups.
+        component.FindAll(".bit-nav-ict")[0].Click();
+        component.WaitForAssertion(() => Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchWithNoResultShouldShowTheEmptyMessageAndRecover()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add(p => p.EmptyListMessage, "Nothing here!");
+        });
+
+        component.Find(".bit-srb-inp").Change("zzz");
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(0, component.FindAll(".bit-nav-ict").Count);
+            Assert.IsTrue(component.Markup.Contains("Nothing here!"));
+        });
+
+        // Typing on after an empty result has to keep filtering rather than showing the whole list again.
+        component.Find(".bit-srb-inp").Change("settings");
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count);
+            Assert.IsFalse(component.Markup.Contains("Nothing here!"));
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelEmptyListTemplateShouldReplaceTheMessage()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add<RenderFragment>(p => p.EmptyListTemplate, b => b.AddMarkupContent(0, "<div class='empty'>None</div>"));
+        });
+
+        component.Find(".bit-srb-inp").Change("zzz");
+
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".empty").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchShouldBindTheSearchTextAndReportIt()
+    {
+        string? searchText = null;
+        string? searched = null;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add(p => p.OnSearch, (string? v) => searched = v);
+            parameters.Bind(p => p.SearchText, searchText, v => searchText = v);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual("settings", searchText);
+            Assert.AreEqual("settings", searched);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldFilterByTheSearchTextParameter()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchText, "settings");
+        });
+
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        component.Render(parameters => parameters.Add(p => p.SearchText, null));
+
+        component.WaitForAssertion(() => Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchFilterShouldReplaceTheDefaultMatching()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add(p => p.SearchFilter, (BitNavItem item, string term) =>
+                item.Text.StartsWith(term, StringComparison.OrdinalIgnoreCase));
+        });
+
+        // "page" is in the description of Home, which the custom filter does not look at.
+        component.Find(".bit-srb-inp").Change("page");
+        component.WaitForAssertion(() => Assert.AreEqual(0, component.FindAll(".bit-nav-ict").Count));
+
+        component.Find(".bit-srb-inp").Change("ho");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelClearSearchShouldRestoreTheWholeList()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        component.InvokeAsync(() => component.Instance.ClearSearch());
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count);
+            Assert.AreEqual(string.Empty, component.Find(".bit-srb-inp").GetAttribute("value") ?? string.Empty);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelTogglingShouldClearTheSearch()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        component.Find(".bit-npn-tbn").Click();
+
+        component.WaitForAssertion(() => Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelEscapeShouldCloseThePanel()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        component.WaitForAssertion(() => Assert.IsFalse(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelEscapeShouldNotCloseThePanelWhileASearchIsInPlace()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+
+        component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelEscapeShouldDoNothingWhenClosedOrDisabled()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsEnabled, false);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelOpenAndCloseShouldDriveTheOpenState()
+    {
+        var isOpen = false;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.InvokeAsync(() => component.Instance.Open());
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
+
+        component.InvokeAsync(() => component.Instance.Close());
+        component.WaitForAssertion(() => Assert.IsFalse(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelExpandAllAndCollapseAllShouldDriveTheTree()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+        });
+
+        component.InvokeAsync(() => component.Instance.ExpandAll());
+        component.WaitForAssertion(() => Assert.AreEqual(5, component.FindAll(".bit-nav-ict").Count));
+
+        component.InvokeAsync(() => component.Instance.CollapseAll());
+        component.WaitForAssertion(() => Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelAllExpandedShouldOpenEveryGroup()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.AllExpanded, true);
+        });
+
+        Assert.AreEqual(5, component.FindAll(".bit-nav-ict").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldSelectTheDefaultSelectedItemInManualMode()
+    {
+        var items = TreeItems();
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.NavMode, BitNavMode.Manual);
+            parameters.Add(p => p.DefaultSelectedItem, items[2]);
+        });
+
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-sel").Count));
+        Assert.IsTrue(component.Find(".bit-nav-sel").TextContent.Contains("Settings"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldNotSelectAnItemOfItsOwnInManualMode()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.NavMode, BitNavMode.Manual);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-nav-sel").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldBindTheSelectedItem()
+    {
+        var items = TreeItems();
+        BitNavItem? selected = null;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.NavMode, BitNavMode.Manual);
+            parameters.Bind(p => p.SelectedItem, selected, v => selected = v);
+        });
+
+        component.FindAll(".bit-nav-ict")[0].Click();
+
+        component.WaitForAssertion(() => Assert.AreEqual("Home", selected?.Text));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldRenderCustomItemsThroughNameSelectors()
+    {
+        List<CustomItem> items =
+        [
+            new()
+            {
+                Name = "Home",
+                Address = "/home",
+                Children = [new() { Name = "Sub", Address = "/sub" }]
+            },
+            new() { Name = "Docs", Address = "/docs" }
+        ];
+
+        var component = RenderComponent<BitNavPanel<CustomItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add(p => p.NameSelectors, new BitNavNameSelectors<CustomItem>
+            {
+                Text = { Name = nameof(CustomItem.Name) },
+                Url = { Name = nameof(CustomItem.Address) },
+                ChildItems = { Name = nameof(CustomItem.Children) },
+            });
+        });
+
+        Assert.AreEqual(2, component.FindAll(".bit-nav-ict").Count);
+        Assert.IsTrue(component.FindAll(".bit-nav-ict")[0].TextContent.Contains("Home"));
+
+        // The search reads the custom item through the very same selectors.
+        component.Find(".bit-srb-inp").Change("docs");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    [DataRow(BitSize.Small, "bit-nav-sm")]
+    [DataRow(BitSize.Medium, "bit-nav-md")]
+    [DataRow(BitSize.Large, "bit-nav-lg")]
+    public void BitNavPanelShouldPassTheSizeToTheNav(BitSize size, string cssClass)
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.Size, size);
+        });
+
+        Assert.IsTrue(component.Find("nav.bit-nav").ClassList.Contains(cssClass));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldRenderTheChevronOfAnIconName()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.ChevronDownIconName, "ChevronDown");
+        });
+
+        var chevron = component.Find(".bit-nav-cbt i");
+
+        Assert.IsTrue(chevron.ClassList.Contains("bit-icon"));
+        Assert.IsTrue(chevron.ClassList.Contains("bit-icon--ChevronDown"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldRenderTheChevronOfAnExternalIcon()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.ChevronDownIcon, BitIconInfo.Fa("solid chevron-down"));
+        });
+
+        var chevron = component.Find(".bit-nav-cbt i");
+
+        Assert.IsTrue(chevron.ClassList.Contains("fa-chevron-down"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldNameTheNavLandmark()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.AriaLabel, "Main menu");
+        });
+
+        Assert.AreEqual("Main menu", component.Find("nav.bit-nav").GetAttribute("aria-label"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelDisabledShouldDisableItsControls()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsEnabled, false);
+        });
+
+        // The button keeps its tab stop and reports the state through aria-disabled (AllowDisabledFocus).
+        Assert.AreEqual("true", component.Find(".bit-npn-tbn").GetAttribute("aria-disabled"));
+        Assert.IsTrue(component.Find(".bit-srb-inp").HasAttribute("disabled"));
+        Assert.IsTrue(component.Find(".bit-npn").ClassList.Contains("bit-dis"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldPickUpItemsAssignedLater()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, new List<BitNavItem>());
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-nav-ict").Count);
+
+        component.Render(parameters => parameters.Add(p => p.Items, Items));
+
+        Assert.AreEqual(2, component.FindAll(".bit-nav-ict").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchShouldSurviveAnItemsChange()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        component.Render(parameters => parameters.Add(p => p.Items, TreeItems()));
+
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelToggledStateShouldRenderTheSearchButtonAndIconOnlyNav()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsToggled, true);
+        });
+
+        Assert.IsTrue(component.Find("nav.bit-nav").ClassList.Contains("bit-nav-ion"));
+
+        // The rail shows a button in place of the box it has no room for.
+        var searchButton = component.FindAll("button").Single(b => b.GetAttribute("aria-label") == "Search");
+
+        Assert.IsNotNull(searchButton);
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchButtonShouldLeaveTheToggledState()
+    {
+        var isToggled = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Bind(p => p.IsToggled, isToggled, v => isToggled = v);
+        });
+
+        component.FindAll("button").Single(b => b.GetAttribute("aria-label") == "Search").Click();
+
+        component.WaitForAssertion(() => Assert.IsFalse(isToggled));
+    }
+
+    [TestMethod]
+    public void BitNavPanelEscapeShouldClearAnActiveSearchFirst()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count);
+            Assert.IsTrue(isOpen);
+        });
+
+        component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        component.WaitForAssertion(() => Assert.IsFalse(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldAnnounceTheSearchResults()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        // Nothing is announced while there is no search in place.
+        Assert.AreEqual(0, component.FindAll(".bit-npn-lvr").Count);
+
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() => Assert.AreEqual("1 item found.", component.Find(".bit-npn-lvr").TextContent));
+
+        component.Find(".bit-srb-inp").Change("zzz");
+        component.WaitForAssertion(() => Assert.AreEqual("No item found.", component.Find(".bit-npn-lvr").TextContent));
+
+        var live = component.Find(".bit-npn-lvr");
+        Assert.AreEqual("status", live.GetAttribute("role"));
+        Assert.AreEqual("polite", live.GetAttribute("aria-live"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchAnnouncementProviderShouldReplaceTheDefaultText()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add(p => p.SearchAnnouncementProvider, (int count) => $"{count} hits");
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+
+        component.WaitForAssertion(() => Assert.AreEqual("1 hits", component.Find(".bit-npn-lvr").TextContent));
+    }
+
+    [TestMethod]
+    public void BitNavPanelExpandOnHoverShouldLeaveTheRailWhileHovered()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsToggled, true);
+            parameters.Add(p => p.ExpandOnHover, true);
+        });
+
+        var root = component.Find(".bit-npn");
+
+        Assert.IsTrue(root.ClassList.Contains("bit-npn-eoh"));
+        Assert.IsTrue(root.ClassList.Contains("bit-npn-tgl"));
+
+        root.MouseEnter();
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsFalse(component.Find(".bit-npn").ClassList.Contains("bit-npn-tgl"));
+            Assert.IsFalse(component.Find("nav.bit-nav").ClassList.Contains("bit-nav-ion"));
+        });
+
+        component.Find(".bit-npn").MouseLeave();
+
+        component.WaitForAssertion(() => Assert.IsTrue(component.Find(".bit-npn").ClassList.Contains("bit-npn-tgl")));
+    }
+
+    [TestMethod]
+    public void BitNavPanelWithoutExpandOnHoverShouldNotListenForHover()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsToggled, true);
+        });
+
+        // No handler is attached at all, so the pointer crossing the panel cannot re-render it.
+        Assert.ThrowsExactly<MissingEventHandlerException>(() => component.Find(".bit-npn").MouseEnter());
+
+        Assert.IsTrue(component.Find(".bit-npn").ClassList.Contains("bit-npn-tgl"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldForwardTheItemApisToTheNav()
+    {
+        var items = TreeItems();
+        BitNavItem? selected = null;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.NavMode, BitNavMode.Manual);
+            parameters.Bind(p => p.SelectedItem, selected, v => selected = v);
+        });
+
+        component.InvokeAsync(() => component.Instance.ExpandItem(items[1]));
+        component.WaitForAssertion(() => Assert.AreEqual(5, component.FindAll(".bit-nav-ict").Count));
+
+        component.InvokeAsync(() => component.Instance.CollapseItem(items[1]));
+        component.WaitForAssertion(() => Assert.AreEqual(3, component.FindAll(".bit-nav-ict").Count));
+
+        component.InvokeAsync(() => component.Instance.ToggleItem(items[1]));
+        component.WaitForAssertion(() => Assert.AreEqual(5, component.FindAll(".bit-nav-ict").Count));
+
+        component.InvokeAsync(() => component.Instance.SelectItem(items[2]));
+        component.WaitForAssertion(() => Assert.AreEqual("Settings", selected?.Text));
+    }
+
+    [TestMethod]
+    public void BitNavPanelLogoLinkShouldCarryAName()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IconUrl, "/logo.png");
+            parameters.Add(p => p.IconNavUrl, "/");
+            parameters.Add(p => p.AriaLabel, "Main menu");
+        });
+
+        var link = component.Find("a:has(img.bit-npn-img)");
+
+        Assert.AreEqual("Main menu", link.GetAttribute("aria-label"));
+        Assert.AreEqual(string.Empty, component.Find("img.bit-npn-img").GetAttribute("alt"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchShouldSeeItemsAppendedToTheSameList()
+    {
+        var items = new List<BitNavItem>(TreeItems());
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        component.Find(".bit-srb-inp").Change("settings");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        items.Add(new() { Text = "Settings backup", Url = "/backup" });
+        component.Render();
+
+        component.WaitForAssertion(() => Assert.AreEqual(2, component.FindAll(".bit-nav-ict").Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelAutoFocusShouldMoveTheFocusIntoThePanelOnOpen()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.AutoFocus, true);
+        });
+
+        component.Render(parameters => parameters.Add(p => p.IsOpen, true));
+
+        component.WaitForAssertion(() =>
+        {
+            var focused = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].ToList();
+            Assert.AreEqual(1, focused.Count);
+            focused[0].Arguments[0].ShouldBeElementReferenceTo(component.Find(".bit-srb-inp"));
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelAutoFocusShouldFallBackToTheFirstItem()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.AutoFocus, true);
+            parameters.Add(p => p.NoSearchBox, true);
+        });
+
+        component.Render(parameters => parameters.Add(p => p.IsOpen, true));
+
+        // A panel without a search box hands the focus to the first item of the nav instead.
+        component.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelWithoutAutoFocusShouldLeaveTheFocusAlone()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        component.Render(parameters => parameters.Add(p => p.IsOpen, true));
+
+        Assert.AreEqual(0, Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldFollowTheCurrentUrlInAutomaticMode()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+        });
+
+        Services.GetRequiredService<NavigationManager>().NavigateTo("settings");
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(1, component.FindAll(".bit-nav-sel").Count);
+            Assert.IsTrue(component.Find(".bit-nav-sel").TextContent.Contains("Settings"));
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldReportTheUrlSelectionThroughTheBoundSelectedItem()
+    {
+        BitNavItem? selected = null;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Bind(p => p.SelectedItem, selected, v => selected = v);
+        });
+
+        Services.GetRequiredService<NavigationManager>().NavigateTo("dashboard");
+
+        component.WaitForAssertion(() => Assert.AreEqual("Dashboard", selected?.Text));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldNotThrowOnNullItems()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, null!);
+        });
+
+        Assert.IsNotNull(component.Find(".bit-npn"));
+        Assert.AreEqual(0, component.FindAll(".bit-nav-ict").Count);
     }
 }

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components;
@@ -255,7 +256,7 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitNavPanelNoToggleShouldIgnoreTheToggleMethod()
+    public async Task BitNavPanelNoToggleShouldIgnoreTheToggleMethod()
     {
         var isToggled = false;
 
@@ -266,9 +267,9 @@ public class BitNavPanelTests : BunitTestContext
             parameters.Bind(p => p.IsToggled, isToggled, v => isToggled = v);
         });
 
-        component.InvokeAsync(() => component.Instance.Toggle());
+        await component.InvokeAsync(() => component.Instance.Toggle());
 
-        component.WaitForAssertion(() => Assert.IsFalse(isToggled));
+        Assert.IsFalse(isToggled);
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bit.BlazorUI.Tests.Components.Extras.NavPanel;
@@ -156,20 +157,18 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitNavPanelDisabledOverlayClickShouldNotClose()
+    public void BitNavPanelDisabledShouldDrawNoOverlay()
     {
-        var isOpen = true;
-
         var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
         {
             parameters.Add(p => p.Items, Items);
             parameters.Add(p => p.IsEnabled, false);
-            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+            parameters.Add(p => p.IsOpen, true);
         });
 
-        component.Find(".bit-npn-ovl").Click();
-
-        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
+        // Nothing of a disabled panel answers a click, so it covers the page with nothing that would then
+        // have to be dismissed.
+        Assert.AreEqual(0, component.FindAll(".bit-npn-ovl").Count);
     }
 
     [TestMethod]
@@ -569,7 +568,7 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitNavPanelEscapeShouldCloseThePanel()
+    public void BitNavPanelEscapeShouldCloseTheDrawer()
     {
         var isOpen = true;
 
@@ -579,9 +578,31 @@ public class BitNavPanelTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
         });
 
+        SetDrawerScreen(component, true);
+
         component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
 
         component.WaitForAssertion(() => Assert.IsFalse(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelEscapeShouldLeaveTheColumnOfAWideScreenAlone()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        SetDrawerScreen(component, false);
+
+        // The column is not a surface over the page: closing it there would report a state change with
+        // nothing on screen to show for it.
+        component.Find(".bit-npn").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        component.WaitForAssertion(() => Assert.IsTrue(isOpen));
     }
 
     [TestMethod]
@@ -595,6 +616,8 @@ public class BitNavPanelTests : BunitTestContext
             parameters.Add(p => p.SearchDebounceTime, 0);
             parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
         });
+
+        SetDrawerScreen(component, true);
 
         component.Find(".bit-srb-inp").Change("settings");
 
@@ -893,6 +916,8 @@ public class BitNavPanelTests : BunitTestContext
             parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
         });
 
+        SetDrawerScreen(component, true);
+
         component.Find(".bit-srb-inp").Change("settings");
         component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
 
@@ -918,8 +943,9 @@ public class BitNavPanelTests : BunitTestContext
             parameters.Add(p => p.SearchDebounceTime, 0);
         });
 
-        // Nothing is announced while there is no search in place.
-        Assert.AreEqual(0, component.FindAll(".bit-npn-lvr").Count);
+        // The region is there from the start, empty: one that enters the DOM together with its first
+        // message is never announced.
+        Assert.AreEqual(string.Empty, component.Find(".bit-npn-lvr").TextContent);
 
         component.Find(".bit-srb-inp").Change("settings");
         component.WaitForAssertion(() => Assert.AreEqual("1 item found.", component.Find(".bit-npn-lvr").TextContent));
@@ -945,6 +971,64 @@ public class BitNavPanelTests : BunitTestContext
         component.Find(".bit-srb-inp").Change("settings");
 
         component.WaitForAssertion(() => Assert.AreEqual("1 hits", component.Find(".bit-npn-lvr").TextContent));
+    }
+
+    [TestMethod]
+    public void BitNavPanelFocusSearchBoxShouldLeaveAnExpandedRailToggled()
+    {
+        var isToggled = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.ExpandOnHover, true);
+            parameters.Bind(p => p.IsToggled, isToggled, v => isToggled = v);
+        });
+
+        component.Find(".bit-npn").MouseEnter();
+
+        component.WaitForAssertion(() => Assert.IsFalse(component.Find(".bit-npn").ClassList.Contains("bit-npn-tgl")));
+
+        component.InvokeAsync(() => component.Instance.FocusSearchBox());
+
+        // The search box is already on screen, so the focus goes to it: leaving the rail for good is not what
+        // asking for the focus asked for.
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsTrue(isToggled);
+            Assert.AreEqual(1, Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldKeepTheKeyDownHandlerItWasGiven()
+    {
+        var isOpen = true;
+        var handled = false;
+
+        // Arbitrary HTML attributes are captured by BitComponentBase from unmatched parameters, so supply
+        // them as raw component attributes (as real markup would) rather than through the builder, which
+        // rejects unmatched params on components without [Parameter(CaptureUnmatchedValues)].
+        var component = Context.Render(builder =>
+        {
+            builder.OpenComponent<BitNavPanel<BitNavItem>>(0);
+            builder.AddAttribute(1, nameof(BitNavPanel<BitNavItem>.Items), Items);
+            builder.AddAttribute(2, nameof(BitNavPanel<BitNavItem>.IsOpen), isOpen);
+            builder.AddAttribute(3, nameof(BitNavPanel<BitNavItem>.IsOpenChanged), EventCallback.Factory.Create<bool>(this, v => isOpen = v));
+            builder.AddAttribute(4, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, () => handled = true));
+            builder.CloseComponent();
+        }).FindComponent<BitNavPanel<BitNavItem>>();
+
+        SetDrawerScreen(component, true);
+
+        component.Find(".bit-npn").KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+        // Both run: the panel still closes on the key, and the handler the caller splatted is still called.
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsFalse(isOpen);
+            Assert.IsTrue(handled);
+        });
     }
 
     [TestMethod]
@@ -1054,13 +1138,15 @@ public class BitNavPanelTests : BunitTestContext
     }
 
     [TestMethod]
-    public void BitNavPanelAutoFocusShouldMoveTheFocusIntoThePanelOnOpen()
+    public void BitNavPanelAutoFocusShouldMoveTheFocusIntoTheDrawerOnOpen()
     {
         var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
         {
             parameters.Add(p => p.Items, Items);
             parameters.Add(p => p.AutoFocus, true);
         });
+
+        SetDrawerScreen(component, true);
 
         component.Render(parameters => parameters.Add(p => p.IsOpen, true));
 
@@ -1082,10 +1168,34 @@ public class BitNavPanelTests : BunitTestContext
             parameters.Add(p => p.NoSearchBox, true);
         });
 
+        SetDrawerScreen(component, true);
+
         component.Render(parameters => parameters.Add(p => p.IsOpen, true));
 
         // A panel without a search box hands the focus to the first item of the nav instead.
         component.WaitForAssertion(() => Assert.AreEqual(1, Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count));
+    }
+
+    [TestMethod]
+    public void BitNavPanelAutoFocusShouldLeaveTheKeyboardAloneOnAWideScreen()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.AutoFocus, true);
+        });
+
+        SetDrawerScreen(component, false);
+
+        component.Render(parameters => parameters.Add(p => p.IsOpen, true));
+
+        // Nothing opened over the page on a wide screen, so nothing takes the keyboard from it - and nothing
+        // was recorded to hand it back to either.
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(0, Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count);
+            Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Utils.captureFocusOrigin"].Count);
+        });
     }
 
     [TestMethod]

--- a/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
+++ b/src/BlazorUI/Tests/Bit.BlazorUI.Tests/Components/Extras/NavPanel/BitNavPanelTests.cs
@@ -386,9 +386,14 @@ public class BitNavPanelTests : BunitTestContext
             Assert.IsTrue(items[0].TextContent.Contains("Settings"));
         });
 
-        // The description of an item.
-        component.Find(".bit-srb-inp").Change("documentation page");
-        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+        // The description of an item, and every word of the term having to be somewhere in it.
+        component.Find(".bit-srb-inp").Change("home page");
+        component.WaitForAssertion(() =>
+        {
+            var items = component.FindAll(".bit-nav-ict");
+            Assert.AreEqual(1, items.Count);
+            Assert.IsTrue(items[0].TextContent.Contains("Home"));
+        });
 
         // The data of an item.
         component.Find(".bit-srb-inp").Change("dashboard");
@@ -1138,5 +1143,496 @@ public class BitNavPanelTests : BunitTestContext
 
         Assert.IsNotNull(component.Find(".bit-npn"));
         Assert.AreEqual(0, component.FindAll(".bit-nav-ict").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldPointTheToggleButtonAtThePanelItControls()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        var root = component.Find(".bit-npn");
+        var toggle = component.Find(".bit-npn-tbn");
+
+        Assert.AreEqual(root.Id, toggle.GetAttribute("aria-controls"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelIconAriaLabelShouldNameTheLogoApartFromTheLandmark()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.AriaLabel, "Main menu");
+            parameters.Add(p => p.IconUrl, "/images/icon.png");
+            parameters.Add(p => p.IconNavUrl, "/");
+            parameters.Add(p => p.IconAriaLabel, "bit platform");
+        });
+
+        Assert.AreEqual("bit platform", component.Find(".bit-npn-hdr a").GetAttribute("aria-label"));
+        Assert.AreEqual("Main menu", component.Find("nav.bit-nav").GetAttribute("aria-label"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelBareLogoShouldTakeTheIconAriaLabelAsItsAlternativeText()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IconUrl, "/images/icon.png");
+            parameters.Add(p => p.IconAriaLabel, "bit platform");
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-npn-hdr a").Count);
+        Assert.AreEqual("bit platform", component.Find(".bit-npn-img").GetAttribute("alt"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldRenderTheSearchIconOfTheRail()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsToggled, true);
+            parameters.Add(p => p.SearchIconName, "Zoom");
+        });
+
+        var icon = component.Find(".bit-npn-tsb i");
+
+        Assert.IsTrue(icon.ClassList.Contains("bit-icon--Zoom"));
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsToggled, true);
+            parameters.Add(p => p.SearchIcon, BitIconInfo.Fa("solid magnifying-glass"));
+        });
+
+        Assert.IsTrue(component.Find(".bit-npn-tsb i").ClassList.Contains("fa-magnifying-glass"));
+    }
+
+    [TestMethod]
+    [DataRow(BitNavPanelPosition.Start, false)]
+    [DataRow(BitNavPanelPosition.End, true)]
+    public void BitNavPanelShouldDockTheDrawerToThePositionItIsGiven(BitNavPanelPosition position, bool isEnd)
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.Position, position);
+        });
+
+        Assert.AreEqual(isEnd, component.Find(".bit-npn").ClassList.Contains("bit-npn-end"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelNoSwipeShouldNotRenderTheSwipeTrap()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        // The gesture is trapped by default, and the trap is what the content sits in.
+        Assert.IsTrue(component.Find(".bit-npn-swp").ClassList.Contains("bit-stp"));
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.NoSwipe, true);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-stp").Count);
+        Assert.AreEqual(1, component.FindAll(".bit-npn-swp").Count);
+        Assert.AreEqual(1, component.FindAll(".bit-npn-cnt").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchShouldRequireEveryWordOfTheTerm()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+        });
+
+        // Both words are somewhere in the same item, so it stays.
+        component.Find(".bit-srb-inp").Change("home page");
+        component.WaitForAssertion(() => Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count));
+
+        // Each word is in an item of its own, and neither item holds both.
+        component.Find(".bit-srb-inp").Change("home settings");
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(0, component.FindAll(".bit-nav-ict").Count);
+            Assert.AreEqual("Nothing found!", component.Find(".bit-txt").TextContent.Trim());
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelSearchFilterShouldAlsoSeeEveryWordOfTheTerm()
+    {
+        List<string> terms = [];
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, TreeItems());
+            parameters.Add(p => p.SearchDebounceTime, 0);
+            parameters.Add(p => p.SearchFilter, (BitNavItem item, string term) =>
+            {
+                terms.Add(term);
+                return item.Text.Contains(term, StringComparison.OrdinalIgnoreCase);
+            });
+        });
+
+        component.Find(".bit-srb-inp").Change("set ting");
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsTrue(terms.Contains("set"));
+            Assert.IsTrue(terms.Contains("ting"));
+            // "Settings" holds both of them, and it is the only item that does.
+            Assert.AreEqual(1, component.FindAll(".bit-nav-ict").Count);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldNotSeedASelectionOfItsOwnInAutomaticMode()
+    {
+        var items = TreeItems();
+        BitNavItem? selected = null;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+            parameters.Add(p => p.DefaultSelectedItem, items[0]);
+            parameters.Bind(p => p.SelectedItem, selected, v => selected = v);
+        });
+
+        // The current URL matches none of the items, and the automatic mode has nothing else to go on.
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsNull(selected);
+            Assert.AreEqual(0, component.FindAll(".bit-nav-sel").Count);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldReportWhetherAnItemIsExpanded()
+    {
+        var items = TreeItems();
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, items);
+        });
+
+        Assert.IsFalse(component.Instance.IsItemExpanded(items[1]));
+
+        component.InvokeAsync(() => component.Instance.ExpandItem(items[1]));
+
+        component.WaitForAssertion(() => Assert.IsTrue(component.Instance.IsItemExpanded(items[1])));
+    }
+
+    [TestMethod]
+    public void BitNavPanelExpandOnHoverShouldLeaveTheRailWhileTheKeyboardIsInside()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsToggled, true);
+            parameters.Add(p => p.ExpandOnHover, true);
+        });
+
+        component.Find(".bit-npn").FocusIn();
+
+        component.WaitForAssertion(() => Assert.IsFalse(component.Find(".bit-npn").ClassList.Contains("bit-npn-tgl")));
+
+        component.Find(".bit-npn").FocusOut();
+
+        // The collapse waits out the gap between the focus leaving one item and landing on the next.
+        component.WaitForAssertion(
+            () => Assert.IsTrue(component.Find(".bit-npn").ClassList.Contains("bit-npn-tgl")),
+            TimeSpan.FromSeconds(3));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldReportItselfAsADialogWhileItCoversThePage()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.AriaLabel, "Main menu");
+        });
+
+        // On a wide screen the panel is a column of the page, and a column is no dialog.
+        Assert.IsNull(component.Find(".bit-npn").GetAttribute("role"));
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(() =>
+        {
+            var root = component.Find(".bit-npn");
+
+            Assert.AreEqual("dialog", root.GetAttribute("role"));
+            Assert.AreEqual("true", root.GetAttribute("aria-modal"));
+            Assert.AreEqual("Main menu", root.GetAttribute("aria-label"));
+        });
+
+        SetDrawerScreen(component, false);
+
+        component.WaitForAssertion(() => Assert.IsNull(component.Find(".bit-npn").GetAttribute("role")));
+    }
+
+    [TestMethod]
+    public void BitNavPanelClosedDrawerShouldNotReportItselfAsADialog()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(() => Assert.IsNull(component.Find(".bit-npn").GetAttribute("role")));
+    }
+
+    [TestMethod]
+    public void BitNavPanelDrawerWithoutOverlayShouldNotReportItselfAsADialog()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.NoOverlay, true);
+        });
+
+        SetDrawerScreen(component, true);
+
+        // Nothing is covered by a drawer that draws no overlay, so nothing behind it is inert either.
+        component.WaitForAssertion(() => Assert.IsNull(component.Find(".bit-npn").GetAttribute("role")));
+    }
+
+    [TestMethod]
+    public void BitNavPanelDrawerShouldFallBackToABuiltInNameWhenTheNavHasNone()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+        });
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(() => Assert.AreEqual("Navigation", component.Find(".bit-npn").GetAttribute("aria-label")));
+    }
+
+    [TestMethod]
+    public void BitNavPanelStickyEndsShouldHandTheOverflowToTheNav()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        Assert.IsFalse(component.Find(".bit-npn").ClassList.Contains("bit-npn-ste"));
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.StickyEnds, true);
+        });
+
+        Assert.IsTrue(component.Find(".bit-npn").ClassList.Contains("bit-npn-ste"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelDrawerWithoutAFocusTrapShouldNotClaimToBeModal()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.NoFocusTrap, true);
+        });
+
+        SetDrawerScreen(component, true);
+
+        // It is still the dialog it looks like, but nothing behind it is inert while the keyboard can walk out.
+        component.WaitForAssertion(() =>
+        {
+            var root = component.Find(".bit-npn");
+
+            Assert.AreEqual("dialog", root.GetAttribute("role"));
+            Assert.IsNull(root.GetAttribute("aria-modal"));
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelCloseButtonShouldCloseThePanel()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        var close = component.Find(".bit-npn-cbn");
+
+        Assert.AreEqual("Close the navigation panel", close.GetAttribute("aria-label"));
+
+        close.Click();
+
+        component.WaitForAssertion(() => Assert.IsFalse(isOpen));
+    }
+
+    [TestMethod]
+    public void BitNavPanelShouldNotRenderTheCloseButtonByDefault()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+        });
+
+        Assert.AreEqual(0, component.FindAll(".bit-npn-cbn").Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelCloseButtonShouldAcceptItsOwnNameAndIcon()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseAriaLabel, "Dismiss the menu");
+            parameters.Add(p => p.CloseIconName, "ChromeClose");
+        });
+
+        var close = component.Find(".bit-npn-cbn");
+
+        Assert.AreEqual("Dismiss the menu", close.GetAttribute("aria-label"));
+        Assert.AreEqual("Dismiss the menu", close.GetAttribute("title"));
+        Assert.IsTrue(component.Find(".bit-npn-cbn i").ClassList.Contains("bit-icon--ChromeClose"));
+
+        component.Render(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.ShowCloseButton, true);
+            parameters.Add(p => p.CloseIcon, BitIconInfo.Fa("solid xmark"));
+        });
+
+        Assert.IsTrue(component.Find(".bit-npn-cbn i").ClassList.Contains("fa-xmark"));
+    }
+
+    [TestMethod]
+    public void BitNavPanelDrawerShouldHoldThePageAndTheFocusWhileItCoversThem()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        var rootId = component.Find(".bit-npn").Id;
+
+        // A column of the page holds nothing.
+        Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Utils.lockScroll"].Count);
+        Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count);
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.lockScroll"].Count);
+            Assert.AreEqual(rootId, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Single().Arguments[0]);
+        });
+
+        component.Find(".bit-npn-ovl").Click();
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsFalse(isOpen);
+            Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.unlockScroll"].Count);
+            Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.disposeFocusTrap"].Count);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelDrawerShouldRespectTheOptOutsOfWhatItHolds()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+            parameters.Add(p => p.NoScrollLock, true);
+            parameters.Add(p => p.NoFocusTrap, true);
+        });
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(() => Assert.AreEqual("dialog", component.Find(".bit-npn").GetAttribute("role")));
+
+        Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Utils.lockScroll"].Count);
+        Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count);
+    }
+
+    [TestMethod]
+    public void BitNavPanelAutoFocusDrawerShouldHandTheFocusBackOnTheWayOut()
+    {
+        var isOpen = true;
+
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.AutoFocus, true);
+            parameters.Bind(p => p.IsOpen, isOpen, v => isOpen = v);
+        });
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(
+            () => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.captureFocusOrigin"].Count));
+
+        component.Find(".bit-npn-ovl").Click();
+
+        component.WaitForAssertion(() =>
+        {
+            Assert.IsFalse(isOpen);
+            Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.restoreFocusOrigin"].Count);
+        });
+    }
+
+    [TestMethod]
+    public void BitNavPanelWithoutAutoFocusShouldRecordNoFocusToHandBack()
+    {
+        var component = RenderComponent<BitNavPanel<BitNavItem>>(parameters =>
+        {
+            parameters.Add(p => p.Items, Items);
+            parameters.Add(p => p.IsOpen, true);
+        });
+
+        SetDrawerScreen(component, true);
+
+        component.WaitForAssertion(
+            () => Assert.AreEqual(1, Context.JSInterop.Invocations["BitBlazorUI.Utils.setupFocusTrap"].Count));
+
+        Assert.AreEqual(0, Context.JSInterop.Invocations["BitBlazorUI.Utils.captureFocusOrigin"].Count);
+    }
+
+    // Drives the media query the panel reads its own shape from, which is the browser's answer in an app and
+    // has none of its own in a test.
+    private static void SetDrawerScreen(IRenderedComponent<BitNavPanel<BitNavItem>> component, bool isDrawer)
+    {
+        var mediaQuery = component.FindComponent<BitMediaQuery>();
+
+        component.InvokeAsync(() => mediaQuery.Instance._OnMatchChange(isDrawer).AsTask());
     }
 }


### PR DESCRIPTION
closes #13246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed NavPanel collapse behavior so hover or focus no longer immediately reopens a collapsed rail.
  - Improved disabled navigation items so they cannot be activated or followed unintentionally.
  - Corrected grouped navigation layouts, including reversed chevrons and icon-only display.

- **Improvements**
  - Added smoother, configurable transitions for desktop panels and mobile drawers.
  - Improved width handling for fit-content and full-width NavPanel modes.
  - Enhanced icon-only navigation styling and updated examples for selection, grouping, RTL, and sticky layouts.

- **Tests**
  - Added regression coverage for NavPanel collapse and grouped navigation rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->